### PR TITLE
JBPM-8437: LightProcessRuntime should not pull WorkItemManager from kruntime

### DIFF
--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/DummyKnowledgeRuntime.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/DummyKnowledgeRuntime.java
@@ -39,11 +39,9 @@ class DummyKnowledgeRuntime implements InternalKnowledgeRuntime {
 
     private final EnvironmentImpl environment;
     private InternalProcessRuntime processRuntime;
-    private final WorkItemManager workItemManager;
 
-    DummyKnowledgeRuntime(InternalProcessRuntime processRuntime, WorkItemManager workItemManager) {
+    DummyKnowledgeRuntime(InternalProcessRuntime processRuntime) {
         this.processRuntime = processRuntime;
-        this.workItemManager = workItemManager;
         this.environment = new EnvironmentImpl();
         // register codegen-based node instances factories
         environment.set("NodeInstanceFactoryRegistry", new CodegenNodeInstanceFactoryRegistry());
@@ -256,7 +254,7 @@ class DummyKnowledgeRuntime implements InternalKnowledgeRuntime {
 
     @Override
     public WorkItemManager getWorkItemManager() {
-        return workItemManager;
+        throw new UnsupportedOperationException("dummy");
     }
 
     @Override

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/DummyKnowledgeRuntime.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/DummyKnowledgeRuntime.java
@@ -254,7 +254,7 @@ class DummyKnowledgeRuntime implements InternalKnowledgeRuntime {
 
     @Override
     public WorkItemManager getWorkItemManager() {
-        throw new UnsupportedOperationException("dummy");
+        return this.processRuntime.getWorkItemManager();
     }
 
     @Override

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/LightProcessRuntime.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/LightProcessRuntime.java
@@ -76,6 +76,7 @@ public class LightProcessRuntime implements InternalProcessRuntime {
     private SignalManager signalManager;
     private TimerManager timerManager;
     private ProcessEventSupport processEventSupport;
+    private final WorkItemManager workItemManager;
 
     public static LightProcessRuntime ofProcess(Process p) {
         LightProcessRuntimeServiceProvider services =
@@ -90,7 +91,7 @@ public class LightProcessRuntime implements InternalProcessRuntime {
     public LightProcessRuntime(
             ProcessRuntimeContext runtimeContext,
             ProcessRuntimeServiceProvider services) {
-        this.knowledgeRuntime = new DummyKnowledgeRuntime(this, services.getWorkItemManager());
+        this.knowledgeRuntime = new DummyKnowledgeRuntime(this);
         TimerService timerService = services.getTimerService();
         if (!(timerService.getTimerJobFactoryManager() instanceof CommandServiceTimerJobFactoryManager)) {
             timerService.setTimerJobFactoryManager(new ThreadSafeTrackableTimeJobFactoryManager());
@@ -104,6 +105,7 @@ public class LightProcessRuntime implements InternalProcessRuntime {
         this.signalManager = services.getSignalManager();
         this.timerManager = new TimerManager(timerManagerRuntime, timerService);
         this.processEventSupport = services.getEventSupport();
+        this.workItemManager = services.getWorkItemManager();
         if (isActive()) {
             initProcessEventListeners();
             initStartTimers();
@@ -451,7 +453,7 @@ public class LightProcessRuntime implements InternalProcessRuntime {
     }
 
     public WorkItemManager getWorkItemManager() {
-        return knowledgeRuntime.getWorkItemManager();
+        return workItemManager;
     }
 
     public void signalEvent(String type, Object event) {

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/LightProcessRuntimeContext.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/LightProcessRuntimeContext.java
@@ -66,11 +66,6 @@ public class LightProcessRuntimeContext implements ProcessRuntimeContext {
     }
 
     @Override
-    public WorkItemManager getWorkItemManager() {
-        return null;
-    }
-
-    @Override
     public void addEventListener(DefaultAgendaEventListener conditional) {
 
     }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/ProcessRuntimeContext.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/ProcessRuntimeContext.java
@@ -22,8 +22,6 @@ public interface ProcessRuntimeContext {
 
     void queueWorkingMemoryAction(WorkingMemoryAction action);
 
-    WorkItemManager getWorkItemManager();
-
     void addEventListener(DefaultAgendaEventListener conditional);
 
     boolean isActive();


### PR DESCRIPTION
kruntime is there for legacy purposes. This PR removes useless API from ProcessRuntimeContext (getWorkItemManager()) because it's already in the ProcessRuntimeServiceProvider, which is already consumed by LightProcessRuntime, and returns the workItemManager instance that its in the service provider.

kruntime delegates to LightProcessRuntime

Rule of thumb: new code should not rely on kruntime, because that's a legacy interface that should go away. The dummy kruntime (if necessary) should only delegate to LightProcessRuntime
