### PR TITLE
JBPM-8533 - Service task support (java invocation)

### DIFF
--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/ServiceTaskHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/ServiceTaskHandler.java
@@ -66,7 +66,8 @@ public class ServiceTaskHandler extends TaskHandler {
 	        }
 	        // avoid overriding parameters set by data input associations
 	        if (workItemNode.getWork().getParameter("Interface") == null) {
-	            workItemNode.getWork().setParameter("Interface", operation.getInterface().getName());
+	            String interfaceRef = operation.getInterface().getImplementationRef();
+	            workItemNode.getWork().setParameter("Interface", interfaceRef != null && !interfaceRef.isEmpty() ? interfaceRef : operation.getInterface().getName());
 	        }
 	        if (workItemNode.getWork().getParameter("Operation") == null) {
 	            workItemNode.getWork().setParameter("Operation", operation.getName());

--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/canonical/ActivityGenerationModelTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/canonical/ActivityGenerationModelTest.java
@@ -324,7 +324,7 @@ public class ActivityGenerationModelTest extends JbpmBpmn2TestCase {
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         Map<String, Object> params = new HashMap<String, Object>();
         params.put("s", "john");
-        Map<String, BpmnProcess> processes = createProcesses(classData, Collections.singletonMap("Service Task", workItemHandler));                
+        Map<String, BpmnProcess> processes = createProcesses(classData, Collections.singletonMap("org.jbpm.bpmn2.objects.HelloService.hello", workItemHandler));                
         ProcessInstance<BpmnVariables> processInstance = processes.get("ServiceProcess").createInstance(BpmnVariables.create(params));
         
         processInstance.start();
@@ -348,6 +348,20 @@ public class ActivityGenerationModelTest extends JbpmBpmn2TestCase {
         String content = metaData.getGeneratedClassModel().toString();
         assertThat(content).isNotNull();
         log(content);
+    }
+    
+    @Test
+    public void testServiceTaskProcess() throws Exception {
+        BpmnProcess process = BpmnProcess.from(new ClassPathResource("BPMN2-ServiceProcess.bpmn2")).get(0);        
+                
+        ProcessMetaData metaData = ProcessToExecModelGenerator.INSTANCE.generate((WorkflowProcess) process.legacyProcess());        
+        String content = metaData.getGeneratedClassModel().toString();
+        assertThat(content).isNotNull();
+        log(content);
+        
+        assertThat(metaData.getWorkItems())
+        .hasSize(1)
+        .contains("org.jbpm.bpmn2.objects.HelloService.hello");
     }
     
     /*

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ProcessMetaData.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ProcessMetaData.java
@@ -16,7 +16,9 @@
 
 package org.jbpm.compiler.canonical;
 
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import com.github.javaparser.ast.CompilationUnit;
@@ -38,6 +40,10 @@ public class ProcessMetaData {
     private CompilationUnit generatedClassModel;
 
     private Set<String> workItems = new HashSet<>();
+    private Set<String> subProcesses = new HashSet<>();
+    
+    private Map<String, CompilationUnit> generatedHandlers = new HashMap<>();
+    private Set<CompilationUnit> generatedListeners = new HashSet<>();
 
     public ProcessMetaData(String processId, String extractedProcessId, String processName, String processVersion, String processPackageName, String processClassName) {
         super();
@@ -114,6 +120,30 @@ public class ProcessMetaData {
 
     public void setWorkItems(Set<String> workItems) {
         this.workItems = workItems;
+    }    
+    
+    public Set<String> getSubProcesses() {
+        return subProcesses;
+    }
+    
+    public void setSubProcesses(Set<String> subProcesses) {
+        this.subProcesses = subProcesses;
+    }
+
+    public Map<String, CompilationUnit> getGeneratedHandlers() {
+        return generatedHandlers;
+    }
+    
+    public void setGeneratedHandlers(Map<String, CompilationUnit> generatedHandlers) {
+        this.generatedHandlers = generatedHandlers;
+    }
+    
+    public Set<CompilationUnit> getGeneratedListeners() {
+        return generatedListeners;
+    }
+    
+    public void setGeneratedListeners(Set<CompilationUnit> generatedListeners) {
+        this.generatedListeners = generatedListeners;
     }
 
     @Override

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/WorkItemNodeVisitor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/WorkItemNodeVisitor.java
@@ -21,10 +21,25 @@ import org.jbpm.process.core.context.variable.VariableScope;
 import org.jbpm.ruleflow.core.factory.WorkItemNodeFactory;
 import org.jbpm.workflow.core.node.WorkItemNode;
 import org.kie.api.definition.process.Node;
+import org.kie.api.runtime.process.WorkItem;
+import org.kie.api.runtime.process.WorkItemHandler;
+import org.kie.api.runtime.process.WorkItemManager;
 
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.VariableDeclarator;
+import com.github.javaparser.ast.expr.CastExpr;
 import com.github.javaparser.ast.expr.LongLiteralExpr;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
+import com.github.javaparser.ast.expr.VariableDeclarationExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.ReturnStmt;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
 
 public class WorkItemNodeVisitor extends AbstractVisitor {
 
@@ -32,16 +47,105 @@ public class WorkItemNodeVisitor extends AbstractVisitor {
     public void visitNode(Node node, BlockStmt body, VariableScope variableScope, ProcessMetaData metadata) {
         WorkItemNode workItemNode = (WorkItemNode) node;
         Work work = workItemNode.getWork();
-        
+        String workName = workItemName(workItemNode, metadata);
         addFactoryMethodWithArgsWithAssignment(body, WorkItemNodeFactory.class, "workItemNode" + node.getId(), "workItemNode", new LongLiteralExpr(workItemNode.getId()));
         addFactoryMethodWithArgs(body, "workItemNode" + node.getId(), "name", new StringLiteralExpr(getOrDefault(workItemNode.getName(), work.getName())));
-        addFactoryMethodWithArgs(body, "workItemNode" + node.getId(), "workName", new StringLiteralExpr(work.getName()));
+        addFactoryMethodWithArgs(body, "workItemNode" + node.getId(), "workName", new StringLiteralExpr(workName));
 
         addWorkItemParameters(work, body, "workItemNode" + node.getId());
         addWorkItemMappings(workItemNode, body, "workItemNode" + node.getId());
         
         addFactoryMethodWithArgs(body, "workItemNode" + node.getId(), "done");
         
-        metadata.getWorkItems().add(work.getName());
+        metadata.getWorkItems().add(workName);
+    }
+    
+    protected String workItemName(WorkItemNode workItemNode, ProcessMetaData metadata) {
+        String workName = workItemNode.getWork().getName();
+        
+        if (workName.equals("Service Task")) {
+            String interfaceName = (String) workItemNode.getWork().getParameter("Interface");
+            String operationName = (String) workItemNode.getWork().getParameter("Operation");
+            String type = (String) workItemNode.getWork().getParameter("ParameterType");
+            
+            workName = interfaceName + "." + operationName;
+            
+            CompilationUnit handlerClass = generateHandlerClassForService(interfaceName, operationName, type, "Parameter");
+            
+            metadata.getGeneratedHandlers().put(workName, handlerClass);
+        }
+        
+        return workName;
+    }
+    
+    protected CompilationUnit generateHandlerClassForService(String interfaceName, String operation, String paramType, String paramName) {
+        CompilationUnit compilationUnit = new CompilationUnit("org.kie.kogito.handlers");        
+        
+        compilationUnit.getTypes().add(classDeclaration(interfaceName, operation, paramType, paramName));
+        
+        return compilationUnit;
+    }
+    
+    public ClassOrInterfaceDeclaration classDeclaration(String interfaceName, String operation, String paramType, String paramName) {
+        ClassOrInterfaceDeclaration cls = new ClassOrInterfaceDeclaration()
+                .setName(interfaceName.substring(interfaceName.lastIndexOf(".") + 1) + "_" + operation + "Handler")
+                .setModifiers(Modifier.Keyword.PUBLIC)
+                .addImplementedType(WorkItemHandler.class.getCanonicalName());
+        ClassOrInterfaceType serviceType = new ClassOrInterfaceType(null, interfaceName);
+        FieldDeclaration serviceField = new FieldDeclaration()
+                .addVariable(new VariableDeclarator(serviceType, "service"));
+        cls.addMember(serviceField);
+        
+        // executeWorkItem method
+        BlockStmt executeWorkItemBody = new BlockStmt();
+        MethodDeclaration executeWorkItem = new MethodDeclaration()
+                .setModifiers(Modifier.Keyword.PUBLIC)
+                .setType(void.class)
+                .setName("executeWorkItem")
+                .setBody(executeWorkItemBody)
+                .addParameter(WorkItem.class.getCanonicalName(), "workItem")
+                .addParameter(WorkItemManager.class.getCanonicalName(), "workItemManager");
+        
+        
+        MethodCallExpr getParamMethod = new MethodCallExpr(new NameExpr("workItem"), "getParameter").addArgument(new StringLiteralExpr(paramName));
+        MethodCallExpr callService = new MethodCallExpr(new NameExpr("service"), operation).addArgument(new CastExpr(new ClassOrInterfaceType(null, paramType), getParamMethod));
+        VariableDeclarationExpr resultField = new VariableDeclarationExpr()
+                .addVariable(new VariableDeclarator(new ClassOrInterfaceType(null, Object.class.getCanonicalName()), "result", callService));
+        
+        executeWorkItemBody.addStatement(resultField);
+        
+        MethodCallExpr completeWorkItem = new MethodCallExpr(new NameExpr("workItemManager"), "completeWorkItem")
+                .addArgument(new MethodCallExpr(new NameExpr("workItem"), "getId"))
+                .addArgument(new MethodCallExpr(new NameExpr("java.util.Collections"), "singletonMap")
+                             .addArgument(new StringLiteralExpr("Result"))
+                             .addArgument(new NameExpr("result")));        
+        executeWorkItemBody.addStatement(completeWorkItem);
+        
+        // abortWorkItem method
+        BlockStmt abortWorkItemBody = new BlockStmt();
+        MethodDeclaration abortWorkItem = new MethodDeclaration()
+                .setModifiers(Modifier.Keyword.PUBLIC)
+                .setType(void.class)
+                .setName("abortWorkItem")
+                .setBody(abortWorkItemBody)
+                .addParameter(WorkItem.class.getCanonicalName(), "workItem")
+                .addParameter(WorkItemManager.class.getCanonicalName(), "workItemManager");
+        
+        
+        // getName method
+        MethodDeclaration getName = new MethodDeclaration()
+                .setModifiers(Modifier.Keyword.PUBLIC)
+                .setType(String.class)
+                .setName("getName")
+                .setBody(new BlockStmt().addStatement(new ReturnStmt(new StringLiteralExpr(interfaceName + "." + operation))));
+        
+         
+        
+        cls
+            .addMember(executeWorkItem)
+            .addMember(abortWorkItem)
+            .addMember(getName);
+        
+        return cls;
     }
 }

--- a/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcess.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcess.java
@@ -30,13 +30,13 @@ import org.kie.kogito.process.Signal;
 
 public abstract class AbstractProcess<T extends Model> implements Process<T> {
 
-    private final MapProcessInstances<T> instances;
+    protected final MapProcessInstances<T> instances;
 
-    private final ProcessRuntimeServiceProvider services;
+    protected final ProcessRuntimeServiceProvider services;
 
     protected AbstractProcess(ProcessRuntimeServiceProvider services) {
         this.services = services;
-        this.instances = new MapProcessInstances<>();
+        this.instances = new MapProcessInstances<>();        
     }
 
     @Override
@@ -66,10 +66,17 @@ public abstract class AbstractProcess<T extends Model> implements Process<T> {
     public final <S> void send(Signal<S> signal) {
         instances().values().forEach(pi -> pi.send(signal));
     }
+    
+    public Process<T> configure() {
+        //services.getWorkItemManager().registerWorkItemHandler(name, handlerConfig.forName(name)
+        //services.getEventSupport().addEventListener(listener)
+        
+        return this;
+    }
 
     protected abstract org.kie.api.definition.process.Process legacyProcess();
 
-    protected ProcessRuntime createLegacyProcessRuntime() {
+    protected ProcessRuntime createLegacyProcessRuntime() {        
         return new LightProcessRuntime(
                 new LightProcessRuntimeContext(Collections.singletonList(legacyProcess())),
                 services);

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/ApplicationGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/ApplicationGenerator.java
@@ -27,13 +27,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.kie.kogito.codegen.metadata.ImageMetaData;
 import org.kie.kogito.Config;
+import org.kie.kogito.codegen.metadata.ImageMetaData;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.body.BodyDeclaration;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
@@ -54,7 +55,7 @@ public class ApplicationGenerator {
 
     private String targetTypeName;
     private boolean hasCdi;
-    private final List<MethodDeclaration> factoryMethods;
+    private final List<BodyDeclaration<?>> factoryMethods;
     private ConfigGenerator configGenerator = new ConfigGenerator();
     private List<Generator> generators = new ArrayList<>();
 

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/GeneratedFile.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/GeneratedFile.java
@@ -23,7 +23,8 @@ public class GeneratedFile {
         PROCESS_INSTANCE,
         REST,
         RULE,
-        MODEL;
+        MODEL,
+        CLASS;
     }
     
     private final String relativePath;

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/Generator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/Generator.java
@@ -20,11 +20,10 @@ import java.util.Collections;
 import java.util.Map;
 
 import com.github.javaparser.ast.body.BodyDeclaration;
-import com.github.javaparser.ast.body.MethodDeclaration;
 
 public interface Generator {
 
-    Collection<MethodDeclaration> factoryMethods();
+    Collection<BodyDeclaration<?>> factoryMethods();
     
     Collection<BodyDeclaration<?>> applicationBodyDeclaration();
 

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ModuleGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ModuleGenerator.java
@@ -57,7 +57,7 @@ public class ModuleGenerator {
     private final String targetCanonicalName;
     private final List<ProcessGenerator> processes;
     private final List<ProcessInstanceGenerator> processInstances;
-    private final List<MethodDeclaration> factoryMethods;
+    private final List<BodyDeclaration<?>> factoryMethods;
     private String targetTypeName;
     private boolean hasCdi;
     private String workItemConfigClass = DefaultWorkItemHandlerConfig.class.getCanonicalName();
@@ -97,7 +97,7 @@ public class ModuleGenerator {
         applicationDeclarations.add(processesMethodDeclaration);
     }
 
-    public List<MethodDeclaration> factoryMethods() {
+    public List<BodyDeclaration<?>> factoryMethods() {
         return factoryMethods;
     }
 
@@ -144,15 +144,19 @@ public class ModuleGenerator {
     }
 
     public MethodDeclaration addProcessFactoryMethod(ProcessGenerator r) {
+        ObjectCreationExpr newProcess = new ObjectCreationExpr()
+                .setType(r.targetCanonicalName())
+                .addArgument(new ThisExpr());
         MethodDeclaration methodDeclaration = new MethodDeclaration()
                 .addModifier(Modifier.Keyword.PUBLIC)
                 .setName("create" + r.targetTypeName())
                 .setType(r.targetCanonicalName())
-                .setBody(new BlockStmt().addStatement(new ReturnStmt(
-                        new ObjectCreationExpr()
-                                .setType(r.targetCanonicalName())
-                                .addArgument(new ThisExpr()))));
+                .setBody(new BlockStmt().addStatement(new ReturnStmt(new MethodCallExpr(
+                                                                             newProcess,
+                                                                             "configure"))));
+        
         this.factoryMethods.add(methodDeclaration);
+        
         return methodDeclaration;
     }
     

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
@@ -15,6 +15,9 @@
 
 package org.kie.kogito.codegen.rules;
 
+import static org.drools.modelcompiler.builder.CanonicalModelKieProject.PROJECT_MODEL_CLASS;
+import static org.drools.modelcompiler.builder.JavaParserCompiler.getPrettyPrinter;
+
 import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -27,10 +30,6 @@ import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.github.javaparser.ast.CompilationUnit;
-import com.github.javaparser.ast.body.BodyDeclaration;
-import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
-import com.github.javaparser.ast.body.MethodDeclaration;
 import org.drools.compiler.builder.impl.KnowledgeBuilderConfigurationImpl;
 import org.drools.compiler.builder.impl.KnowledgeBuilderUtil;
 import org.drools.compiler.lang.descr.CompositePackageDescr;
@@ -46,8 +45,9 @@ import org.kie.kogito.codegen.ConfigGenerator;
 import org.kie.kogito.codegen.GeneratedFile;
 import org.kie.kogito.codegen.Generator;
 
-import static org.drools.modelcompiler.builder.CanonicalModelKieProject.PROJECT_MODEL_CLASS;
-import static org.drools.modelcompiler.builder.JavaParserCompiler.getPrettyPrinter;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.BodyDeclaration;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 
 public class IncrementalRuleCodegen implements Generator {
 
@@ -77,7 +77,7 @@ public class IncrementalRuleCodegen implements Generator {
     }
 
     @Override
-    public Collection<MethodDeclaration> factoryMethods() {
+    public Collection<BodyDeclaration<?>> factoryMethods() {
         return null;
     }
 

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/ModuleSourceClass.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/ModuleSourceClass.java
@@ -45,7 +45,7 @@ public class ModuleSourceClass {
     private final List<RuleUnitSourceClass> ruleUnits;
     private String targetTypeName;
     private boolean hasCdi;
-    private List<MethodDeclaration> factoryMethods = new ArrayList<>();
+    private List<BodyDeclaration<?>> factoryMethods = new ArrayList<>();
     
     private String ruleEventListenersConfigClass = DefaultRuleEventListenerConfig.class.getCanonicalName();
 
@@ -57,7 +57,7 @@ public class ModuleSourceClass {
         this.ruleUnits = new ArrayList<>();
     }
 
-    public List<MethodDeclaration> factoryMethods() {
+    public List<BodyDeclaration<?>> factoryMethods() {
         return factoryMethods;
     }
 

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/RuleCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/RuleCodegen.java
@@ -37,7 +37,6 @@ import org.kie.kogito.codegen.Generator;
 import org.kie.kogito.codegen.rules.config.RuleConfigGenerator;
 
 import com.github.javaparser.ast.body.BodyDeclaration;
-import com.github.javaparser.ast.body.MethodDeclaration;
 
 public class RuleCodegen implements Generator {
 
@@ -101,7 +100,7 @@ public class RuleCodegen implements Generator {
     }
 
     @Override
-    public Collection<MethodDeclaration> factoryMethods() {
+    public Collection<BodyDeclaration<?>> factoryMethods() {
         return moduleGenerator.factoryMethods();
     }
 

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/AbstractCodegenTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/AbstractCodegenTest.java
@@ -61,7 +61,6 @@ public class AbstractCodegenTest {
         ApplicationGenerator appGen =
                 new ApplicationGenerator(this.getClass().getPackage().getName(), new File("target/codegen-tests"))
                                                                                                     .withDependencyInjection(false);
-
         if (!rulesResources.isEmpty()) {
             appGen.withGenerator(RuleCodegen.ofFiles(Paths.get("src", "test", "resources"),
                                                      rulesResources

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/ApplicationGeneratorTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/ApplicationGeneratorTest.java
@@ -15,6 +15,10 @@
 
 package org.kie.kogito.codegen;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -29,20 +33,18 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.javaparser.ast.CompilationUnit;
-import com.github.javaparser.ast.body.FieldDeclaration;
-import com.github.javaparser.ast.body.MethodDeclaration;
-import com.github.javaparser.ast.body.TypeDeclaration;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.kie.kogito.Config;
 import org.mockito.Mockito;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.BodyDeclaration;
+import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.TypeDeclaration;
 
 public class ApplicationGeneratorTest {
 
@@ -114,7 +116,7 @@ public class ApplicationGeneratorTest {
         final Generator mockGenerator = Mockito.mock(Generator.class);
 
         final MethodDeclaration mockMethod = new MethodDeclaration();
-        final Collection<MethodDeclaration> mockedMethods = Collections.singleton(mockMethod);
+        final Collection<BodyDeclaration<?>> mockedMethods = Collections.singleton(mockMethod);
         when(mockGenerator.factoryMethods()).thenReturn(mockedMethods);
 
         final GeneratedFile generatedFile = mock(GeneratedFile.class);

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/GeneratorInterfaceTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/GeneratorInterfaceTest.java
@@ -17,10 +17,10 @@ package org.kie.kogito.codegen;
 
 import java.util.Collection;
 
-import com.github.javaparser.ast.body.BodyDeclaration;
-import com.github.javaparser.ast.body.MethodDeclaration;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
+
+import com.github.javaparser.ast.body.BodyDeclaration;
 
 public class GeneratorInterfaceTest {
 
@@ -32,7 +32,7 @@ public class GeneratorInterfaceTest {
     private Generator getAnonymousGeneratorInstance() {
         return new Generator() {
             @Override
-            public Collection<MethodDeclaration> factoryMethods() {
+            public Collection<BodyDeclaration<?>> factoryMethods() {
                 return null;
             }
 

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/data/HelloService.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/data/HelloService.java
@@ -3,8 +3,9 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,18 +14,17 @@
  * limitations under the License.
  */
 
-package org.kie.kogito.process.impl;
+package org.kie.kogito.codegen.data;
 
-import org.jbpm.process.instance.AbstractProcessRuntimeServiceProvider;
-import org.kie.kogito.process.ProcessConfig;
-import org.kie.services.time.impl.JDKTimerService;
-
-public class ConfiguredProcessServices extends AbstractProcessRuntimeServiceProvider {
-
-    public ConfiguredProcessServices(ProcessConfig config) {
-        super(new JDKTimerService(),
-              config.workItemHandlers(),
-              config.processEventListeners());
-
+public class HelloService {
+	
+    public String hello(String name) {
+        System.out.println("Service invoked with " + name + " on service " + this.toString());
+        return "Hello " + name + "!";
+    }
+    
+    public String goodbye(String name) {
+        System.out.println("Service invoked with " + name + " on service " + this.toString());
+        return "Goodbye " + name + "!";
     }
 }

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/tests/ServiceTaskTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/tests/ServiceTaskTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.codegen.tests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+import org.kie.kogito.Application;
+import org.kie.kogito.Model;
+import org.kie.kogito.codegen.AbstractCodegenTest;
+import org.kie.kogito.process.Process;
+import org.kie.kogito.process.ProcessInstance;
+
+
+public class ServiceTaskTest extends AbstractCodegenTest {
+
+    
+    @Test
+    public void testBasicServiceProcessTask() throws Exception {
+        
+        Application app = generateCodeProcessesOnly("servicetask/ServiceProcess.bpmn2");        
+        assertThat(app).isNotNull();
+                
+        Process<? extends Model> p = app.processes().processById("ServiceProcess");
+        
+        Model m = p.createModel();
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("s", "john");
+        m.fromMap(parameters);
+        
+        ProcessInstance<?> processInstance = p.createInstance(m);
+        processInstance.start();
+        
+        assertThat(processInstance.status()).isEqualTo(org.kie.api.runtime.process.ProcessInstance.STATE_COMPLETED); 
+        Model result = (Model)processInstance.variables();
+        assertThat(result.toMap()).hasSize(1).containsKeys("s");
+        assertThat(result.toMap().get("s")).isNotNull().isEqualTo("Hello john!");
+    }
+    
+    @Test
+    public void testServiceProcessDifferentOperationsTask() throws Exception {
+        
+        Application app = generateCodeProcessesOnly("servicetask/ServiceProcessDifferentOperations.bpmn2");        
+        assertThat(app).isNotNull();
+                
+        Process<? extends Model> p = app.processes().processById("ServiceProcessDifferentOperations");
+        
+        Model m = p.createModel();
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("s", "john");
+        m.fromMap(parameters);
+        
+        ProcessInstance<?> processInstance = p.createInstance(m);
+        processInstance.start();
+        
+        assertThat(processInstance.status()).isEqualTo(org.kie.api.runtime.process.ProcessInstance.STATE_COMPLETED); 
+        Model result = (Model)processInstance.variables();
+        assertThat(result.toMap()).hasSize(1).containsKeys("s");
+        assertThat(result.toMap().get("s")).isNotNull().isEqualTo("Goodbye Hello john!!");
+    }
+    
+    @Test
+    public void testServiceProcessSameOperationsTask() throws Exception {
+        
+        Application app = generateCodeProcessesOnly("servicetask/ServiceProcessSameOperations.bpmn2");        
+        assertThat(app).isNotNull();
+                
+        Process<? extends Model> p = app.processes().processById("ServiceProcessSameOperations");
+        
+        Model m = p.createModel();
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("s", "john");
+        m.fromMap(parameters);
+        
+        ProcessInstance<?> processInstance = p.createInstance(m);
+        processInstance.start();
+        
+        assertThat(processInstance.status()).isEqualTo(org.kie.api.runtime.process.ProcessInstance.STATE_COMPLETED); 
+        Model result = (Model)processInstance.variables();
+        assertThat(result.toMap()).hasSize(1).containsKeys("s");
+        assertThat(result.toMap().get("s")).isNotNull().isEqualTo("Hello Hello john!!");
+    }
+}

--- a/kogito-codegen/src/test/resources/servicetask/ServiceProcess.bpmn2
+++ b/kogito-codegen/src/test/resources/servicetask/ServiceProcess.bpmn2
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<definitions id="Definition"
+             targetNamespace="http://www.example.org/MinimalExample"
+             typeLanguage="http://www.java.com/javaTypes"
+             expressionLanguage="http://www.mvel.org/2.0"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+             xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+             xmlns:tns="http://www.jboss.org/drools">
+
+  <itemDefinition id="_sItem" structureRef="String" />
+
+  <itemDefinition id="_2_InMessageType" structureRef="java.lang.String"/>
+  <message id="_2_InMessage" itemRef="_2_InMessageType" />
+  <interface id="_2_ServiceInterface" implementationRef="org.kie.kogito.codegen.data.HelloService" name="HelloService">
+    <operation id="_2_ServiceOperation" name="hello">
+      <inMessageRef>_2_InMessage</inMessageRef>
+    </operation>
+  </interface>
+
+  <process processType="Private" isExecutable="true" id="ServiceProcess" name="Service Process" >
+
+    <!-- process variables -->
+    <property id="s" itemSubjectRef="_sItem"/>
+
+    <!-- nodes -->
+    <startEvent id="_1" name="StartProcess" />
+    <serviceTask id="_2" name="Hello" operationRef="_2_ServiceOperation" implementation="Other" >
+      <ioSpecification>
+        <dataInput id="_2_param" name="Parameter" />
+        <dataOutput id="_2_result" name="Result" />
+        <inputSet>
+          <dataInputRefs>_2_param</dataInputRefs>
+        </inputSet>
+        <outputSet>
+          <dataOutputRefs>_2_result</dataOutputRefs>
+        </outputSet>
+      </ioSpecification>
+      <dataInputAssociation>
+        <sourceRef>s</sourceRef>
+        <targetRef>_2_param</targetRef>
+      </dataInputAssociation>
+      <dataOutputAssociation>
+        <sourceRef>_2_result</sourceRef>
+        <targetRef>s</targetRef>
+      </dataOutputAssociation>
+    </serviceTask>
+    <endEvent id="_3" name="EndProcess" >
+        <terminateEventDefinition/>
+    </endEvent>
+
+    <!-- connections -->
+    <sequenceFlow id="_1-_2" sourceRef="_1" targetRef="_2" />
+    <sequenceFlow id="_2-_3" sourceRef="_2" targetRef="_3" />
+
+  </process>
+
+  <bpmndi:BPMNDiagram>
+    <bpmndi:BPMNPlane bpmnElement="ServiceProcess" >
+      <bpmndi:BPMNShape bpmnElement="_1" >
+        <dc:Bounds x="16" y="16" width="48" height="48" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_2" >
+        <dc:Bounds x="96" y="16" width="100" height="48" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_3" >
+        <dc:Bounds x="228" y="16" width="48" height="48" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="_1-_2" >
+        <di:waypoint x="40" y="40" />
+        <di:waypoint x="146" y="40" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="_2-_3" >
+        <di:waypoint x="146" y="40" />
+        <di:waypoint x="252" y="40" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+
+</definitions>

--- a/kogito-codegen/src/test/resources/servicetask/ServiceProcessDifferentOperations.bpmn2
+++ b/kogito-codegen/src/test/resources/servicetask/ServiceProcessDifferentOperations.bpmn2
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_aSjpYIEmEemgIL72M4lYRQ" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" exporter="jBPM Designer" exporterVersion="1.0" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.omg.org/bpmn20" typeLanguage="http://www.java.com/javaTypes">
+  <bpmn2:itemDefinition id="_sItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="_38E04E27-3CCA-47F9-927B-E37DC4B8CE25_InMessageType" structureRef="java.lang.String"/>
+  <bpmn2:itemDefinition id="_A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4_InMessageType" structureRef="java.lang.String"/>
+  <bpmn2:message id="_38E04E27-3CCA-47F9-927B-E37DC4B8CE25_InMessage" itemRef="_38E04E27-3CCA-47F9-927B-E37DC4B8CE25_InMessageType"/>
+  <bpmn2:message id="_A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4_InMessage" itemRef="_A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4_InMessageType"/>
+  <bpmn2:interface id="_38E04E27-3CCA-47F9-927B-E37DC4B8CE25_ServiceInterface" name="HelloService" implementationRef="org.kie.kogito.codegen.data.HelloService">
+    <bpmn2:operation id="_38E04E27-3CCA-47F9-927B-E37DC4B8CE25_ServiceOperation" name="hello" implementationRef="hello">
+      <bpmn2:inMessageRef>_38E04E27-3CCA-47F9-927B-E37DC4B8CE25_InMessage</bpmn2:inMessageRef>
+    </bpmn2:operation>
+  </bpmn2:interface>
+  <bpmn2:interface id="_A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4_ServiceInterface" name="HelloService" implementationRef="org.kie.kogito.codegen.data.HelloService">
+    <bpmn2:operation id="_A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4_ServiceOperation" name="goodbye" implementationRef="goodbye">
+      <bpmn2:inMessageRef>_A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4_InMessage</bpmn2:inMessageRef>
+    </bpmn2:operation>
+  </bpmn2:interface>
+  <bpmn2:itemDefinition id="__38E04E27-3CCA-47F9-927B-E37DC4B8CE25_ParameterInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__38E04E27-3CCA-47F9-927B-E37DC4B8CE25_ResultOutputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4_ParameterInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4_ResultOutputXItem" structureRef="Object"/>
+  <bpmn2:process id="ServiceProcessDifferentOperations" drools:packageName="com.myspace.test" drools:version="1.0" name="Service Process" isExecutable="true">
+    <bpmn2:property id="s" itemSubjectRef="_sItem"/>
+    <bpmn2:startEvent id="_1747DF71-D65B-409B-A5B4-D265AE64E41A" drools:selectable="true" color:background-color="#9acd32" color:border-color="#000000" color:color="#000000" name="StartProcess">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[StartProcess]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:outgoing>_2D052977-41FD-43AD-9CDE-A96F40EDDEAC</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:serviceTask id="_38E04E27-3CCA-47F9-927B-E37DC4B8CE25" drools:selectable="true" drools:serviceimplementation="Other" drools:serviceoperation="hello" drools:serviceinterface="org.kie.kogito.codegen.data.HelloService" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="Hello" implementation="Other" operationRef="_38E04E27-3CCA-47F9-927B-E37DC4B8CE25_ServiceOperation">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Hello]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_2D052977-41FD-43AD-9CDE-A96F40EDDEAC</bpmn2:incoming>
+      <bpmn2:outgoing>_F39893C8-F27C-4BFA-946B-D92EB085FD30</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_aSjpYYEmEemgIL72M4lYRQ">
+        <bpmn2:dataInput id="_38E04E27-3CCA-47F9-927B-E37DC4B8CE25_ParameterInputX" drools:dtype="Object" itemSubjectRef="__38E04E27-3CCA-47F9-927B-E37DC4B8CE25_ParameterInputXItem" name="Parameter"/>
+        <bpmn2:dataOutput id="_38E04E27-3CCA-47F9-927B-E37DC4B8CE25_ResultOutputX" drools:dtype="Object" itemSubjectRef="__38E04E27-3CCA-47F9-927B-E37DC4B8CE25_ResultOutputXItem" name="Result"/>
+        <bpmn2:inputSet id="_aSjpYoEmEemgIL72M4lYRQ">
+          <bpmn2:dataInputRefs>_38E04E27-3CCA-47F9-927B-E37DC4B8CE25_ParameterInputX</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet id="_aSjpY4EmEemgIL72M4lYRQ">
+          <bpmn2:dataOutputRefs>_38E04E27-3CCA-47F9-927B-E37DC4B8CE25_ResultOutputX</bpmn2:dataOutputRefs>
+        </bpmn2:outputSet>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="_aSjpZIEmEemgIL72M4lYRQ">
+        <bpmn2:sourceRef>s</bpmn2:sourceRef>
+        <bpmn2:targetRef>_38E04E27-3CCA-47F9-927B-E37DC4B8CE25_ParameterInputX</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataOutputAssociation id="_aSjpZYEmEemgIL72M4lYRQ">
+        <bpmn2:sourceRef>_38E04E27-3CCA-47F9-927B-E37DC4B8CE25_ResultOutputX</bpmn2:sourceRef>
+        <bpmn2:targetRef>s</bpmn2:targetRef>
+      </bpmn2:dataOutputAssociation>
+    </bpmn2:serviceTask>
+    <bpmn2:endEvent id="_EFFEBFD6-C5B1-42BF-A4D9-865BF04CD00C" drools:selectable="true" color:background-color="#ff6347" color:border-color="#000000" color:color="#000000" name="EndProcess">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[EndProcess]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_9C0FB01D-F622-456E-A1D8-AFCC5C54588E</bpmn2:incoming>
+      <bpmn2:terminateEventDefinition id="_aSjpZoEmEemgIL72M4lYRQ"/>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="_2D052977-41FD-43AD-9CDE-A96F40EDDEAC" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_1747DF71-D65B-409B-A5B4-D265AE64E41A" targetRef="_38E04E27-3CCA-47F9-927B-E37DC4B8CE25"/>
+    <bpmn2:sequenceFlow id="_F39893C8-F27C-4BFA-946B-D92EB085FD30" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_38E04E27-3CCA-47F9-927B-E37DC4B8CE25" targetRef="_A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4"/>
+    <bpmn2:serviceTask id="_A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4" drools:selectable="true" drools:serviceimplementation="Other" drools:serviceoperation="goodbye" drools:serviceinterface="org.kie.kogito.codegen.data.HelloService" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="Goodbye" implementation="Other" operationRef="_A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4_ServiceOperation">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Goodbye]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_F39893C8-F27C-4BFA-946B-D92EB085FD30</bpmn2:incoming>
+      <bpmn2:outgoing>_9C0FB01D-F622-456E-A1D8-AFCC5C54588E</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_aSjpZ4EmEemgIL72M4lYRQ">
+        <bpmn2:dataInput id="_A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4_ParameterInputX" drools:dtype="Object" itemSubjectRef="__A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4_ParameterInputXItem" name="Parameter"/>
+        <bpmn2:dataOutput id="_A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4_ResultOutputX" drools:dtype="Object" itemSubjectRef="__A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4_ResultOutputXItem" name="Result"/>
+        <bpmn2:inputSet id="_aSjpaIEmEemgIL72M4lYRQ">
+          <bpmn2:dataInputRefs>_A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4_ParameterInputX</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet id="_aSjpaYEmEemgIL72M4lYRQ">
+          <bpmn2:dataOutputRefs>_A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4_ResultOutputX</bpmn2:dataOutputRefs>
+        </bpmn2:outputSet>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="_aSjpaoEmEemgIL72M4lYRQ">
+        <bpmn2:sourceRef>s</bpmn2:sourceRef>
+        <bpmn2:targetRef>_A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4_ParameterInputX</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataOutputAssociation id="_aSjpa4EmEemgIL72M4lYRQ">
+        <bpmn2:sourceRef>_A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4_ResultOutputX</bpmn2:sourceRef>
+        <bpmn2:targetRef>s</bpmn2:targetRef>
+      </bpmn2:dataOutputAssociation>
+    </bpmn2:serviceTask>
+    <bpmn2:sequenceFlow id="_9C0FB01D-F622-456E-A1D8-AFCC5C54588E" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4" targetRef="_EFFEBFD6-C5B1-42BF-A4D9-865BF04CD00C"/>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="_aSjpbIEmEemgIL72M4lYRQ">
+    <bpmndi:BPMNPlane id="_aSjpbYEmEemgIL72M4lYRQ" bpmnElement="ServiceProcessDifferentOperations">
+      <bpmndi:BPMNShape id="_aSjpboEmEemgIL72M4lYRQ" bpmnElement="_1747DF71-D65B-409B-A5B4-D265AE64E41A">
+        <dc:Bounds height="30.0" width="30.0" x="15.0" y="131.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_aSkQcIEmEemgIL72M4lYRQ" bpmnElement="_38E04E27-3CCA-47F9-927B-E37DC4B8CE25">
+        <dc:Bounds height="72.0" width="123.0" x="135.0" y="110.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_aSkQcYEmEemgIL72M4lYRQ" bpmnElement="_EFFEBFD6-C5B1-42BF-A4D9-865BF04CD00C">
+        <dc:Bounds height="28.0" width="28.0" x="555.0" y="132.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_aSkQcoEmEemgIL72M4lYRQ" bpmnElement="_A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4">
+        <dc:Bounds height="71.0" width="136.0" x="345.0" y="110.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_aSkQc4EmEemgIL72M4lYRQ" bpmnElement="_2D052977-41FD-43AD-9CDE-A96F40EDDEAC" sourceElement="_aSjpboEmEemgIL72M4lYRQ" targetElement="_aSkQcIEmEemgIL72M4lYRQ">
+        <di:waypoint xsi:type="dc:Point" x="30.0" y="146.0"/>
+        <di:waypoint xsi:type="dc:Point" x="196.5" y="146.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_aSkQdIEmEemgIL72M4lYRQ" bpmnElement="_F39893C8-F27C-4BFA-946B-D92EB085FD30" sourceElement="_aSkQcIEmEemgIL72M4lYRQ" targetElement="_aSkQcoEmEemgIL72M4lYRQ">
+        <di:waypoint xsi:type="dc:Point" x="196.5" y="146.0"/>
+        <di:waypoint xsi:type="dc:Point" x="413.0" y="145.5"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_aSkQdYEmEemgIL72M4lYRQ" bpmnElement="_9C0FB01D-F622-456E-A1D8-AFCC5C54588E" sourceElement="_aSkQcoEmEemgIL72M4lYRQ" targetElement="_aSkQcYEmEemgIL72M4lYRQ">
+        <di:waypoint xsi:type="dc:Point" x="413.0" y="145.5"/>
+        <di:waypoint xsi:type="dc:Point" x="569.0" y="146.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn2:definitions>

--- a/kogito-codegen/src/test/resources/servicetask/ServiceProcessSameOperations.bpmn2
+++ b/kogito-codegen/src/test/resources/servicetask/ServiceProcessSameOperations.bpmn2
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_RRBXcIEmEemgIL72M4lYRQ" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" exporter="jBPM Designer" exporterVersion="1.0" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.omg.org/bpmn20" typeLanguage="http://www.java.com/javaTypes">
+  <bpmn2:itemDefinition id="_sItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="_38E04E27-3CCA-47F9-927B-E37DC4B8CE25_InMessageType" structureRef="java.lang.String"/>
+  <bpmn2:itemDefinition id="_A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4_InMessageType" structureRef="java.lang.String"/>
+  <bpmn2:message id="_38E04E27-3CCA-47F9-927B-E37DC4B8CE25_InMessage" itemRef="_38E04E27-3CCA-47F9-927B-E37DC4B8CE25_InMessageType"/>
+  <bpmn2:message id="_A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4_InMessage" itemRef="_A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4_InMessageType"/>
+  <bpmn2:interface id="_38E04E27-3CCA-47F9-927B-E37DC4B8CE25_ServiceInterface" name="HelloService" implementationRef="org.kie.kogito.codegen.data.HelloService">
+    <bpmn2:operation id="_38E04E27-3CCA-47F9-927B-E37DC4B8CE25_ServiceOperation" name="hello" implementationRef="hello">
+      <bpmn2:inMessageRef>_38E04E27-3CCA-47F9-927B-E37DC4B8CE25_InMessage</bpmn2:inMessageRef>
+    </bpmn2:operation>
+  </bpmn2:interface>
+  <bpmn2:interface id="_A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4_ServiceInterface" name="org.kie.kogito.codegen.data.HelloService" implementationRef="org.kie.kogito.codegen.data.HelloService">
+    <bpmn2:operation id="_A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4_ServiceOperation" name="hello" implementationRef="hello">
+      <bpmn2:inMessageRef>_A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4_InMessage</bpmn2:inMessageRef>
+    </bpmn2:operation>
+  </bpmn2:interface>
+  <bpmn2:itemDefinition id="__38E04E27-3CCA-47F9-927B-E37DC4B8CE25_ParameterInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__38E04E27-3CCA-47F9-927B-E37DC4B8CE25_ResultOutputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4_ParameterInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4_ResultOutputXItem" structureRef="Object"/>
+  <bpmn2:process id="ServiceProcessSameOperations" drools:packageName="com.myspace.test" drools:version="1.0" name="Service Process" isExecutable="true">
+    <bpmn2:property id="s" itemSubjectRef="_sItem"/>
+    <bpmn2:startEvent id="_1747DF71-D65B-409B-A5B4-D265AE64E41A" drools:selectable="true" color:background-color="#9acd32" color:border-color="#000000" color:color="#000000" name="StartProcess">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[StartProcess]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:outgoing>_2D052977-41FD-43AD-9CDE-A96F40EDDEAC</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:serviceTask id="_38E04E27-3CCA-47F9-927B-E37DC4B8CE25" drools:selectable="true" drools:serviceimplementation="Other" drools:serviceoperation="hello" drools:serviceinterface="org.kie.kogito.codegen.data.HelloService" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="Hello" implementation="Other" operationRef="_38E04E27-3CCA-47F9-927B-E37DC4B8CE25_ServiceOperation">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Hello]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_2D052977-41FD-43AD-9CDE-A96F40EDDEAC</bpmn2:incoming>
+      <bpmn2:outgoing>_F39893C8-F27C-4BFA-946B-D92EB085FD30</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_RRB-gIEmEemgIL72M4lYRQ">
+        <bpmn2:dataInput id="_38E04E27-3CCA-47F9-927B-E37DC4B8CE25_ParameterInputX" drools:dtype="Object" itemSubjectRef="__38E04E27-3CCA-47F9-927B-E37DC4B8CE25_ParameterInputXItem" name="Parameter"/>
+        <bpmn2:dataOutput id="_38E04E27-3CCA-47F9-927B-E37DC4B8CE25_ResultOutputX" drools:dtype="Object" itemSubjectRef="__38E04E27-3CCA-47F9-927B-E37DC4B8CE25_ResultOutputXItem" name="Result"/>
+        <bpmn2:inputSet id="_RRB-gYEmEemgIL72M4lYRQ">
+          <bpmn2:dataInputRefs>_38E04E27-3CCA-47F9-927B-E37DC4B8CE25_ParameterInputX</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet id="_RRB-goEmEemgIL72M4lYRQ">
+          <bpmn2:dataOutputRefs>_38E04E27-3CCA-47F9-927B-E37DC4B8CE25_ResultOutputX</bpmn2:dataOutputRefs>
+        </bpmn2:outputSet>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="_RRB-g4EmEemgIL72M4lYRQ">
+        <bpmn2:sourceRef>s</bpmn2:sourceRef>
+        <bpmn2:targetRef>_38E04E27-3CCA-47F9-927B-E37DC4B8CE25_ParameterInputX</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataOutputAssociation id="_RRB-hIEmEemgIL72M4lYRQ">
+        <bpmn2:sourceRef>_38E04E27-3CCA-47F9-927B-E37DC4B8CE25_ResultOutputX</bpmn2:sourceRef>
+        <bpmn2:targetRef>s</bpmn2:targetRef>
+      </bpmn2:dataOutputAssociation>
+    </bpmn2:serviceTask>
+    <bpmn2:endEvent id="_EFFEBFD6-C5B1-42BF-A4D9-865BF04CD00C" drools:selectable="true" color:background-color="#ff6347" color:border-color="#000000" color:color="#000000" name="EndProcess">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[EndProcess]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_9C0FB01D-F622-456E-A1D8-AFCC5C54588E</bpmn2:incoming>
+      <bpmn2:terminateEventDefinition id="_RRB-hYEmEemgIL72M4lYRQ"/>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="_2D052977-41FD-43AD-9CDE-A96F40EDDEAC" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_1747DF71-D65B-409B-A5B4-D265AE64E41A" targetRef="_38E04E27-3CCA-47F9-927B-E37DC4B8CE25"/>
+    <bpmn2:sequenceFlow id="_F39893C8-F27C-4BFA-946B-D92EB085FD30" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_38E04E27-3CCA-47F9-927B-E37DC4B8CE25" targetRef="_A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4"/>
+    <bpmn2:serviceTask id="_A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4" drools:selectable="true" drools:serviceimplementation="Other" drools:serviceoperation="hello" drools:serviceinterface="org.kie.kogito.codegen.data.HelloService" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="Goodbye" implementation="Other" operationRef="_A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4_ServiceOperation">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Goodbye]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_F39893C8-F27C-4BFA-946B-D92EB085FD30</bpmn2:incoming>
+      <bpmn2:outgoing>_9C0FB01D-F622-456E-A1D8-AFCC5C54588E</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_RRB-hoEmEemgIL72M4lYRQ">
+        <bpmn2:dataInput id="_A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4_ParameterInputX" drools:dtype="Object" itemSubjectRef="__A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4_ParameterInputXItem" name="Parameter"/>
+        <bpmn2:dataOutput id="_A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4_ResultOutputX" drools:dtype="Object" itemSubjectRef="__A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4_ResultOutputXItem" name="Result"/>
+        <bpmn2:inputSet id="_RRB-h4EmEemgIL72M4lYRQ">
+          <bpmn2:dataInputRefs>_A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4_ParameterInputX</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet id="_RRB-iIEmEemgIL72M4lYRQ">
+          <bpmn2:dataOutputRefs>_A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4_ResultOutputX</bpmn2:dataOutputRefs>
+        </bpmn2:outputSet>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="_RRClkIEmEemgIL72M4lYRQ">
+        <bpmn2:sourceRef>s</bpmn2:sourceRef>
+        <bpmn2:targetRef>_A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4_ParameterInputX</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataOutputAssociation id="_RRClkYEmEemgIL72M4lYRQ">
+        <bpmn2:sourceRef>_A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4_ResultOutputX</bpmn2:sourceRef>
+        <bpmn2:targetRef>s</bpmn2:targetRef>
+      </bpmn2:dataOutputAssociation>
+    </bpmn2:serviceTask>
+    <bpmn2:sequenceFlow id="_9C0FB01D-F622-456E-A1D8-AFCC5C54588E" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4" targetRef="_EFFEBFD6-C5B1-42BF-A4D9-865BF04CD00C"/>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="_RRClkoEmEemgIL72M4lYRQ">
+    <bpmndi:BPMNPlane id="_RRClk4EmEemgIL72M4lYRQ" bpmnElement="ServiceProcessSameOperations">
+      <bpmndi:BPMNShape id="_RRCllIEmEemgIL72M4lYRQ" bpmnElement="_1747DF71-D65B-409B-A5B4-D265AE64E41A">
+        <dc:Bounds height="30.0" width="30.0" x="15.0" y="131.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_RRCllYEmEemgIL72M4lYRQ" bpmnElement="_38E04E27-3CCA-47F9-927B-E37DC4B8CE25">
+        <dc:Bounds height="72.0" width="123.0" x="135.0" y="110.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_RRClloEmEemgIL72M4lYRQ" bpmnElement="_EFFEBFD6-C5B1-42BF-A4D9-865BF04CD00C">
+        <dc:Bounds height="28.0" width="28.0" x="555.0" y="132.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_RRCll4EmEemgIL72M4lYRQ" bpmnElement="_A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4">
+        <dc:Bounds height="71.0" width="136.0" x="345.0" y="110.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_RRClmIEmEemgIL72M4lYRQ" bpmnElement="_2D052977-41FD-43AD-9CDE-A96F40EDDEAC" sourceElement="_RRCllIEmEemgIL72M4lYRQ" targetElement="_RRCllYEmEemgIL72M4lYRQ">
+        <di:waypoint xsi:type="dc:Point" x="30.0" y="146.0"/>
+        <di:waypoint xsi:type="dc:Point" x="196.5" y="146.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_RRClmYEmEemgIL72M4lYRQ" bpmnElement="_F39893C8-F27C-4BFA-946B-D92EB085FD30" sourceElement="_RRCllYEmEemgIL72M4lYRQ" targetElement="_RRCll4EmEemgIL72M4lYRQ">
+        <di:waypoint xsi:type="dc:Point" x="196.5" y="146.0"/>
+        <di:waypoint xsi:type="dc:Point" x="413.0" y="145.5"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_RRClmoEmEemgIL72M4lYRQ" bpmnElement="_9C0FB01D-F622-456E-A1D8-AFCC5C54588E" sourceElement="_RRCll4EmEemgIL72M4lYRQ" targetElement="_RRClloEmEemgIL72M4lYRQ">
+        <di:waypoint xsi:type="dc:Point" x="413.0" y="145.5"/>
+        <di:waypoint xsi:type="dc:Point" x="569.0" y="146.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn2:definitions>


### PR DESCRIPTION
Adds support for service tasks that allow to call java classes/methods. It does allow to call cdi beans when running in quarkus so it make it really easy to use application code inside the process. No reflection involved. Each service task will get generated and auto registered work item handler that can also be injected and thus can receive other beans like the service class.

See the jbpm-quarkus-example for details how it makes use of the cdi beans as service task in a process.

depends on https://github.com/kiegroup/kogito-bom/pull/27