### PR TITLE
fixes for quarkus and springboot archetypes

### DIFF
--- a/archetypes/kogito-quarkus-archetype/README.md
+++ b/archetypes/kogito-quarkus-archetype/README.md
@@ -4,15 +4,15 @@ To generate new project for KaaS (Kjar as a Service) based on Quarkus use follow
 
     ```
      mvn archetype:generate 
-    -DarchetypeGroupId=org.kie
-    -DarchetypeArtifactId=kaas-quarkus-archetype 
+    -DarchetypeGroupId=org.kie.kogito
+    -DarchetypeArtifactId=kogito-quarkus-archetype
     -DarchetypeVersion=8.0.0-SNAPSHOT 
     -DgroupId=com.company 
-    -DartifactId=sample-kaas     
+    -DartifactId=sample-kogito     
     ```
 
 or cut/paste this one-liner
 
     ```
-     mvn archetype:generate -DarchetypeGroupId=org.kie -DarchetypeArtifactId=kaas-quarkus-archetype -DarchetypeVersion=8.0.0-SNAPSHOT -DgroupId=com.company -DartifactId=sample-kaas     
+     mvn archetype:generate -DarchetypeGroupId=org.kie.kogito -DarchetypeArtifactId=kogito-quarkus-archetype -DarchetypeVersion=8.0.0-SNAPSHOT -DgroupId=com.company -DartifactId=sample-kogito     
     ```

--- a/archetypes/kogito-springboot-archetype/README.md
+++ b/archetypes/kogito-springboot-archetype/README.md
@@ -4,16 +4,16 @@ To generate new project for KaaS (Kjar as a Service) based on Quarkus use follow
 
     ```
      mvn archetype:generate 
-    -DarchetypeGroupId=org.kie
-    -DarchetypeArtifactId=kaas-springboot-archetype 
+    -DarchetypeGroupId=org.kie.kogito
+    -DarchetypeArtifactId=kogito-springboot-archetype
     -DarchetypeVersion=8.0.0-SNAPSHOT 
     -DgroupId=com.company 
-    -DartifactId=sample-kaas     
+    -DartifactId=sample-kogito    
     ```
     
  or cut/paste this one-liner:
  
     ```
-      mvn archetype:generate -DarchetypeGroupId=org.kie -DarchetypeArtifactId=kaas-springboot-archetype -DarchetypeVersion=8.0.0-SNAPSHOT -DgroupId=com.company -DartifactId=sample-kaas     
+      mvn archetype:generate -DarchetypeGroupId=org.kie.kogito -DarchetypeArtifactId=kogito-springboot-archetype -DarchetypeVersion=8.0.0-SNAPSHOT -DgroupId=com.company -DartifactId=sample-kogito     
     ```
 

--- a/archetypes/kogito-springboot-archetype/src/main/resources/archetype-resources/src/main/java/KogitoApplication.java
+++ b/archetypes/kogito-springboot-archetype/src/main/resources/archetype-resources/src/main/java/KogitoApplication.java
@@ -4,10 +4,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class Application {
+public class KogitoApplication {
 
     public static void main(String[] args) {
-        SpringApplication.run(Application.class, args);
+        SpringApplication.run(KogitoApplication.class, args);
     }
 
 }


### PR DESCRIPTION
@mswiderski the kogito-maven-plugin already generates Application.java under target/generated-sources. This clashes with the Application.java for the spring-boot app, so thats why I renamed it to KogitoApplication.java. 

I think maybe its better to have the kogito-maven-plugin generate under a different name, but maybe this is a valid option as well. Either way we need something to change in order for the spring-boot archetype generated project to compile and run properly.