### PR TITLE
DROOLS-4160: Enable DRL codegen by default, rename config properties

### DIFF
--- a/archetypes/kogito-springboot-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/kogito-springboot-archetype/src/main/resources/archetype-resources/pom.xml
@@ -20,7 +20,7 @@
     <kogito.version>${version.org.kie.kogito}</kogito.version>
     <swagger.version>${version.swagger}</swagger.version>
     <cxf.version>3.2.6</cxf.version>
-    <dependencyInjection>false</dependencyInjection>
+    <kogito.di.enabled>false</kogito.di.enabled>
   </properties>
 
   <dependencies>

--- a/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
+++ b/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
@@ -72,7 +72,7 @@ public class GenerateModelMojo extends AbstractKieMojo {
     @Parameter(defaultValue = "${project.build.directory}/generated-sources/kogito")
     private File generatedSources;
 
-    @Parameter(property = "generateModel", defaultValue = "no")
+    @Parameter(property = "generateModel", defaultValue = "yes")
     private String generateModel;
 
     @Parameter(property = "generateProcessModel", defaultValue = "yes")

--- a/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
+++ b/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
@@ -72,11 +72,11 @@ public class GenerateModelMojo extends AbstractKieMojo {
     @Parameter(defaultValue = "${project.build.directory}/generated-sources/kogito")
     private File generatedSources;
 
-    @Parameter(property = "kogito.compile.rules", defaultValue = "true")
-    private boolean generateRules;
+    @Parameter(property = "kogito.codegen.rules", defaultValue = "null")
+    private Boolean generateRules; // defaults to true iff there exist DRL files
 
-    @Parameter(property = "kogito.compile.processes", defaultValue = "true")
-    private boolean generateProcesses;
+    @Parameter(property = "kogito.codegen.processes", defaultValue = "null")
+    private Boolean generateProcesses; // defaults to true iff there exist BPMN files
 
     @Parameter(property = "kogito.sources.keep", defaultValue = "false")
     private boolean keepSources;
@@ -95,6 +95,7 @@ public class GenerateModelMojo extends AbstractKieMojo {
 
     private void generateModel() throws MojoExecutionException, IOException {
 <<<<<<< HEAD
+<<<<<<< HEAD
         // these should be probably substituted by boolean params
         boolean generateRuleUnits =
                 ExecModelMode.shouldGenerateModel(generateModel) &&
@@ -105,6 +106,17 @@ public class GenerateModelMojo extends AbstractKieMojo {
 
 =======
 >>>>>>> DROOLS-3924: Refactor Maven plugin to adopt best practices
+=======
+        // if unspecified, then default to checking for file type existence
+        // if not null, the property has been overridden, and we should use the specified value
+        if (generateRules == null) {
+            generateRules = rulesExist();
+        }
+        if (generateProcesses == null) {
+            generateProcesses = processesExist();
+        }
+
+>>>>>>> comments
         project.addCompileSourceRoot(generatedSources.getPath());
 
         ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();

--- a/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
+++ b/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
@@ -1,7 +1,5 @@
 package org.kie.kogito.maven.plugin;
 
-import static org.drools.compiler.kie.builder.impl.KieBuilderImpl.setDefaultsforEmptyKieModule;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -43,6 +41,8 @@ import org.kie.kogito.codegen.GeneratedFile;
 import org.kie.kogito.codegen.process.ProcessCodegen;
 import org.kie.kogito.codegen.rules.RuleCodegen;
 
+import static org.drools.compiler.kie.builder.impl.KieBuilderImpl.setDefaultsforEmptyKieModule;
+
 @Mojo(name = "generateModel",
         requiresDependencyResolution = ResolutionScope.NONE,
         requiresProject = true,
@@ -72,11 +72,16 @@ public class GenerateModelMojo extends AbstractKieMojo {
     @Parameter(defaultValue = "${project.build.directory}/generated-sources/kogito")
     private File generatedSources;
 
-    @Parameter(property = "kogito.codegen.rules", defaultValue = "null")
-    private Boolean generateRules; // defaults to true iff there exist DRL files
+    // due to a limitation of the injector, the following 2 params have to be Strings
+    // otherwise we cannot get the default value to null
+    // when the value is null, the semantics is to enable the corresponding
+    // codegen backend only if at least one file of the given type exist
+    
+    @Parameter(property = "kogito.codegen.rules", defaultValue = "")
+    private String generateRules; // defaults to true iff there exist DRL files
 
-    @Parameter(property = "kogito.codegen.processes", defaultValue = "null")
-    private Boolean generateProcesses; // defaults to true iff there exist BPMN files
+    @Parameter(property = "kogito.codegen.processes", defaultValue = "")
+    private String generateProcesses; // defaults to true iff there exist BPMN files
 
     @Parameter(property = "kogito.sources.keep", defaultValue = "false")
     private boolean keepSources;
@@ -94,29 +99,11 @@ public class GenerateModelMojo extends AbstractKieMojo {
     }
 
     private void generateModel() throws MojoExecutionException, IOException {
-<<<<<<< HEAD
-<<<<<<< HEAD
-        // these should be probably substituted by boolean params
-        boolean generateRuleUnits =
-                ExecModelMode.shouldGenerateModel(generateModel) &&
-                        rulesExist();
-        boolean generateProcesses =
-                BPMNModelMode.shouldGenerateBPMNModel(generateProcessModel) &&
-                        processesExist();
-
-=======
->>>>>>> DROOLS-3924: Refactor Maven plugin to adopt best practices
-=======
         // if unspecified, then default to checking for file type existence
         // if not null, the property has been overridden, and we should use the specified value
-        if (generateRules == null) {
-            generateRules = rulesExist();
-        }
-        if (generateProcesses == null) {
-            generateProcesses = processesExist();
-        }
+        boolean genRules = generateRules == null ? rulesExist() : Boolean.parseBoolean(generateRules);
+        boolean genProcesses = generateProcesses == null ? processesExist() : Boolean.parseBoolean(generateProcesses);
 
->>>>>>> comments
         project.addCompileSourceRoot(generatedSources.getPath());
 
         ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
@@ -128,7 +115,7 @@ public class GenerateModelMojo extends AbstractKieMojo {
             Thread.currentThread().setContextClassLoader(projectClassLoader);
 
             ApplicationGenerator appGen = createApplicationGenerator(
-                    generateRules, generateProcesses);
+                    genRules, genProcesses);
 
             for (GeneratedFile generatedFile : appGen.generate()) {
                 writeGeneratedFile(generatedFile);
@@ -158,7 +145,7 @@ public class GenerateModelMojo extends AbstractKieMojo {
         Path projectPath = projectDir.toPath();
         // safe guard to not generate application classes that would clash with interfaces
         if (appPackageName.equals("org.kie.kogito")) {
-        	appPackageName = "org.kie.kogito.app";
+            appPackageName = "org.kie.kogito.app";
         }
 
         ApplicationGenerator appGen =
@@ -167,7 +154,7 @@ public class GenerateModelMojo extends AbstractKieMojo {
 
         if (generateRuleUnits) {
             appGen.withGenerator(RuleCodegen.ofPath(projectPath, false))
-                .withRuleEventListenersConfig(customRuleEventListenerConfigExists(appPackageName));
+                    .withRuleEventListenersConfig(customRuleEventListenerConfigExists(appPackageName));
         }
 
         if (generateProcesses) {
@@ -189,6 +176,7 @@ public class GenerateModelMojo extends AbstractKieMojo {
                            workItemHandlerConfigClass.replace('.', '/') + ".java");
         return Files.exists(p) ? workItemHandlerConfigClass : null;
     }
+
     private String customProcessListenerConfigExists(String appPackageName) {
         String sourceDir = Paths.get(projectDir.getPath(), "src").toString();
         String processEventListenerClass = ProcessCodegen.defaultProcessListenerConfigClass(appPackageName);
@@ -197,6 +185,7 @@ public class GenerateModelMojo extends AbstractKieMojo {
                            processEventListenerClass.replace('.', '/') + ".java");
         return Files.exists(p) ? processEventListenerClass : null;
     }
+
     private String customRuleEventListenerConfigExists(String appPackageName) {
         String sourceDir = Paths.get(projectDir.getPath(), "src").toString();
         String ruleEventListenerConfiglass = RuleCodegen.defaultRuleEventListenerConfigClass(appPackageName);
@@ -205,7 +194,6 @@ public class GenerateModelMojo extends AbstractKieMojo {
                            ruleEventListenerConfiglass.replace('.', '/') + ".java");
         return Files.exists(p) ? ruleEventListenerConfiglass : null;
     }
-
 
     private void writeAll(List<GeneratedFile> generatedFiles) throws IOException {
         for (GeneratedFile f : generatedFiles) {

--- a/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
+++ b/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
@@ -93,9 +93,11 @@ public class GenerateModelMojo extends AbstractKieMojo {
     private void generateModel() throws MojoExecutionException, IOException {
         // these should be probably substituted by boolean params
         boolean generateRuleUnits =
-                ExecModelMode.shouldGenerateModel(generateModel);
+                ExecModelMode.shouldGenerateModel(generateModel) &&
+                        rulesExist();
         boolean generateProcesses =
-                BPMNModelMode.shouldGenerateBPMNModel(generateProcessModel);
+                BPMNModelMode.shouldGenerateBPMNModel(generateProcessModel) &&
+                        processesExist();
 
         project.addCompileSourceRoot(generatedSources.getPath());
 
@@ -120,6 +122,17 @@ public class GenerateModelMojo extends AbstractKieMojo {
         } finally {
             Thread.currentThread().setContextClassLoader(contextClassLoader);
         }
+    }
+
+    private boolean processesExist() throws IOException {
+        return Files.walk(projectDir.toPath())
+                .map(p -> p.toString().toLowerCase())
+                .anyMatch(p -> p.endsWith(".bpmn") || p.endsWith(".bpmn2"));
+    }
+
+    private boolean rulesExist() throws IOException {
+        return Files.walk(projectDir.toPath())
+                .anyMatch(p -> p.toString().toLowerCase().endsWith(".drl"));
     }
 
     private ApplicationGenerator createApplicationGenerator(boolean generateRuleUnits, boolean generateProcesses) throws IOException {

--- a/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
+++ b/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
@@ -72,13 +72,16 @@ public class GenerateModelMojo extends AbstractKieMojo {
     @Parameter(defaultValue = "${project.build.directory}/generated-sources/kogito")
     private File generatedSources;
 
-    @Parameter(property = "generateModel", defaultValue = "yes")
-    private String generateModel;
+    @Parameter(property = "kogito.compile.rules", defaultValue = "true")
+    private boolean generateRules;
 
-    @Parameter(property = "generateProcessModel", defaultValue = "yes")
-    private String generateProcessModel;
+    @Parameter(property = "kogito.compile.processes", defaultValue = "true")
+    private boolean generateProcesses;
 
-    @Parameter(property = "dependencyInjection", defaultValue = "true")
+    @Parameter(property = "kogito.sources.keep", defaultValue = "false")
+    private boolean keepSources;
+
+    @Parameter(property = "kogito.di.enabled", defaultValue = "true")
     private boolean dependencyInjection;
 
     @Override
@@ -91,6 +94,7 @@ public class GenerateModelMojo extends AbstractKieMojo {
     }
 
     private void generateModel() throws MojoExecutionException, IOException {
+<<<<<<< HEAD
         // these should be probably substituted by boolean params
         boolean generateRuleUnits =
                 ExecModelMode.shouldGenerateModel(generateModel) &&
@@ -99,6 +103,8 @@ public class GenerateModelMojo extends AbstractKieMojo {
                 BPMNModelMode.shouldGenerateBPMNModel(generateProcessModel) &&
                         processesExist();
 
+=======
+>>>>>>> DROOLS-3924: Refactor Maven plugin to adopt best practices
         project.addCompileSourceRoot(generatedSources.getPath());
 
         ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
@@ -110,13 +116,13 @@ public class GenerateModelMojo extends AbstractKieMojo {
             Thread.currentThread().setContextClassLoader(projectClassLoader);
 
             ApplicationGenerator appGen = createApplicationGenerator(
-                    generateRuleUnits, generateProcesses);
+                    generateRules, generateProcesses);
 
             for (GeneratedFile generatedFile : appGen.generate()) {
                 writeGeneratedFile(generatedFile);
             }
 
-            if (ExecModelMode.shouldDeleteFile(generateModel)) {
+            if (!keepSources) {
                 deleteDrlFiles();
             }
         } finally {


### PR DESCRIPTION
MAKE CODEGEN GREAT AGAIN 💣

- enable model generation by default.

contextually rename properties as follows:

- `kogito.codegen.rules` : boolean -- enable codegen for rules. Defaults to null, meaning that codegen is enabled iff DRLs are found
- `kogito.codegen.processes` : boolean -- enable codegen for processes. Defaults to null, meaning that codegen is enabled iff BPMNs are founds 
- `kogito.sources.keep` : boolean -- keep DRL files in the generated artifact. Defaults to false.
- `kogito.di.enabled` : boolean  -- generate dependency injection annotation. Defaults to true.


