### PR TITLE
DROOLS-4242: NPE in Kogito Quickstart: broken codegen

### DIFF
--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/AbstractApplicationSection.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/AbstractApplicationSection.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.codegen;
+
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.VariableDeclarator;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.ReturnStmt;
+
+public class AbstractApplicationSection implements ApplicationSection {
+
+    private final String innerClassName;
+    private final String methodName;
+    private final String classType;
+
+    public AbstractApplicationSection(String innerClassName, String methodName, Class<?> classType) {
+        this.innerClassName = innerClassName;
+        this.methodName = methodName;
+        this.classType = classType.getCanonicalName();
+    }
+
+    @Override
+    public ClassOrInterfaceDeclaration classDeclaration() {
+        return new ClassOrInterfaceDeclaration()
+                .setModifiers(Modifier.Keyword.PUBLIC)
+                .setName(innerClassName)
+                .addImplementedType(classType);
+    }
+
+    @Override
+    public FieldDeclaration fieldDeclaration() {
+        return new FieldDeclaration()
+                .addVariable(
+                        new VariableDeclarator()
+                                .setType(classType)
+                                .setName(methodName)
+                                .setInitializer(new ObjectCreationExpr().setType(innerClassName)));
+    }
+
+    public MethodDeclaration factoryMethod() {
+        return new MethodDeclaration()
+                .setModifiers(Modifier.Keyword.PUBLIC)
+                .setType(classType)
+                .setName(methodName)
+                .setBody(new BlockStmt().addStatement(new ReturnStmt(new NameExpr(methodName))));
+    }
+}

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/AbstractApplicationSection.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/AbstractApplicationSection.java
@@ -50,7 +50,7 @@ public class AbstractApplicationSection implements ApplicationSection {
         return new FieldDeclaration()
                 .addVariable(
                         new VariableDeclarator()
-                                .setType(classType)
+                                .setType(innerClassName)
                                 .setName(methodName)
                                 .setInitializer(new ObjectCreationExpr().setType(innerClassName)));
     }
@@ -58,7 +58,7 @@ public class AbstractApplicationSection implements ApplicationSection {
     public MethodDeclaration factoryMethod() {
         return new MethodDeclaration()
                 .setModifiers(Modifier.Keyword.PUBLIC)
-                .setType(classType)
+                .setType(innerClassName)
                 .setName(methodName)
                 .setBody(new BlockStmt().addStatement(new ReturnStmt(new NameExpr(methodName))));
     }

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/ApplicationGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/ApplicationGenerator.java
@@ -136,9 +136,12 @@ public class ApplicationGenerator {
 
         factoryMethods.forEach(cls::addMember);
 
-        generators.stream().map(Generator::section).forEach(sect -> cls.addMember(sect.fieldDeclaration()));
-        generators.stream().map(Generator::section).forEach(sect -> cls.addMember(sect.factoryMethod()));
-        generators.stream().map(Generator::section).forEach(sect -> cls.addMember(sect.classDeclaration()));
+        for (Generator generator : generators) {
+            ApplicationSection section = generator.section();
+            cls.addMember(section.fieldDeclaration());
+            cls.addMember(section.factoryMethod());
+            cls.addMember(section.classDeclaration());
+        }
 
         return compilationUnit;
     }

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/ApplicationGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/ApplicationGenerator.java
@@ -136,6 +136,7 @@ public class ApplicationGenerator {
 
         factoryMethods.forEach(cls::addMember);
 
+        generators.stream().map(Generator::section).forEach(sect -> cls.addMember(sect.fieldDeclaration()));
         generators.stream().map(Generator::section).forEach(sect -> cls.addMember(sect.factoryMethod()));
         generators.stream().map(Generator::section).forEach(sect -> cls.addMember(sect.classDeclaration()));
 

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/ApplicationSection.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/ApplicationSection.java
@@ -16,6 +16,7 @@
 package org.kie.kogito.codegen;
 
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 
 /**
@@ -30,6 +31,8 @@ import com.github.javaparser.ast.body.MethodDeclaration;
  *    app.processes().createMyProcess()
  */
 public interface ApplicationSection {
+
+    FieldDeclaration fieldDeclaration();
 
     MethodDeclaration factoryMethod();
 

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ProcessesContainerGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ProcessesContainerGenerator.java
@@ -26,7 +26,9 @@ import com.github.javaparser.ast.Modifier.Keyword;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.BodyDeclaration;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.NameExpr;
@@ -147,13 +149,21 @@ public class ProcessesContainerGenerator implements ApplicationSection {
         NodeList<Expression> processIds = NodeList.nodeList(processes.stream().map(p -> new StringLiteralExpr(p.processId())).collect(Collectors.toList()));
         processesMethodDeclaration.getBody().get().addStatement(new ReturnStmt(new MethodCallExpr(new NameExpr(Arrays.class.getCanonicalName()), "asList", processIds)));
 
-
         return new ClassOrInterfaceDeclaration()
                 .setModifiers(Keyword.PUBLIC)
                 .setName("Processes")
                 .addImplementedType(Processes.class.getCanonicalName())
                 .setMembers(applicationDeclarations);
+    }
 
+    @Override
+    public FieldDeclaration fieldDeclaration() {
+        return new FieldDeclaration()
+                .addVariable(new VariableDeclarator()
+                                     .setType(Processes.class)
+                                     .setName("processes")
+                                     .setInitializer(new ObjectCreationExpr().setType("Processes")))
+                .setModifiers(Keyword.PUBLIC);
     }
 
     public MethodDeclaration factoryMethod() {
@@ -161,7 +171,7 @@ public class ProcessesContainerGenerator implements ApplicationSection {
                 .setName("processes")
                 .setModifiers(Keyword.PUBLIC)
                 .setType(Processes.class)
-                .setBody(new BlockStmt().addStatement(new ReturnStmt(new ObjectCreationExpr().setType("Processes"))));
+                .setBody(new BlockStmt().addStatement(new ReturnStmt(new NameExpr("processes"))));
         return processesMethod;
     }
 }

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ProcessesContainerGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ProcessesContainerGenerator.java
@@ -22,13 +22,10 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.github.javaparser.ast.Modifier;
-import com.github.javaparser.ast.Modifier.Keyword;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.BodyDeclaration;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
-import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
-import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.NameExpr;
@@ -42,12 +39,12 @@ import com.github.javaparser.ast.stmt.ReturnStmt;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.WildcardType;
 import org.kie.kogito.Model;
-import org.kie.kogito.codegen.ApplicationSection;
+import org.kie.kogito.codegen.AbstractApplicationSection;
 import org.kie.kogito.process.Processes;
 import org.kie.kogito.process.impl.DefaultProcessEventListenerConfig;
 import org.kie.kogito.process.impl.DefaultWorkItemHandlerConfig;
 
-public class ProcessesContainerGenerator implements ApplicationSection {
+public class ProcessesContainerGenerator extends AbstractApplicationSection {
 
     //    private static final String RESOURCE = "/class-templates/ModuleTemplate.java";
     private final List<ProcessGenerator> processes;
@@ -62,6 +59,8 @@ public class ProcessesContainerGenerator implements ApplicationSection {
     private MethodDeclaration processesMethodDeclaration;
 
     public ProcessesContainerGenerator(String packageName) {
+        super("Processes", "processes", Processes.class);
+
         this.processes = new ArrayList<>();
         this.processInstances = new ArrayList<>();
         this.factoryMethods = new ArrayList<>();
@@ -149,29 +148,6 @@ public class ProcessesContainerGenerator implements ApplicationSection {
         NodeList<Expression> processIds = NodeList.nodeList(processes.stream().map(p -> new StringLiteralExpr(p.processId())).collect(Collectors.toList()));
         processesMethodDeclaration.getBody().get().addStatement(new ReturnStmt(new MethodCallExpr(new NameExpr(Arrays.class.getCanonicalName()), "asList", processIds)));
 
-        return new ClassOrInterfaceDeclaration()
-                .setModifiers(Keyword.PUBLIC)
-                .setName("Processes")
-                .addImplementedType(Processes.class.getCanonicalName())
-                .setMembers(applicationDeclarations);
-    }
-
-    @Override
-    public FieldDeclaration fieldDeclaration() {
-        return new FieldDeclaration()
-                .addVariable(new VariableDeclarator()
-                                     .setType(Processes.class)
-                                     .setName("processes")
-                                     .setInitializer(new ObjectCreationExpr().setType("Processes")))
-                .setModifiers(Keyword.PUBLIC);
-    }
-
-    public MethodDeclaration factoryMethod() {
-        MethodDeclaration processesMethod = new MethodDeclaration()
-                .setName("processes")
-                .setModifiers(Keyword.PUBLIC)
-                .setType(Processes.class)
-                .setBody(new BlockStmt().addStatement(new ReturnStmt(new NameExpr("processes"))));
-        return processesMethod;
+        return super.classDeclaration().setMembers(applicationDeclarations);
     }
 }

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/RuleUnitContainerGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/RuleUnitContainerGenerator.java
@@ -33,6 +33,7 @@ import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.ReturnStmt;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import org.drools.core.config.DefaultRuleEventListenerConfig;
+import org.drools.modelcompiler.builder.CanonicalModelKieProject;
 import org.kie.kogito.codegen.ApplicationSection;
 import org.kie.kogito.rules.KieRuntimeBuilder;
 import org.kie.kogito.rules.RuleUnit;
@@ -114,8 +115,10 @@ public class RuleUnitContainerGenerator implements ApplicationSection {
         FieldDeclaration kieRuntimeFieldDeclaration = new FieldDeclaration();
 
         if (hasCdi) {
-            kieRuntimeFieldDeclaration.addAnnotation("javax.inject.Inject")
-                    .addVariable(new VariableDeclarator(new ClassOrInterfaceType(null, KieRuntimeBuilder.class.getCanonicalName()), "ruleRuntimeBuilder"));
+            kieRuntimeFieldDeclaration
+                    .addVariable(
+                            new VariableDeclarator(new ClassOrInterfaceType(null, KieRuntimeBuilder.class.getCanonicalName()), "ruleRuntimeBuilder")
+                            .setInitializer(new ObjectCreationExpr().setType(CanonicalModelKieProject.PROJECT_RUNTIME_CLASS)));
         } else {
             kieRuntimeFieldDeclaration.addVariable(new VariableDeclarator(
                     new ClassOrInterfaceType(null, KieRuntimeBuilder.class.getCanonicalName()),

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/RuleUnitContainerGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/RuleUnitContainerGenerator.java
@@ -27,7 +27,6 @@ import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.expr.FieldAccessExpr;
-import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
 import com.github.javaparser.ast.expr.ThisExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
@@ -35,13 +34,12 @@ import com.github.javaparser.ast.stmt.ReturnStmt;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import org.drools.core.config.DefaultRuleEventListenerConfig;
 import org.drools.modelcompiler.builder.CanonicalModelKieProject;
-import org.kie.kogito.codegen.ApplicationSection;
-import org.kie.kogito.process.Processes;
+import org.kie.kogito.codegen.AbstractApplicationSection;
 import org.kie.kogito.rules.KieRuntimeBuilder;
 import org.kie.kogito.rules.RuleUnit;
 import org.kie.kogito.rules.RuleUnits;
 
-public class RuleUnitContainerGenerator implements ApplicationSection {
+public class RuleUnitContainerGenerator extends AbstractApplicationSection {
 
     private final String packageName;
     private final String generatedFilePath;
@@ -54,6 +52,7 @@ public class RuleUnitContainerGenerator implements ApplicationSection {
     private String ruleEventListenersConfigClass = DefaultRuleEventListenerConfig.class.getCanonicalName();
 
     public RuleUnitContainerGenerator(String packageName) {
+        super("RuleUnits", "ruleUnits", RuleUnits.class);
         this.packageName = packageName;
         this.targetTypeName = "Module";
         this.targetCanonicalName = packageName + "." + targetTypeName;
@@ -100,27 +99,6 @@ public class RuleUnitContainerGenerator implements ApplicationSection {
         return methodDeclaration;
     }
 
-    public MethodDeclaration factoryMethod() {
-        return new MethodDeclaration()
-                .setType(RuleUnits.class.getCanonicalName())
-                .setName("ruleUnits")
-                .setModifiers(Modifier.Keyword.PUBLIC)
-                .setBody(new BlockStmt().addStatement(new ReturnStmt().setExpression(
-                        new NameExpr("ruleUnits")
-                )));
-    }
-
-    @Override
-    public FieldDeclaration fieldDeclaration() {
-        return new FieldDeclaration()
-                .addVariable(new VariableDeclarator()
-                                     .setType(RuleUnits.class)
-                                     .setName("ruleUnits")
-                                     .setInitializer(new ObjectCreationExpr().setType("RuleUnits")))
-                .setModifiers(Modifier.Keyword.PUBLIC);
-    }
-
-
     @Override
     public ClassOrInterfaceDeclaration classDeclaration() {
 
@@ -147,10 +125,7 @@ public class RuleUnitContainerGenerator implements ApplicationSection {
 
         declarations.addAll(factoryMethods);
 
-        return new ClassOrInterfaceDeclaration()
-                .setModifiers(Modifier.Keyword.PUBLIC)
-                .setName("RuleUnits")
-                .addImplementedType(RuleUnits.class.getCanonicalName())
+        return super.classDeclaration()
                 .setMembers(declarations);
     }
 

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/AbstractCodegenTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/AbstractCodegenTest.java
@@ -88,7 +88,6 @@ public class AbstractCodegenTest {
             String fileName = entry.relativePath();
             sources[index++] = fileName;
             srcMfs.write(fileName, entry.contents());
-            System.out.println(new String(entry.contents()));
         }
 
         CompilationResult result = JAVA_COMPILER.compile(sources, srcMfs, trgMfs, this.getClass().getClassLoader());

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/ApplicationGeneratorTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/ApplicationGeneratorTest.java
@@ -34,6 +34,7 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.VariableDeclarator;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.kie.kogito.Config;
@@ -122,6 +123,13 @@ public class ApplicationGeneratorTest {
                     new ClassOrInterfaceDeclaration().setName("Foo");
             private MethodDeclaration methodDeclaration =
                     new MethodDeclaration().setType("void");
+            private FieldDeclaration fieldDeclaration =
+                    new FieldDeclaration().addVariable(new VariableDeclarator().setType(int.class).setName("i"));
+
+            @Override
+            public FieldDeclaration fieldDeclaration() {
+                return fieldDeclaration;
+            }
 
             @Override
             public MethodDeclaration factoryMethod() {
@@ -152,7 +160,7 @@ public class ApplicationGeneratorTest {
         final CompilationUnit compilationUnit = appGenerator.compilationUnit();
         assertGeneratedFiles(generatedFiles, compilationUnit.toString().getBytes(StandardCharsets.UTF_8), 2);
 
-        assertCompilationUnit(compilationUnit, false, 2);
+        assertCompilationUnit(compilationUnit, false, 3);
         final TypeDeclaration mainAppClass = compilationUnit.getTypes().get(0);
         assertThat(mainAppClass.getMembers()).filteredOn(member -> member == appSection.factoryMethod()).hasSize(1);
         assertThat(mainAppClass.getMembers()).filteredOn(member -> member == appSection.classDeclaration()).hasSize(1);


### PR DESCRIPTION
Verified that this work by adding the following to my local copy of https://github.com/quarkusio/quarkus-quickstarts/tree/development/using-kogito

```
     <dependency>
      <groupId>org.kie.kogito</groupId>
      <artifactId>kogito-codegen</artifactId>
      <version>8.0.0-SNAPSHOT</version>
    </dependency>
    
```

new release? @mswiderski @mariofusco 
