### PR TITLE
KOGITO-4: Migrate codegen to JUnit 5

### DIFF
--- a/kogito-codegen/pom.xml
+++ b/kogito-codegen/pom.xml
@@ -76,8 +76,8 @@
 
     <!-- test -->
     <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/ApplicationGeneratorTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/ApplicationGeneratorTest.java
@@ -15,10 +15,6 @@
 
 package org.kie.kogito.codegen;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -33,20 +29,20 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
-import com.github.javaparser.ast.body.VariableDeclarator;
-import org.assertj.core.api.Assertions;
-import org.junit.Test;
-import org.kie.kogito.Config;
-import org.mockito.Mockito;
-
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.javaparser.ast.CompilationUnit;
-import com.github.javaparser.ast.body.BodyDeclaration;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.TypeDeclaration;
+import com.github.javaparser.ast.body.VariableDeclarator;
+import org.junit.jupiter.api.Test;
+import org.kie.kogito.Config;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 public class ApplicationGeneratorTest {
 
@@ -62,7 +58,7 @@ public class ApplicationGeneratorTest {
 
     @Test
     public void packageNameNull() {
-        Assertions.assertThatThrownBy(() -> new ApplicationGenerator(null, new File("")))
+        assertThatThrownBy(() -> new ApplicationGenerator(null, new File("")))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/ConfigGeneratorTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/ConfigGeneratorTest.java
@@ -17,12 +17,12 @@ package org.kie.kogito.codegen;
 
 import com.github.javaparser.ast.expr.NullLiteralExpr;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.kie.kogito.StaticConfig;
 import org.kie.kogito.codegen.process.config.ProcessConfigGenerator;
 import org.mockito.Mockito;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 
 public class ConfigGeneratorTest {
 

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/GeneratedFileTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/GeneratedFileTest.java
@@ -17,10 +17,10 @@ package org.kie.kogito.codegen;
 
 import java.nio.charset.StandardCharsets;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 
 public class GeneratedFileTest {
 
@@ -30,7 +30,7 @@ public class GeneratedFileTest {
 
     private static GeneratedFile testFile;
 
-    @BeforeClass
+    @BeforeAll
     public static void createTestFile() {
         testFile = new GeneratedFile(TEST_TYPE, TEST_RELATIVE_PATH, TEST_CONTENTS);
     }

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/GeneratorInterfaceTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/GeneratorInterfaceTest.java
@@ -18,7 +18,7 @@ package org.kie.kogito.codegen;
 import java.util.Collection;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class GeneratorInterfaceTest {
 

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/RuleUnitCompilerTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/RuleUnitCompilerTest.java
@@ -16,7 +16,7 @@
 
 package org.kie.kogito.codegen;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.kie.kogito.codegen.data.AdultUnit;
 import org.kie.kogito.codegen.data.Person;
 import org.kie.kogito.codegen.data.Results;
@@ -25,9 +25,8 @@ import org.kie.kogito.rules.RuleUnitInstance;
 import org.kie.kogito.rules.impl.RuleUnitRegistry;
 
 import static java.util.Arrays.asList;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RuleUnitCompilerTest extends AbstractCodegenTest {
 

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/metadata/ImageMetaDataTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/metadata/ImageMetaDataTest.java
@@ -20,9 +20,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 
 public class ImageMetaDataTest {
 

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/tests/BusinessRuleTaskTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/tests/BusinessRuleTaskTest.java
@@ -15,14 +15,12 @@
 
 package org.kie.kogito.codegen.tests;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.drools.core.config.DefaultRuleEventListenerConfig;
 import org.drools.core.event.DefaultAgendaEventListener;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.kie.api.event.rule.AfterMatchFiredEvent;
 import org.kie.kogito.Application;
 import org.kie.kogito.Model;
@@ -31,10 +29,11 @@ import org.kie.kogito.codegen.data.Person;
 import org.kie.kogito.process.Process;
 import org.kie.kogito.process.ProcessInstance;
 
+import static org.assertj.core.api.Assertions.*;
+
 
 public class BusinessRuleTaskTest extends AbstractCodegenTest {
 
-    
     @Test
     public void testBasicBusinessRuleTask() throws Exception {
         

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/tests/CallActivityTaskTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/tests/CallActivityTaskTest.java
@@ -15,22 +15,21 @@
 
 package org.kie.kogito.codegen.tests;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.kie.kogito.Application;
 import org.kie.kogito.Model;
 import org.kie.kogito.codegen.AbstractCodegenTest;
 import org.kie.kogito.process.Process;
 import org.kie.kogito.process.ProcessInstance;
 
+import static org.assertj.core.api.Assertions.*;
+
 
 public class CallActivityTaskTest extends AbstractCodegenTest {
 
-    
     @Test
     public void testBasicCallActivityTask() throws Exception {
         

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/tests/ServiceTaskTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/tests/ServiceTaskTest.java
@@ -15,21 +15,19 @@
 
 package org.kie.kogito.codegen.tests;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.kie.kogito.Application;
 import org.kie.kogito.Model;
 import org.kie.kogito.codegen.AbstractCodegenTest;
 import org.kie.kogito.process.Process;
 import org.kie.kogito.process.ProcessInstance;
 
+import static org.assertj.core.api.Assertions.*;
 
 public class ServiceTaskTest extends AbstractCodegenTest {
-
     
     @Test
     public void testBasicServiceProcessTask() throws Exception {

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/tests/SignalEventTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/tests/SignalEventTest.java
@@ -15,12 +15,10 @@
 
 package org.kie.kogito.codegen.tests;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.kie.kogito.Application;
 import org.kie.kogito.Model;
 import org.kie.kogito.codegen.AbstractCodegenTest;
@@ -29,9 +27,9 @@ import org.kie.kogito.process.ProcessInstance;
 import org.kie.kogito.process.WorkItem;
 import org.kie.kogito.process.impl.Sig;
 
+import static org.assertj.core.api.Assertions.*;
 
 public class SignalEventTest extends AbstractCodegenTest {
-
     
     @Test
     public void testIntermediateSignalEventWithData() throws Exception {


### PR DESCRIPTION
This is fairly straightforward. All tests passing before, all tests passing now.