### PR TITLE
[DROOLS-3960] Executable Model - kie-maven-plugin fails to generate model

### DIFF
--- a/drools/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/JavaParserCompiler.java
+++ b/drools/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/JavaParserCompiler.java
@@ -94,7 +94,7 @@ public class JavaParserCompiler {
         MemoryFileSystem trgMfs = new MemoryFileSystem();
 
         String[] resources = writeModel(classes, srcMfs);
-        CompilationResult resultCompilation = getCompiler().compile(resources, srcMfs, trgMfs, classLoader);
+        CompilationResult resultCompilation = createEclipseCompiler().compile(resources, srcMfs, trgMfs, classLoader);
         CompilationProblem[] errors = resultCompilation.getErrors();
         if(errors.length != 0) {
             classes.forEach(c -> logger.error(c.toString()));


### PR DESCRIPTION
with a mix of Java and DRL facts (#2327) - Tests in DROOLS-4011 (droolsjbpm-integration)