### PR TITLE
[KOGITO-70] kogito-quarkus-archetype pom dependencyManagement

### DIFF
--- a/archetypes/kogito-quarkus-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/kogito-quarkus-archetype/src/main/resources/archetype-resources/pom.xml
@@ -25,6 +25,69 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-bom</artifactId>
+        <version>${kogito.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>drools-bom</artifactId>
+        <version>${kogito.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>jbpm-bom</artifactId>
+        <version>${kogito.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <!-- make sure that kogito dependencies are taken from current version 
+        instead of quarkus bom -->
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-api</artifactId>
+        <version>${kogito.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>drools-model-compiler</artifactId>
+        <version>${kogito.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>drools-core</artifactId>
+        <version>${kogito.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>drools-core-static</artifactId>
+        <version>${kogito.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-codegen</artifactId>
+        <version>${kogito.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>drools-decisiontables</artifactId>
+        <version>${kogito.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>jbpm-flow</artifactId>
+        <version>${kogito.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>jbpm-bpmn2</artifactId>
+        <version>${kogito.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -37,32 +100,26 @@
     <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-api</artifactId>
-      <version>${kogito.version}</version>
     </dependency>
     <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>drools-core-static</artifactId>
-      <version>${kogito.version}</version>
     </dependency>
     <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>drools-compiler</artifactId>
-      <version>${kogito.version}</version>
     </dependency>
     <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>drools-canonical-model</artifactId>
-      <version>${kogito.version}</version>
     </dependency>
     <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>drools-model-compiler</artifactId>
-      <version>${kogito.version}</version>
     </dependency>
     <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>jbpm-flow</artifactId>
-      <version>${kogito.version}</version>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
Applying the same dependencyManagement from kogito-examples/pom.xml. It may not be fully required for the test-process but aligning with kogito-examples sounds good to me.