### PR TITLE
KOGITO-101: Add Kube labels for rule endpoints

### DIFF
--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/metadata/ImageMetaData.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/metadata/ImageMetaData.java
@@ -21,6 +21,8 @@ import java.util.Map;
 
 public class ImageMetaData {
 
+    public final static String LABEL_PREFIX = "org.kie/";
+
     private List<Map<String, String>> labels;
 
     public ImageMetaData() {}

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ProcessExecutableModelGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ProcessExecutableModelGenerator.java
@@ -22,9 +22,9 @@ import org.jbpm.compiler.canonical.ProcessMetaData;
 import org.jbpm.compiler.canonical.ProcessToExecModelGenerator;
 import org.kie.api.definition.process.WorkflowProcess;
 
-public class ProcessExecutableModelGenerator {
+import static org.kie.kogito.codegen.metadata.ImageMetaData.LABEL_PREFIX;
 
-    protected final static String LABEL_PREFIX = "org.kie/";
+public class ProcessExecutableModelGenerator {
 
     private final WorkflowProcess workFlowProcess;
     private final ProcessToExecModelGenerator execModelGenerator;

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
@@ -124,6 +124,7 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
     private final Collection<Resource> resources;
     private String ruleEventListenersConfigClass;
     private RuleUnitContainerGenerator moduleGenerator;
+    private final Map<String, String> labels;
 
     private boolean dependencyInjection;
     private DependencyInjectionAnnotator annotator;
@@ -145,6 +146,7 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
         this.kieModuleModel = new KieModuleModelImpl();
         setDefaultsforEmptyKieModule(kieModuleModel);
         this.contextClassLoader = getClass().getClassLoader();
+        this.labels = new HashMap<>();
     }
 
     @Override
@@ -269,6 +271,9 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
             generatedFiles.add( new RuleUnitsRegisterClass(unitsMap).generateFile(GeneratedFile.Type.RULE) );
 
             for (RuleUnitSourceClass ruleUnit : moduleGenerator.getRuleUnits()) {
+                // add the label id of the rule unit with value set to `rules` as resource type
+                labels.put(ruleUnit.label(), "rules");
+
                 generatedFiles.add( ruleUnit.generateFile(GeneratedFile.Type.RULE) );
 
                 RuleUnitInstanceSourceClass ruleUnitInstance = ruleUnit.instance(contextClassLoader);
@@ -325,6 +330,11 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
 
     private String pojoName(String folderName, String nameAsString) {
         return folderName + "/" + nameAsString + ".java";
+    }
+
+    @Override
+    public Map<String, String> getLabels() {
+        return labels;
     }
 
     @Override

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/RuleCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/RuleCodegen.java
@@ -38,6 +38,10 @@ import org.kie.kogito.codegen.GeneratedFile;
 import org.kie.kogito.codegen.di.DependencyInjectionAnnotator;
 import org.kie.kogito.codegen.rules.config.RuleConfigGenerator;
 
+/**
+ * @deprecated use {@link IncrementalRuleCodegen}
+ */
+@Deprecated
 public class RuleCodegen extends AbstractGenerator {
 
     private String packageName;

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/RuleUnitSourceClass.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/RuleUnitSourceClass.java
@@ -38,6 +38,7 @@ import org.kie.kogito.rules.impl.AbstractRuleUnit;
 import static java.util.stream.Collectors.toList;
 
 import static com.github.javaparser.ast.NodeList.nodeList;
+import static org.kie.kogito.codegen.metadata.ImageMetaData.LABEL_PREFIX;
 
 public class RuleUnitSourceClass implements FileGenerator {
 
@@ -85,6 +86,14 @@ public class RuleUnitSourceClass implements FileGenerator {
 
     public String targetTypeName() {
         return targetTypeName;
+    }
+
+    public String typeName() {
+        return typeName;
+    }
+
+    public String label() {
+        return LABEL_PREFIX + typeName();
     }
 
     @Override


### PR DESCRIPTION
very simple change. Add rule unit labels to the collection, should be written in the output file, like processes.