### PR TITLE
KOGITO-183: Explore annotation-based rule definition

### DIFF
--- a/drools/kogito-ruleunits/src/main/java/org/kie/kogito/rules/units/annotations/When.java
+++ b/drools/kogito-ruleunits/src/main/java/org/kie/kogito/rules/units/annotations/When.java
@@ -1,0 +1,9 @@
+package org.kie.kogito.rules.units.annotations;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface When {
+    String value();
+}

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/AnnotatedClassPostProcessor.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/AnnotatedClassPostProcessor.java
@@ -1,0 +1,133 @@
+package org.kie.kogito.codegen.rules;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.PackageDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.Parameter;
+import com.github.javaparser.ast.expr.AnnotationExpr;
+import com.github.javaparser.ast.nodeTypes.NodeWithSimpleName;
+import org.drools.core.io.impl.ByteArrayResource;
+import org.kie.api.io.Resource;
+import org.kie.api.io.ResourceType;
+
+import static java.util.stream.Collectors.joining;
+
+public class AnnotatedClassPostProcessor {
+
+    private final List<CompilationUnit> annotatedUnits;
+
+    public static AnnotatedClassPostProcessor of(Collection<Path> files) {
+        return scan(files.stream());
+    }
+
+    public static AnnotatedClassPostProcessor scan(Stream<Path> files) {
+        List<CompilationUnit> annotatedUnits = files
+                .peek(System.out::println)
+                .map(p -> {
+                    try {
+                        return StaticJavaParser.parse(p);
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                }).filter(cu -> cu.findFirst(AnnotationExpr.class, ann -> ann.getNameAsString().endsWith("When")).isPresent())
+                .collect(Collectors.toList());
+
+        return new AnnotatedClassPostProcessor(annotatedUnits);
+    }
+
+    public AnnotatedClassPostProcessor(List<CompilationUnit> annotatedUnits) {
+        this.annotatedUnits = annotatedUnits;
+    }
+
+    public List<Resource> generate() {
+        return annotatedUnits.stream().map(UnitGenerator::new).map(g -> {
+            String source = g.generate();
+            System.out.println(source);
+            ByteArrayResource r = new ByteArrayResource(source.getBytes(StandardCharsets.UTF_8));
+            r.setSourcePath(g.unitClass.getPackageDeclaration().get().getNameAsString().replace('.', '/') + '/' + g.fileName());
+            r.setResourceType(ResourceType.DRL);
+            return r;
+        }).collect(Collectors.toList());
+    }
+
+    static class UnitGenerator {
+
+        private final CompilationUnit unitClass;
+
+        public UnitGenerator(CompilationUnit unitClass) {
+            this.unitClass = unitClass;
+        }
+
+        String packageName() {
+            return unitClass.getPackageDeclaration().map(PackageDeclaration::getNameAsString).orElse("");
+        }
+
+        String fileName() {
+            return String.format("%s.drl", unitClass.getPrimaryTypeName().orElse(""));
+        }
+
+        String generate() {
+            String imports = unitClass.getImports().stream()
+                    .map(i -> String.format(
+                            "import %s %s;",
+                            (i.isStatic() ? "static" : ""),
+                            i.getName()))
+                    .collect(joining("\n"));
+            String rules = unitClass.getPrimaryType().get().getMethods().stream()
+                    .filter(m -> m.getParameters().stream().flatMap(p -> p.getAnnotations().stream()).anyMatch(a -> a.getNameAsString().endsWith("When")))
+                    .map(this::generateRule).collect(joining());
+            String drl = String.format(
+
+                    "package %s;\n" +
+                            "unit %s;\n" +
+                            "%s\n" +
+                            "%s\n",
+
+                    packageName(), // package
+                    unitClass.getPrimaryTypeName().get(),
+                    imports,
+                    rules);
+            return drl;
+        }
+
+        String generateRule(MethodDeclaration method) {
+            String methodName = method.getName().asString();
+            String patterns = method.getParameters().stream()
+                    .map(this::formatPattern)
+                    .collect(joining());
+
+            String methodArgs = method.getParameters().stream()
+                    .map(NodeWithSimpleName::getNameAsString)
+                    .collect(joining(", "));
+
+            return String.format(
+                    "rule %s when\n" +
+                            "%s" +
+                            "then\n" +
+                            "  unit.%s(%s);\n" +
+                            "end\n",
+                    methodName,
+                    patterns,
+                    methodName,
+                    methodArgs);
+        }
+
+        private String formatPattern(Parameter el) {
+            AnnotationExpr when = el.getAnnotationByName("When").get();
+            return String.format(
+                    "  %s : %s\n",
+                    el.getNameAsString(),
+                    when.asSingleMemberAnnotationExpr().getMemberValue().asStringLiteralExpr().getValue());
+        }
+    }
+}

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
@@ -21,6 +21,7 @@ import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -91,6 +92,12 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
 
     public static IncrementalRuleCodegen ofFiles(Collection<File> files, ResourceType resourceType) {
         return new IncrementalRuleCodegen(toResources(files.stream(), resourceType));
+    }
+
+    public static IncrementalRuleCodegen ofJavaFiles(Collection<File> files) {
+        List<Resource> generatedRules =
+                AnnotatedClassPostProcessor.scan(files.stream().map(File::toPath)).generate();
+        return ofResources(generatedRules);
     }
 
     public static IncrementalRuleCodegen ofFiles(Collection<File> files) {

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/AnnotatedRuleUnitCompilerTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/AnnotatedRuleUnitCompilerTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.codegen;
+
+import org.junit.jupiter.api.Test;
+import org.kie.kogito.Application;
+import org.kie.kogito.codegen.data.Person;
+import org.kie.kogito.codegen.unit.AnnotatedRules;
+import org.kie.kogito.rules.DataHandle;
+import org.kie.kogito.rules.RuleUnit;
+import org.kie.kogito.rules.RuleUnitInstance;
+
+public class AnnotatedRuleUnitCompilerTest extends AbstractCodegenTest {
+
+    @Test
+    public void testAnnotatedRuleUnit() throws Exception {
+        Application application = generateRulesFromJava("org/kie/kogito/codegen/unit/AnnotatedRules.java");
+
+        AnnotatedRules adults = new AnnotatedRules();
+
+        adults.getPersons().add(new Person( "Mario", 45 ));
+        adults.getPersons().add(new Person( "Marilena", 47 ));
+
+        Person sofia = new Person( "Sofia", 7 );
+        DataHandle dhSofia = adults.getPersons().add(sofia);
+
+        RuleUnit<AnnotatedRules> unit = application.ruleUnits().create(AnnotatedRules.class);
+        RuleUnitInstance<AnnotatedRules> instance = unit.createInstance(adults);
+
+    }
+
+}

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/unit/AnnotatedRules.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/unit/AnnotatedRules.java
@@ -1,0 +1,24 @@
+package org.kie.kogito.codegen.unit;
+
+import org.kie.kogito.codegen.data.Person;
+import org.kie.kogito.rules.DataSource;
+import org.kie.kogito.rules.DataStore;
+import org.kie.kogito.rules.RuleUnitData;
+import org.kie.kogito.rules.units.annotations.When;
+
+public class AnnotatedRules implements RuleUnitData {
+
+    private final DataStore<Person> persons = DataSource.createStore();
+
+    public void adult(@When("/persons[ age >= 18 ]") Person person) {
+        System.out.println(person);
+    }
+
+    public DataStore<Person> getPersons() {
+        return persons;
+    }
+
+    public AnnotatedRules getUnit() {
+        return this;
+    }
+}


### PR DESCRIPTION
### Exploratory work. 

An annotation processor is provided to pre-process a Java class and generate a corresponding DRL file (in the future we should skip the intermediate DRL file)

```java
public class AnnotatedUnit implements RuleUnitMemory {
    private final DataStore<Person> persons = DataSource.createStore();

    public void adultRule(
            @When("/persons[ age >= 18 ]") Person adult,
            @When("/persons[ age != 0 ]") Person anotherBinding) {

        System.out.printf("%s is an adult\n", adult.getName());
    }
    ...
```

The DRL file contains one rule per annotated method;
- the method name is the rule name
- each annotated parameter is a condition
- the parameter is the binding for that condition  
- the RHS of the rule **delegates** to the method, passing the matched variables


e.g., consider the generated code for the rule above:

```java
package org.kie.kogito.queries;
unit org.kie.kogito.queries.AnnotatedUnit;
rule adultRule when
  adult : /persons[ age >= 18 ]
  anotherBinding : /persons[ age != 1 ]
then
  unit.adultRule(adult, anotherBinding);
end
```

### Benefits: 
- it is always possible to compile this class file. 
- It is always possible to add a break point inside of the rule body!
- it is always possible to instantiate the class as a regular class for testing purposes (i.e. just invoke rules as regular methods!!)
- IDE support! this is just a regular method in a class!
- **polyglot rules!** we only need to parse the pattern, while we can safely ignore all of the body, because it's typechecked by the language compiler. This means we may easily support... Kotlin rule bodies, completely for free, with *IDE assistance*. And, of course, why stop at Kotlin! any language with annotation can be supported, so Scala, and, why not, even Python or JS (with GraalVM, even native compilation is possible!)

### Downsides:

we may need to think of a way to break up large rule bases in a language-meaningful way (many interfaces with default methods, mixing-in in a class? a delegate system? disallow it because we favor smaller rule bases, and usage of rule unit dispatch?)

see example at https://github.com/kiegroup/kogito-examples/pull/79



