### PR TITLE
[KOGITO-196] Setting default bootstrap server to handle env vars

### DIFF
--- a/data-index/data-index-service/src/main/resources/application.properties
+++ b/data-index/data-index-service/src/main/resources/application.properties
@@ -17,3 +17,4 @@ quarkus.infinispan-client.server-list=localhost:11222
 mp.messaging.incoming.kogito-processinstances-events.connector=smallrye-kafka
 mp.messaging.incoming.kogito-processinstances-events.topic=kogito-processinstances-events
 mp.messaging.incoming.kogito-processinstances-events.value.deserializer=org.kie.kogito.index.messaging.KogitoCloudEventDeserializer
+mp.messaging.incoming.kogito-processinstances-events.bootstrap.servers=localhost:9092


### PR DESCRIPTION
Super simple change that makes this work:

```
export MP_MESSAGING_INCOMING_KOGITO_PROCESSINSTANCES_EVENTS_BOOTSTRAP_SERVERS=999999
```

And then the server is correctly set:

```
java -jar data-index-service-8.0.0-SNAPSHOT-runner.jar 
2019-08-27 19:10:41,092 INFO  [io.sma.rea.mes.ext.MediatorManager] (main) Deployment done... start processing
2019-08-27 19:10:41,097 INFO  [io.sma.rea.mes.imp.ConfiguredChannelFactory] (main) Found incoming connectors: [smallrye-kafka]
2019-08-27 19:10:41,098 INFO  [io.sma.rea.mes.imp.ConfiguredChannelFactory] (main) Found outgoing connectors: [smallrye-kafka]
2019-08-27 19:10:41,098 INFO  [io.sma.rea.mes.imp.ConfiguredChannelFactory] (main) Stream manager initializing...
2019-08-27 19:10:41,103 WARN  [io.sma.rea.mes.kaf.KafkaSource] (main) No `group.id` set in the configuration, generate a random id: c33fc0e9-f2c1-4943-85bf-6552df5518c5
2019-08-27 19:10:41,107 INFO  [io.sma.rea.mes.kaf.KafkaSource] (main) Key deserializer omitted, using String as default
2019-08-27 19:10:41,124 INFO  [org.apa.kaf.cli.con.ConsumerConfig] (main) ConsumerConfig values: 
	auto.commit.interval.ms = 5000
	auto.offset.reset = latest
	bootstrap.servers = [999999]
```

Microprofile is smart to remove non `_` characters from the env vars, but the property must exist in the application properties.

See the comments here: https://issues.jboss.org/browse/KOGITO-196