### PR TITLE
[KOGITO-222] Add support for creating cache programmatically and

### DIFF
--- a/data-index/data-index-service/src/main/resources/META-INF/hotrod-client.properties
+++ b/data-index/data-index-service/src/main/resources/META-INF/hotrod-client.properties
@@ -1,2 +1,9 @@
 # Docker 4 Mac workaround
 infinispan.client.hotrod.client_intelligence=BASIC
+# https://docs.jboss.org/infinispan/9.4/apidocs/org/infinispan/client/hotrod/configuration/package-summary.html
+# https://infinispan.org/docs/dev/user_guide/user_guide.html#configuration_10
+infinispan.client.hotrod.auth_username=${infinispan_username}
+infinispan.client.hotrod.auth_password=${infinispan_password}
+infinispan.client.hotrod.use_auth=${infinispan_useauth}
+infinispan.client.hotrod.auth_realm=${infinispan_authrealm}
+infinispan.client.hotrod.sasl_mechanism=${infinispan_saslmechanism}

--- a/data-index/data-index-service/src/main/resources/META-INF/kogito-cache-default.xml
+++ b/data-index/data-index-service/src/main/resources/META-INF/kogito-cache-default.xml
@@ -3,9 +3,8 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="urn:infinispan:config:10.0 http://www.infinispan.org/schemas/infinispan-config-10.0.xsd"
   xmlns="urn:infinispan:config:10.0">
-  <cache-container statistics="true"
-    default-cache="processinstances" shutdown-hook="DEFAULT">
-    <local-cache name="processinstances">
+  <cache-container statistics="true" shutdown-hook="DEFAULT">
+    <local-cache name="${cache_name}">
       <indexing index="ALL">
         <property name="default.directory_provider">local-heap</property>
       </indexing>

--- a/data-index/data-index-service/src/main/resources/META-INF/kogito-cache-default.xml
+++ b/data-index/data-index-service/src/main/resources/META-INF/kogito-cache-default.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<infinispan
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="urn:infinispan:config:10.0 http://www.infinispan.org/schemas/infinispan-config-10.0.xsd"
+  xmlns="urn:infinispan:config:10.0">
+  <cache-container statistics="true"
+    default-cache="processinstances" shutdown-hook="DEFAULT">
+    <local-cache name="processinstances">
+      <indexing index="ALL">
+        <property name="default.directory_provider">local-heap</property>
+      </indexing>
+    </local-cache>
+  </cache-container>
+</infinispan>
+

--- a/data-index/data-index-service/src/test/resources/META-INF/hotrod-client.properties
+++ b/data-index/data-index-service/src/test/resources/META-INF/hotrod-client.properties
@@ -1,0 +1,1 @@
+# placeholder to not mess with tests

--- a/data-index/data-index-storage/data-index-storage-infinispan/src/main/java/org/kie/kogito/index/infinispan/cache/KogitoCacheDefaultConfiguration.java
+++ b/data-index/data-index-storage/data-index-storage-infinispan/src/main/java/org/kie/kogito/index/infinispan/cache/KogitoCacheDefaultConfiguration.java
@@ -21,23 +21,29 @@ import java.util.Scanner;
 
 import org.infinispan.commons.configuration.XMLStringConfiguration;
 
+/**
+ * Default process event cache configuration
+ *  
+ */
 public class KogitoCacheDefaultConfiguration extends XMLStringConfiguration {
 
     private static final String CACHE_CONFIG_PATH = "META-INF/kogito-cache-default.xml";
+    private static final String CACHE_NAME_PLACEHOLDER = "${cache_name}";
 
-    public KogitoCacheDefaultConfiguration() {
-        super(defaultCacheTemplate());
+    public KogitoCacheDefaultConfiguration(final String cacheName) {
+        super(defaultCacheTemplate(cacheName));
     }
 
-    private static final String defaultCacheTemplate() {
-        InputStream is = KogitoCacheDefaultConfiguration.class.getClassLoader().getResourceAsStream(CACHE_CONFIG_PATH);
+    private static final String defaultCacheTemplate(final String cacheName) {
+        final InputStream is = KogitoCacheDefaultConfiguration.class.getClassLoader().getResourceAsStream(CACHE_CONFIG_PATH);
         if (is == null) {
             throw new IllegalArgumentException(String.format("Cache configuration file %s not found", CACHE_CONFIG_PATH));
         }
 
         try (Scanner s = new Scanner(is)) {
             s.useDelimiter("\\A");
-            return s.hasNext() ? s.next() : "";
+            final String xmlCacheConfig = s.hasNext() ? s.next() : "";
+            return xmlCacheConfig.replace(CACHE_NAME_PLACEHOLDER, cacheName);
         }
     }
 

--- a/data-index/data-index-storage/data-index-storage-infinispan/src/main/java/org/kie/kogito/index/infinispan/cache/KogitoCacheDefaultConfiguration.java
+++ b/data-index/data-index-storage/data-index-storage-infinispan/src/main/java/org/kie/kogito/index/infinispan/cache/KogitoCacheDefaultConfiguration.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.index.infinispan.cache;
+
+import java.io.InputStream;
+import java.util.Scanner;
+
+import org.infinispan.commons.configuration.XMLStringConfiguration;
+
+public class KogitoCacheDefaultConfiguration extends XMLStringConfiguration {
+
+    private static final String CACHE_CONFIG_PATH = "META-INF/kogito-cache-default.xml";
+
+    public KogitoCacheDefaultConfiguration() {
+        super(defaultCacheTemplate());
+    }
+
+    private static final String defaultCacheTemplate() {
+        InputStream is = KogitoCacheDefaultConfiguration.class.getClassLoader().getResourceAsStream(CACHE_CONFIG_PATH);
+        if (is == null) {
+            throw new IllegalArgumentException(String.format("Cache configuration file %s not found", CACHE_CONFIG_PATH));
+        }
+
+        try (Scanner s = new Scanner(is)) {
+            s.useDelimiter("\\A");
+            return s.hasNext() ? s.next() : "";
+        }
+    }
+
+}


### PR DESCRIPTION
externalize authentication options

See:
https://issues.jboss.org/browse/KOGITO-222

In this PR:

1. We can now leverage from the externalize authentication options. Unfortunately we have to use the `hotrod-client.properties` with system property substitutions. I'll update the kogito-data-index image to also have those properties set on the start up
2. Create the cache if not exists in the remote server. Even if the **template** does not exist. In the cloud, will be impossible to manage the Infinispan configuration and caches that the application needs. So, if the template or the cache are not configured, we have now a default option