### PR TITLE
KOGITO-245: Rule Unit implementation for non-codegenerated use cases

### DIFF
--- a/drools/drools-compiler/src/main/java/org/kie/kogito/rules/InterpretedRuleUnit.java
+++ b/drools/drools-compiler/src/main/java/org/kie/kogito/rules/InterpretedRuleUnit.java
@@ -1,0 +1,45 @@
+package org.kie.kogito.rules;
+
+import java.io.InputStream;
+
+import org.drools.compiler.builder.impl.KnowledgeBuilderImpl;
+import org.drools.core.impl.InternalKnowledgeBase;
+import org.drools.core.impl.KnowledgeBaseFactory;
+import org.drools.core.io.impl.InputStreamResource;
+import org.kie.api.io.ResourceType;
+import org.kie.api.runtime.KieSession;
+import org.kie.internal.builder.KnowledgeBuilder;
+import org.kie.kogito.rules.impl.AbstractRuleUnit;
+
+/**
+ * A fully-runtime, reflective implementation of a rule unit, useful for testing
+ */
+public class InterpretedRuleUnit<T extends RuleUnitMemory> extends AbstractRuleUnit<T> {
+
+    public static <T extends RuleUnitMemory> RuleUnit<T> of(Class<T> type) {
+        return new InterpretedRuleUnit<>();
+    }
+
+    private InterpretedRuleUnit() {
+        super(null);
+    }
+
+    @Override
+    public RuleUnitInstance<T> createInstance(T workingMemory) {
+        KnowledgeBuilder kBuilder = new KnowledgeBuilderImpl();
+        Class<? extends RuleUnitMemory> wmClass = workingMemory.getClass();
+        String canonicalName = wmClass.getCanonicalName();
+
+        // transform foo.bar.Baz to /foo/bar/Baz.drl
+        // this currently only works for single files
+        InputStream resourceAsStream = wmClass.getResourceAsStream(
+                String.format("/%s.drl", canonicalName.replace('.', '/')));
+        kBuilder.add(new InputStreamResource(resourceAsStream), ResourceType.DRL);
+
+        InternalKnowledgeBase kBase = KnowledgeBaseFactory.newKnowledgeBase();
+        kBase.addPackages(kBuilder.getKnowledgePackages());
+        KieSession kSession = kBase.newKieSession();
+
+        return new InterpretedRuleUnitInstance<>(this, workingMemory, kSession);
+    }
+}

--- a/drools/drools-compiler/src/main/java/org/kie/kogito/rules/InterpretedRuleUnitInstance.java
+++ b/drools/drools-compiler/src/main/java/org/kie/kogito/rules/InterpretedRuleUnitInstance.java
@@ -1,0 +1,12 @@
+package org.kie.kogito.rules;
+
+import org.kie.api.runtime.KieSession;
+import org.kie.kogito.rules.RuleUnit;
+import org.kie.kogito.rules.RuleUnitMemory;
+
+public class InterpretedRuleUnitInstance<T extends RuleUnitMemory> extends org.drools.core.ruleunit.impl.AbstractRuleUnitInstance<T> {
+
+    InterpretedRuleUnitInstance(RuleUnit<T> unit, T workingMemory, KieSession ksession) {
+        super(unit, workingMemory, ksession);
+    }
+}

--- a/drools/drools-compiler/src/test/java/org/kie/kogito/rules/HelloWorld.java
+++ b/drools/drools-compiler/src/test/java/org/kie/kogito/rules/HelloWorld.java
@@ -1,0 +1,14 @@
+package org.kie.kogito.rules;
+
+import org.drools.core.ruleunit.impl.ListDataStore;
+import org.kie.kogito.rules.DataStore;
+import org.kie.kogito.rules.RuleUnitMemory;
+
+public class HelloWorld implements RuleUnitMemory {
+
+    private final DataStore<String> strings = new ListDataStore<>();
+
+    public DataStore<String> getStrings() {
+        return strings;
+    }
+}

--- a/drools/drools-compiler/src/test/java/org/kie/kogito/rules/InterpretedRuleUnitTest.java
+++ b/drools/drools-compiler/src/test/java/org/kie/kogito/rules/InterpretedRuleUnitTest.java
@@ -1,0 +1,27 @@
+package org.kie.kogito.rules;
+
+import java.util.ArrayList;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class InterpretedRuleUnitTest {
+    @Test
+    public void fireRules() {
+        HelloWorld workingMemory = new HelloWorld();
+        RuleUnit<HelloWorld> ruleUnit = InterpretedRuleUnit.of(HelloWorld.class);
+        RuleUnitInstance<HelloWorld> instance = ruleUnit.createInstance(workingMemory);
+        ArrayList<String> messages = new ArrayList<>();
+        workingMemory.getStrings().subscribe(DataObserver.of(messages::add));
+        instance.fire();
+
+        assertTrue(messages.isEmpty());
+
+        workingMemory.getStrings().add("Hello World");
+        assertEquals(1, messages.size());
+
+        instance.fire();
+        assertEquals(2, messages.size());
+    }
+}

--- a/drools/drools-compiler/src/test/resources/org/kie/kogito/rules/HelloWorld.drl
+++ b/drools/drools-compiler/src/test/resources/org/kie/kogito/rules/HelloWorld.drl
@@ -1,0 +1,9 @@
+package org.kie.kogito.rules;
+unit HelloWorld;
+
+rule HelloWorld
+when
+    /strings [ this == "Hello World" ]
+then
+    strings.add("it worked!");
+end


### PR DESCRIPTION
This is the exact equivalent of [BpmnProcess](https://github.com/kiegroup/kogito-runtimes/blob/79cec20bd06195840671d1528f07d18e8d5ec695/jbpm/jbpm-bpmn2/src/main/java/org/kie/kogito/process/bpmn2/BpmnProcess.java#L35-L34) but for rule units. See test for example usage.