### PR TITLE
[DROOLS-4339] [DROOLS-4277] [DROOLS-4342] [DROOLS-4374][DROOLS-4375][DROOLS-4376] [DROOLS-4377] [DROOLS-4831]

### DIFF
--- a/drools/drools-compiler/src/main/java/org/drools/compiler/rule/builder/util/AccumulateUtil.java
+++ b/drools/drools-compiler/src/main/java/org/drools/compiler/rule/builder/util/AccumulateUtil.java
@@ -33,12 +33,20 @@ public class AccumulateUtil {
             }
         } else if (functionName.equals("max")) {
             final Class<?> exprClass = convertFromPrimitiveType( exprClassSupplier.get() );
-            if (Number.class.isAssignableFrom( exprClass )) {
+            if (exprClass == Integer.class) {
+                functionName = "maxI";
+            } else if (exprClass == Long.class) {
+                functionName = "maxL";
+            } else if (Number.class.isAssignableFrom( exprClass )) {
                 functionName = "maxN";
             }
         } else if (functionName.equals("min")) {
             final Class<?> exprClass = convertFromPrimitiveType( exprClassSupplier.get() );
-            if (Number.class.isAssignableFrom( exprClass )) {
+            if (exprClass == Integer.class) {
+                functionName = "minI";
+            } else if (exprClass == Long.class) {
+                functionName = "minL";
+            } else if (Number.class.isAssignableFrom( exprClass )) {
                 functionName = "minN";
             }
         }

--- a/drools/drools-core-reflective/src/main/java/org/drools/reflective/util/ClassUtils.java
+++ b/drools/drools-core-reflective/src/main/java/org/drools/reflective/util/ClassUtils.java
@@ -461,6 +461,27 @@ public abstract class ClassUtils {
                 .map( f -> getMethod(clazz, f.get()) ).filter( Optional::isPresent ).findFirst().flatMap( Function.identity() ).orElse( null );
     }
 
+    public static Method getSetter(Class<?> clazz, String field, Class<?>... parameterTypes) {
+        return Stream.<Supplier<String>>of(
+                () -> "set" + ucFirst(field),
+                () -> field,
+                () -> "set" + field
+        )
+                .map( f -> getMethod(clazz, f.get(), parameterTypes) )
+                .filter( Optional::isPresent )
+                .findFirst()
+                .flatMap( Function.identity() )
+                .orElse( null );
+    }
+
+    private static Optional<Method> getMethod(Class<?> clazz, String name, Class<?>... parameterTypes) {
+        try {
+            return Optional.of( clazz.getMethod(name, parameterTypes) );
+        } catch (NoSuchMethodException e) {
+            return Optional.empty();
+        }
+    }
+
     public static String ucFirst(final String s) {
         return Character.isLowerCase(s.charAt( 0 )) ? Character.toUpperCase( s.charAt( 0 ) ) + s.substring( 1 ) : s;
     }

--- a/drools/drools-core/src/main/java/org/drools/core/base/accumulators/IntegerMaxAccumulateFunction.java
+++ b/drools/drools-core/src/main/java/org/drools/core/base/accumulators/IntegerMaxAccumulateFunction.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2010 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.core.base.accumulators;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+/**
+ * An implementation of an accumulator capable of calculating maximum values
+ */
+public class IntegerMaxAccumulateFunction extends AbstractAccumulateFunction<IntegerMaxAccumulateFunction.MaxData> {
+
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+
+    }
+
+    public void writeExternal(ObjectOutput out) throws IOException {
+
+    }
+
+    protected static class MaxData implements Externalizable {
+        public Integer max = null;
+
+        public MaxData() {}
+
+        public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+            max = (Integer) in.readObject();
+        }
+
+        public void writeExternal(ObjectOutput out) throws IOException {
+            out.writeObject(max);
+        }
+
+        @Override
+        public String toString() {
+            return "max";
+        }
+    }
+
+    public MaxData createContext() {
+        return new MaxData();
+    }
+
+    public void init(MaxData data) {
+        data.max = null;
+    }
+
+    public void accumulate(MaxData data,
+                           Object value) {
+        if (value != null) {
+            Integer number = (Integer)value;
+            data.max = data.max == null || data.max < number ? number : data.max;
+        }
+    }
+
+    public void reverse(MaxData data,
+                        Object value) {
+    }
+
+    public Object getResult(MaxData data) {
+        return data.max;
+    }
+
+    public boolean supportsReverse() {
+        return false;
+    }
+
+    public Class<?> getResultType() {
+        return Integer.class;
+    }
+}

--- a/drools/drools-core/src/main/java/org/drools/core/base/accumulators/IntegerMinAccumulateFunction.java
+++ b/drools/drools-core/src/main/java/org/drools/core/base/accumulators/IntegerMinAccumulateFunction.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2010 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.core.base.accumulators;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+/**
+ * An implementation of an accumulator capable of calculating maximum values
+ */
+public class IntegerMinAccumulateFunction extends AbstractAccumulateFunction<IntegerMinAccumulateFunction.MaxData> {
+
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+
+    }
+
+    public void writeExternal(ObjectOutput out) throws IOException {
+
+    }
+
+    protected static class MaxData implements Externalizable {
+        public Integer min = null;
+
+        public MaxData() {}
+
+        public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+            min = (Integer) in.readObject();
+        }
+
+        public void writeExternal(ObjectOutput out) throws IOException {
+            out.writeObject(min);
+        }
+
+        @Override
+        public String toString() {
+            return "min";
+        }
+    }
+
+    public MaxData createContext() {
+        return new MaxData();
+    }
+
+    public void init(MaxData data) {
+        data.min = null;
+    }
+
+    public void accumulate(MaxData data,
+                           Object value) {
+        if (value != null) {
+            Integer number = (Integer)value;
+            data.min = data.min == null || data.min > number ? number : data.min;
+        }
+    }
+
+    public void reverse(MaxData data,
+                        Object value) {
+    }
+
+    public Object getResult(MaxData data) {
+        return data.min;
+    }
+
+    public boolean supportsReverse() {
+        return false;
+    }
+
+    public Class<?> getResultType() {
+        return Integer.class;
+    }
+}

--- a/drools/drools-core/src/main/java/org/drools/core/base/accumulators/LongMaxAccumulateFunction.java
+++ b/drools/drools-core/src/main/java/org/drools/core/base/accumulators/LongMaxAccumulateFunction.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2010 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.core.base.accumulators;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+/**
+ * An implementation of an accumulator capable of calculating maximum values
+ */
+public class LongMaxAccumulateFunction extends AbstractAccumulateFunction<LongMaxAccumulateFunction.MaxData> {
+
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+
+    }
+
+    public void writeExternal(ObjectOutput out) throws IOException {
+
+    }
+
+    protected static class MaxData implements Externalizable {
+        public Long max = null;
+
+        public MaxData() {}
+
+        public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+            max = (Long) in.readObject();
+        }
+
+        public void writeExternal(ObjectOutput out) throws IOException {
+            out.writeObject(max);
+        }
+
+        @Override
+        public String toString() {
+            return "max";
+        }
+    }
+
+    public MaxData createContext() {
+        return new MaxData();
+    }
+
+    public void init(MaxData data) {
+        data.max = null;
+    }
+
+    public void accumulate(MaxData data,
+                           Object value) {
+        if (value != null) {
+            Long number = (Long)value;
+            data.max = data.max == null || data.max < number ? number : data.max;
+        }
+    }
+
+    public void reverse(MaxData data,
+                        Object value) {
+    }
+
+    public Object getResult(MaxData data) {
+        return data.max;
+    }
+
+    public boolean supportsReverse() {
+        return false;
+    }
+
+    public Class<?> getResultType() {
+        return Long.class;
+    }
+}

--- a/drools/drools-core/src/main/java/org/drools/core/base/accumulators/LongMinAccumulateFunction.java
+++ b/drools/drools-core/src/main/java/org/drools/core/base/accumulators/LongMinAccumulateFunction.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2010 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.core.base.accumulators;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+/**
+ * An implementation of an accumulator capable of calculating maximum values
+ */
+public class LongMinAccumulateFunction extends AbstractAccumulateFunction<LongMinAccumulateFunction.MaxData> {
+
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+
+    }
+
+    public void writeExternal(ObjectOutput out) throws IOException {
+
+    }
+
+    protected static class MaxData implements Externalizable {
+        public Long min = null;
+
+        public MaxData() {}
+
+        public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+            min = (Long) in.readObject();
+        }
+
+        public void writeExternal(ObjectOutput out) throws IOException {
+            out.writeObject(min);
+        }
+
+        @Override
+        public String toString() {
+            return "min";
+        }
+    }
+
+    public MaxData createContext() {
+        return new MaxData();
+    }
+
+    public void init(MaxData data) {
+        data.min = null;
+    }
+
+    public void accumulate(MaxData data,
+                           Object value) {
+        if (value != null) {
+            Long number = (Long)value;
+            data.min = data.min == null || data.min > number ? number : data.min;
+        }
+    }
+
+    public void reverse(MaxData data,
+                        Object value) {
+    }
+
+    public Object getResult(MaxData data) {
+        return data.min;
+    }
+
+    public boolean supportsReverse() {
+        return false;
+    }
+
+    public Class<?> getResultType() {
+        return Long.class;
+    }
+}

--- a/drools/drools-core/src/main/resources/META-INF/kie.default.properties.conf
+++ b/drools/drools-core/src/main/resources/META-INF/kie.default.properties.conf
@@ -30,8 +30,12 @@ drools.dialect.mvel.langLevel = 4
 
 drools.accumulate.function.max = org.drools.core.base.accumulators.MaxAccumulateFunction
 drools.accumulate.function.maxN = org.drools.core.base.accumulators.NumericMaxAccumulateFunction
+drools.accumulate.function.maxI = org.drools.core.base.accumulators.IntegerMaxAccumulateFunction
+drools.accumulate.function.maxL = org.drools.core.base.accumulators.LongMaxAccumulateFunction
 drools.accumulate.function.min = org.drools.core.base.accumulators.MinAccumulateFunction
 drools.accumulate.function.minN = org.drools.core.base.accumulators.NumericMinAccumulateFunction
+drools.accumulate.function.minI = org.drools.core.base.accumulators.IntegerMinAccumulateFunction
+drools.accumulate.function.minL = org.drools.core.base.accumulators.LongMinAccumulateFunction
 drools.accumulate.function.count = org.drools.core.base.accumulators.CountAccumulateFunction
 drools.accumulate.function.collectList = org.drools.core.base.accumulators.CollectListAccumulateFunction
 drools.accumulate.function.collectSet = org.drools.core.base.accumulators.CollectSetAccumulateFunction

--- a/drools/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/DrlxParseUtil.java
+++ b/drools/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/DrlxParseUtil.java
@@ -835,4 +835,8 @@ public class DrlxParseUtil {
     public static String addCurlyBracesToBlock(String blockString) {
         return String.format("{%s}", blockString);
     }
+
+    public static String addSemicolon(String block) {
+        return block.endsWith(";") ? block : block + ";";
+    }
 }

--- a/drools/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/RuleContext.java
+++ b/drools/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/RuleContext.java
@@ -249,9 +249,6 @@ public class RuleContext {
         final String bindingId = d.getBindingId();
         final Optional<DeclarationSpec> declarationById = getDeclarationById(bindingId);
         if (declarationById.isPresent()) {
-            if ( d.getDeclarationClass().isAssignableFrom( declarationById.get().getDeclarationClass() )) {
-                return;
-            }
             removeDeclarationById(bindingId);
         }
         this.scopedDeclarations.put(d.getBindingId(), d);

--- a/drools/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/CoercedExpression.java
+++ b/drools/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/CoercedExpression.java
@@ -55,34 +55,32 @@ public class CoercedExpression {
 
     public CoercedExpressionResult coerce() {
         final TypedExpression coercedRight;
-        final Expression rightExpression = right.getExpression();
 
         final Class<?> leftClass = left.getRawClass();
         final Class<?> rightClass = right.getRawClass();
 
+        if (cannotCoerce()) {
+            throw new CoercedExpressionException(new InvalidExpressionErrorResult("Comparison operation requires compatible types. Found " + leftClass + " and " + rightClass));
+        }
+
+        final Expression rightExpression = right.getExpression();
+
         final boolean leftIsPrimitive = leftClass.isPrimitive();
         final boolean canCoerceLiteralNumberExpr = canCoerceLiteralNumberExpr(leftClass);
-
-        if (leftIsPrimitive && canCoerceLiteralNumberExpr) {
-            if (!rightClass.isPrimitive() && !Number.class.isAssignableFrom(rightClass) &&
-                    !Boolean.class.isAssignableFrom(rightClass) && !String.class.isAssignableFrom(rightClass)) {
-                throw new CoercedExpressionException(new InvalidExpressionErrorResult("Comparison operation requires compatible types. Found " + leftClass + " and " + rightClass));
-            }
-        }
 
         if (leftIsPrimitive && canCoerceLiteralNumberExpr && rightExpression instanceof LiteralStringValueExpr) {
             final Expression coercedLiteralNumberExprToType = coerceLiteralNumberExprToType((LiteralStringValueExpr) right.getExpression(), leftClass);
             coercedRight = right.cloneWithNewExpression(coercedLiteralNumberExprToType);
         } else if (shouldCoerceBToString(left, right)) {
             coercedRight = coerceToString(right);
-        } else if (isNotBinaryExpression(right) && canBeNarrowed(leftClass, rightClass)) {
-            coercedRight = right.cloneWithNewExpression(new CastExpr(toJavaParserType(leftClass, rightClass.isPrimitive()), right.getExpression()));
-        } else if (isNotBinaryExpression(right) && left.getType().equals(Object.class) && right.getType() != Object.class) {
-            coercedRight = right.cloneWithNewExpression(new CastExpr(toJavaParserType(Object.class, rightClass.isPrimitive()), right.getExpression()));
+        } else if (isNotBinaryExpression(right) && canBeNarrowed(leftClass, rightClass) && right.isNumberLiteral()) {
+            coercedRight = castToClass(leftClass);
         } else if (leftClass == long.class && rightClass == int.class) {
             coercedRight = right.cloneWithNewExpression(new CastExpr(PrimitiveType.longType(), right.getExpression()));
         } else if (leftClass == Date.class && rightClass == String.class) {
             coercedRight = coerceToDate(right);
+        } else if(shouldCoerceBToMap()) {
+            coercedRight = castToClass(toNonPrimitiveType(leftClass));
         } else if (Boolean.class.isAssignableFrom(leftClass) && !Boolean.class.isAssignableFrom(rightClass)) {
             coercedRight = coerceBoolean(right);
         } else {
@@ -97,6 +95,31 @@ public class CoercedExpression {
         }
 
         return new CoercedExpressionResult(coercedLeft, coercedRight);
+    }
+
+    private boolean shouldCoerceBToMap() {
+        return isNotBinaryExpression(right) && Map.class.isAssignableFrom(right.getRawClass());
+    }
+
+    private boolean cannotCoerce() {
+        final Class<?> leftClass = left.getRawClass();
+        final Class<?> rightClass = right.getRawClass();
+
+        final boolean leftIsPrimitive = leftClass.isPrimitive();
+        final boolean canCoerceLiteralNumberExpr = canCoerceLiteralNumberExpr(leftClass);
+
+        return leftIsPrimitive
+                && canCoerceLiteralNumberExpr
+                && !rightClass.isPrimitive()
+                && !Number.class.isAssignableFrom(rightClass)
+                && !Boolean.class.isAssignableFrom(rightClass)
+                && !String.class.isAssignableFrom(rightClass)
+                && !(Map.class.isAssignableFrom(leftClass) || Map.class.isAssignableFrom(rightClass));
+
+    }
+
+    private TypedExpression castToClass(Class<?> clazz) {
+        return right.cloneWithNewExpression(new CastExpr(toJavaParserType(clazz, right.isPrimitive()), right.getExpression()));
     }
 
     private static TypedExpression coerceToString(TypedExpression typedExpression) {
@@ -137,7 +160,7 @@ public class CoercedExpression {
         }
     }
 
-    public static boolean canCoerceLiteralNumberExpr(Class<?> type) {
+    private static boolean canCoerceLiteralNumberExpr(Class<?> type) {
         return LITERAL_NUMBER_CLASSES.contains(type);
     }
 
@@ -145,7 +168,7 @@ public class CoercedExpression {
         boolean aIsString = a.getType() == String.class;
         boolean bIsNotString = b.getType() != String.class;
         boolean bIsNotNull = !(b.getExpression() instanceof NullLiteralExpr);
-        boolean bIsNotSerializable = !(b.getType() == Serializable.class);
+        boolean bIsNotSerializable = b.getType() != Serializable.class;
         boolean bExpressionExists = b.getExpression() != null;
         return bExpressionExists && isNotBinaryExpression(b) && aIsString && (bIsNotString && bIsNotNull && bIsNotSerializable);
     }
@@ -164,7 +187,7 @@ public class CoercedExpression {
         if (type == double.class) {
             return new DoubleLiteralExpr(expr.getValue().endsWith("d") ? expr.getValue() : expr.getValue() + "d");
         }
-        throw new RuntimeException("Unknown literal: " + expr);
+        throw new CoercedExpressionException(new InvalidExpressionErrorResult("Unknown literal: " + expr));
     }
 
     private boolean canBeNarrowed(Class<?> leftType, Class<?> rightType) {
@@ -181,7 +204,7 @@ public class CoercedExpression {
             this.coercedRight = coercedRight;
         }
 
-        public TypedExpression getCoercedLeft() {
+        TypedExpression getCoercedLeft() {
             return coercedLeft;
         }
 
@@ -190,15 +213,15 @@ public class CoercedExpression {
         }
     }
 
-    public static class CoercedExpressionException extends RuntimeException {
+    static class CoercedExpressionException extends RuntimeException {
 
-        private final InvalidExpressionErrorResult invalidExpressionErrorResult;
+        private final transient InvalidExpressionErrorResult invalidExpressionErrorResult;
 
-        public CoercedExpressionException(InvalidExpressionErrorResult invalidExpressionErrorResult) {
+        CoercedExpressionException(InvalidExpressionErrorResult invalidExpressionErrorResult) {
             this.invalidExpressionErrorResult = invalidExpressionErrorResult;
         }
 
-        public InvalidExpressionErrorResult getInvalidExpressionErrorResult() {
+        InvalidExpressionErrorResult getInvalidExpressionErrorResult() {
             return invalidExpressionErrorResult;
         }
     }

--- a/drools/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/ConstraintParser.java
+++ b/drools/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/ConstraintParser.java
@@ -1,5 +1,20 @@
 package org.drools.modelcompiler.builder.generator.drlxparse;
 
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.*;
+import com.github.javaparser.ast.nodeTypes.NodeWithArguments;
+import com.github.javaparser.ast.nodeTypes.NodeWithOptionalScope;
+import org.drools.core.util.DateUtils;
+import org.drools.modelcompiler.builder.PackageModel;
+import org.drools.modelcompiler.builder.errors.InvalidExpressionErrorResult;
+import org.drools.modelcompiler.builder.errors.ParseExpressionErrorResult;
+import org.drools.modelcompiler.builder.generator.*;
+import org.drools.modelcompiler.builder.generator.expressiontyper.ExpressionTyper;
+import org.drools.modelcompiler.builder.generator.expressiontyper.ExpressionTyperContext;
+import org.drools.modelcompiler.builder.generator.expressiontyper.TypedExpressionResult;
+import org.drools.mvel.parser.ast.expr.*;
+
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -8,51 +23,12 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import com.github.javaparser.ast.NodeList;
-import com.github.javaparser.ast.body.MethodDeclaration;
-import com.github.javaparser.ast.expr.BinaryExpr;
-import com.github.javaparser.ast.expr.CastExpr;
-import com.github.javaparser.ast.expr.EnclosedExpr;
-import com.github.javaparser.ast.expr.Expression;
-import com.github.javaparser.ast.expr.FieldAccessExpr;
-import com.github.javaparser.ast.expr.LiteralExpr;
-import com.github.javaparser.ast.expr.MethodCallExpr;
-import com.github.javaparser.ast.expr.NameExpr;
-import com.github.javaparser.ast.expr.NullLiteralExpr;
-import com.github.javaparser.ast.expr.ObjectCreationExpr;
-import com.github.javaparser.ast.expr.StringLiteralExpr;
-import com.github.javaparser.ast.expr.ThisExpr;
-import com.github.javaparser.ast.expr.UnaryExpr;
-import com.github.javaparser.ast.nodeTypes.NodeWithArguments;
-import com.github.javaparser.ast.nodeTypes.NodeWithOptionalScope;
-import org.drools.core.util.DateUtils;
-import org.drools.modelcompiler.builder.PackageModel;
-import org.drools.modelcompiler.builder.errors.InvalidExpressionErrorResult;
-import org.drools.modelcompiler.builder.errors.ParseExpressionErrorResult;
-import org.drools.modelcompiler.builder.generator.DrlxParseUtil;
-import org.drools.modelcompiler.builder.generator.ModelGenerator;
-import org.drools.modelcompiler.builder.generator.RuleContext;
-import org.drools.modelcompiler.builder.generator.TypedExpression;
-import org.drools.modelcompiler.builder.generator.expressiontyper.ExpressionTyper;
-import org.drools.modelcompiler.builder.generator.expressiontyper.ExpressionTyperContext;
-import org.drools.modelcompiler.builder.generator.expressiontyper.TypedExpressionResult;
-import org.drools.mvel.parser.ast.expr.BigDecimalLiteralExpr;
-import org.drools.mvel.parser.ast.expr.BigIntegerLiteralExpr;
-import org.drools.mvel.parser.ast.expr.DrlNameExpr;
-import org.drools.mvel.parser.ast.expr.DrlxExpression;
-import org.drools.mvel.parser.ast.expr.HalfBinaryExpr;
-import org.drools.mvel.parser.ast.expr.HalfPointFreeExpr;
-import org.drools.mvel.parser.ast.expr.OOPathExpr;
-import org.drools.mvel.parser.ast.expr.PointFreeExpr;
-
-import static com.github.javaparser.ast.expr.BinaryExpr.Operator.GREATER;
-import static com.github.javaparser.ast.expr.BinaryExpr.Operator.GREATER_EQUALS;
-import static com.github.javaparser.ast.expr.BinaryExpr.Operator.LESS;
-import static com.github.javaparser.ast.expr.BinaryExpr.Operator.LESS_EQUALS;
+import static com.github.javaparser.ast.expr.BinaryExpr.Operator.*;
 import static org.drools.core.util.StringUtils.lcFirst;
 import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.THIS_PLACEHOLDER;
 import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.getLiteralExpressionType;
 import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.toClassOrInterfaceType;
+import static org.drools.modelcompiler.builder.generator.drlxparse.SpecialComparisonCase.specialComparisonFactory;
 import static org.drools.mvel.parser.printer.PrintUtil.printConstraint;
 
 public class ConstraintParser {
@@ -185,22 +161,26 @@ public class ConstraintParser {
             methodCallExpr.replace(t, new NameExpr(THIS_PLACEHOLDER));
         }
 
-        Class<?> returnType = DrlxParseUtil.getClassFromContext(context.getTypeResolver(), functionCall.get().getType().asString());
-        NodeList<Expression> arguments = methodCallExpr.getArguments();
-        List<String> usedDeclarations = new ArrayList<>();
-        for (Expression arg : arguments) {
-            String argString = printConstraint(arg);
-            if (arg instanceof DrlNameExpr && !argString.equals(THIS_PLACEHOLDER)) {
-                usedDeclarations.add(argString);
-            } else if (arg instanceof CastExpr ) {
-                String s = printConstraint(((CastExpr) arg).getExpression());
-                usedDeclarations.add(s);
-            } else if (arg instanceof MethodCallExpr) {
-                TypedExpressionResult typedExpressionResult = new ExpressionTyper(context, null, bindingId, isPositional).toTypedExpression(arg);
-                usedDeclarations.addAll(typedExpressionResult.getUsedDeclarations());
+        if (functionCall.isPresent()) {
+            Class<?> returnType = DrlxParseUtil.getClassFromContext(context.getTypeResolver(), functionCall.get().getType().asString());
+            NodeList<Expression> arguments = methodCallExpr.getArguments();
+            List<String> usedDeclarations = new ArrayList<>();
+            for (Expression arg : arguments) {
+                String argString = printConstraint(arg);
+                if (arg instanceof DrlNameExpr && !argString.equals(THIS_PLACEHOLDER)) {
+                    usedDeclarations.add(argString);
+                } else if (arg instanceof CastExpr ) {
+                    String s = printConstraint(((CastExpr) arg).getExpression());
+                    usedDeclarations.add(s);
+                } else if (arg instanceof MethodCallExpr) {
+                    TypedExpressionResult typedExpressionResult = new ExpressionTyper(context, null, bindingId, isPositional).toTypedExpression(arg);
+                    usedDeclarations.addAll(typedExpressionResult.getUsedDeclarations());
+                }
             }
+            return new SingleDrlxParseSuccess(patternType, exprId, bindingId, methodCallExpr, returnType).setUsedDeclarations(usedDeclarations);
+        } else {
+            throw new IllegalArgumentException("Specified function call is not present!");
         }
-        return new SingleDrlxParseSuccess(patternType, exprId, bindingId, methodCallExpr, returnType).setUsedDeclarations(usedDeclarations);
     }
 
     private DrlxParseResult parseNameExpr(DrlNameExpr nameExpr, Class<?> patternType, String bindingId, Expression drlxExpr, boolean hasBind, String expression, String exprId) {
@@ -215,7 +195,12 @@ public class ConstraintParser {
                     .setLeft( new TypedExpression( withThis, converted.getType() ) )
                     .addReactOnProperty( lcFirst(nameExpr.getNameAsString()) );
         } else if (context.hasDeclaration( expression )) {
-            return new SingleDrlxParseSuccess(patternType, exprId, bindingId, context.getVarExpr(printConstraint(drlxExpr)), context.getDeclarationById(expression ).get().getDeclarationClass() );
+            Optional<DeclarationSpec> declarationSpec = context.getDeclarationById(expression);
+            if (declarationSpec.isPresent()) {
+                return new SingleDrlxParseSuccess(patternType, exprId, bindingId, context.getVarExpr(printConstraint(drlxExpr)), declarationSpec.get().getDeclarationClass() );
+            } else {
+                throw new IllegalArgumentException("Cannot find declaration specification by specified expression " + expression + "!");
+            }
         } else {
             return new SingleDrlxParseSuccess(patternType, exprId, bindingId, withThis, converted.getType() )
                     .addReactOnProperty( nameExpr.getNameAsString() );
@@ -319,13 +304,16 @@ public class ConstraintParser {
         switch (operator) {
             case EQUALS:
             case NOT_EQUALS:
-                combo = getEqualityExpression(left, right, operator);
+                combo = getEqualityExpression(left, right, operator).expression;
                 break;
             default:
                 if (left.getExpression() == null || right.getExpression() == null) {
                     return new DrlxParseFail(new ParseExpressionErrorResult(drlxExpr));
                 }
-                combo = handleSpecialComparisonCases(operator, left, right);
+                SpecialComparisonResult specialComparisonResult = handleSpecialComparisonCases(operator, left, right);
+                combo = specialComparisonResult.expression;
+                left = specialComparisonResult.coercedLeft;
+                right = specialComparisonResult.coercedRight;
         }
 
         for(Expression e : leftTypedExpressionResult.getPrefixExpressions()) {
@@ -357,8 +345,11 @@ public class ConstraintParser {
     }
 
     private static String getExpressionSymbol(Expression expr) {
-        if (expr instanceof MethodCallExpr && (( MethodCallExpr ) expr).getScope().isPresent()) {
-            return getExpressionSymbol( (( MethodCallExpr ) expr).getScope().get() );
+        if (expr instanceof MethodCallExpr) {
+            Optional<Expression> scopeExpression = (( MethodCallExpr ) expr).getScope();
+            if (scopeExpression.isPresent()) {
+                return getExpressionSymbol( scopeExpression.get() );
+            }
         }
         if (expr instanceof FieldAccessExpr ) {
             return getExpressionSymbol( (( FieldAccessExpr ) expr).getScope() );
@@ -366,7 +357,7 @@ public class ConstraintParser {
         return printConstraint(expr);
     }
 
-    private static Expression getEqualityExpression( TypedExpression left, TypedExpression right, BinaryExpr.Operator operator ) {
+    private static SpecialComparisonResult getEqualityExpression(TypedExpression left, TypedExpression right, BinaryExpr.Operator operator ) {
         if((isAnyOperandBigDecimal(left, right) || isAnyOperandBigInteger(left, right)) && !isAnyOperandNullLiteral( left, right )) {
             return compareBigDecimal(operator, left, right);
         }
@@ -379,14 +370,15 @@ public class ConstraintParser {
         // Avoid casts, by using an helper method we leverage autoboxing and equals
         methodCallExpr.addArgument(uncastExpr(left.getExpression()));
         methodCallExpr.addArgument(uncastExpr(right.getExpression()));
-        return operator == BinaryExpr.Operator.EQUALS ? methodCallExpr : new UnaryExpr(methodCallExpr, UnaryExpr.Operator.LOGICAL_COMPLEMENT );
+        Expression expression = operator == BinaryExpr.Operator.EQUALS ? methodCallExpr : new UnaryExpr(methodCallExpr, UnaryExpr.Operator.LOGICAL_COMPLEMENT);
+        return new SpecialComparisonResult(expression, left, right);
     }
 
-    private static Boolean isNumber(TypedExpression left) {
+    static Boolean isNumber(TypedExpression left) {
         return left.getBoxedType().map(ConstraintParser::isNumericType).orElse(false);
     }
 
-    private static Expression uncastExpr(Expression e) {
+    static Expression uncastExpr(Expression e) {
         if(e == null) { // Not sure why a null should be here - check QueryTest.testPositionalRecursiveQuery
             return null;
         }
@@ -397,37 +389,32 @@ public class ConstraintParser {
         }
     }
 
-    private static Expression handleSpecialComparisonCases(BinaryExpr.Operator operator, TypedExpression left, TypedExpression right) {
+    private static SpecialComparisonResult handleSpecialComparisonCases(BinaryExpr.Operator operator, TypedExpression left, TypedExpression right) {
         if ((isAnyOperandBigDecimal(left, right) || isAnyOperandBigInteger(left, right)) && (isComparisonOperator(operator))) {
             return compareBigDecimal(operator, left, right);
         }
 
         if ( isComparisonOperator( operator ) ) {
-            String methodName = getComparisonMethodName(operator, left, right);
-            if (methodName != null) {
-                MethodCallExpr compareMethod = new MethodCallExpr( null, methodName );
-                compareMethod.addArgument(uncastExpr(left.getExpression()));
-                compareMethod.addArgument(uncastExpr(right.getExpression()));
-                return compareMethod;
-            }
+            SpecialComparisonCase methodName = specialComparisonFactory(left, right);
+            return methodName.createCompareMethod(operator);
         }
 
-        return new BinaryExpr( left.getExpression(), right.getExpression(), operator );
+        return new SpecialComparisonResult(new BinaryExpr( left.getExpression(), right.getExpression(), operator ), left, right);
     }
 
-    private static String getComparisonMethodName(BinaryExpr.Operator operator, TypedExpression left, TypedExpression right) {
-        String methodName = "org.drools.modelcompiler.util.EvaluationUtil." + operatorToName(operator);
-        if (left.getType() == String.class && right.getType() == String.class) {
-            return methodName + "StringsAsNumbers";
-        } else if (isNumber(left) || isNumber(right)) {
-            return methodName + "Numbers";
-        } else if (Comparable.class.isAssignableFrom(left.getRawClass()) && Comparable.class.isAssignableFrom(right.getRawClass())) {
-            return methodName;
+    static class SpecialComparisonResult {
+        Expression expression;
+        TypedExpression coercedLeft;
+        TypedExpression coercedRight;
+
+        SpecialComparisonResult(Expression expression, TypedExpression coercedLeft, TypedExpression coercedRight) {
+            this.expression = expression;
+            this.coercedLeft = coercedLeft;
+            this.coercedRight = coercedRight;
         }
-        return null;
     }
 
-    private static String operatorToName(BinaryExpr.Operator operator) {
+    static String operatorToName(BinaryExpr.Operator operator) {
         switch (operator.asString()) {
             case "==" : return "equals";
             case "!=" : return "notEquals";
@@ -455,12 +442,12 @@ public class ConstraintParser {
         return left.getExpression() instanceof NullLiteralExpr || right.getExpression() instanceof NullLiteralExpr;
     }
 
-    private static Expression compareBigDecimal(BinaryExpr.Operator operator, TypedExpression left, TypedExpression right) {
+    private static SpecialComparisonResult compareBigDecimal(BinaryExpr.Operator operator, TypedExpression left, TypedExpression right) {
         String methodName = "org.drools.modelcompiler.util.EvaluationUtil." + operatorToName(operator);
         MethodCallExpr compareMethod = new MethodCallExpr( null, methodName );
         compareMethod.addArgument( toBigDecimalExpression( left ) );
         compareMethod.addArgument( toBigDecimalExpression( right ) );
-        return compareMethod;
+        return new SpecialComparisonResult(compareMethod, left, right);
     }
 
     private static Expression toBigDecimalExpression( TypedExpression typedExpression ) {
@@ -483,8 +470,9 @@ public class ConstraintParser {
         List<Expression> res = new ArrayList<>( methodCallExpr.getArguments() );
         if ( methodCallExpr instanceof NodeWithOptionalScope ) {
             NodeWithOptionalScope<?> nodeWithOptionalScope = (NodeWithOptionalScope) methodCallExpr;
-            if ( nodeWithOptionalScope.getScope().isPresent() ) {
-                Object scope = nodeWithOptionalScope.getScope().get();
+            Optional<Expression> scopeExpression = nodeWithOptionalScope.getScope();
+            if ( scopeExpression.isPresent() ) {
+                Object scope = scopeExpression.get();
                 if (scope instanceof NodeWithArguments) {
                     res.addAll(recurseCollectArguments((NodeWithArguments<?>) scope));
                 }

--- a/drools/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/SpecialComparisonCase.java
+++ b/drools/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/drlxparse/SpecialComparisonCase.java
@@ -1,0 +1,157 @@
+package org.drools.modelcompiler.builder.generator.drlxparse;
+
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import com.github.javaparser.ast.expr.BinaryExpr;
+import com.github.javaparser.ast.expr.CastExpr;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import org.drools.modelcompiler.builder.generator.TypedExpression;
+
+import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.toClassOrInterfaceType;
+import static org.drools.modelcompiler.builder.generator.drlxparse.ConstraintParser.isNumber;
+import static org.drools.modelcompiler.builder.generator.drlxparse.ConstraintParser.operatorToName;
+import static org.drools.modelcompiler.builder.generator.drlxparse.ConstraintParser.uncastExpr;
+
+// TODO need to add a specific case for map.
+// Also it would be better to move every coercion case here
+abstract class SpecialComparisonCase {
+
+    TypedExpression left;
+    TypedExpression right;
+
+    SpecialComparisonCase(TypedExpression left, TypedExpression right) {
+        this.left = left;
+        this.right = right;
+    }
+
+    String getMethodName(BinaryExpr.Operator operator) {
+        return "org.drools.modelcompiler.util.EvaluationUtil." + operatorToName(operator);
+    }
+
+    abstract ConstraintParser.SpecialComparisonResult createCompareMethod(BinaryExpr.Operator operator);
+
+    static SpecialComparisonCase specialComparisonFactory(TypedExpression left, TypedExpression right) {
+        if (left.getType() == String.class && right.getType() == String.class) {
+            return new StringAsNumber(left, right);
+        } else if (isNumber(left) || isNumber(right)) {
+            Optional<Class<?>> leftCast = typeNeedsCast(left.getType());
+            Optional<Class<?>> rightCast = typeNeedsCast(right.getType());
+            if (leftCast.isPresent() || rightCast.isPresent()) {
+                return new NumberComparisonWithCast(left, right, leftCast, rightCast);
+            } else {
+                return new NumberComparisonWithoutCast(left, right);
+            }
+        } else {
+            return new PlainEvaluation(left, right);
+        }
+    }
+
+    private static Optional<Class<?>> typeNeedsCast(Type t) {
+        boolean needCast = t.equals(Object.class) || Map.class.isAssignableFrom((Class<?>) t) || List.class.isAssignableFrom((Class<?>) t);
+        if (needCast) {
+            return Optional.of((Class<?>) t);
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    public TypedExpression getLeft() {
+        return left;
+    }
+
+    public TypedExpression getRight() {
+        return right;
+    }
+}
+
+class StringAsNumber extends SpecialComparisonCase {
+
+    StringAsNumber(TypedExpression left, TypedExpression right) {
+        super(left, right);
+    }
+
+    @Override
+    public ConstraintParser.SpecialComparisonResult createCompareMethod(BinaryExpr.Operator operator) {
+        String methodName = getMethodName(operator) + "StringsAsNumbers";
+        MethodCallExpr compareMethod = new MethodCallExpr(null, methodName);
+        compareMethod.addArgument(uncastExpr(left.getExpression()));
+        compareMethod.addArgument(uncastExpr(right.getExpression()));
+        return new ConstraintParser.SpecialComparisonResult(compareMethod, left, right);
+    }
+}
+
+class NumberComparisonWithoutCast extends SpecialComparisonCase {
+
+    NumberComparisonWithoutCast(TypedExpression left, TypedExpression right) {
+        super(left, right);
+    }
+
+    @Override
+    public ConstraintParser.SpecialComparisonResult createCompareMethod(BinaryExpr.Operator operator) {
+        String methodName = getMethodName(operator) + "Numbers";
+        MethodCallExpr compareMethod = new MethodCallExpr(null, methodName);
+        compareMethod.addArgument(uncastExpr(left.getExpression()));
+        compareMethod.addArgument(uncastExpr(right.getExpression()));
+        return new ConstraintParser.SpecialComparisonResult(compareMethod, left, right);
+    }
+}
+
+class NumberComparisonWithCast extends SpecialComparisonCase {
+
+    Optional<Class<?>> leftTypeCast;
+    Optional<Class<?>> rightTypeCast;
+
+    NumberComparisonWithCast(TypedExpression left, TypedExpression right, Optional<Class<?>> leftTypeCast, Optional<Class<?>> rightTypeCast) {
+        super(left, right);
+        this.leftTypeCast = leftTypeCast;
+        this.rightTypeCast = rightTypeCast;
+    }
+
+    @Override
+    public ConstraintParser.SpecialComparisonResult createCompareMethod(BinaryExpr.Operator operator) {
+        String methodName = getMethodName(operator) + "Numbers";
+        MethodCallExpr compareMethod = new MethodCallExpr(null, methodName);
+
+        ClassOrInterfaceType numberClass = toClassOrInterfaceType(Number.class);
+
+        if(leftTypeCast.isPresent()) {
+            CastExpr castExpr = new CastExpr(numberClass, left.getExpression());
+            compareMethod.addArgument(castExpr);
+            this.left = right.cloneWithNewExpression(castExpr);
+        } else {
+            compareMethod.addArgument(left.getExpression());
+        }
+
+
+        if(rightTypeCast.isPresent()) {
+            CastExpr castExpr = new CastExpr(numberClass, right.getExpression());
+            this.right = right.cloneWithNewExpression(castExpr);
+            compareMethod.addArgument(castExpr);
+        } else {
+            compareMethod.addArgument(right.getExpression());
+        }
+
+        return new ConstraintParser.SpecialComparisonResult(compareMethod, this.left, this.right);
+    }
+}
+
+class PlainEvaluation extends SpecialComparisonCase {
+
+    PlainEvaluation(TypedExpression left, TypedExpression right) {
+        super(left, right);
+    }
+
+    @Override
+    public ConstraintParser.SpecialComparisonResult createCompareMethod(BinaryExpr.Operator operator) {
+        String methodName = getMethodName(operator);
+        MethodCallExpr compareMethod = new MethodCallExpr(null, methodName);
+        compareMethod.addArgument(uncastExpr(left.getExpression()));
+        compareMethod.addArgument(uncastExpr(right.getExpression()));
+        return new ConstraintParser.SpecialComparisonResult(compareMethod, left, right);
+    }
+}

--- a/drools/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expression/AbstractExpressionBuilder.java
+++ b/drools/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expression/AbstractExpressionBuilder.java
@@ -252,7 +252,7 @@ public abstract class AbstractExpressionBuilder {
 
         // Use Number.class if they're both Numbers but different in order to use best possible type in the index
         Optional<Class<?>> numberType = leftType.flatMap(l -> rightType.map(r -> {
-            if (Number.class.isAssignableFrom(l) && Number.class.isAssignableFrom(r) && !l.equals(r)) {
+            if ((Number.class.isAssignableFrom(l) && Number.class.isAssignableFrom(r)) && !l.equals(r)) {
                 return Number.class;
             } else {
                 return l;

--- a/drools/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expressiontyper/ExpressionTyper.java
+++ b/drools/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/expressiontyper/ExpressionTyper.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.TypeVariable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -64,10 +65,9 @@ import org.drools.mvel.parser.printer.PrintUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.github.javaparser.ast.NodeList.nodeList;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
-
-import static com.github.javaparser.ast.NodeList.nodeList;
 import static org.drools.core.util.ClassUtils.getter2property;
 import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.THIS_PLACEHOLDER;
 import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.findRootNodeViaParent;
@@ -98,7 +98,6 @@ public class ExpressionTyper {
     private final List<Expression> prefixExpressions;
 
     private static final Logger logger          = LoggerFactory.getLogger(ExpressionTyper.class);
-
 
     public ExpressionTyper(RuleContext ruleContext, Class<?> patternType, String bindingId, boolean isPositional) {
         this(ruleContext, patternType, bindingId, isPositional, new ExpressionTyperContext());
@@ -176,7 +175,7 @@ public class ExpressionTyper {
         } else if (drlxExpr instanceof LiteralExpr) {
             return of(new TypedExpression(drlxExpr, getLiteralExpressionType( ( LiteralExpr ) drlxExpr )));
 
-        } else if (drlxExpr instanceof ThisExpr) {
+        } else if (drlxExpr instanceof ThisExpr || (drlxExpr instanceof NameExpr && THIS_PLACEHOLDER.equals(printConstraint(drlxExpr)))) {
             return of(new TypedExpression(new NameExpr(THIS_PLACEHOLDER), patternType));
 
         } else if (drlxExpr instanceof CastExpr) {
@@ -284,7 +283,7 @@ public class ExpressionTyper {
     private Optional<TypedExpression> createMapAccessExpression(Expression index, Expression scope) {
         MethodCallExpr mapAccessExpr = new MethodCallExpr(scope, "get" );
         mapAccessExpr.addArgument(index);
-        TypedExpression typedExpression = new TypedExpression(mapAccessExpr, Object.class);
+        TypedExpression typedExpression = new TypedExpression(mapAccessExpr, Map.class);
         return of(typedExpression);
     }
 
@@ -654,7 +653,12 @@ public class ExpressionTyper {
             return new TypedExpressionCursor(methodCallExpr, ((ParameterizedType) originalTypeCursor).getActualTypeArguments()[0]);
         }
 
-        return new TypedExpressionCursor(methodCallExpr, m.getGenericReturnType());
+        java.lang.reflect.Type genericReturnType = m.getGenericReturnType();
+        if (genericReturnType instanceof TypeVariable) {
+            return new TypedExpressionCursor(methodCallExpr, originalTypeCursor);
+        } else {
+            return new TypedExpressionCursor(methodCallExpr, genericReturnType);
+        }
     }
 
     private TypedExpressionCursor objectCreationExpr(ObjectCreationExpr objectCreationExpr) {
@@ -864,18 +868,15 @@ public class ExpressionTyper {
         return fieldName.getIdentifier();
     }
 
+
     public static Expression findLeftLeafOfNameExpr(Node expression) {
-        if(expression instanceof BinaryExpr) {
-            BinaryExpr be = (BinaryExpr)expression;
+        if (expression instanceof BinaryExpr) {
+            BinaryExpr be = (BinaryExpr) expression;
             return findLeftLeafOfNameExpr(be.getLeft());
-        } else if(expression instanceof DrlNameExpr) {
-            return (Expression) expression;
-        } else if(expression instanceof ThisExpr) {
-            return (Expression) expression;
-        } else if(expression instanceof PointFreeExpr) {
+        } else if (expression instanceof PointFreeExpr) {
             return findLeftLeafOfNameExpr(((PointFreeExpr) expression).getLeft());
         } else {
-            throw new UnsupportedOperationException("Unknown expression: " + expression);
+            return (Expression) expression;
         }
     }
 

--- a/drools/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/accumulate/AccumulateInline.java
+++ b/drools/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/accumulate/AccumulateInline.java
@@ -1,0 +1,292 @@
+package org.drools.modelcompiler.builder.generator.visitor.accumulate;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.VariableDeclarator;
+import com.github.javaparser.ast.expr.AssignExpr;
+import com.github.javaparser.ast.expr.ClassExpr;
+import com.github.javaparser.ast.expr.EnclosedExpr;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.FieldAccessExpr;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.MethodReferenceExpr;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.expr.VariableDeclarationExpr;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.ExpressionStmt;
+import com.github.javaparser.ast.stmt.ReturnStmt;
+import com.github.javaparser.ast.stmt.Statement;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import com.github.javaparser.ast.type.Type;
+import org.drools.compiler.lang.descr.AccumulateDescr;
+import org.drools.compiler.lang.descr.PatternDescr;
+import org.drools.modelcompiler.builder.PackageModel;
+import org.drools.modelcompiler.builder.generator.DeclarationSpec;
+import org.drools.modelcompiler.builder.generator.DrlxParseUtil;
+import org.drools.modelcompiler.builder.generator.RuleContext;
+import org.drools.modelcompiler.util.StringUtil;
+import org.drools.mvelcompiler.MvelCompiler;
+import org.drools.mvelcompiler.ParsingResult;
+import org.drools.mvelcompiler.context.MvelCompilerContext;
+
+import static com.github.javaparser.StaticJavaParser.parseStatement;
+import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.addCurlyBracesToBlock;
+import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.forceCastForName;
+import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.rescopeNamesToNewScope;
+import static org.drools.modelcompiler.builder.generator.DslMethodNames.ACC_FUNCTION_CALL;
+import static org.drools.modelcompiler.builder.generator.DslMethodNames.BIND_AS_CALL;
+import static org.drools.modelcompiler.builder.generator.visitor.accumulate.AccumulateVisitor.collectNamesInBlock;
+
+public class AccumulateInline {
+
+    protected final RuleContext context;
+    protected final PackageModel packageModel;
+    private AccumulateDescr accumulateDescr;
+    private PatternDescr basePattern;
+
+    private ClassOrInterfaceDeclaration accumulateInlineClass;
+    private ClassOrInterfaceDeclaration contextData;
+    private String accumulateInlineClassName;
+
+    private final List<DeclarationSpec> accumulateDeclarations = new ArrayList<>();
+    private final List<String> contextFieldNames = new ArrayList<>();
+    private Set<String> usedExternalDeclarations = new HashSet<>();
+    private Type singleAccumulateType;
+
+    Set<String> getUsedExternalDeclarations() {
+        return usedExternalDeclarations;
+    }
+
+    private MvelCompiler mvelCompiler;
+
+    AccumulateInline(RuleContext context,
+                     PackageModel packageModel,
+                     AccumulateDescr descr,
+                     PatternDescr basePattern) {
+        this.context = context;
+        this.packageModel = packageModel;
+        this.accumulateDescr = descr;
+        this.basePattern = basePattern;
+
+        MvelCompilerContext mvelCompilerContext = new MvelCompilerContext(context.getTypeResolver());
+
+        for (DeclarationSpec ds : context.getAllDeclarations()) {
+            mvelCompilerContext.addDeclaration(ds.getBindingId(), ds.getDeclarationClass());
+        }
+
+        mvelCompiler = new MvelCompiler(mvelCompilerContext);
+        singleAccumulateType = null;
+    }
+
+    /**
+     * By design this legacy accumulate (with inline custome code) visitor supports only with 1-and-only binding in the accumulate code/expressions.
+     */
+    void visitAccInlineCustomCode(MethodCallExpr accumulateDSL, Set<String> externalDeclarations, String identifier) {
+        initInlineAccumulateTemplate();
+
+        context.pushExprPointer(accumulateDSL::addArgument);
+
+        parseInitBlock();
+        Collection<String> allNamesInActionBlock = parseAccumulateMethod(externalDeclarations);
+        parseReverseBlock(externalDeclarations, allNamesInActionBlock);
+        parseResultMethod();
+
+        if (!usedExternalDeclarations.isEmpty()) {
+            throw new UnsupportedInlineAccumulate();
+        }
+
+        for (DeclarationSpec d : accumulateDeclarations) {
+            context.addDeclaration(d);
+        }
+
+        addAccumulateClassInitializationToMethod(accumulateDSL, identifier);
+
+        context.popExprPointer();
+    }
+
+    private void initInlineAccumulateTemplate() {
+        accumulateInlineClassName = StringUtil.toId(context.getRuleDescr().getName()) + "Accumulate" + accumulateDescr.getLine();
+
+        CompilationUnit templateCU;
+        try {
+            templateCU = StaticJavaParser.parseResource("AccumulateInlineTemplate.java");
+        } catch (IOException e) {
+            throw new InvalidInlineTemplateException(e);
+        }
+
+        ClassOrInterfaceDeclaration parsedClass =
+                templateCU
+                        .getClassByName("AccumulateInlineFunction")
+                        .orElseThrow(InvalidInlineTemplateException::new);
+
+        parsedClass.setName(accumulateInlineClassName);
+        parsedClass.findAll(ClassOrInterfaceType.class, c -> "CONTEXT_DATA_GENERIC".equals(c.asString()))
+                .forEach(c -> c.setName(accumulateInlineClassName + ".ContextData"));
+
+        this.accumulateInlineClass = parsedClass;
+
+        contextData = this.accumulateInlineClass.findFirst(ClassOrInterfaceDeclaration.class
+                , c -> "ContextData".equals(c.getNameAsString()))
+                .orElseThrow(InvalidInlineTemplateException::new);
+    }
+
+    private void parseInitBlock() {
+        MethodDeclaration initMethod = getMethodFromTemplateClass("init");
+        ParsingResult initCodeCompilationResult = mvelCompiler.compile(addCurlyBracesToBlock(accumulateDescr.getInitCode()));
+        BlockStmt initBlock = initCodeCompilationResult.statementResults();
+
+        for (Statement stmt : initBlock.getStatements()) {
+            final BlockStmt initMethodBody = initMethod.getBody().orElseThrow(InvalidInlineTemplateException::new);
+            if (stmt.isExpressionStmt() && stmt.asExpressionStmt().getExpression().isVariableDeclarationExpr()) {
+                VariableDeclarationExpr vdExpr = stmt.asExpressionStmt().getExpression().asVariableDeclarationExpr();
+                for (VariableDeclarator vd : vdExpr.getVariables()) {
+                    final String variableName = vd.getNameAsString();
+                    contextFieldNames.add(variableName);
+                    contextData.addField(vd.getType(), variableName, Modifier.publicModifier().getKeyword());
+                    Optional<Expression> optInitializer = vd.getInitializer();
+                    optInitializer.ifPresent(initializer -> {
+                        Expression target = new FieldAccessExpr(getDataNameExpr(), variableName);
+                        Statement initStmt = new ExpressionStmt(new AssignExpr(target, initializer, AssignExpr.Operator.ASSIGN));
+                        initMethodBody.addStatement(initStmt);
+                        initStmt.findAll(NameExpr.class).stream().map(Node::toString).filter(context::hasDeclaration).forEach(usedExternalDeclarations::add);
+                    });
+                    accumulateDeclarations.add(new DeclarationSpec(variableName, DrlxParseUtil.getClassFromContext(context.getTypeResolver(), vd.getType().asString())));
+                }
+            }
+        }
+    }
+
+    private void writeAccumulateMethod(List<String> contextFieldNames, MethodDeclaration accumulateMethod, BlockStmt actionBlock) {
+        for (Statement stmt : actionBlock.getStatements()) {
+            final ExpressionStmt convertedExpressionStatement = new ExpressionStmt();
+            for (ExpressionStmt eStmt : stmt.findAll(ExpressionStmt.class)) {
+                final Expression expressionUntyped = eStmt.getExpression();
+                final String parameterName = accumulateMethod.getParameter(1).getNameAsString();
+
+                forceCastForName(parameterName, singleAccumulateType, expressionUntyped);
+                rescopeNamesToNewScope(getDataNameExpr(), contextFieldNames, expressionUntyped);
+                convertedExpressionStatement.setExpression(expressionUntyped);
+            }
+            accumulateMethod.getBody().orElseThrow(InvalidInlineTemplateException::new)
+                    .addStatement(convertedExpressionStatement);
+        }
+    }
+
+    private Collection<String> parseAccumulateMethod(Set<String> externalDeclarations) {
+        MethodDeclaration accumulateMethod = getMethodFromTemplateClass("accumulate");
+
+        ParsingResult actionBlockCompilationResult = mvelCompiler.compile(addCurlyBracesToBlock(accumulateDescr.getActionCode()));
+
+        BlockStmt actionBlock = actionBlockCompilationResult.statementResults();
+
+        Collection<String> allNamesInActionBlock = collectNamesInBlock(actionBlock, context);
+        if (allNamesInActionBlock.size() == 1) {
+            String nameExpr = allNamesInActionBlock.iterator().next();
+            accumulateMethod.getParameter(1).setName(nameExpr);
+            singleAccumulateType =
+                    context.getDeclarationById(nameExpr)
+                            .orElseThrow(() -> new IllegalStateException("Cannot find declaration by name " + nameExpr + "!"))
+                            .getBoxedType();
+
+            writeAccumulateMethod(contextFieldNames, accumulateMethod, actionBlock);
+
+        } else {
+            allNamesInActionBlock.removeIf(name -> !externalDeclarations.contains(name));
+            usedExternalDeclarations.addAll(allNamesInActionBlock);
+            throw new UnsupportedInlineAccumulate();
+        }
+        return allNamesInActionBlock;
+    }
+
+    private void parseReverseBlock(Set<String> externalDeclarations, Collection<String> allNamesInActionBlock) {
+        ParsingResult reverseBlockCompilationResult = mvelCompiler.compile(addCurlyBracesToBlock(accumulateDescr.getReverseCode()));
+
+        BlockStmt reverseBlock = reverseBlockCompilationResult.statementResults();
+
+        if (accumulateDescr.getReverseCode() != null) {
+            Collection<String> allNamesInReverseBlock = collectNamesInBlock(reverseBlock, context);
+            if (allNamesInReverseBlock.size() == 1) {
+                MethodDeclaration reverseMethod = getMethodFromTemplateClass("reverse");
+                reverseMethod.getParameter(1).setName(allNamesInReverseBlock.iterator().next());
+                writeAccumulateMethod(contextFieldNames, reverseMethod, reverseBlock);
+
+                MethodDeclaration supportsReverseMethod = getMethodFromTemplateClass("supportsReverse");
+                supportsReverseMethod
+                        .getBody()
+                        .orElseThrow(InvalidInlineTemplateException::new)
+                        .addStatement(parseStatement("return true;"));
+            } else {
+                allNamesInActionBlock.removeIf(name -> !externalDeclarations.contains(name));
+                usedExternalDeclarations.addAll(allNamesInActionBlock);
+                throw new UnsupportedInlineAccumulate();
+            }
+        } else {
+            MethodDeclaration supportsReverseMethod = getMethodFromTemplateClass("supportsReverse");
+            supportsReverseMethod
+                    .getBody()
+                    .orElseThrow(InvalidInlineTemplateException::new)
+                    .addStatement(parseStatement("return false;"));
+
+            MethodDeclaration reverseMethod = getMethodFromTemplateClass("reverse");
+            reverseMethod
+                    .getBody()
+                    .orElseThrow(InvalidInlineTemplateException::new)
+                    .addStatement(parseStatement("throw new UnsupportedOperationException(\"This function does not support reverse.\");"));
+        }
+    }
+
+    private void parseResultMethod() {
+        // <result expression>: this is a semantic expression in the selected dialect that is executed after all source objects are iterated.
+        MethodDeclaration resultMethod = getMethodFromTemplateClass("getResult");
+        Type returnExpressionType = StaticJavaParser.parseType("java.lang.Object");
+        Expression returnExpression = StaticJavaParser.parseExpression(accumulateDescr.getResultCode());
+        if (returnExpression instanceof NameExpr) {
+            returnExpression = new EnclosedExpr(returnExpression);
+        }
+        rescopeNamesToNewScope(getDataNameExpr(), contextFieldNames, returnExpression);
+
+        resultMethod
+                .getBody()
+                .orElseThrow(InvalidInlineTemplateException::new)
+                .addStatement(new ReturnStmt(returnExpression));
+        MethodDeclaration getResultTypeMethod = getMethodFromTemplateClass("getResultType");
+        getResultTypeMethod
+                .getBody()
+                .orElseThrow(InvalidInlineTemplateException::new)
+                .addStatement(new ReturnStmt(new ClassExpr(returnExpressionType)));
+    }
+
+    private void addAccumulateClassInitializationToMethod(MethodCallExpr accumulateDSL, String identifier) {
+        this.packageModel.addGeneratedPOJO(accumulateInlineClass);
+
+        final MethodCallExpr functionDSL = new MethodCallExpr(null, ACC_FUNCTION_CALL);
+        functionDSL.addArgument(new MethodReferenceExpr(new NameExpr(accumulateInlineClassName), new NodeList<>(), "new"));
+        functionDSL.addArgument(context.getVarExpr(identifier));
+
+        final String bindingId = this.basePattern.getIdentifier();
+        final MethodCallExpr asDSL = new MethodCallExpr(functionDSL, BIND_AS_CALL);
+        asDSL.addArgument(context.getVarExpr(bindingId));
+        accumulateDSL.addArgument(asDSL);
+    }
+
+    private NameExpr getDataNameExpr() {
+        return new NameExpr("data");
+    }
+
+    private MethodDeclaration getMethodFromTemplateClass(String init) {
+        return accumulateInlineClass.getMethodsByName(init).get(0);
+    }
+}

--- a/drools/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/accumulate/AccumulateVisitor.java
+++ b/drools/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/accumulate/AccumulateVisitor.java
@@ -225,7 +225,7 @@ public abstract class AccumulateVisitor {
                         return Optional.empty();
                     }
                 });
-            } else if (accumulateFunctionParameter.isMethodCallExpr() || accumulateFunctionParameter.isArrayAccessExpr()) {
+            } else if (accumulateFunctionParameter.isMethodCallExpr() || accumulateFunctionParameter.isArrayAccessExpr() || accumulateFunctionParameter.isFieldAccessExpr()) {
 
                 final Expression parameterConverted;
                 if(accumulateFunctionParameter.isArrayAccessExpr()) {
@@ -233,8 +233,15 @@ public abstract class AccumulateVisitor {
                             .toTypedExpression(accumulateFunctionParameter)
                     .getTypedExpression().orElseThrow(() -> new RuntimeException("Cannot convert expression to method call"  + accumulateFunctionParameter))
                     .getExpression();
-                } else {
+                } else if(accumulateFunctionParameter.isMethodCallExpr()){
                     parameterConverted = DrlxParseUtil.sanitizeDrlNameExpr((MethodCallExpr) accumulateFunctionParameter);
+                } else if(accumulateFunctionParameter.isFieldAccessExpr()){
+                    parameterConverted = new ExpressionTyper(context, Object.class, null, false)
+                            .toTypedExpression(accumulateFunctionParameter)
+                            .getTypedExpression().orElseThrow(() -> new RuntimeException("Cannot convert expression to method call"  + accumulateFunctionParameter))
+                            .getExpression();
+                } else {
+                    parameterConverted = accumulateFunctionParameter;
                 }
 
                 final DrlxParseUtil.RemoveRootNodeResult methodCallWithoutRootNode = DrlxParseUtil.removeRootNode(parameterConverted);
@@ -259,7 +266,7 @@ public abstract class AccumulateVisitor {
                 final Class accumulateFunctionResultType = accumulateFunction.getResultType();
                 final String bindExpressionVariable = context.getExprId(accumulateFunctionResultType, typedExpression.toString());
 
-                final DrlxParseResult drlxParseResult = new ConstraintParser(context, context.getPackageModel()).drlxParse(Object.class, rootNodeName, accumulateFunctionParameterStr);
+                final DrlxParseResult drlxParseResult = new ConstraintParser(context, context.getPackageModel()).drlxParse(Object.class, rootNodeName, printConstraint(parameterConverted));
 
                 newBinding = drlxParseResult.acceptWithReturnValue(new ParseResultVisitor<Optional<NewBinding>>() {
                        @Override

--- a/drools/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/accumulate/AccumulateVisitor.java
+++ b/drools/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/accumulate/AccumulateVisitor.java
@@ -1,6 +1,5 @@
 package org.drools.modelcompiler.builder.generator.visitor.accumulate;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -9,31 +8,17 @@ import java.util.Optional;
 import java.util.Set;
 
 import com.github.javaparser.StaticJavaParser;
-import com.github.javaparser.ast.CompilationUnit;
-import com.github.javaparser.ast.Modifier;
-import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
-import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
-import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.Parameter;
-import com.github.javaparser.ast.body.VariableDeclarator;
-import com.github.javaparser.ast.expr.AssignExpr;
 import com.github.javaparser.ast.expr.BinaryExpr;
-import com.github.javaparser.ast.expr.ClassExpr;
-import com.github.javaparser.ast.expr.EnclosedExpr;
 import com.github.javaparser.ast.expr.Expression;
-import com.github.javaparser.ast.expr.FieldAccessExpr;
 import com.github.javaparser.ast.expr.LambdaExpr;
 import com.github.javaparser.ast.expr.LiteralExpr;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.MethodReferenceExpr;
 import com.github.javaparser.ast.expr.NameExpr;
-import com.github.javaparser.ast.expr.VariableDeclarationExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
-import com.github.javaparser.ast.stmt.ReturnStmt;
-import com.github.javaparser.ast.stmt.Statement;
-import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.type.UnknownType;
 import org.drools.compiler.lang.descr.AccumulateDescr;
 import org.drools.compiler.lang.descr.AndDescr;
@@ -58,23 +43,13 @@ import org.drools.modelcompiler.builder.generator.drlxparse.ParseResultVisitor;
 import org.drools.modelcompiler.builder.generator.drlxparse.SingleDrlxParseSuccess;
 import org.drools.modelcompiler.builder.generator.expression.AbstractExpressionBuilder;
 import org.drools.modelcompiler.builder.generator.expressiontyper.ExpressionTyper;
-import org.drools.modelcompiler.builder.generator.expressiontyper.TypedExpressionResult;
 import org.drools.modelcompiler.builder.generator.visitor.ModelGeneratorVisitor;
-import org.drools.modelcompiler.util.StringUtil;
 import org.drools.mvel.parser.ast.expr.DrlNameExpr;
-import org.drools.mvelcompiler.MvelCompiler;
-import org.drools.mvelcompiler.ParsingResult;
-import org.drools.mvelcompiler.context.MvelCompilerContext;
 import org.kie.api.runtime.rule.AccumulateFunction;
 
 import static java.util.stream.Collectors.toList;
-
-import static com.github.javaparser.StaticJavaParser.parseStatement;
-import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.addCurlyBracesToBlock;
 import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.addSemicolon;
-import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.forceCastForName;
 import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.getLiteralExpressionType;
-import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.rescopeNamesToNewScope;
 import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.validateDuplicateBindings;
 import static org.drools.modelcompiler.builder.generator.DslMethodNames.ACCUMULATE_CALL;
 import static org.drools.modelcompiler.builder.generator.DslMethodNames.ACC_FUNCTION_CALL;
@@ -87,10 +62,11 @@ public abstract class AccumulateVisitor {
 
     protected final RuleContext context;
     protected final PackageModel packageModel;
-    protected final ModelGeneratorVisitor modelGeneratorVisitor;
+
+    private final ModelGeneratorVisitor modelGeneratorVisitor;
     protected AbstractExpressionBuilder expressionBuilder;
 
-    public AccumulateVisitor(RuleContext context, ModelGeneratorVisitor modelGeneratorVisitor, PackageModel packageModel) {
+    AccumulateVisitor(RuleContext context, ModelGeneratorVisitor modelGeneratorVisitor, PackageModel packageModel) {
         this.context = context;
         this.modelGeneratorVisitor = modelGeneratorVisitor;
         this.packageModel = packageModel;
@@ -115,12 +91,10 @@ public abstract class AccumulateVisitor {
         }
 
         if (!descr.getFunctions().isEmpty()) {
-            boolean inputPatternHasConstraints = (input instanceof PatternDescr) && (!((PatternDescr) input).getConstraint().getDescrs().isEmpty());
-
             final List<String> allBindings = descr
                     .getFunctions()
                     .stream()
-                    .map(f -> f.getBind())
+                    .map(AccumulateDescr.AccumulateFunctionCallDescr::getBind)
                     .filter(Objects::nonNull)
                     .collect(toList());
 
@@ -131,23 +105,38 @@ public abstract class AccumulateVisitor {
             }
 
             for (AccumulateDescr.AccumulateFunctionCallDescr function : descr.getFunctions()) {
-                final Optional<NewBinding> optNewBinding = visit(context, function, accumulateDSL, basePattern, inputPatternHasConstraints);
+                final Optional<NewBinding> optNewBinding = visit(context, function, accumulateDSL, basePattern);
                 processNewBinding(optNewBinding);
             }
         } else if (descr.getFunctions().isEmpty() && descr.getInitCode() != null) {
             // LEGACY: Accumulate with inline custom code
+            AccumulateInline accumulateInline = new AccumulateInline(context, packageModel, descr, basePattern);
             if (input instanceof PatternDescr) {
-                visitAccInlineCustomCode(context, descr, accumulateDSL, basePattern, (PatternDescr) input, externalDeclrs);
+                try {
+                    accumulateInline.visitAccInlineCustomCode(accumulateDSL, externalDeclrs, ((PatternDescr) input).getIdentifier());
+                } catch (UnsupportedInlineAccumulate e) {
+                    new LegacyAccumulate(context, descr, basePattern, accumulateInline.getUsedExternalDeclarations()).build();
+                } catch (MissingSemicolonInlineAccumulateException e) {
+                    context.addCompilationError(new InvalidExpressionErrorResult(e.getMessage()));
+                }
             } else if (input instanceof AndDescr) {
-
                 BlockStmt actionBlock = parseBlockAddSemicolon(descr.getActionCode());
-                Collection<String> allNamesInActionBlock = collectNamesInBlock(context, actionBlock);
+                Collection<String> allNamesInActionBlock = collectNamesInBlock(actionBlock, context);
 
-                final Optional<BaseDescr> bindingUsedInAccumulate = ((AndDescr) input).getDescrs().stream().filter(b -> {
-                    return allNamesInActionBlock.contains(((PatternDescr) b).getIdentifier());
-                }).findFirst();
+                final Optional<BaseDescr> bindingUsedInAccumulate =
+                        ((AndDescr) input).getDescrs()
+                                .stream()
+                                .filter(b -> allNamesInActionBlock.contains(((PatternDescr) b).getIdentifier()))
+                                .findFirst();
 
-                bindingUsedInAccumulate.ifPresent(b -> visitAccInlineCustomCode(context, descr, accumulateDSL, basePattern, (PatternDescr) b, externalDeclrs));
+                if(bindingUsedInAccumulate.isPresent()) {
+                    BaseDescr binding = bindingUsedInAccumulate.get();
+                    try {
+                        accumulateInline.visitAccInlineCustomCode(accumulateDSL, externalDeclrs, ((PatternDescr) binding).getIdentifier());
+                    } catch (UnsupportedInlineAccumulate e) {
+                        new LegacyAccumulate(context, descr, basePattern, accumulateInline.getUsedExternalDeclarations()).build();
+                    }
+                }
             } else {
                 throw new UnsupportedOperationException("I was expecting input to be of type PatternDescr. " + input);
             }
@@ -159,7 +148,7 @@ public abstract class AccumulateVisitor {
         postVisit();
     }
 
-    protected Optional<AccumulateVisitorPatternDSL.NewBinding> visit(RuleContext context, AccumulateDescr.AccumulateFunctionCallDescr function, MethodCallExpr accumulateDSL, PatternDescr basePattern, boolean inputPatternHasConstraints) {
+    protected Optional<AccumulateVisitorPatternDSL.NewBinding> visit(RuleContext context, AccumulateDescr.AccumulateFunctionCallDescr function, MethodCallExpr accumulateDSL, PatternDescr basePattern) {
 
         context.pushExprPointer(accumulateDSL::addArgument);
 
@@ -170,16 +159,14 @@ public abstract class AccumulateVisitor {
 
         Optional<AccumulateVisitorPatternDSL.NewBinding> newBinding = Optional.empty();
 
-        if (function.getParams().length == 0) {
+        if(function.getParams().length == 0) {
             final Optional<AccumulateFunction> optAccumulateFunction = AccumulateVisitor.this.getAccumulateFunction(function, Object.class);
-            if (!optAccumulateFunction.isPresent()) {
+            if(!optAccumulateFunction.isPresent()) {
                 addNonExistingFunctionError(context, function);
                 return Optional.empty();
             }
-
             final AccumulateFunction accumulateFunction = optAccumulateFunction.get();
             validateAccFunctionTypeAgainstPatternType(context, basePattern, accumulateFunction);
-
             functionDSL.addArgument( createAccSupplierExpr( accumulateFunction ) );
             Class accumulateFunctionResultType = accumulateFunction.getResultType();
             context.addDeclarationReplacing(new DeclarationSpec(bindingId, accumulateFunctionResultType));
@@ -214,7 +201,6 @@ public abstract class AccumulateVisitor {
                         context.addDeclarationReplacing(new DeclarationSpec(singleResult.getPatternBinding(), exprRawClass));
 
                         functionDSL.addArgument( createAccSupplierExpr( accumulateFunction ) );
-
                         final MethodCallExpr newBindingFromBinary = AccumulateVisitor.this.buildBinding(bindExpressionVariable, singleResult.getUsedDeclarations(), singleResult.getExpr());
                         context.addDeclarationReplacing(new DeclarationSpec(bindExpressionVariable, exprRawClass));
                         functionDSL.addArgument(context.getVarExpr(bindExpressionVariable));
@@ -232,8 +218,8 @@ public abstract class AccumulateVisitor {
                 if(accumulateFunctionParameter.isArrayAccessExpr()) {
                     parameterConverted = new ExpressionTyper(context, Object.class, null, false)
                             .toTypedExpression(accumulateFunctionParameter)
-                    .getTypedExpression().orElseThrow(() -> new RuntimeException("Cannot convert expression to method call"  + accumulateFunctionParameter))
-                    .getExpression();
+                            .getTypedExpression().orElseThrow(() -> new RuntimeException("Cannot convert expression to method call"  + accumulateFunctionParameter))
+                            .getExpression();
                 } else if(accumulateFunctionParameter.isMethodCallExpr()){
                     parameterConverted = DrlxParseUtil.sanitizeDrlNameExpr((MethodCallExpr) accumulateFunctionParameter);
                 } else if(accumulateFunctionParameter.isFieldAccessExpr()){
@@ -260,7 +246,7 @@ public abstract class AccumulateVisitor {
 
                 final AccumulateFunction accumulateFunction = optAccumulateFunction.get();
                 validateAccFunctionTypeAgainstPatternType(context, basePattern, accumulateFunction);
-                functionDSL.addArgument(createAccSupplierExpr( accumulateFunction ));
+                functionDSL.addArgument( createAccSupplierExpr( accumulateFunction ) );
 
                 // Every expression in an accumulate function gets transformed in a bind expression with a generated id
                 // Then the accumulate function will have that binding expression as a source
@@ -270,23 +256,23 @@ public abstract class AccumulateVisitor {
                 final DrlxParseResult drlxParseResult = new ConstraintParser(context, context.getPackageModel()).drlxParse(Object.class, rootNodeName, printConstraint(parameterConverted));
 
                 newBinding = drlxParseResult.acceptWithReturnValue(new ParseResultVisitor<Optional<NewBinding>>() {
-                       @Override
-                       public Optional<NewBinding> onSuccess(DrlxParseSuccess result) {
-                           SingleDrlxParseSuccess singleResult = (SingleDrlxParseSuccess) drlxParseResult;
-                           singleResult.setExprBinding(bindExpressionVariable);
-                           final MethodCallExpr binding = expressionBuilder.buildBinding(singleResult);
-                           context.addDeclarationReplacing(new DeclarationSpec(bindExpressionVariable, methodCallExprType));
-                           functionDSL.addArgument(context.getVarExpr(bindExpressionVariable));
+                                                                       @Override
+                                                                       public Optional<NewBinding> onSuccess(DrlxParseSuccess result) {
+                                                                           SingleDrlxParseSuccess singleResult = (SingleDrlxParseSuccess) drlxParseResult;
+                                                                           singleResult.setExprBinding(bindExpressionVariable);
+                                                                           final MethodCallExpr binding = expressionBuilder.buildBinding(singleResult);
+                                                                           context.addDeclarationReplacing(new DeclarationSpec(bindExpressionVariable, methodCallExprType));
+                                                                           functionDSL.addArgument(context.getVarExpr(bindExpressionVariable));
 
-                           context.addDeclarationReplacing(new DeclarationSpec(bindingId, accumulateFunctionResultType));
-                           return Optional.of(new NewBinding(Optional.of(singleResult.getPatternBinding()), binding));
-                       }
+                                                                           context.addDeclarationReplacing(new DeclarationSpec(bindingId, accumulateFunctionResultType));
+                                                                           return Optional.of(new NewBinding(Optional.of(singleResult.getPatternBinding()), binding));
+                                                                       }
 
-                       @Override
-                       public Optional<NewBinding> onFail(DrlxParseFail failure) {
-                           return Optional.empty();
-                       }
-                   }
+                                                                       @Override
+                                                                       public Optional<NewBinding> onFail(DrlxParseFail failure) {
+                                                                           return Optional.empty();
+                                                                       }
+                                                                   }
                 );
 
             } else if (accumulateFunctionParameter instanceof DrlNameExpr) {
@@ -305,7 +291,7 @@ public abstract class AccumulateVisitor {
                 final AccumulateFunction accumulateFunction = optAccumulateFunction.get();
                 validateAccFunctionTypeAgainstPatternType(context, basePattern, accumulateFunction);
                 functionDSL.addArgument( createAccSupplierExpr( accumulateFunction ) );
-                functionDSL.addArgument( context.getVarExpr(nameExpr) );
+                functionDSL.addArgument(context.getVarExpr(nameExpr));
 
                 addBindingAsDeclaration(context, bindingId, accumulateFunction);
             } else if (accumulateFunctionParameter instanceof LiteralExpr) {
@@ -341,7 +327,7 @@ public abstract class AccumulateVisitor {
 
     private static MethodReferenceExpr createAccSupplierExpr( AccumulateFunction accumulateFunction ) {
         NameExpr nameExpr = new NameExpr( accumulateFunction.getClass().getCanonicalName() );
-        return new MethodReferenceExpr( nameExpr, new NodeList<Type>(), "new" );
+        return new MethodReferenceExpr(nameExpr, new NodeList<>(), "new" );
     }
 
     private void validateAccFunctionTypeAgainstPatternType(RuleContext context, PatternDescr basePattern, AccumulateFunction accumulateFunction) {
@@ -361,7 +347,7 @@ public abstract class AccumulateVisitor {
                             "Pattern of type: '[ClassObjectType class=%s]' " +
                                     "on rule '%s' " +
                                     "is not compatible with type %s returned by accumulate function."
-                                    , expectedResultType.getCanonicalName(), context.getRuleName(), actualResultType.getCanonicalName())));
+                            , expectedResultType.getCanonicalName(), context.getRuleName(), actualResultType.getCanonicalName())));
         }
     }
 
@@ -382,7 +368,7 @@ public abstract class AccumulateVisitor {
         }
     }
 
-    protected Optional<AccumulateFunction> getAccumulateFunction(AccumulateDescr.AccumulateFunctionCallDescr function, Class<?> methodCallExprType) {
+    Optional<AccumulateFunction> getAccumulateFunction(AccumulateDescr.AccumulateFunctionCallDescr function, Class<?> methodCallExprType) {
         final String accumulateFunctionName = AccumulateUtil.getFunctionName(() -> methodCallExprType, function.getFunction());
         final Optional<AccumulateFunction> bundledAccumulateFunction = Optional.ofNullable(packageModel.getConfiguration().getAccumulateFunction(accumulateFunctionName));
         final Optional<AccumulateFunction> importedAccumulateFunction = Optional.ofNullable(packageModel.getAccumulateFunctions().get(accumulateFunctionName));
@@ -392,7 +378,7 @@ public abstract class AccumulateVisitor {
                 .orElse(importedAccumulateFunction);
     }
 
-    protected String getRootNodeName(DrlxParseUtil.RemoveRootNodeResult methodCallWithoutRootNode) {
+    String getRootNodeName(DrlxParseUtil.RemoveRootNodeResult methodCallWithoutRootNode) {
         final Expression rootNode = methodCallWithoutRootNode.getRootNode().orElseThrow(UnsupportedOperationException::new);
 
         final String rootNodeName;
@@ -404,7 +390,7 @@ public abstract class AccumulateVisitor {
         return rootNodeName;
     }
 
-    protected TypedExpression parseMethodCallType(RuleContext context, String variableName, Expression methodCallWithoutRoot) {
+    TypedExpression parseMethodCallType(RuleContext context, String variableName, Expression methodCallWithoutRoot) {
         final Class clazz = context.getDeclarationById(variableName)
                 .map(DeclarationSpec::getDeclarationClass)
                 .orElseThrow(RuntimeException::new);
@@ -412,7 +398,7 @@ public abstract class AccumulateVisitor {
         return DrlxParseUtil.toMethodCallWithClassCheck(context, methodCallWithoutRoot, null, clazz, context.getTypeResolver());
     }
 
-    protected Expression buildConstraintExpression(Expression expr, Collection<String> usedDeclarations) {
+    Expression buildConstraintExpression(Expression expr, Collection<String> usedDeclarations) {
         LambdaExpr lambdaExpr = new LambdaExpr();
         lambdaExpr.setEnclosingParameters(true);
         usedDeclarations.stream().map(s -> new Parameter(new UnknownType(), s)).forEach(lambdaExpr::addParameter);
@@ -420,198 +406,14 @@ public abstract class AccumulateVisitor {
         return lambdaExpr;
     }
 
-    /**
-     * By design this legacy accumulate (with inline custome code) visitor supports only with 1-and-only binding in the accumulate code/expressions.
-     */
-    protected void visitAccInlineCustomCode(RuleContext context2, AccumulateDescr descr, MethodCallExpr accumulateDSL, PatternDescr basePattern, PatternDescr inputDescr, Set<String> externalDeclrs) {
-        context.pushExprPointer(accumulateDSL::addArgument);
-
-        String targetClassName = StringUtil.toId(context2.getRuleDescr().getName()) + "Accumulate" + descr.getLine();
-        String code = ACCUMULATE_INLINE_FUNCTION.replaceAll("AccumulateInlineFunction", targetClassName);
-
-        CompilationUnit templateCU = StaticJavaParser.parse(code);
-        ClassOrInterfaceDeclaration templateClass = templateCU.getClassByName(targetClassName).orElseThrow(() -> new RuntimeException("Template did not contain expected type definition."));
-        ClassOrInterfaceDeclaration templateContextClass = templateClass.getMembers().stream().filter(m -> m instanceof ClassOrInterfaceDeclaration && ((ClassOrInterfaceDeclaration) m).getNameAsString().equals("ContextData")).map(ClassOrInterfaceDeclaration.class::cast).findFirst().orElseThrow(() -> new RuntimeException("Template did not contain expected type definition."));
-
-        List<String> contextFieldNames = new ArrayList<>();
-        MethodDeclaration initMethod = templateClass.getMethodsByName("init").get(0);
-        BlockStmt initBlock = StaticJavaParser.parseBlock("{" + descr.getInitCode() + "}");
-        List<DeclarationSpec> accumulateDeclarations = new ArrayList<>();
-        Set<String> usedExtDeclrs = parseInitBlock(context2, templateContextClass, contextFieldNames, initMethod, initBlock, accumulateDeclarations );
-
-        boolean useLegacyAccumulate = false;
-        Type singleAccumulateType = null;
-        MethodDeclaration accumulateMethod = templateClass.getMethodsByName("accumulate").get(0);
-        BlockStmt actionBlock = parseBlockAddSemicolon(descr.getActionCode());
-        Collection<String> allNamesInActionBlock = collectNamesInBlock(context2, actionBlock);
-        if (allNamesInActionBlock.size() == 1) {
-            String nameExpr = allNamesInActionBlock.iterator().next();
-            accumulateMethod.getParameter(1).setName(nameExpr);
-            singleAccumulateType = context2.getDeclarationById(nameExpr).get().getBoxedType();
-        } else {
-            allNamesInActionBlock.removeIf( name -> !externalDeclrs.contains( name ) );
-            usedExtDeclrs.addAll( allNamesInActionBlock );
-            useLegacyAccumulate = true;
-        }
-
-        Optional<MethodDeclaration> optReverseMethod = Optional.empty();
-        if(descr.getReverseCode() != null) {
-            BlockStmt reverseBlock = parseBlockAddSemicolon(descr.getReverseCode());
-            Collection<String> allNamesInReverseBlock = collectNamesInBlock(context2, reverseBlock);
-            if (allNamesInReverseBlock.size() == 1) {
-                MethodDeclaration reverseMethod = templateClass.getMethodsByName("reverse").get(0);
-                reverseMethod.getParameter(1).setName(allNamesInReverseBlock.iterator().next());
-                optReverseMethod = Optional.of(reverseMethod);
-            } else {
-                allNamesInActionBlock.removeIf( name -> !externalDeclrs.contains( name ) );
-                usedExtDeclrs.addAll( allNamesInActionBlock );
-                useLegacyAccumulate = true;
-            }
-        }
-
-        if ( useLegacyAccumulate || !usedExtDeclrs.isEmpty() ) {
-            new LegacyAccumulate(context, descr, basePattern, usedExtDeclrs).build();
-            return;
-        }
-
-        for(DeclarationSpec d : accumulateDeclarations) {
-            context2.addDeclaration(d);
-        }
-
-        writeAccumulateMethod(contextFieldNames, singleAccumulateType, accumulateMethod, actionBlock);
-
-        // <result expression>: this is a semantic expression in the selected dialect that is executed after all source objects are iterated.
-        MethodDeclaration resultMethod = templateClass.getMethodsByName("getResult").get(0);
-        Type returnExpressionType = StaticJavaParser.parseType("java.lang.Object");
-        Expression returnExpression = StaticJavaParser.parseExpression(descr.getResultCode());
-        if (returnExpression instanceof NameExpr) {
-            returnExpression = new EnclosedExpr(returnExpression);
-        }
-        rescopeNamesToNewScope(new NameExpr("data"), contextFieldNames, returnExpression);
-        resultMethod.getBody().get().addStatement(new ReturnStmt(returnExpression));
-        MethodDeclaration getResultTypeMethod = templateClass.getMethodsByName("getResultType").get(0);
-        getResultTypeMethod.getBody().get().addStatement(new ReturnStmt(new ClassExpr(returnExpressionType)));
-
-        if (optReverseMethod.isPresent()) {
-            MethodDeclaration supportsReverseMethod = templateClass.getMethodsByName("supportsReverse").get(0);
-            supportsReverseMethod.getBody().get().addStatement(parseStatement("return true;"));
-
-            BlockStmt reverseBlock = parseBlockAddSemicolon(descr.getReverseCode());
-            writeAccumulateMethod(contextFieldNames, singleAccumulateType, optReverseMethod.get(), reverseBlock);
-        } else {
-            MethodDeclaration supportsReverseMethod = templateClass.getMethodsByName("supportsReverse").get(0);
-            supportsReverseMethod.getBody().get().addStatement(parseStatement("return false;"));
-
-            MethodDeclaration reverseMethod = templateClass.getMethodsByName("reverse").get(0);
-            reverseMethod.getBody().get().addStatement(parseStatement("throw new UnsupportedOperationException(\"This function does not support reverse.\");"));
-        }
-
-        // add resulting accumulator class into the package model
-        this.packageModel.addGeneratedPOJO(templateClass);
-
-        final MethodCallExpr functionDSL = new MethodCallExpr(null, ACC_FUNCTION_CALL);
-        functionDSL.addArgument( new MethodReferenceExpr(new NameExpr( targetClassName ), new NodeList<Type>(), "new") );
-        functionDSL.addArgument( context.getVarExpr(inputDescr.getIdentifier()) );
-
-        final String bindingId = basePattern.getIdentifier();
-        final MethodCallExpr asDSL = new MethodCallExpr(functionDSL, BIND_AS_CALL);
-        asDSL.addArgument( context.getVarExpr( bindingId ) );
-        accumulateDSL.addArgument(asDSL);
-
-        context.popExprPointer();
-    }
-
-    private Set<String> parseInitBlock(RuleContext context2, ClassOrInterfaceDeclaration templateContextClass, List<String> contextFieldNames, MethodDeclaration initMethod, BlockStmt initBlock, List<DeclarationSpec> accumulateDeclarations) {
-        Set<String> externalDeclrs = new HashSet<>();
-
-        for (Statement stmt : initBlock.getStatements()) {
-            final BlockStmt initMethodBody = initMethod.getBody().get();
-            if (stmt instanceof ExpressionStmt && ((ExpressionStmt) stmt).getExpression() instanceof VariableDeclarationExpr ) {
-                VariableDeclarationExpr vdExpr = (VariableDeclarationExpr) ((ExpressionStmt) stmt).getExpression();
-                for (VariableDeclarator vd : vdExpr.getVariables()) {
-                    final String variableName = vd.getNameAsString();
-                    contextFieldNames.add(variableName);
-                    templateContextClass.addField(vd.getType(), variableName, Modifier.publicModifier().getKeyword());
-                    createInitializer(variableName, vd.getInitializer()).ifPresent(statement -> {
-                        initMethodBody.addStatement(statement);
-                        statement.findAll(NameExpr.class).stream().map(Node::toString).filter(context2::hasDeclaration ).forEach(externalDeclrs::add );
-                    }
-                    );
-                    accumulateDeclarations.add(new DeclarationSpec(variableName, DrlxParseUtil.getClassFromContext(context2.getTypeResolver(), vd.getType().asString()) ));
-                }
-            } else {
-                if(stmt.isExpressionStmt()) {
-                    final Expression statementExpression = stmt.asExpressionStmt().getExpression();
-                    if(statementExpression.isAssignExpr()) {
-                        final AssignExpr assignExpr = statementExpression.asAssignExpr();
-                        final String targetName = assignExpr.getTarget().asNameExpr().toString();
-                        // Mvel allows using a field without declaration
-                        if(!contextFieldNames.contains(targetName)) {
-                            contextFieldNames.add(targetName);
-                            final String variableName = assignExpr.getTarget().toString();
-                            final Expression initCreationExpression = assignExpr.getValue();
-
-                            MvelCompilerContext mvelCompilerContext = new MvelCompilerContext(context2.getTypeResolver());
-                            ParsingResult compile = new MvelCompiler(mvelCompilerContext).compile(addCurlyBracesToBlock(printConstraint(stmt)));
-
-                            final Type type =
-                                    compile.lastExpressionType()
-                                    .map(t -> DrlxParseUtil.classToReferenceType((Class<?>) t))
-                                    .orElseThrow(() -> new RuntimeException("Unknown type: " + initCreationExpression));
-
-                            templateContextClass.addField(type, variableName, Modifier.publicModifier().getKeyword());
-                            final Optional<Statement> initializer = createInitializer(variableName, Optional.of(initCreationExpression));
-                            initializer.ifPresent(initMethodBody::addStatement);
-                            accumulateDeclarations.add(new DeclarationSpec(variableName, DrlxParseUtil.getClassFromContext(context2.getTypeResolver(), type.asString())));
-                        }
-
-                    }
-                } else {
-                    initMethodBody.addStatement(stmt); // add as-is.
-                }
-            }
-        }
-
-        return externalDeclrs;
-    }
 
     private BlockStmt parseBlockAddSemicolon(String block) {
         return StaticJavaParser.parseBlock(String.format("{%s}", addSemicolon(block)));
     }
 
-    private Optional<Statement> createInitializer(String variableName, Optional<Expression> optInitializer) {
-        if (optInitializer.isPresent()) {
-            Expression initializer = optInitializer.get();
-            Expression target = new FieldAccessExpr(new NameExpr("data"), variableName);
-            Statement initStmt = new ExpressionStmt(new AssignExpr(target, initializer, AssignExpr.Operator.ASSIGN));
-            return Optional.of(initStmt);
-        }
-        return Optional.empty();
-    }
-
-    void writeAccumulateMethod(List<String> contextFieldNames, Type singleAccumulateType, MethodDeclaration accumulateMethod, BlockStmt actionBlock) {
-        for (Statement stmt : actionBlock.getStatements()) {
-            final ExpressionStmt convertedExpressionStatement = new ExpressionStmt();
-            for (ExpressionStmt eStmt : stmt.findAll(ExpressionStmt.class)) {
-                final Expression expressionUntyped = eStmt.getExpression();
-                final String parameterName = accumulateMethod.getParameter(1).getNameAsString();
-
-                final ExpressionTyper expressionTyper = new ExpressionTyper(context, Object.class, "", false);
-                final TypedExpressionResult typedExpression = expressionTyper.toTypedExpression(expressionUntyped);
-
-                final Expression expression = typedExpression.getTypedExpression().get().getExpression();
-
-                forceCastForName(parameterName, singleAccumulateType, expression);
-                rescopeNamesToNewScope(new NameExpr("data"), contextFieldNames, expression);
-                convertedExpressionStatement.setExpression(expression);
-            }
-            accumulateMethod.getBody().get().addStatement(convertedExpressionStatement);
-        }
-    }
-
-    List<String> collectNamesInBlock(RuleContext context2, BlockStmt block) {
+    static List<String> collectNamesInBlock(BlockStmt block, RuleContext context) {
         return block.findAll(NameExpr.class, n -> {
-            Optional<DeclarationSpec> optD = context2.getDeclarationById(n.getNameAsString());
+            Optional<DeclarationSpec> optD = context.getDeclarationById(n.getNameAsString());
             return optD.filter(d -> !d.isGlobal()).isPresent(); // Global aren't supported
         })
                 .stream()
@@ -621,7 +423,7 @@ public abstract class AccumulateVisitor {
     }
     /*
         Since accumulate are always relative to the Pattern, it may happen that the declaration inside the accumulate
-        was already set in the relative Pattern.
+        was already se  t in the relative Pattern.
         Here though the type is more precise as it checks the result type Accumulate Function, so we use
         addDeclarationReplacing instead of addDeclaration to overwrite the previous declaration.
      */
@@ -632,52 +434,14 @@ public abstract class AccumulateVisitor {
 
     protected abstract void postVisit();
 
-    public static class NewBinding {
+    static class NewBinding {
 
         Optional<String> patternBinding;
         MethodCallExpr bindExpression;
 
-        public NewBinding(Optional<String> patternBinding, MethodCallExpr bindExpression) {
+        NewBinding(Optional<String> patternBinding, MethodCallExpr bindExpression) {
             this.patternBinding = patternBinding;
             this.bindExpression = bindExpression;
         }
     }
-
-    private static final String ACCUMULATE_INLINE_FUNCTION =
-            "public class AccumulateInlineFunction implements org.kie.api.runtime.rule.AccumulateFunction<AccumulateInlineFunction.ContextData> {\n" +
-                    "\n" +
-                    "    public static class ContextData implements java.io.Serializable {\n" +
-                    "        // context fields will go here.\n" +
-                    "    }\n" +
-                    "\n" +
-                    "    public void readExternal(java.io.ObjectInput in) throws java.io.IOException, ClassNotFoundException {\n" +
-                    "        // functions are stateless, so nothing to serialize\n" +
-                    "    }\n" +
-                    "\n" +
-                    "    public void writeExternal(java.io.ObjectOutput out) throws java.io.IOException {\n" +
-                    "        // functions are stateless, so nothing to serialize\n" +
-                    "    }\n" +
-                    "\n" +
-                    "    public ContextData createContext() {\n" +
-                    "        return new ContextData();\n" +
-                    "    }\n" +
-                    "\n" +
-                    "    public void init(ContextData data) {\n" +
-                    "    }\n" +
-                    "\n" +
-                    "    public void accumulate(ContextData data, Object $single) {\n" +
-                    "    }\n" +
-                    "\n" +
-                    "    public void reverse(ContextData data, Object $single) {\n" +
-                    "    }\n" +
-                    "\n" +
-                    "    public Object getResult(ContextData data) {\n" +
-                    "    }\n" +
-                    "\n" +
-                    "    public boolean supportsReverse() {\n" +
-                    "    }\n" +
-                    "\n" +
-                    "    public Class<?> getResultType() {\n" +
-                    "    }\n" +
-                    "}";
 }

--- a/drools/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/accumulate/AccumulateVisitor.java
+++ b/drools/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/accumulate/AccumulateVisitor.java
@@ -299,7 +299,7 @@ public abstract class AccumulateVisitor {
                 functionDSL.addArgument( createAccSupplierExpr( accumulateFunction ) );
                 functionDSL.addArgument( context.getVarExpr(nameExpr) );
 
-                addBindingAsDeclaration(context, bindingId, declarationClass, accumulateFunction);
+                addBindingAsDeclaration(context, bindingId, accumulateFunction);
             } else if (accumulateFunctionParameter instanceof LiteralExpr) {
                 final Class<?> declarationClass = getLiteralExpressionType((LiteralExpr) accumulateFunctionParameter);
 
@@ -314,7 +314,7 @@ public abstract class AccumulateVisitor {
                 functionDSL.addArgument( createAccSupplierExpr( accumulateFunction ) );
                 functionDSL.addArgument(new MethodCallExpr(null, VALUE_OF_CALL, NodeList.nodeList(accumulateFunctionParameter)));
 
-                addBindingAsDeclaration(context, bindingId, declarationClass, accumulateFunction);
+                addBindingAsDeclaration(context, bindingId, accumulateFunction);
             } else {
                 context.addCompilationError(new InvalidExpressionErrorResult("Invalid expression " + accumulateFunctionParameterStr));
                 return Optional.empty();
@@ -367,13 +367,9 @@ public abstract class AccumulateVisitor {
         context.addCompilationError(new InvalidExpressionErrorResult(String.format("Unknown accumulate function: '%s' on rule '%s'.", function.getFunction(), context.getRuleDescr().getName())));
     }
 
-    private void addBindingAsDeclaration(RuleContext context, String bindingId, Class<?> declarationClass, AccumulateFunction accumulateFunction) {
+    private void addBindingAsDeclaration(RuleContext context, String bindingId, AccumulateFunction accumulateFunction) {
         if (bindingId != null) {
             Class accumulateFunctionResultType = accumulateFunction.getResultType();
-            if ((accumulateFunctionResultType == Comparable.class || accumulateFunctionResultType == Number.class) &&
-                    (Comparable.class.isAssignableFrom(declarationClass) || declarationClass.isPrimitive())) {
-                accumulateFunctionResultType = declarationClass;
-            }
             context.addDeclarationReplacing(new DeclarationSpec(bindingId, accumulateFunctionResultType));
         }
     }

--- a/drools/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/accumulate/AccumulateVisitor.java
+++ b/drools/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/accumulate/AccumulateVisitor.java
@@ -71,6 +71,7 @@ import static java.util.stream.Collectors.toList;
 
 import static com.github.javaparser.StaticJavaParser.parseStatement;
 import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.addCurlyBracesToBlock;
+import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.addSemicolon;
 import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.forceCastForName;
 import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.getLiteralExpressionType;
 import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.rescopeNamesToNewScope;
@@ -575,8 +576,7 @@ public abstract class AccumulateVisitor {
     }
 
     private BlockStmt parseBlockAddSemicolon(String block) {
-        final String withTerminator = block.endsWith(";") ? block : block + ";";
-        return StaticJavaParser.parseBlock("{" + withTerminator + "}");
+        return StaticJavaParser.parseBlock(String.format("{%s}", addSemicolon(block)));
     }
 
     private Optional<Statement> createInitializer(String variableName, Optional<Expression> optInitializer) {

--- a/drools/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/accumulate/InvalidInlineTemplateException.java
+++ b/drools/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/accumulate/InvalidInlineTemplateException.java
@@ -1,0 +1,16 @@
+package org.drools.modelcompiler.builder.generator.visitor.accumulate;
+
+public class InvalidInlineTemplateException extends RuntimeException {
+
+    InvalidInlineTemplateException() {
+    }
+
+    InvalidInlineTemplateException(Throwable cause) {
+        super(cause);
+    }
+
+    @Override
+    public String getMessage() {
+        return "Inline accumulate template is not valid";
+    }
+}

--- a/drools/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/accumulate/MissingSemicolonInlineAccumulateException.java
+++ b/drools/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/accumulate/MissingSemicolonInlineAccumulateException.java
@@ -1,0 +1,16 @@
+package org.drools.modelcompiler.builder.generator.visitor.accumulate;
+
+public class MissingSemicolonInlineAccumulateException extends RuntimeException {
+
+    private final String field;
+
+    MissingSemicolonInlineAccumulateException(String field) {
+
+        this.field = field;
+    }
+
+    @Override
+    public String getMessage() {
+        return String.format("Syntax error in %s block, insert ; to complete Statement ", field);
+    }
+}

--- a/drools/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/accumulate/UnsupportedInlineAccumulate.java
+++ b/drools/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/accumulate/UnsupportedInlineAccumulate.java
@@ -1,0 +1,5 @@
+package org.drools.modelcompiler.builder.generator.visitor.accumulate;
+
+public class UnsupportedInlineAccumulate extends RuntimeException {
+
+}

--- a/drools/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/pattern/FlowDSLPattern.java
+++ b/drools/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/pattern/FlowDSLPattern.java
@@ -24,8 +24,11 @@ import static org.drools.modelcompiler.builder.generator.DslMethodNames.WATCH_CA
 
 class FlowDSLPattern extends PatternDSL {
 
+    private final boolean allConstraintsPositional;
+
     public FlowDSLPattern(RuleContext context, PackageModel packageModel, PatternDescr pattern, List<? extends BaseDescr> constraintDescrs, Class<?> patternType, boolean allConstraintsPositional) {
-        super(context, packageModel, pattern, constraintDescrs, allConstraintsPositional, patternType);
+        super(context, packageModel, pattern, constraintDescrs, patternType);
+        this.allConstraintsPositional = allConstraintsPositional;
     }
 
     @Override

--- a/drools/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/pattern/PatternDSL.java
+++ b/drools/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/pattern/PatternDSL.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.github.javaparser.ast.expr.BinaryExpr;
 import org.drools.compiler.lang.descr.AccumulateDescr;
 import org.drools.compiler.lang.descr.BaseDescr;
 import org.drools.compiler.lang.descr.ExprConstraintDescr;
@@ -35,6 +36,7 @@ import org.drools.modelcompiler.builder.generator.visitor.FromVisitor;
 import static org.drools.model.impl.NamesGenerator.generateName;
 import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.getPatternListenedProperties;
 import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.validateDuplicateBindings;
+import static org.drools.mvel.parser.printer.PrintUtil.printConstraint;
 
 public abstract class PatternDSL implements DSLNode {
 
@@ -43,16 +45,14 @@ public abstract class PatternDSL implements DSLNode {
     protected final RuleContext context;
     protected final PackageModel packageModel;
     protected final PatternDescr pattern;
-    protected final List<? extends BaseDescr> constraintDescrs;
-    protected final Class<?> patternType;
-    protected final boolean allConstraintsPositional;
+    private final List<? extends BaseDescr> constraintDescrs;
+    protected Class<?> patternType;
 
-    PatternDSL(RuleContext context, PackageModel packageModel, PatternDescr pattern, List<? extends BaseDescr> constraintDescrs, boolean allConstraintsPositional, Class<?> patternType) {
+    PatternDSL(RuleContext context, PackageModel packageModel, PatternDescr pattern, List<? extends BaseDescr> constraintDescrs, Class<?> patternType) {
         this.context = context;
         this.packageModel = packageModel;
         this.pattern = pattern;
         this.constraintDescrs = constraintDescrs;
-        this.allConstraintsPositional = allConstraintsPositional;
         this.patternType = patternType;
     }
 
@@ -62,25 +62,14 @@ public abstract class PatternDSL implements DSLNode {
         return context.addDeclaration(pattern.getIdentifier(), patternType, Optional.of(pattern), declarationSource);
     }
 
-    protected static boolean isPositional(BaseDescr constraint) {
+    private static boolean isPositional(BaseDescr constraint) {
         return constraint instanceof ExprConstraintDescr &&
                 ((ExprConstraintDescr) constraint).getType() == ExprConstraintDescr.Type.POSITIONAL &&
                 !constraint.getText().contains( ":=" );
     }
 
-    private Optional<String> findInnerBindingName(List<PatternConstraintParseResult> firstParsedConstraints) {
-        return firstParsedConstraints.stream()
-                .map(PatternConstraintParseResult::getDrlxParseResult)
-                .filter(DrlxParseResult::isSuccess)
-                .map(d -> (DrlxParseSuccess)d)
-                .map(DrlxParseSuccess::getExprBinding)
-                .filter(Objects::nonNull)
-                .findFirst();
-    }
-
-    protected Optional<Expression> buildFromDeclaration(PatternDescr pattern) {
+    private Optional<Expression> buildFromDeclaration(PatternDescr pattern) {
         Optional<PatternSourceDescr> source = Optional.ofNullable(pattern.getSource());
-        Class<?> patternType;
         try {
             patternType = context.getTypeResolver().resolveType( pattern.getObjectType() );
         } catch (ClassNotFoundException e) {
@@ -93,17 +82,17 @@ public abstract class PatternDSL implements DSLNode {
         return source.flatMap(new WindowReferenceGenerator(packageModel, context.getTypeResolver())::visit);
     }
 
-    protected void generatePatternIdentifierIfMissing() {
+    private void generatePatternIdentifierIfMissing() {
         if (pattern.getIdentifier() == null) {
             final String generatedName = generateName("pattern_" + patternType.getSimpleName());
-            final String patternNameAggregated = findFirstInnerBinding(pattern, constraintDescrs, patternType)
+            final String patternNameAggregated = findFirstInnerBinding(constraintDescrs, patternType)
                     .map(ib -> context.getAggregatePatternMap().putIfAbsent(ib, generatedName))
                     .orElse(generatedName);
             pattern.setIdentifier(GENERATED_PATTERN_PREFIX + patternNameAggregated);
         }
     }
 
-    public Optional<String> findFirstInnerBinding(PatternDescr pattern, List<? extends BaseDescr> constraintDescrs, Class<?> patternType) {
+    private Optional<String> findFirstInnerBinding(List<? extends BaseDescr> constraintDescrs, Class<?> patternType) {
         return constraintDescrs.stream()
                 .map( constraint -> ConstraintExpression.createConstraintExpression( patternType, constraint, isPositional(constraint) ).getExpression() )
                 .map( DrlxParseUtil::parseExpression )
@@ -112,7 +101,7 @@ public abstract class PatternDSL implements DSLNode {
                 .findFirst();
     }
 
-    protected List<PatternConstraintParseResult> findAllConstraint(PatternDescr pattern, List<? extends BaseDescr> constraintDescrs, Class<?> patternType) {
+    private List<PatternConstraintParseResult> findAllConstraint(PatternDescr pattern, List<? extends BaseDescr> constraintDescrs, Class<?> patternType) {
         ConstraintParser constraintParser = new ConstraintParser(context, packageModel);
         List<PatternConstraintParseResult> patternConstraintParseResults = new ArrayList<>();
 
@@ -126,16 +115,15 @@ public abstract class PatternDSL implements DSLNode {
             DrlxParseResult drlxParseResult = constraintParser.drlxParse(patternType, patternIdentifier, constraintExpression, isPositional);
 
             String expression = constraintExpression.getExpression();
-            if (drlxParseResult.isSuccess() && (( DrlxParseSuccess ) drlxParseResult).isRequiresSplit()) {
-                int splitPos = expression.indexOf( "&&" );
-                String expr1 = expression.substring( 0, splitPos ).trim();
-                String expr2 = expr1.substring( 0, firstNonIdentifierPos( expr1 ) ) + " " + expression.substring( splitPos+2 ).trim();
+            if (drlxParseResult.isSuccess() && (( DrlxParseSuccess ) drlxParseResult).isRequiresSplit() && (( DrlxParseSuccess ) drlxParseResult).getExpr().isBinaryExpr()) {
+                BinaryExpr expr = ((DrlxParseSuccess) drlxParseResult).getExpr().asBinaryExpr();
+                String leftExpression = printConstraint(expr.asBinaryExpr().getLeft());
+                DrlxParseResult leftExpressionReparsed = constraintParser.drlxParse(patternType, patternIdentifier, leftExpression, isPositional);
+                patternConstraintParseResults.add(new PatternConstraintParseResult(leftExpression, patternIdentifier, leftExpressionReparsed));
 
-                DrlxParseResult drlxParseResult1 = constraintParser.drlxParse(patternType, patternIdentifier, expr1, isPositional);
-                patternConstraintParseResults.add(new PatternConstraintParseResult(expr1, patternIdentifier, drlxParseResult1));
-
-                DrlxParseResult drlxParseResult2 = constraintParser.drlxParse(patternType, patternIdentifier, expr2, isPositional);
-                patternConstraintParseResults.add(new PatternConstraintParseResult(expr2, patternIdentifier, drlxParseResult2));
+                String rightExpression = printConstraint(expr.asBinaryExpr().getRight());
+                DrlxParseResult rightExpressionReparsed = constraintParser.drlxParse(patternType, patternIdentifier, rightExpression, isPositional);
+                patternConstraintParseResults.add(new PatternConstraintParseResult(rightExpression, patternIdentifier, rightExpressionReparsed));
             } else {
                 patternConstraintParseResults.add(new PatternConstraintParseResult(expression, patternIdentifier, drlxParseResult));
             }
@@ -144,16 +132,7 @@ public abstract class PatternDSL implements DSLNode {
         return patternConstraintParseResults;
     }
 
-    private int firstNonIdentifierPos(String expr) {
-        for (int i = 0; i < expr.length(); i++) {
-            if (!Character.isJavaIdentifierPart( expr.charAt( i ))) {
-                return i;
-            }
-        }
-        return expr.length();
-    }
-
-    protected void buildConstraint(PatternDescr pattern, Class<?> patternType, PatternConstraintParseResult patternConstraintParseResult) {
+    void buildConstraint(PatternDescr pattern, Class<?> patternType, PatternConstraintParseResult patternConstraintParseResult) {
         DrlxParseResult drlxParseResult1 = patternConstraintParseResult.getDrlxParseResult();
         String expression = patternConstraintParseResult.getExpression();
 
@@ -205,7 +184,7 @@ public abstract class PatternDSL implements DSLNode {
         }
     }
 
-    protected Set<String> getSettableWatchedProps() {
+    Set<String> getSettableWatchedProps() {
         Set<String> watchedProps = new HashSet<>();
         watchedProps.addAll(context.getRuleDescr().lookAheadFieldsOfIdentifier(pattern));
         watchedProps.addAll(getPatternListenedProperties(pattern));

--- a/drools/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/pattern/PatternDSLPattern.java
+++ b/drools/drools-model/drools-model-compiler/src/main/java/org/drools/modelcompiler/builder/generator/visitor/pattern/PatternDSLPattern.java
@@ -24,7 +24,7 @@ import static org.drools.modelcompiler.builder.generator.DslMethodNames.WATCH_CA
 class PatternDSLPattern extends PatternDSL {
 
     protected PatternDSLPattern(RuleContext context, PackageModel packageModel, PatternDescr pattern, List<? extends BaseDescr> constraintDescrs, Class<?> patternType, boolean allConstraintsPositional) {
-        super(context, packageModel, pattern, constraintDescrs, allConstraintsPositional, patternType);
+        super(context, packageModel, pattern, constraintDescrs, patternType);
     }
 
     @Override

--- a/drools/drools-model/drools-model-compiler/src/main/resources/AccumulateInlineTemplate.java
+++ b/drools/drools-model/drools-model-compiler/src/main/resources/AccumulateInlineTemplate.java
@@ -1,0 +1,36 @@
+public class AccumulateInlineFunction implements org.kie.api.runtime.rule.AccumulateFunction<CONTEXT_DATA_GENERIC> {
+
+    public static class ContextData implements java.io.Serializable {
+        // context fields will go here.
+    }
+
+    public void readExternal(java.io.ObjectInput in) throws java.io.IOException, ClassNotFoundException {
+        // functions are stateless, so nothing to serialize
+    }
+
+    public void writeExternal(java.io.ObjectOutput out) throws java.io.IOException {
+        // functions are stateless, so nothing to serialize
+    }
+
+    public ContextData createContext() {
+        return new ContextData();
+    }
+
+    public void init(ContextData data) {
+    }
+
+    public void accumulate(ContextData data, Object $single) {
+    }
+
+    public void reverse(ContextData data, Object $single) {
+    }
+
+    public Object getResult(ContextData data) {
+    }
+
+    public boolean supportsReverse() {
+    }
+
+    public Class<?> getResultType() {
+    }
+}

--- a/drools/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/AccumulateTest.java
+++ b/drools/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/AccumulateTest.java
@@ -1146,4 +1146,65 @@ public class AccumulateTest extends BaseModelTest {
         assertEquals(5, list.get(0).intValue());
     }
 
+    @Test
+    public void testPatternMatchingOverNumberWhileAccumulatingShort() {
+        String drl=
+                "import " + AccumulateResult.class.getCanonicalName() + "\n" +
+                "import " + Person.class.getCanonicalName() + "\n" +
+                "\n" +
+                "rule \"accumulate_max_short_using_double\"\n" +
+                "	dialect \"java\"\n" +
+                "	when\n" +
+                "		$accumulateResult : AccumulateResult( resultAccumulated == false ) \n" +
+                "		\n" +
+                "		$maxOfAllShort : Number() from accumulate (\n" +
+                "		$accumulateTest_short_max : Person( $age : ageAsShort);max($age))\n" +
+                "		\n" +
+                "then\n" +
+                "		$accumulateResult.setResultAccumulated(true);\n" +
+                "		$accumulateResult.setMaxShortValue($maxOfAllShort.shortValue()\n);\n" +
+                "		update($accumulateResult);\n" +
+                "end";
+
+        KieSession ksession = getKieSession(drl);
+
+        AccumulateResult result = new AccumulateResult(false);
+
+        ksession.insert(result);
+
+        ksession.insert(new Person("Mark", 37));
+        ksession.insert(new Person("Edson", 35));
+        ksession.insert(new Person("Mario", 40));
+
+        ksession.fireAllRules();
+
+        assertEquals(true, result.isResultAccumulated());
+        assertEquals(40, result.getMaxShortValue());
+    }
+
+    public static class AccumulateResult {
+
+        private boolean resultAccumulated;
+        private short maxShortValue;
+
+        public AccumulateResult(boolean resultAccumulated) {
+            this.resultAccumulated = resultAccumulated;
+        }
+
+        public boolean isResultAccumulated() {
+            return resultAccumulated;
+        }
+
+        public void setResultAccumulated(boolean resultAccumulated) {
+            this.resultAccumulated = resultAccumulated;
+        }
+
+        public short getMaxShortValue() {
+            return maxShortValue;
+        }
+
+        public void setMaxShortValue(short maxShortValue) {
+            this.maxShortValue = maxShortValue;
+        }
+    }
 }

--- a/drools/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/AccumulateTest.java
+++ b/drools/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/AccumulateTest.java
@@ -1254,6 +1254,41 @@ public class AccumulateTest extends BaseModelTest {
 
 
     @Test
+    public void testFromAccumulateBigDecimalMvel() {
+        String str = "import " + Person.class.getCanonicalName() + ";\n" +
+                "import " + BigDecimal.class.getCanonicalName() + ";\n" +
+                "global java.util.List list;\n" +
+                "dialect \"mvel\"\n" +
+                "rule R when\n" +
+                "  $b : BigDecimal() from accumulate (\n" +
+                "            Person( $money : money ),\n" +
+                "                init( BigDecimal sum = 0; ),\n" +
+                "                action( sum += $money; ),\n" +
+                "                reverse( sum -= $money; ),\n" +
+                "                result( sum )\n" +
+                "         )\n" +
+                "then\n" +
+                "  list.add($b);\n" +
+                "end";
+
+        KieSession ksession = getKieSession(str);
+        final List<Number> list = new ArrayList<>();
+        ksession.setGlobal("list", list);
+
+        Person john = new Person("John");
+        john.setMoney(new BigDecimal(100));
+        ksession.insert(john);
+        Person paul = new Person("Paul");
+        paul.setMoney(new BigDecimal(200));
+        ksession.insert(paul);
+
+        ksession.fireAllRules();
+
+        assertEquals(new BigDecimal(300), list.get(0));
+    }
+
+
+    @Test
     public void testSemicolonMissingInInit() {
         String str = "import " + Person.class.getCanonicalName() + ";\n" +
                 "import " + BigDecimal.class.getCanonicalName() + ";\n" +

--- a/drools/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/AccumulateTest.java
+++ b/drools/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/AccumulateTest.java
@@ -1251,4 +1251,82 @@ public class AccumulateTest extends BaseModelTest {
         assertEquals(1, rulesFired);
         assertEquals(BigDecimal.valueOf(3000), result.getBigDecimalValue());
     }
+
+
+    @Test
+    public void testSemicolonMissingInInit() {
+        String str = "import " + Person.class.getCanonicalName() + ";\n" +
+                "import " + BigDecimal.class.getCanonicalName() + ";\n" +
+                "global java.util.List list;\n" +
+                "rule R when\n" +
+                "  $sum : Integer() from accumulate (\n" +
+                "            Person( age > 18, $age : age ),\n" +
+                "                init( int sum = 0),\n" +
+                "                action( sum += $age; ),\n" +
+                "                reverse( sum -= $age; ),\n" +
+                "                result( sum )\n" +
+                "         )\n" +
+                "then\n" +
+                "  list.add($sum);\n" +
+                "end";
+
+        KieSession ksession = getKieSession(str);
+        final List<Number> list = new ArrayList<>();
+        ksession.setGlobal("list", list);
+
+        Person john = new Person("John", 23);
+        ksession.insert(john);
+
+        Person paul = new Person("Paul", 40);
+        ksession.insert(paul);
+
+        Person jones = new Person("Jones", 16);
+        ksession.insert(jones);
+
+        ksession.fireAllRules();
+
+        assertEquals(63, list.get(0));
+    }
+
+
+    @Test(expected = AssertionError.class)
+    public void testSemicolonMissingInAction() {
+        String str = "import " + Person.class.getCanonicalName() + ";\n" +
+                "import " + BigDecimal.class.getCanonicalName() + ";\n" +
+                "global java.util.List list;\n" +
+                "rule R when\n" +
+                "  $sum : Integer() from accumulate (\n" +
+                "            Person( age > 18, $age : age ),\n" +
+                "                init( int sum = 0; ),\n" +
+                "                action( sum += $age ),\n" +
+                "                reverse( sum -= $age; ),\n" +
+                "                result( sum )\n" +
+                "         )\n" +
+                "then\n" +
+                "  list.add($sum);\n" +
+                "end";
+
+        getKieSession(str);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testSemicolonMissingInReverse() {
+        String str = "import " + Person.class.getCanonicalName() + ";\n" +
+                "import " + BigDecimal.class.getCanonicalName() + ";\n" +
+                "global java.util.List list;\n" +
+                "rule R when\n" +
+                "  $sum : Integer() from accumulate (\n" +
+                "            Person( age > 18, $age : age ),\n" +
+                "                init( int sum = 0; ),\n" +
+                "                action( sum += $age; ),\n" +
+                "                reverse( sum -= $age ),\n" +
+                "                result( sum )\n" +
+                "         )\n" +
+                "then\n" +
+                "  list.add($sum);\n" +
+                "end";
+
+        getKieSession(str);
+    }
+
 }

--- a/drools/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/CompilationFailuresTest.java
+++ b/drools/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/CompilationFailuresTest.java
@@ -17,6 +17,7 @@
 package org.drools.modelcompiler;
 
 import org.drools.modelcompiler.domain.Person;
+import org.drools.modelcompiler.domain.Result;
 import org.junit.Test;
 import org.kie.api.builder.Message;
 import org.kie.api.builder.Results;
@@ -98,4 +99,39 @@ public class CompilationFailuresTest extends BaseModelTest {
         assertFalse(results.getMessages( Message.Level.ERROR).isEmpty());
     }
 
+    @Test
+    public void testMaxIntegerResultOnDoublePatternShouldntCompile() {
+        checkCompilationFailureOnMismatchingAccumulate("Integer", "max");
+    }
+
+    @Test
+    public void testMinIntegerResultOnDoublePatternShouldntCompile() {
+        checkCompilationFailureOnMismatchingAccumulate("Integer", "min");
+    }
+
+    @Test
+    public void testMaxLongResultOnDoublePatternShouldntCompile() {
+        checkCompilationFailureOnMismatchingAccumulate("Long", "max");
+    }
+
+    @Test
+    public void testMinLongResultOnDoublePatternShouldntCompile() {
+        checkCompilationFailureOnMismatchingAccumulate("Long", "min");
+    }
+
+    private void checkCompilationFailureOnMismatchingAccumulate(String type, String accFunc) {
+        String drl =
+                "import " + Person.class.getCanonicalName() + ";" +
+                "import " + Result.class.getCanonicalName() + ";" +
+                "rule X when\n" +
+                "  $max : Double() from accumulate ( $num : " + type + "(); " + accFunc + "($num) ) \n" +
+                "then\n" +
+                "  Double res = null;" +
+                "  res = $max;\n" +
+                "  System.out.println($max);\n" +
+                "end";
+
+        Results results = getCompilationResults(drl);
+        assertFalse(results.getMessages( Message.Level.ERROR).isEmpty());
+    }
 }

--- a/drools/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/CompilerTest.java
+++ b/drools/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/CompilerTest.java
@@ -1838,6 +1838,81 @@ public class CompilerTest extends BaseModelTest {
 
     }
 
+
+
+    @Test
+    public void testMapAbbreviatedComparison() {
+        final String drl1 =
+                "import java.util.Map;\n" +
+                        "rule R1 when\n" +
+                        "    Map(this['money'] >= 65 && <= 75)\n" +
+                        "then\n" +
+                        "end\n";
+
+        KieSession ksession = getKieSession( drl1 );
+
+        final Map<String, Object> map = new HashMap<>();
+        map.put("money", new BigDecimal(70));
+
+        ksession.insert( map );
+        assertEquals( 1, ksession.fireAllRules() );
+    }
+
+    @Test
+    public void testHalfBinary() {
+        final String drl1 =
+                "rule R1 when\n" +
+                        "    Integer(this > 2 && < 5)\n" +
+                        "then\n" +
+                        "end\n";
+
+        KieSession ksession = getKieSession( drl1 );
+
+        ksession.insert( 3 );
+        ksession.insert( 4 );
+        ksession.insert( 6 );
+        assertEquals( 2, ksession.fireAllRules() );
+    }
+
+    @Test
+    public void testMapPrimitiveComparison() {
+        final String drl1 =
+                "import java.util.Map;\n" +
+                        "import " + Person.class.getCanonicalName() + ";\n" +
+                        "rule R1 when\n" +
+                        "    $m : Map()\n" +
+                        "    Person(age == $m['age'] )\n" +
+                        "then\n" +
+                        "end\n";
+
+        KieSession ksession = getKieSession( drl1 );
+
+        final Map<String, Object> map = new HashMap<>();
+        map.put("age", 20);
+        Person john = new Person("John", 20);
+
+        ksession.insert( map );
+        ksession.insert( john );
+        assertEquals( 1, ksession.fireAllRules() );
+    }
+
+    @Test
+    public void testBigDecimalIntCoercion() {
+        String str = "import " + Result.class.getCanonicalName() + ";\n" +
+                "rule \"rule1\"\n" +
+                "when\n" +
+                "    $r : Result( value <= 20 )\n" +
+                "then\n" +
+                "end\n";
+
+        KieSession ksession1 = getKieSession(str);
+
+        Result fact = new Result();
+        fact.setValue( new BigDecimal(10) );
+        ksession1.insert( fact );
+        assertEquals( 1, ksession1.fireAllRules() );
+    }
+
     @Test
     public void testBooleanCoercion() {
         String str =

--- a/drools/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/builder/generator/ExpressionTyperTest.java
+++ b/drools/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/builder/generator/ExpressionTyperTest.java
@@ -131,18 +131,18 @@ public class ExpressionTyperTest {
 
     @Test
     public void arrayAccessExpr() {
-        final TypedExpression expected = typedResult(THIS_PLACEHOLDER + ".getItems().get(1)", Object.class);
+        final TypedExpression expected = typedResult(THIS_PLACEHOLDER + ".getItems().get(1)", Map.class);
         final TypedExpression actual = toTypedExpression("items[1]", Person.class);
         assertEquals(expected, actual);
 
-        final TypedExpression expected2 = typedResult(THIS_PLACEHOLDER + ".getItems().get(((Integer)1))", Object.class);
+        final TypedExpression expected2 = typedResult(THIS_PLACEHOLDER + ".getItems().get(((Integer)1))", Map.class);
         final TypedExpression actual2 = toTypedExpression("items[(Integer)1]", Person.class);
         assertEquals(expected2, actual2);
     }
 
     @Test
     public void mapAccessExpr() {
-        final TypedExpression expected3 = typedResult(THIS_PLACEHOLDER + ".get(\"type\")", Object.class);
+        final TypedExpression expected3 = typedResult(THIS_PLACEHOLDER + ".get(\"type\")", Map.class);
         final TypedExpression actual3 = toTypedExpression("this[\"type\"]", Map.class);
         assertEquals(expected3, actual3);
     }

--- a/drools/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/builder/generator/drlxparse/CoercedExpressionTest.java
+++ b/drools/drools-model/drools-model-compiler/src/test/java/org/drools/modelcompiler/builder/generator/drlxparse/CoercedExpressionTest.java
@@ -1,5 +1,7 @@
 package org.drools.modelcompiler.builder.generator.drlxparse;
 
+import java.util.Map;
+
 import com.github.javaparser.ast.expr.StringLiteralExpr;
 import org.assertj.core.api.Assertions;
 import org.drools.modelcompiler.builder.generator.DrlxParseUtil;
@@ -96,19 +98,43 @@ public class CoercedExpressionTest {
     }
 
     @Test
-    public void castToObject() {
-        final TypedExpression left = expr(THIS_PLACEHOLDER + ".getItems().get((Integer) 1)", java.lang.Object.class);
-        final TypedExpression right = expr("2000", int.class);
-        final CoercedExpression.CoercedExpressionResult coerce = new CoercedExpression(left, right).coerce();
-        assertEquals(expr("(java.lang.Object)2000", int.class), coerce.getCoercedRight());
-    }
-
-    @Test
     public void castToShort() {
         final TypedExpression left = expr(THIS_PLACEHOLDER + ".getAgeAsShort()", java.lang.Short.class);
         final TypedExpression right = expr("40", int.class);
         final CoercedExpression.CoercedExpressionResult coerce = new CoercedExpression(left, right).coerce();
         assertEquals(expr("(short)40", int.class), coerce.getCoercedRight());
+    }
+
+    @Test
+    public void castMaps() {
+        final TypedExpression left = expr(THIS_PLACEHOLDER + ".getAge()", Integer.class);
+        final TypedExpression right = expr("$m.get(\"age\")", java.util.Map.class);
+        final CoercedExpression.CoercedExpressionResult coerce = new CoercedExpression(left, right).coerce();
+        assertEquals(expr("(java.lang.Integer)$m.get(\"age\")", Map.class), coerce.getCoercedRight());
+    }
+
+    @Test
+    public void doNotCastNumberLiteralInt() {
+        final TypedExpression left = expr("getValue()", java.lang.Object.class);
+        final TypedExpression right = expr("20", int.class);
+        final CoercedExpression.CoercedExpressionResult coerce = new CoercedExpression(left, right).coerce();
+        assertEquals(expr("20", int.class), coerce.getCoercedRight());
+    }
+
+    @Test
+    public void doNotCastNumberLiteralShort() {
+        final TypedExpression left = expr("getValue()", java.lang.Object.class);
+        final TypedExpression right = expr("20", short.class);
+        final CoercedExpression.CoercedExpressionResult coerce = new CoercedExpression(left, right).coerce();
+        assertEquals(expr("20", short.class), coerce.getCoercedRight());
+    }
+
+    @Test
+    public void doNotCastNumberLiteralDouble() {
+        final TypedExpression left = expr("getValue()", java.lang.Object.class);
+        final TypedExpression right = expr("20", double.class);
+        final CoercedExpression.CoercedExpressionResult coerce = new CoercedExpression(left, right).coerce();
+        assertEquals(expr("20", double.class), coerce.getCoercedRight());
     }
 
     @Test

--- a/drools/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/LHSPhase.java
+++ b/drools/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/LHSPhase.java
@@ -5,12 +5,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.expr.AssignExpr;
 import com.github.javaparser.ast.expr.FieldAccessExpr;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.VariableDeclarationExpr;
-import com.github.javaparser.ast.nodeTypes.NodeWithType;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
 import com.github.javaparser.ast.stmt.IfStmt;
 import com.github.javaparser.ast.stmt.Statement;
@@ -23,6 +23,7 @@ import org.drools.mvelcompiler.ast.SimpleNameTExpr;
 import org.drools.mvelcompiler.ast.TypedExpression;
 import org.drools.mvelcompiler.ast.UnalteredTypedExpression;
 import org.drools.mvelcompiler.ast.VariableDeclaratorTExpr;
+import org.drools.mvelcompiler.bigdecimal.BigDecimalConversion;
 import org.drools.mvelcompiler.context.Declaration;
 import org.drools.mvelcompiler.context.MvelCompilerContext;
 import org.slf4j.Logger;
@@ -30,8 +31,9 @@ import org.slf4j.LoggerFactory;
 
 import static java.util.Collections.emptyList;
 import static java.util.Optional.ofNullable;
+import static org.drools.core.util.ClassUtils.getSetter;
 import static org.drools.mvel.parser.printer.PrintUtil.printConstraint;
-import static org.mvel2.util.PropertyTools.getSetter;
+import static org.drools.mvelcompiler.bigdecimal.BigDecimalConversion.shouldConvertPlusEqualsOperatorBigDecimal;
 
 /**
  * This phase processes the left hand side of a MVEL target expression, if present, such as
@@ -48,13 +50,9 @@ import static org.mvel2.util.PropertyTools.getSetter;
  *
  * person.setName("Name");
  */
-public class LHSPhase implements DrlGenericVisitor<TypedExpression, LHSPhase.Context> {
+public class LHSPhase implements DrlGenericVisitor<TypedExpression, Void> {
 
-    Logger logger = LoggerFactory.getLogger(LHSPhase.class);
-
-    static class Context {
-
-    }
+    private Logger logger = LoggerFactory.getLogger(LHSPhase.class);
 
     private final MvelCompilerContext mvelCompilerContext;
     private final Optional<TypedExpression> rhs;
@@ -65,10 +63,9 @@ public class LHSPhase implements DrlGenericVisitor<TypedExpression, LHSPhase.Con
     }
 
     public TypedExpression invoke(Statement statement) {
-        logger.debug("LHS phase on:\t\t" + printConstraint(statement));
-        Context ctx = new Context();
+        logPhase("LHS phase on: {}", statement);
 
-        TypedExpression typedExpression = statement.accept(this, ctx);
+        TypedExpression typedExpression = statement.accept(this, null);
         if (typedExpression == null) {
             throw new MvelCompilerException("Type check of " + printConstraint(statement) + " failed.");
         }
@@ -77,8 +74,8 @@ public class LHSPhase implements DrlGenericVisitor<TypedExpression, LHSPhase.Con
     }
 
     @Override
-    public TypedExpression visit(DrlNameExpr n, Context arg) {
-        logger.debug("DrlNameExpr:\t\t" + printConstraint(n));
+    public TypedExpression visit(DrlNameExpr n, Void arg) {
+        logPhase("DrlNameExpr {}", n);
 
         String variableName = printConstraint(n);
         Optional<Declaration> declaration = mvelCompilerContext.findDeclarations(variableName);
@@ -91,8 +88,8 @@ public class LHSPhase implements DrlGenericVisitor<TypedExpression, LHSPhase.Con
     }
 
     @Override
-    public TypedExpression visit(FieldAccessExpr n, Context arg) {
-        logger.debug("FieldAccessExpr:\t\t" + printConstraint(n));
+    public TypedExpression visit(FieldAccessExpr n, Void arg) {
+        logPhase("FieldAccessExpr {}", n);
 
         if (parentIsExpressionStmt(n)) {
             return rhsOrError();
@@ -120,23 +117,23 @@ public class LHSPhase implements DrlGenericVisitor<TypedExpression, LHSPhase.Con
     }
 
     @Override
-    public TypedExpression visit(MethodCallExpr n, Context arg) {
-        logger.debug("MethodCallExpr:\t\t" + printConstraint(n));
+    public TypedExpression visit(MethodCallExpr n, Void arg) {
+        logPhase("MethodCallExpr {}", n);
 
         return rhsOrError();
     }
 
     @Override
-    public TypedExpression visit(VariableDeclarationExpr n, Context arg) {
-        logger.debug("VariableDeclarationExpr:\t\t" + printConstraint(n));
+    public TypedExpression visit(VariableDeclarationExpr n, Void arg) {
+        logPhase("VariableDeclarationExpr {}", n);
 
         // assuming there's always one declaration for variable
         return n.getVariables().iterator().next().accept(this, arg);
     }
 
     @Override
-    public TypedExpression visit(VariableDeclarator n, Context arg) {
-        logger.debug("VariableDeclarator:\t\t" + printConstraint(n));
+    public TypedExpression visit(VariableDeclarator n, Void arg) {
+        logPhase("VariableDeclarator {}", n);
 
         String variableName = n.getName().asString();
         Class<?> type = getRHSorLHSType(n);
@@ -147,19 +144,23 @@ public class LHSPhase implements DrlGenericVisitor<TypedExpression, LHSPhase.Con
     }
 
     @Override
-    public TypedExpression visit(ExpressionStmt n, Context arg) {
-        logger.debug("ExpressionStmt:\t\t" + printConstraint(n));
+    public TypedExpression visit(ExpressionStmt n, Void arg) {
+        logPhase("ExpressionStmt {}", n);
 
         Optional<TypedExpression> expression = ofNullable(n.getExpression().accept(this, arg));
         return new ExpressionStmtT(expression.orElseGet(this::rhsOrError));
     }
 
     @Override
-    public TypedExpression visit(AssignExpr n, Context arg) {
-        logger.debug("AssignExpr:\t\t" + printConstraint(n));
+    public TypedExpression visit(AssignExpr n, Void arg) {
+        logPhase("AssignExpr {}", n);
 
         TypedExpression target = n.getTarget().accept(this, arg);
-        if (target instanceof FieldToAccessorTExpr) {
+
+        BigDecimalConversion bigDecimalConversion = shouldConvertPlusEqualsOperatorBigDecimal(n, rhs);
+        if(bigDecimalConversion.shouldConvert()) {
+            return bigDecimalConversion.convertExpression(target);
+        } else if (target instanceof FieldToAccessorTExpr) {
             return target;
         } else if (target instanceof VariableDeclaratorTExpr) {
             return target;
@@ -169,7 +170,7 @@ public class LHSPhase implements DrlGenericVisitor<TypedExpression, LHSPhase.Con
     }
 
     @Override
-    public TypedExpression visit(IfStmt n, Context arg) {
+    public TypedExpression visit(IfStmt n, Void arg) {
         return new UnalteredTypedExpression(n);
     }
 
@@ -193,8 +194,13 @@ public class LHSPhase implements DrlGenericVisitor<TypedExpression, LHSPhase.Con
     }
 
     private Class<?> getRHSorLHSType(VariableDeclarator n) {
-        return (Class<?>) rhs.flatMap(TypedExpression::getType)
-                .orElseGet(() -> mvelCompilerContext.resolveType(((NodeWithType) n).getType().asString()));
+        return mvelCompilerContext.resolveType(n.getType().asString());
+    }
+
+    private void logPhase(String phase, Node statement) {
+        if(logger.isDebugEnabled()) {
+            logger.debug(phase, printConstraint(statement));
+        }
     }
 }
 

--- a/drools/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/MvelCompiler.java
+++ b/drools/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/MvelCompiler.java
@@ -1,6 +1,5 @@
 package org.drools.mvelcompiler;
 
-import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -18,6 +17,7 @@ import org.drools.mvel.parser.ast.expr.WithStatement;
 import org.drools.mvelcompiler.ast.TypedExpression;
 import org.drools.mvelcompiler.context.MvelCompilerContext;
 
+import static java.util.Optional.of;
 import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toList;
 
@@ -51,14 +51,12 @@ public class MvelCompiler {
         allUsedBindings.addAll(withUsedBindings);
 
         List<Statement> statements = new ArrayList<>();
-        Optional<Type> lastExpressionType = Optional.empty();
         for (Statement s : mvelExpression.getStatements()) {
-            lastExpressionType = processWithMvelCompiler(statements, s);
+            processWithMvelCompiler(statements, s);
         }
 
         return new ParsingResult(statements)
-                .setUsedBindings(allUsedBindings)
-                .setLastExpressionType(lastExpressionType); // Used in the inline accumulate definition
+                .setUsedBindings(allUsedBindings);
     }
 
     private Stream<String> transformStatementWithPreprocessing(Statement s) {
@@ -72,7 +70,7 @@ public class MvelCompiler {
         return invoke.getUsedBindings().stream();
     }
 
-    private Optional<Type> processWithMvelCompiler(List<Statement> statements, Statement s) {
+    private void processWithMvelCompiler(List<Statement> statements, Statement s) {
         if (s.isBlockStmt()) {
             BlockStmt body = s.asBlockStmt();
             for (Statement children : body.getStatements()) {
@@ -89,14 +87,14 @@ public class MvelCompiler {
             statements.add(new IfStmt(ifStmt.getCondition(), new BlockStmt(thenStmts), new BlockStmt(elseStmts)));
 
         } else {
-            Optional<Type> lastExpressionType;
             TypedExpression rhs = new RHSPhase(mvelCompilerContext).invoke(s);
             TypedExpression lhs = new LHSPhase(mvelCompilerContext, ofNullable(rhs)).invoke(s);
-            Statement expression = (Statement) lhs.toJavaExpression();
+
+            Optional<TypedExpression> postProcessedRHS = new PostProcessRHSPhase().invoke(rhs, lhs);
+            TypedExpression postProcessedLHS = postProcessedRHS.map(ppr -> new LHSPhase(mvelCompilerContext, of(ppr)).invoke(s)).orElse(lhs);
+
+            Statement expression = (Statement) postProcessedLHS.toJavaExpression();
             statements.add(expression);
-            lastExpressionType = ofNullable(rhs).flatMap(TypedExpression::getType);
-            return lastExpressionType;
         }
-        return Optional.empty();
     }
 }

--- a/drools/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ParsingResult.java
+++ b/drools/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ParsingResult.java
@@ -1,9 +1,7 @@
 package org.drools.mvelcompiler;
 
-import java.lang.reflect.Type;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 import com.github.javaparser.ast.NodeList;
@@ -16,7 +14,6 @@ public class ParsingResult {
 
     private List<Statement> statements;
     private Set<String> usedBindings = new HashSet<>();
-    private Optional<Type> lastExpressionType;
 
     public ParsingResult(List<Statement> statements) {
         this.statements = statements;
@@ -37,15 +34,6 @@ public class ParsingResult {
 
     public Set<String> getUsedBindings() {
         return usedBindings;
-    }
-
-    public ParsingResult setLastExpressionType(Optional<Type> lastExpressionType) {
-        this.lastExpressionType = lastExpressionType;
-        return this;
-    }
-
-    public Optional<Type> lastExpressionType() {
-        return lastExpressionType;
     }
 
     @Override

--- a/drools/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/PostProcessRHSPhase.java
+++ b/drools/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/PostProcessRHSPhase.java
@@ -1,0 +1,52 @@
+package org.drools.mvelcompiler;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.expr.IntegerLiteralExpr;
+import org.drools.mvel.parser.ast.visitor.DrlGenericVisitor;
+import org.drools.mvelcompiler.ast.IntegerLiteralExpressionT;
+import org.drools.mvelcompiler.ast.MethodCallExprT;
+import org.drools.mvelcompiler.ast.SimpleNameTExpr;
+import org.drools.mvelcompiler.ast.TypedExpression;
+
+/**
+ * Used when you need to reprocess the RHS after having processed the LHS
+ */
+public class PostProcessRHSPhase implements DrlGenericVisitor<Optional<TypedExpression>, Void> {
+
+    private TypedExpression lhs;
+
+    PostProcessRHSPhase() {
+    }
+
+    public Optional<TypedExpression> invoke(TypedExpression rhs, TypedExpression lhs) {
+        this.lhs = lhs;
+        return Optional.ofNullable(rhs).flatMap(r -> r.toJavaExpression().accept(this, null));
+    }
+
+    @Override
+    public Optional<TypedExpression> defaultMethod(Node n, Void context) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<TypedExpression> visit(IntegerLiteralExpr n, Void arg) {
+        return lhs.getType().flatMap(t -> {
+            if (BigDecimal.class.equals(t)) {
+                return asBigDecimalValueOf(n);
+            }
+            return Optional.empty();
+        });
+    }
+
+    private Optional<TypedExpression> asBigDecimalValueOf(IntegerLiteralExpr n) {
+        Optional<TypedExpression> bigDecimal = Optional.of(new SimpleNameTExpr(BigDecimal.class.getCanonicalName(), null));
+        List<TypedExpression> arguments = Collections.singletonList(new IntegerLiteralExpressionT(new IntegerLiteralExpr(n.asInt())));
+        MethodCallExprT valueOf = new MethodCallExprT("valueOf", bigDecimal, arguments, Optional.of(BigDecimal.class));
+        return Optional.of(valueOf);
+    }
+}

--- a/drools/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/RHSPhase.java
+++ b/drools/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/RHSPhase.java
@@ -159,7 +159,7 @@ public class RHSPhase implements DrlGenericVisitor<TypedExpression, RHSPhase.Con
             TypedExpression a = child.accept(this, arg);
             arguments.add(a);
         }
-        return new MethodCallExprT(n, n.getName().asString(), scope, arguments, name.getType());
+        return new MethodCallExprT(n.getName().asString(), scope, arguments, name.getType());
     }
 
     @Override

--- a/drools/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/ExpressionStmtT.java
+++ b/drools/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/ExpressionStmtT.java
@@ -17,7 +17,7 @@ public class ExpressionStmtT implements TypedExpression {
 
     @Override
     public Optional<Type> getType() {
-        return Optional.empty();
+        return child.getType();
     }
 
     @Override

--- a/drools/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/MethodCallExprT.java
+++ b/drools/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/MethodCallExprT.java
@@ -18,8 +18,7 @@ public class MethodCallExprT implements TypedExpression {
     private final List<TypedExpression> arguments;
     private final Optional<Type> type;
 
-    public MethodCallExprT(Node originalExpression, String name, Optional<TypedExpression> scope, List<TypedExpression> arguments, Optional<Type> type) {
-
+    public MethodCallExprT(String name, Optional<TypedExpression> scope, List<TypedExpression> arguments, Optional<Type> type) {
         this.name = name;
         this.scope = scope;
         this.arguments = arguments;
@@ -34,11 +33,21 @@ public class MethodCallExprT implements TypedExpression {
     @Override
     public Node toJavaExpression() {
         Node scopeE = scope.map(TypedExpression::toJavaExpression).orElse(null);
-        List<Expression> arguments = this.arguments
+        List<Expression> methodArguments = this.arguments
                 .stream()
                 .map(a -> (Expression) a.toJavaExpression())
                 .collect(Collectors.toList());
 
-        return new MethodCallExpr((Expression) scopeE, name, nodeList(arguments));
+        return new MethodCallExpr((Expression) scopeE, name, nodeList(methodArguments));
+    }
+
+    @Override
+    public String toString() {
+        return "MethodCallExprT{" +
+                "name='" + name + '\'' +
+                ", scope=" + scope +
+                ", arguments=" + arguments +
+                ", type=" + type +
+                '}';
     }
 }

--- a/drools/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/SimpleNameTExpr.java
+++ b/drools/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/SimpleNameTExpr.java
@@ -13,7 +13,6 @@ public class SimpleNameTExpr implements TypedExpression {
 
     public SimpleNameTExpr(String constraintName, Class<?> clazz) {
         this.constraintName = constraintName;
-
         this.clazz = clazz;
     }
 

--- a/drools/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/VariableDeclaratorTExpr.java
+++ b/drools/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/ast/VariableDeclaratorTExpr.java
@@ -33,8 +33,7 @@ public class VariableDeclaratorTExpr implements TypedExpression {
     @Override
     public Node toJavaExpression() {
         Optional<Type> optInitType = initExpression.flatMap(TypedExpression::getType);
-        final Type ieType = optInitType.orElse(this.type);
-        com.github.javaparser.ast.type.Type jpType = StaticJavaParser.parseType(ieType.getTypeName());
+        com.github.javaparser.ast.type.Type jpType = StaticJavaParser.parseType(this.type.getTypeName());
 
         return initExpression.map(ie -> {
 

--- a/drools/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/bigdecimal/BigDecimalConversion.java
+++ b/drools/drools-model/drools-mvel-compiler/src/main/java/org/drools/mvelcompiler/bigdecimal/BigDecimalConversion.java
@@ -1,0 +1,110 @@
+package org.drools.mvelcompiler.bigdecimal;
+
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import com.github.javaparser.ast.expr.AssignExpr;
+import org.drools.mvelcompiler.ast.AssignExprT;
+import org.drools.mvelcompiler.ast.MethodCallExprT;
+import org.drools.mvelcompiler.ast.TypedExpression;
+
+import static java.util.Collections.singletonList;
+import static java.util.Optional.of;
+
+public abstract class BigDecimalConversion {
+    TypedExpression rhs;
+
+    BigDecimalConversion(TypedExpression rhs) {
+        this.rhs = rhs;
+    }
+
+    public static BigDecimalConversion shouldConvertPlusEqualsOperatorBigDecimal(AssignExpr n, Optional<TypedExpression> optRHS) {
+        if(!optRHS.isPresent() || (!optRHS.get().getType().isPresent())) {
+            return new DoNotConvert(null);
+        }
+
+        TypedExpression rhs = optRHS.get();
+        Optional<Type> optRHSType = rhs.getType();
+        if(!optRHSType.isPresent()) {
+            return new DoNotConvert(null);
+        }
+
+        Type rhsType = optRHSType.get();
+
+        boolean isBigDecimal = BigDecimal.class.equals(rhsType);
+        if(isBigDecimal) {
+            if(AssignExpr.Operator.PLUS.equals(n.getOperator())) {
+                return new ConvertPlus(rhs);
+            } else if(AssignExpr.Operator.MINUS.equals(n.getOperator())) {
+                return new ConvertMinus(rhs);
+            } else {
+                return new DoNotConvert(rhs);
+            }
+        }
+        return new DoNotConvert(null);
+    }
+
+    public abstract boolean shouldConvert();
+
+    protected abstract TypedExpression convertPlusEqualsOperatorBigDecimal(TypedExpression target);
+
+    public TypedExpression convertExpression(TypedExpression target) {
+        TypedExpression arithmeticExpression = convertPlusEqualsOperatorBigDecimal(target);
+        return new AssignExprT(AssignExpr.Operator.ASSIGN, target, arithmeticExpression);
+    }
+
+    static class ConvertPlus extends BigDecimalConversion {
+
+        ConvertPlus(TypedExpression rhs) {
+            super(rhs);
+        }
+
+        @Override
+        public boolean shouldConvert() {
+            return true;
+        }
+
+        @Override
+        public TypedExpression convertPlusEqualsOperatorBigDecimal(TypedExpression target) {
+            return new MethodCallExprT("add", of(target), singletonList(rhs), of(BigDecimal.class));
+        }
+    }
+
+    static class ConvertMinus extends BigDecimalConversion {
+
+        ConvertMinus(TypedExpression rhs) {
+            super(rhs);
+        }
+
+        @Override
+        public boolean shouldConvert() {
+            return true;
+        }
+
+        @Override
+        public TypedExpression convertPlusEqualsOperatorBigDecimal(TypedExpression target) {
+            return new MethodCallExprT("subtract", of(target), singletonList(rhs), of(BigDecimal.class));
+        }
+    }
+
+    static class DoNotConvert extends BigDecimalConversion {
+
+        DoNotConvert(TypedExpression rhs) {
+            super(rhs);
+        }
+
+        @Override
+        public boolean shouldConvert() {
+            return false;
+        }
+
+        @Override
+        public TypedExpression convertPlusEqualsOperatorBigDecimal(TypedExpression target) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}
+
+
+

--- a/drools/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/CompilerTest.java
+++ b/drools/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/CompilerTest.java
@@ -24,6 +24,7 @@ interface CompilerTest {
         imports.add("java.util.ArrayList");
         imports.add("java.util.HashMap");
         imports.add("java.util.Map");
+        imports.add("java.math.BigDecimal");
         imports.add("org.drools.Address");
         imports.add(Person.class.getCanonicalName());
         TypeResolver typeResolver = new ClassTypeResolver(imports, this.getClass().getClassLoader());

--- a/drools/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/MvelCompilerTest.java
+++ b/drools/drools-model/drools-mvel-compiler/src/test/java/org/drools/mvelcompiler/MvelCompilerTest.java
@@ -11,21 +11,23 @@ public class MvelCompilerTest implements CompilerTest {
 
     @Test
     public void testConvertPropertyToAccessor() {
+        String expectedJavaCode = "{ $p.getParent().getParent().getName(); }";
+
         test(ctx -> ctx.addDeclaration("$p", Person.class),
              "{ $p.parent.getParent().name; } ",
-             "{ $p.getParent().getParent().getName(); }");
+             expectedJavaCode);
 
         test(ctx -> ctx.addDeclaration("$p", Person.class),
              "{ $p.getParent().parent.name; } ",
-             "{ $p.getParent().getParent().getName(); }");
+             expectedJavaCode);
 
         test(ctx -> ctx.addDeclaration("$p", Person.class),
              "{ $p.parent.parent.name; } ",
-             "{ $p.getParent().getParent().getName(); }");
+             expectedJavaCode);
 
         test(ctx -> ctx.addDeclaration("$p", Person.class),
              "{ $p.getParent().getParent().getName(); } ",
-             "{ $p.getParent().getParent().getName(); }");
+             expectedJavaCode);
     }
 
     @Test
@@ -76,8 +78,8 @@ public class MvelCompilerTest implements CompilerTest {
     @Test
     public void testSetterPublicField() {
         test(ctx -> ctx.addDeclaration("$p", Person.class),
-             "{ $p.nickamePublic = \"Luca\"; } ",
-             "{ $p.nickamePublic = \"Luca\"; } ");
+             "{ $p.nickName = \"Luca\"; } ",
+             "{ $p.nickName = \"Luca\"; } ");
     }
 
     @Test
@@ -141,6 +143,22 @@ public class MvelCompilerTest implements CompilerTest {
                      "    m.put(\"content\", l);\n" +
                      "    System.out.println(((java.util.ArrayList) m.get(\"content\")).get(0));\n" +
                      "    list.add(((java.util.ArrayList) m.get(\"content\")).get(0));\n" +
+                     "}");
+    }
+
+    @Test
+    public void testBigDecimal() {
+        test("{ " +
+                     "    BigDecimal sum = 0;\n" +
+                     "    BigDecimal money = 10;\n" +
+                     "    sum += money;\n" +
+                     "    sum -= money;\n" +
+                     "}",
+             "{ " +
+                     "    java.math.BigDecimal sum = java.math.BigDecimal.valueOf(0);\n" +
+                     "    java.math.BigDecimal money = java.math.BigDecimal.valueOf(10);\n" +
+                     "    sum = sum.add(money);\n" +
+                     "    sum = sum.subtract(money);\n" +
                      "}");
     }
 

--- a/drools/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/HalfBinaryExpr.java
+++ b/drools/drools-model/drools-mvel-parser/src/main/java/org/drools/mvel/parser/ast/expr/HalfBinaryExpr.java
@@ -42,14 +42,6 @@ import com.github.javaparser.printer.Printable;
 
 import static com.github.javaparser.utils.Utils.assertNotNull;
 
-/**
- * An expression with an expression on the left, an expression on the right, and an operator in the middle.
- * It supports the operators that are found the the BinaryExpr.Operator enum.
- * <br/><code>a && b</code>
- * <br/><code>155 * 33</code>
- *
- * @author Julio Vilmar Gesser
- */
 public final class HalfBinaryExpr extends Expression {
 
     public enum Operator implements Printable {


### PR DESCRIPTION
[DROOLS-4339] Avoid implicit conversion while accumulating, type is always one returned from the function
[DROOLS-4277] add min and max accumulate functions specific for Integer
[DROOLS-4342] Using BigDecimal with From Accumulate causes an "Error: argument type mismatch"
[DROOLS-4374] Align error messages when missing semicolons 
[DROOLS-4375] BigDecimal in from accumulate with MVEL with executable model
[DROOLS-4376] 
[DROOLS-4377] 
[DROOLS-4831]
