### PR TITLE
KOGITO-304: Rule Unit fixes for BPMN integration

### DIFF
--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/RuleSetNodeVisitor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/RuleSetNodeVisitor.java
@@ -54,6 +54,8 @@ import org.jbpm.workflow.core.node.RuleSetNode;
 import org.kie.api.definition.process.Node;
 import org.kie.kogito.rules.DataObserver;
 import org.kie.kogito.rules.DataSource;
+import org.kie.kogito.rules.DataStore;
+import org.kie.kogito.rules.DataStream;
 
 import static com.github.javaparser.StaticJavaParser.parse;
 import static com.github.javaparser.StaticJavaParser.parseClassOrInterfaceType;
@@ -175,11 +177,13 @@ public class RuleSetNodeVisitor extends AbstractVisitor {
         Method m;
         try {
             m = unitClass.getMethod(methodName);
-            if ( DataSource.class.isAssignableFrom( m.getReturnType() ) ) {
-                Expression fieldAccessor =
-                        new MethodCallExpr(new NameExpr("model"), methodName);
-
+            Expression fieldAccessor =
+                    new MethodCallExpr(new NameExpr("model"), methodName);
+            if ( DataStore.class.isAssignableFrom(m.getReturnType() ) ) {
                 return new MethodCallExpr(fieldAccessor, "add")
+                        .addArgument(value);
+            } else if ( DataStream.class.isAssignableFrom(m.getReturnType() ) ) {
+                return new MethodCallExpr(fieldAccessor, "append")
                         .addArgument(value);
             } // else fallback to the following
         } catch (NoSuchMethodException e) {

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/RuleSetNodeVisitor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/RuleSetNodeVisitor.java
@@ -82,13 +82,13 @@ public class RuleSetNodeVisitor extends AbstractVisitor {
 
         RuleSetNode.RuleType ruleType = ruleSetNode.getRuleType();
 
-        if (ruleSetNode.getLanguage().equals(RuleSetNode.DRL_LANG)) {
+        if (ruleType.isRuleFlowGroup()) {
             MethodCallExpr ruleRuntimeBuilder = new MethodCallExpr(
                     new MethodCallExpr(new NameExpr("app"), "ruleUnits"), "ruleRuntimeBuilder");
             MethodCallExpr ruleRuntimeSupplier = new MethodCallExpr(ruleRuntimeBuilder, "newKieSession", NodeList.nodeList(new StringLiteralExpr("defaultStatelessKieSession"), new NameExpr("app.config().rule()")));
             actionBody.addStatement(new ReturnStmt(ruleRuntimeSupplier));
             addFactoryMethodWithArgs(body, "ruleSetNode" + node.getId(), "ruleFlowGroup", new StringLiteralExpr(ruleType.getName()), lambda);
-        } else if (ruleSetNode.getLanguage().equals(RuleSetNode.RULE_UNIT_LANG)) {
+        } else if (ruleType.isRuleUnit()) {
             InputStream resourceAsStream = this.getClass().getResourceAsStream("/class-templates/RuleUnitFactoryTemplate.java");
             Expression ruleUnitFactory = parse(resourceAsStream).findFirst(Expression.class).get();
 
@@ -108,7 +108,7 @@ public class RuleSetNodeVisitor extends AbstractVisitor {
                     .ifPresent(m -> m.setBody(unbind(variableScope, ruleSetNode, unitClass)));
 
             addFactoryMethodWithArgs(body, "ruleSetNode" + node.getId(), "ruleUnit", new StringLiteralExpr(ruleType.getName()), ruleUnitFactory);
-        } else if (ruleSetNode.getLanguage().equals(RuleSetNode.DMN_LANG)) {
+        } else if (ruleType.isDecision()) {
             RuleSetNode.RuleType.Decision decisionModel = (RuleSetNode.RuleType.Decision) ruleType;
             MethodCallExpr ruleRuntimeSupplier = new MethodCallExpr(new NameExpr("app"), "dmnRuntimeBuilder");
             actionBody.addStatement(new ReturnStmt(ruleRuntimeSupplier));

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/RuleSetNode.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/RuleSetNode.java
@@ -41,14 +41,24 @@ public class RuleSetNode extends StateBasedNode implements ContextContainer {
 
     public static abstract class RuleType implements Serializable {
 
+        public static final String UNIT_RULEFLOW_PREFIX = "unit:";
+
         public static RuleType of(String name, String language) {
             if (language.equals(DRL_LANG)) {
-                return ruleFlowGroup(name);
+                return parseRuleFlowGroup(name);
             } else if (language.equals(RULE_UNIT_LANG)){
                 return ruleUnit(name);
             } else {
                 throw new IllegalArgumentException("Unsupported language " + language);
             }
+        }
+
+        public static RuleType parseRuleFlowGroup(String name) {
+            if (name.startsWith("unit:")) {
+                String unitId = name.substring(UNIT_RULEFLOW_PREFIX.length());
+                return ruleUnit(unitId);
+            }
+            return ruleFlowGroup(name);
         }
 
         public static RuleFlowGroup ruleFlowGroup(String name) {

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/RuleSetNode.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/RuleSetNode.java
@@ -41,7 +41,7 @@ public class RuleSetNode extends StateBasedNode implements ContextContainer {
 
     public static abstract class RuleType implements Serializable {
 
-        public static final String UNIT_RULEFLOW_PREFIX = "unit:";
+        private static final String UNIT_RULEFLOW_PREFIX = "unit:";
 
         public static RuleType of(String name, String language) {
             if (language.equals(DRL_LANG)) {
@@ -53,8 +53,8 @@ public class RuleSetNode extends StateBasedNode implements ContextContainer {
             }
         }
 
-        public static RuleType parseRuleFlowGroup(String name) {
-            if (name.startsWith("unit:")) {
+        private static RuleType parseRuleFlowGroup(String name) {
+            if (name.startsWith(UNIT_RULEFLOW_PREFIX)) {
                 String unitId = name.substring(UNIT_RULEFLOW_PREFIX.length());
                 return ruleUnit(unitId);
             }

--- a/kogito-codegen/pom.xml
+++ b/kogito-codegen/pom.xml
@@ -95,6 +95,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ProcessCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ProcessCodegen.java
@@ -136,7 +136,7 @@ public class ProcessCodegen extends AbstractGenerator {
 
         // set default package name
         setPackageName(ApplicationGenerator.DEFAULT_PACKAGE_NAME);
-        contextClassLoader = this.getClass().getClassLoader();
+        contextClassLoader = Thread.currentThread().getContextClassLoader();
     }
 
     public static String defaultWorkItemHandlerConfigClass(String packageName) {

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/tests/BusinessRuleUnit.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/tests/BusinessRuleUnit.java
@@ -17,12 +17,28 @@ package org.kie.kogito.codegen.tests;
 import org.kie.kogito.codegen.data.Person;
 import org.kie.kogito.rules.DataSource;
 import org.kie.kogito.rules.DataStore;
+import org.kie.kogito.rules.DataStream;
 import org.kie.kogito.rules.RuleUnitMemory;
 
 public class BusinessRuleUnit implements RuleUnitMemory {
-    DataStore<Person> persons = DataSource.createStore();
+
+    private DataStore<Person> persons = DataSource.createStore();
+    private DataStream<String> strings = DataSource.createStream();
+    private String myGlobal;
 
     public DataStore<Person> getPersons() {
         return persons;
+    }
+
+    public DataStream<String> getStrings() {
+        return strings;
+    }
+
+    public void setMyGlobal(String myGlobal) {
+        this.myGlobal = myGlobal;
+    }
+
+    public String getMyGlobal() {
+        return myGlobal;
     }
 }

--- a/kogito-codegen/src/test/resources/org/kie/kogito/codegen/tests/BusinessRuleUnit.drl
+++ b/kogito-codegen/src/test/resources/org/kie/kogito/codegen/tests/BusinessRuleUnit.drl
@@ -24,3 +24,15 @@ rule isAdult
         System.out.println("Person " + $person.getName() + " is adult");
 		$person.setAdult(true);
 end
+
+
+rule hasString
+    when
+        $string : /strings
+    then
+        System.out.println("Found String " + $string);
+        System.out.println("also there is a global " + myGlobal);
+
+end
+
+

--- a/kogito-codegen/src/test/resources/org/kie/kogito/codegen/tests/BusinessRuleUnitAlternateSyntax.bpmn2
+++ b/kogito-codegen/src/test/resources/org/kie/kogito/codegen/tests/BusinessRuleUnitAlternateSyntax.bpmn2
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- origin at X=0.0 Y=0.0 -->
+<bpmn2:definitions targetNamespace="http://www.jboss.org/drools" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:ns="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://www.jboss.org/drools" xmlns="http://www.jboss.org/drools" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" id="Definitions_1" exporter="org.eclipse.bpmn2.modeler.core" exporterVersion="1.5.0.Final-v20180515-1642-B1">
+  <bpmn2:itemDefinition id="ItemDefinition_1" isCollection="false" structureRef="org.kie.kogito.codegen.data.Person"/>
+  <bpmn2:process id="BusinessRuleUnit" tns:version="1" tns:packageName="org.kie.kogito.codegen.tests" name="Default Process" isExecutable="false">
+    <bpmn2:extensionElements>
+      <tns:import name="org.kie.kogito.codegen.data.Person"/>
+    </bpmn2:extensionElements>
+    <bpmn2:property id="person" itemSubjectRef="ItemDefinition_1" name="person"/>
+    <bpmn2:startEvent id="StartEvent_1">
+      <bpmn2:extensionElements>
+        <tns:metaData name="elementname">
+          <tns:metaValue><![CDATA[]]></tns:metaValue>
+        </tns:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:outgoing>SequenceFlow_2</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:endEvent id="EndEvent_1">
+      <bpmn2:extensionElements>
+        <tns:metaData name="elementname">
+          <tns:metaValue><![CDATA[]]></tns:metaValue>
+        </tns:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>SequenceFlow_1</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="SequenceFlow_2" tns:priority="1" name="" sourceRef="StartEvent_1" targetRef="BusinessRuleTask_2"/>
+    <bpmn2:businessRuleTask id="BusinessRuleTask_2" tns:ruleFlowGroup="unit:org.kie.kogito.codegen.tests.BusinessRuleUnit" name="Business Rule Task">
+      <bpmn2:extensionElements>
+        <tns:metaData name="elementname">
+          <tns:metaValue><![CDATA[Business Rule Task]]></tns:metaValue>
+        </tns:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>SequenceFlow_2</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_1</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="InputOutputSpecification_1">
+        <bpmn2:dataInput id="DataInput_1" itemSubjectRef="ItemDefinition_1" name="persons"/>
+        <bpmn2:dataOutput id="DataOutput_1" itemSubjectRef="ItemDefinition_1" name="persons"/>
+        <bpmn2:inputSet id="InputSet_1" name="Input Set 1">
+          <bpmn2:dataInputRefs>DataInput_1</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet id="OutputSet_1" name="Output Set 1">
+          <bpmn2:dataOutputRefs>DataOutput_1</bpmn2:dataOutputRefs>
+        </bpmn2:outputSet>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="DataInputAssociation_1">
+        <bpmn2:sourceRef>person</bpmn2:sourceRef>
+        <bpmn2:targetRef>DataInput_1</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataOutputAssociation id="DataOutputAssociation_1">
+        <bpmn2:sourceRef>DataOutput_1</bpmn2:sourceRef>
+        <bpmn2:targetRef>person</bpmn2:targetRef>
+      </bpmn2:dataOutputAssociation>
+    </bpmn2:businessRuleTask>
+    <bpmn2:sequenceFlow id="SequenceFlow_1" tns:priority="1" sourceRef="BusinessRuleTask_2" targetRef="EndEvent_1"/>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1" name="Default Process Diagram">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="BusinessRuleTask">
+      <bpmndi:BPMNShape id="BPMNShape_1" bpmnElement="StartEvent_1">
+        <dc:Bounds height="36.0" width="36.0" x="100.0" y="100.0"/>
+        <bpmndi:BPMNLabel/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_2" bpmnElement="EndEvent_1">
+        <dc:Bounds height="36.0" width="36.0" x="500.0" y="100.0"/>
+        <bpmndi:BPMNLabel/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_BusinessRuleTask_2" bpmnElement="BusinessRuleTask_2">
+        <dc:Bounds height="50.0" width="160.0" x="240.0" y="93.0"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="11.0" width="79.0" x="280.0" y="112.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_1" bpmnElement="SequenceFlow_1" sourceElement="BPMNShape_BusinessRuleTask_2" targetElement="BPMNShape_2">
+        <di:waypoint xsi:type="dc:Point" x="400.0" y="118.0"/>
+        <di:waypoint xsi:type="dc:Point" x="500.0" y="118.0"/>
+        <bpmndi:BPMNLabel/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_2" bpmnElement="SequenceFlow_2" sourceElement="BPMNShape_1" targetElement="BPMNShape_BusinessRuleTask_2">
+        <di:waypoint xsi:type="dc:Point" x="136.0" y="118.0"/>
+        <di:waypoint xsi:type="dc:Point" x="240.0" y="118.0"/>
+        <bpmndi:BPMNLabel/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn2:definitions>


### PR DESCRIPTION
- use correctly `add` or `append` method when using different kinds of data sources (store and stream respectively)
- add back support for ruleFlowGroup="unit:fully.qualified.ClassName" for interim compat with editors