### PR TITLE
[KOGITO-290] - Adding Prometheus label metadata to codegen

### DIFF
--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/AbstractGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/AbstractGenerator.java
@@ -16,16 +16,19 @@
 package org.kie.kogito.codegen;
 
 import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
 
 public abstract class AbstractGenerator implements Generator {
-    
+
     protected Path projectDirectory;
     protected GeneratorContext context;
+
+    private final Map<String, String> labels = new HashMap<>();
 
     @Override
     public void setProjectDirectory(Path projectDirectory) {
         this.projectDirectory = projectDirectory;
-        
     }
 
     @Override
@@ -38,5 +41,13 @@ public abstract class AbstractGenerator implements Generator {
         return this.context;
     }
 
+    public final void addLabel(final String key, final String value) {
+        this.labels.put(key, value);
+    }
+
+    @Override
+    public final Map<String, String> getLabels() {
+        return labels;
+    }
 
 }

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/ApplicationGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/ApplicationGenerator.java
@@ -51,6 +51,8 @@ import org.drools.modelcompiler.builder.BodyDeclarationComparator;
 import org.kie.kogito.Config;
 import org.kie.kogito.codegen.di.DependencyInjectionAnnotator;
 import org.kie.kogito.codegen.metadata.ImageMetaData;
+import org.kie.kogito.codegen.metadata.Labeler;
+import org.kie.kogito.codegen.metadata.PrometheusLabeler;
 import org.kie.kogito.event.EventPublisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -82,6 +84,7 @@ public class ApplicationGenerator {
     private final List<BodyDeclaration<?>> factoryMethods;
     private ConfigGenerator configGenerator;
     private List<Generator> generators = new ArrayList<>();
+    private List<Labeler> labelers = new ArrayList<>();
 
     private GeneratorContext context = new GeneratorContext();
     private boolean persistence;
@@ -203,6 +206,13 @@ public class ApplicationGenerator {
        this.persistence = persistence;
        return this;
    }
+   
+   public ApplicationGenerator withMonitoring(boolean monitoring) {
+       if (monitoring) {
+           this.labelers.add(new PrometheusLabeler());
+       }
+       return this;
+   }
 
     public Collection<GeneratedFile> generate() {
         List<GeneratedFile> generatedFiles = generateComponents();
@@ -213,6 +223,7 @@ public class ApplicationGenerator {
         if (useInjection()) {
             generators.forEach(gen -> generateSectionClass(gen.section(), generatedFiles));
         }
+        this.labelers.forEach(l -> writeLabelsImageMetadata(l.generateLabels()));
         return generatedFiles;
     }
 

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionCodegen.java
@@ -86,7 +86,6 @@ public class DecisionCodegen extends AbstractGenerator {
     private DecisionContainerGenerator moduleGenerator;
 
     private final Map<String, Definitions> models;
-    private final Map<String, String> labels = new HashMap<>();
     private final List<GeneratedFile> generatedFiles = new ArrayList<>();
 
     public DecisionCodegen(Collection<? extends Definitions> models) {
@@ -143,10 +142,6 @@ public class DecisionCodegen extends AbstractGenerator {
 
     public List<GeneratedFile> getGeneratedFiles() {
         return generatedFiles;
-    }
-
-    public Map<String, String> getLabels() {
-        return labels;
     }
 
     @Override

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/metadata/Labeler.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/metadata/Labeler.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.kogito.codegen.metadata;
+
+import java.util.Map;
+
+/**
+ * Base interface for providing labels to Generators 
+ */
+public interface Labeler {
+
+    Map<String, String> generateLabels();
+
+}

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/metadata/PrometheusLabeler.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/metadata/PrometheusLabeler.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.kogito.codegen.metadata;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Adds Prometheus metadata labels
+ */
+public class PrometheusLabeler implements Labeler {
+
+    static final String PROMETHEUS_LABEL_PREFIX = "prometheus.io";
+    static final String LABEL_PATH = PROMETHEUS_LABEL_PREFIX + "/path";
+    static final String LABEL_SCHEME = PROMETHEUS_LABEL_PREFIX + "/scheme";
+    static final String LABEL_PORT = PROMETHEUS_LABEL_PREFIX + "/port";
+    static final String LABEL_SCRAPE = PROMETHEUS_LABEL_PREFIX + "/scrape";
+    static final String DEFAULT_PATH = "/metrics";
+    static final String DEFAULT_SCHEME = "http";
+    static final String DEFAULT_PORT = "8080";
+    static final String DEFAULT_SCRAPE = "true";
+
+    private final Map<String, String> labels = new HashMap<>();
+
+    public PrometheusLabeler() {
+        labels.put(LABEL_PATH, DEFAULT_PATH);
+        labels.put(LABEL_SCHEME, DEFAULT_SCHEME);
+        labels.put(LABEL_PORT, DEFAULT_PORT);
+        labels.put(LABEL_SCRAPE, DEFAULT_SCRAPE);
+    }
+
+    @Override
+    public Map<String, String> generateLabels() {
+        return labels;
+    }
+
+}

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ProcessCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ProcessCodegen.java
@@ -122,7 +122,6 @@ public class ProcessCodegen extends AbstractGenerator {
     private ProcessesContainerGenerator moduleGenerator;
 
     private final Map<String, WorkflowProcess> processes;
-    private final Map<String, String> labels = new HashMap<>();
     private final List<GeneratedFile> generatedFiles = new ArrayList<>();
     
     private boolean persistence;
@@ -336,7 +335,7 @@ public class ProcessCodegen extends AbstractGenerator {
         for (ProcessExecutableModelGenerator legacyProcessGenerator : processExecutableModelGenerators) {
             if (legacyProcessGenerator.isPublic()) {
                 publicProcesses.add(legacyProcessGenerator.extractedProcessId());
-                labels.put(legacyProcessGenerator.label(), "process");// add the label id of the process with value set to process as resource type
+                this.addLabel(legacyProcessGenerator.label(), "process"); // add the label id of the process with value set to process as resource type
             }
         }
 
@@ -357,10 +356,6 @@ public class ProcessCodegen extends AbstractGenerator {
 
     public List<GeneratedFile> getGeneratedFiles() {
         return generatedFiles;
-    }
-
-    public Map<String, String> getLabels() {
-        return labels;
     }
 
     @Override

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
@@ -121,7 +121,6 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
     };
     private final Collection<Resource> resources;
     private RuleUnitContainerGenerator moduleGenerator;
-    private final Map<String, String> labels;
 
     private boolean dependencyInjection;
     private DependencyInjectionAnnotator annotator;
@@ -143,7 +142,6 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
         this.kieModuleModel = new KieModuleModelImpl();
         setDefaultsforEmptyKieModule(kieModuleModel);
         this.contextClassLoader = getClass().getClassLoader();
-        this.labels = new HashMap<>();
     }
 
     @Override
@@ -217,7 +215,7 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
 
             for (RuleUnitSourceClass ruleUnit : moduleGenerator.getRuleUnits()) {
                 // add the label id of the rule unit with value set to `rules` as resource type
-                labels.put(ruleUnit.label(), "rules");
+                this.addLabel(ruleUnit.label(), "rules");
                 ruleUnit.setApplicationPackageName(packageName);
 
                 generatedFiles.add( ruleUnit.generateFile(GeneratedFile.Type.RULE) );
@@ -289,11 +287,6 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
     private void addGeneratedFile( List<GeneratedFile> generatedFiles, org.drools.modelcompiler.builder.GeneratedFile source, String pathPrefix ) {
         ApplicationGenerator.log( source.getData() );
         generatedFiles.add( new GeneratedFile(GeneratedFile.Type.RULE, pathPrefix + source.getPath(), source.getData()) );
-    }
-
-    @Override
-    public Map<String, String> getLabels() {
-        return labels;
     }
 
     @Override

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/ApplicationGeneratorTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/ApplicationGeneratorTest.java
@@ -40,6 +40,7 @@ import com.github.javaparser.ast.body.VariableDeclarator;
 import org.junit.jupiter.api.Test;
 import org.kie.kogito.Config;
 import org.kie.kogito.codegen.di.CDIDependencyInjectionAnnotator;
+import org.kie.kogito.codegen.metadata.PrometheusLabeler;
 import org.mockito.Mockito;
 
 import static org.assertj.core.api.Assertions.*;
@@ -108,6 +109,14 @@ public class ApplicationGeneratorTest {
         final ApplicationGenerator appGenerator = new ApplicationGenerator(PACKAGE_NAME, new File("target"));
         final Collection<GeneratedFile> generatedFiles = appGenerator.generate();
         assertGeneratedFiles(generatedFiles, appGenerator.compilationUnit().toString().getBytes(StandardCharsets.UTF_8), 2);
+    }
+    
+    @Test
+    public void generateWithMonitoring() throws IOException {
+        final Path targetDirectory = Paths.get("target");
+        final ApplicationGenerator appGenerator = new ApplicationGenerator(PACKAGE_NAME, targetDirectory.toFile()).withMonitoring(true);
+        appGenerator.generate();
+        assertImageMetadata(targetDirectory, new PrometheusLabeler().generateLabels());
     }
 
     @Test

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/metadata/PrometheusLabelerTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/metadata/PrometheusLabelerTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.codegen.metadata;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PrometheusLabelerTest {
+
+    @Test
+    void testGenerateLabels() {
+       final Labeler labeler = new PrometheusLabeler();
+       final Map<String, String> labels = labeler.generateLabels();
+       
+       assertThat(labels).size().isEqualTo(4);
+       assertThat(labels).containsEntry(PrometheusLabeler.LABEL_PATH, PrometheusLabeler.DEFAULT_PATH);
+       assertThat(labels).containsEntry(PrometheusLabeler.LABEL_PORT, PrometheusLabeler.DEFAULT_PORT);
+       assertThat(labels).containsEntry(PrometheusLabeler.LABEL_SCHEME, PrometheusLabeler.DEFAULT_SCHEME);
+       assertThat(labels).containsEntry(PrometheusLabeler.LABEL_SCRAPE, PrometheusLabeler.DEFAULT_SCRAPE);
+    }
+
+}

--- a/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
+++ b/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
@@ -173,11 +173,13 @@ public class GenerateModelMojo extends AbstractKieMojo {
             appPackageName = ApplicationGenerator.DEFAULT_PACKAGE_NAME;
         }
         boolean usePersistence = persistence || hasClassOnClasspath("org.kie.kogito.persistence.KogitoProcessInstancesFactory");
+        boolean useMonitoring = hasClassOnClasspath("org.kie.addons.monitoring.rest.MetricsResource"); 
         
         ApplicationGenerator appGen =
                 new ApplicationGenerator(appPackageName, targetDirectory)
                         .withDependencyInjection(discoverDependencyInjectionAnnotator(dependencyInjection, project))
-                        .withPersistence(usePersistence);
+                        .withPersistence(usePersistence)
+                        .withMonitoring(useMonitoring);
 
         ClassLoader projectClassLoader = MojoUtil.createProjectClassLoader(this.getClass().getClassLoader(),
                                                                            project,


### PR DESCRIPTION
See:
https://issues.jboss.org/browse/KOGITO-290

In this PR we added the support for the Prometheus labels in the  `image_metadata.json` file. The final result is going to be like this:

```json
cat rain-forecast-process/target/image_metadata.json 
{
  "labels" : [ {
    "org.kie/rainforecast" : "process",
    "prometheus.io/path" : "/metrics",
    "prometheus.io/scheme" : "http",
    "prometheus.io/port" : "8080",
    "prometheus.io/scrape" : "true"
  } ]
}
```

**TODO:**

[x]  - Unit tests