### PR TITLE
[KOGITO-309] Adding support for external hotrod-client.properties

### DIFF
--- a/data-index/data-index-service/src/main/resources/META-INF/hotrod-client.properties
+++ b/data-index/data-index-service/src/main/resources/META-INF/hotrod-client.properties
@@ -1,9 +1,0 @@
-# Docker 4 Mac workaround
-infinispan.client.hotrod.client_intelligence=BASIC
-# https://docs.jboss.org/infinispan/9.4/apidocs/org/infinispan/client/hotrod/configuration/package-summary.html
-# https://infinispan.org/docs/dev/user_guide/user_guide.html#configuration_10
-infinispan.client.hotrod.auth_username=${infinispan_username}
-infinispan.client.hotrod.auth_password=${infinispan_password}
-infinispan.client.hotrod.use_auth=${infinispan_useauth}
-infinispan.client.hotrod.auth_realm=${infinispan_authrealm}
-infinispan.client.hotrod.sasl_mechanism=${infinispan_saslmechanism}

--- a/data-index/data-index-service/src/main/resources/META-INF/kogito-cache-default.xml
+++ b/data-index/data-index-service/src/main/resources/META-INF/kogito-cache-default.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <infinispan
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="urn:infinispan:config:10.0 http://www.infinispan.org/schemas/infinispan-config-10.0.xsd"
+  xsi:schemaLocation="urn:infinispan:config:10.0 https://infinispan.org/schemas/infinispan-config-10.0.xsd"
   xmlns="urn:infinispan:config:10.0">
   <cache-container statistics="true" shutdown-hook="DEFAULT">
     <local-cache name="${cache_name}">

--- a/data-index/data-index-storage/data-index-storage-infinispan/pom.xml
+++ b/data-index/data-index-storage/data-index-storage-infinispan/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>data-index-storage</artifactId>
@@ -41,6 +41,27 @@
       <groupId>javax.json</groupId>
       <artifactId>javax.json-api</artifactId>
       <scope>provided</scope>
+    </dependency>
+    <!-- test dependencies -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/data-index/data-index-storage/data-index-storage-infinispan/src/test/java/org/kie/kogito/index/infinispan/cache/InfinispanCacheManagerTest.java
+++ b/data-index/data-index-storage/data-index-storage-infinispan/src/test/java/org/kie/kogito/index/infinispan/cache/InfinispanCacheManagerTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.index.infinispan.cache;
+
+import java.io.IOException;
+
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InfinispanCacheManagerTest {
+
+    @Test
+    void testConfigureWithNoAditionalProperties() throws IOException {
+        final InfinispanCacheManager cm = new InfinispanCacheManager();
+        cm.configure();
+        // null b/c we're not relying on inject here
+        assertThat(cm.manager).isNull();
+    }
+
+    @Test
+    void testConfigureWithAuthHotRodProperty() throws IOException {
+        final InfinispanCacheManager cm = new InfinispanCacheManager();
+        cm.hotRodPropertiesFilePath = this.getClass().getResource("/auth-properties").getPath();
+        cm.configure();
+        assertThat(cm.manager).isNotNull();
+        assertThat(cm.manager.getConfiguration().properties().getProperty("infinispan.client.hotrod.use_auth")).isEqualTo("true");
+    }
+    
+    @Test
+    void testConfigureWithNoAuthHotRodProperty() throws IOException {
+        final InfinispanCacheManager cm = new InfinispanCacheManager();
+        cm.hotRodPropertiesFilePath = this.getClass().getResource("/no-auth-properties").getPath();
+        cm.configure();
+        assertThat(cm.manager).isNotNull();
+        assertThat(cm.manager.getConfiguration().properties().getProperty("infinispan.client.hotrod.use_auth")).isEqualTo("false");
+    }
+    
+    @Test
+    void testConfigureWithAlreadyConfiguredCache() throws IOException {
+        final InfinispanCacheManager cm = new InfinispanCacheManager();
+        cm.manager = new RemoteCacheManager();
+        assertThat(cm.manager.getConfiguration().properties().getProperty("infinispan.client.hotrod.use_auth")).isEqualTo("false");
+        cm.hotRodPropertiesFilePath = this.getClass().getResource("/auth-properties").getPath();
+        cm.init();
+        assertThat(cm.manager).isNotNull();
+        assertThat(cm.manager.getConfiguration().properties().getProperty("infinispan.client.hotrod.use_auth")).isEqualTo("true");
+    }
+
+    @Test
+    void testConfigureFileDoesNotExist() throws IOException {
+        final InfinispanCacheManager cm = new InfinispanCacheManager();
+        cm.hotRodPropertiesFilePath = "/this/path/does/not/exist";
+        cm.configure();
+        assertThat(cm.manager).isNull();
+    }
+    
+}

--- a/data-index/data-index-storage/data-index-storage-infinispan/src/test/resources/auth-properties/hotrod-client.properties
+++ b/data-index/data-index-storage/data-index-storage-infinispan/src/test/resources/auth-properties/hotrod-client.properties
@@ -1,0 +1,4 @@
+# https://docs.jboss.org/infinispan/9.4/apidocs/org/infinispan/client/hotrod/configuration/package-summary.html
+# https://infinispan.org/docs/dev/user_guide/user_guide.html#configuration_10
+infinispan.client.hotrod.auth_username=test
+infinispan.client.hotrod.auth_password=test

--- a/data-index/data-index-storage/data-index-storage-infinispan/src/test/resources/no-auth-properties/hotrod-client.properties
+++ b/data-index/data-index-storage/data-index-storage-infinispan/src/test/resources/no-auth-properties/hotrod-client.properties
@@ -1,0 +1,1 @@
+infinispan.client.hotrod.use_auth=false


### PR DESCRIPTION
See:
https://issues.jboss.org/browse/KOGITO-309

In this PR we added the possibility to users to set their custom `hotrod-client.properties` via `kogito.cache.hotrod.property.path` property. 

This way, the Operator would mount a property file inside a ConfigMap and set this property to where the file is.

We also removed the older placeholder since those variables will be vanished, being replaced by the custom hothod-client file. To keep the compatibility with older versions, the Operator will continue to accept the authentication options, setting them to the ConfigMap instead of using env vars.

The image will change too, since it won't need to inject auth vars to env.