### PR TITLE
KOGITO-412: Infer parameter type for workitems (processes)

### DIFF
--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ProcessToExecModelGenerator.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ProcessToExecModelGenerator.java
@@ -86,7 +86,7 @@ public class ProcessToExecModelGenerator extends AbstractVisitor {
         this.nodesVisitors.put(ActionNode.class, new ActionNodeVisitor());
         this.nodesVisitors.put(EndNode.class, new EndNodeVisitor());
         this.nodesVisitors.put(HumanTaskNode.class, new HumanTaskNodeVisitor());
-        this.nodesVisitors.put(WorkItemNode.class, new WorkItemNodeVisitor());
+        this.nodesVisitors.put(WorkItemNode.class, new WorkItemNodeVisitor(contextClassLoader));
         this.nodesVisitors.put(SubProcessNode.class, new LambdaSubProcessNodeVisitor());
         this.nodesVisitors.put(Split.class, new SplitNodeVisitor());
         this.nodesVisitors.put(Join.class, new JoinNodeVisitor());

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/tests/ServiceTaskTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/tests/ServiceTaskTest.java
@@ -128,9 +128,16 @@ public class ServiceTaskTest extends AbstractCodegenTest {
     }
 
     @Test
-    public void malformedShouldThrowException() {
+    public void malformedShouldThrowException() throws Exception {
         assertThrows(ProcessCodegenException.class, () -> {
             generateCodeProcessesOnly("servicetask/ServiceProcessMalformed.bpmn2");
         });
     }
+
+    @Test
+    public void shouldInferMethodSignatureFromClass() throws Exception {
+        // should no throw
+        generateCodeProcessesOnly("servicetask/ServiceProcessInferMethod.bpmn2");
+    }
+
 }

--- a/kogito-codegen/src/test/resources/servicetask/ServiceProcessInferMethod.bpmn2
+++ b/kogito-codegen/src/test/resources/servicetask/ServiceProcessInferMethod.bpmn2
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions id="_6403D79B-D01C-478F-8D3F-44F0137A7F99" exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools">
+  <bpmn2:itemDefinition id="_A4520009-200E-46DD-B0F4-6B50B3703612_InMessageType" structureRef=""/>
+  <bpmn2:itemDefinition id="_A4520009-200E-46DD-B0F4-6B50B3703612_OutMessageType" structureRef=""/>
+  <bpmn2:itemDefinition id="__A4520009-200E-46DD-B0F4-6B50B3703612_ParameterInputXItem" structureRef="String"/>
+  <bpmn2:message id="_A4520009-200E-46DD-B0F4-6B50B3703612_InMessage" itemRef="_A4520009-200E-46DD-B0F4-6B50B3703612_InMessageType"/>
+  <bpmn2:message id="_A4520009-200E-46DD-B0F4-6B50B3703612_OutMessage" itemRef="_A4520009-200E-46DD-B0F4-6B50B3703612_OutMessageType"/>
+  <bpmn2:interface id="_A4520009-200E-46DD-B0F4-6B50B3703612_ServiceInterface" name="org.kie.kogito.codegen.data.HelloService" implementationRef="org.kie.kogito.codegen.data.HelloService">
+    <bpmn2:operation id="_A4520009-200E-46DD-B0F4-6B50B3703612_ServiceOperation" name="hello" implementationRef="hello">
+      <bpmn2:inMessageRef>_A4520009-200E-46DD-B0F4-6B50B3703612_InMessage</bpmn2:inMessageRef>
+      <bpmn2:outMessageRef>_A4520009-200E-46DD-B0F4-6B50B3703612_OutMessage</bpmn2:outMessageRef>
+    </bpmn2:operation>
+  </bpmn2:interface>
+  <bpmn2:process id="foobar" drools:version="1.0" drools:adHoc="false" name="foobar" isExecutable="true" processType="Public">
+    <bpmn2:sequenceFlow id="_780B6632-C650-4753-99E6-E89746DFB51E" sourceRef="_A4520009-200E-46DD-B0F4-6B50B3703612" targetRef="_01749F2C-5AA6-4CC3-AFF2-E65AA714E903">
+      <bpmn2:extensionElements>
+        <drools:metaData name="isAutoConnection.source">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+        <drools:metaData name="isAutoConnection.target">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+    </bpmn2:sequenceFlow>
+    <bpmn2:sequenceFlow id="_3B0D7E71-5757-473E-8431-EA5C1E1388EE" sourceRef="_B56F6C7C-5A4A-4FF1-96A7-AB83FCD7C68C" targetRef="_A4520009-200E-46DD-B0F4-6B50B3703612">
+      <bpmn2:extensionElements>
+        <drools:metaData name="isAutoConnection.source">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+        <drools:metaData name="isAutoConnection.target">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+    </bpmn2:sequenceFlow>
+    <bpmn2:endEvent id="_01749F2C-5AA6-4CC3-AFF2-E65AA714E903">
+      <bpmn2:incoming>_780B6632-C650-4753-99E6-E89746DFB51E</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:serviceTask id="_A4520009-200E-46DD-B0F4-6B50B3703612" drools:serviceimplementation="Java" drools:serviceinterface="org.kie.kogito.codegen.data.HelloService" drools:serviceoperation="hello" name="Task" implementation="Java" operationRef="_A4520009-200E-46DD-B0F4-6B50B3703612_ServiceOperation">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Task]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_3B0D7E71-5757-473E-8431-EA5C1E1388EE</bpmn2:incoming>
+      <bpmn2:outgoing>_780B6632-C650-4753-99E6-E89746DFB51E</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_OvxXANFUEDed7vZfaMZkog">
+        <bpmn2:dataInput id="_A4520009-200E-46DD-B0F4-6B50B3703612_ParameterInputX" drools:dtype="String" itemSubjectRef="__A4520009-200E-46DD-B0F4-6B50B3703612_ParameterInputXItem" name="Parameter"/>
+        <bpmn2:inputSet id="_Ovx-ENFUEDed7vZfaMZkog">
+          <bpmn2:dataInputRefs>_A4520009-200E-46DD-B0F4-6B50B3703612_ParameterInputX</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="_OvylINFUEDed7vZfaMZkog">
+        <bpmn2:targetRef>_A4520009-200E-46DD-B0F4-6B50B3703612_ParameterInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_OvylIdFUEDed7vZfaMZkog">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_OvzzQNFUEDed7vZfaMZkog"><![CDATA["Hello"]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_Ov0aUNFUEDed7vZfaMZkog">_A4520009-200E-46DD-B0F4-6B50B3703612_ParameterInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+    </bpmn2:serviceTask>
+    <bpmn2:startEvent id="_B56F6C7C-5A4A-4FF1-96A7-AB83FCD7C68C">
+      <bpmn2:outgoing>_3B0D7E71-5757-473E-8431-EA5C1E1388EE</bpmn2:outgoing>
+    </bpmn2:startEvent>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram>
+    <bpmndi:BPMNPlane bpmnElement="foobar">
+      <bpmndi:BPMNShape id="shape__B56F6C7C-5A4A-4FF1-96A7-AB83FCD7C68C" bpmnElement="_B56F6C7C-5A4A-4FF1-96A7-AB83FCD7C68C">
+        <dc:Bounds height="56" width="56" x="100" y="100"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__A4520009-200E-46DD-B0F4-6B50B3703612" bpmnElement="_A4520009-200E-46DD-B0F4-6B50B3703612">
+        <dc:Bounds height="102" width="154" x="236" y="77"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__01749F2C-5AA6-4CC3-AFF2-E65AA714E903" bpmnElement="_01749F2C-5AA6-4CC3-AFF2-E65AA714E903">
+        <dc:Bounds height="56" width="56" x="470" y="100"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="edge_shape__B56F6C7C-5A4A-4FF1-96A7-AB83FCD7C68C_to_shape__A4520009-200E-46DD-B0F4-6B50B3703612" bpmnElement="_3B0D7E71-5757-473E-8431-EA5C1E1388EE">
+        <di:waypoint x="156" y="128"/>
+        <di:waypoint x="236" y="128"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_shape__A4520009-200E-46DD-B0F4-6B50B3703612_to_shape__01749F2C-5AA6-4CC3-AFF2-E65AA714E903" bpmnElement="_780B6632-C650-4753-99E6-E89746DFB51E">
+        <di:waypoint x="390" y="128"/>
+        <di:waypoint x="470" y="128"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship id="_Ov2PgNFUEDed7vZfaMZkog" type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters/>
+          <bpsim:ElementParameters elementRef="_B56F6C7C-5A4A-4FF1-96A7-AB83FCD7C68C">
+            <bpsim:TimeParameters>
+              <bpsim:ProcessingTime>
+                <bpsim:NormalDistribution mean="0" standardDeviation="0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters elementRef="_A4520009-200E-46DD-B0F4-6B50B3703612">
+            <bpsim:TimeParameters>
+              <bpsim:ProcessingTime>
+                <bpsim:NormalDistribution mean="0" standardDeviation="0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters>
+              <bpsim:Availability>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:Availability>
+              <bpsim:Quantity>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters>
+              <bpsim:UnitCost>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_6403D79B-D01C-478F-8D3F-44F0137A7F99</bpmn2:source>
+    <bpmn2:target>_6403D79B-D01C-478F-8D3F-44F0137A7F99</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>


### PR DESCRIPTION
Currently it looks like the parameter type for the WorkItem generated handler is taken from the type of the input `Parameter`. However, if the input `Parameter` is not a variable (e.g. a constant or an expression) it is just defaulted to `java.lang.Object`

This modification does a bit of reflection *at compile time* attempting to look up the given interface and operation; for a given interface X and operation y, it looks up method `X#y(T)` and tries to infer `ParameterType` to `T` when `ParameterType` is `java.lang.Object` instead of relying on the type declaration of the inputType.

