### PR TITLE
KOGITO-388: ApplicationGenerator breaks when packageName contains hyphens

### DIFF
--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/ApplicationGeneratorTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/ApplicationGeneratorTest.java
@@ -66,6 +66,12 @@ public class ApplicationGeneratorTest {
     }
 
     @Test
+    public void packageNameInvalid() {
+        assertThatThrownBy(() -> new ApplicationGenerator("i.am.an-invalid.package-name.sorry", new File("")))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
     public void generatedFilePath() {
         final ApplicationGenerator appGenerator = new ApplicationGenerator(PACKAGE_NAME, new File(""));
         assertThat(appGenerator.generatedFilePath()).isNotNull();


### PR DESCRIPTION
now it throws if the package name is invalid. On a slightly-related note, we found out about this bug because a user was using dashes inside their groupId. I was wondering whether we really need to use a packageName == groupId instead of a default package name like quarkus. Doing so could simplify a few assumptions we make sometimes (e.g., where `Application` class is)