### PR TITLE
KOGITO-463 - Move to javax.annotation-api instead of jsr250-api

### DIFF
--- a/drools/drools-model/drools-mvel-parser/pom.xml
+++ b/drools/drools-model/drools-mvel-parser/pom.xml
@@ -23,8 +23,7 @@
     </dependency>
     <dependency>
       <groupId>javax.annotation</groupId>
-      <artifactId>jsr250-api</artifactId>
-      <version>1.0</version>
+      <artifactId>javax.annotation-api</artifactId>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
depends on https://github.com/kiegroup/kogito-bom/pull/64