### PR TITLE
[KOGITO-496] Writing compressed labels for protobuf files

### DIFF
--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/metadata/PersistenceLabelerTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/metadata/PersistenceLabelerTest.java
@@ -15,10 +15,11 @@
 
 package org.kie.kogito.codegen.metadata;
 
-import java.io.File;
-import java.io.UncheckedIOException;
+import java.io.*;
 import java.net.URISyntaxException;
+import java.util.Base64;
 import java.util.Map;
+import java.util.zip.GZIPInputStream;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -28,7 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class PersistenceLabelerTest {
 
     @Test
-    void testGenerateLabels() throws URISyntaxException {
+    void testGenerateLabels() throws URISyntaxException, IOException {
         final PersistenceLabeler labeler = new PersistenceLabeler();
         final File protoFile = new File(this.getClass().getResource("/kogito-types.proto").toURI());
         final File kogitoApplication = new File(this.getClass().getResource("/kogito-application.proto").toURI());
@@ -43,6 +44,8 @@ public class PersistenceLabelerTest {
 
         assertThat(labels).size().isEqualTo(1);
         assertThat(labels).containsKey(labeler.generateKey(protoFile));
+        final byte[] bytes = Base64.getDecoder().decode(labels.get("org.kie/persistence/proto/kogito-types.proto"));
+        assertThat(bytes).hasSize(229); //compressed bytes: http://www.txtwizard.net/compression
     }
 
     @Test


### PR DESCRIPTION
See:
https://issues.jboss.org/browse/KOGITO-496

Now we are compressing the protobuf file content as a workaround for the OpenShift labels limit size until we finish the new solution to those files during runtime.

Related:
https://github.com/kiegroup/kogito-cloud-operator/pull/99

