### PR TITLE
[KOGITO-309] - Removing custom hotrod-client.properties

### DIFF
--- a/data-index/data-index-service/src/main/resources/META-INF/hotrod-client.properties
+++ b/data-index/data-index-service/src/main/resources/META-INF/hotrod-client.properties
@@ -2,8 +2,3 @@
 infinispan.client.hotrod.client_intelligence=BASIC
 # https://docs.jboss.org/infinispan/9.4/apidocs/org/infinispan/client/hotrod/configuration/package-summary.html
 # https://infinispan.org/docs/dev/user_guide/user_guide.html#configuration_10
-infinispan.client.hotrod.auth_username=${infinispan_username}
-infinispan.client.hotrod.auth_password=${infinispan_password}
-infinispan.client.hotrod.use_auth=${infinispan_useauth}
-infinispan.client.hotrod.auth_realm=${infinispan_authrealm}
-infinispan.client.hotrod.sasl_mechanism=${infinispan_saslmechanism}

--- a/data-index/data-index-service/src/main/resources/META-INF/kogito-cache-default.xml
+++ b/data-index/data-index-service/src/main/resources/META-INF/kogito-cache-default.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <infinispan
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="urn:infinispan:config:10.0 http://www.infinispan.org/schemas/infinispan-config-10.0.xsd"
+  xsi:schemaLocation="urn:infinispan:config:10.0 https://infinispan.org/schemas/infinispan-config-10.0.xsd"
   xmlns="urn:infinispan:config:10.0">
   <cache-container statistics="true" shutdown-hook="DEFAULT">
     <local-cache name="${cache_name}">


### PR DESCRIPTION
After having this PR (https://github.com/quarkusio/quarkus/pull/4502) merged, we don't need to rely on properties override in the hotrod-client.properties in the classpath.

For more info see:
https://quarkus.io/guides/infinispan-client-guide#quarkus-infinispan-client_configuration