### PR TITLE
KOGITO-535: securing the GraphQL endpoint using quarkus security conf

### DIFF
--- a/data-index/data-index-service/src/main/java/org/kie/kogito/index/vertx/VertxRouterSetup.java
+++ b/data-index/data-index-service/src/main/java/org/kie/kogito/index/vertx/VertxRouterSetup.java
@@ -22,7 +22,6 @@ import javax.inject.Inject;
 
 import graphql.GraphQL;
 import io.vertx.ext.web.Router;
-import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.FaviconHandler;
 import io.vertx.ext.web.handler.LoggerHandler;
 import io.vertx.ext.web.handler.StaticHandler;
@@ -45,46 +44,17 @@ public class VertxRouterSetup {
     Boolean authEnabled;
 
     @Inject
-    @ConfigProperty(name = "kogito.dataindex.auth.requiredrole", defaultValue = "none")
-    String requiredRole;
-
-    @Inject
     GraphQL graphQL;
 
     void setupRouter(@Observes Router router) {
-        if (authEnabled) {
-            router.route().handler(routeContext -> authCheck(routeContext));
+        if (!authEnabled) {
+            router.route("/graphiql/*").handler(GraphiQLHandler.create(new GraphiQLHandlerOptions().setEnabled(true)));
+            router.route().handler(LoggerHandler.create());
+            router.route().handler(StaticHandler.create());
+            router.route().handler(FaviconHandler.create());
+            router.route("/").handler(ctx -> ctx.response().putHeader("location", "/graphiql/").setStatusCode(302).end());
         }
         router.route("/graphql").handler(ApolloWSHandler.create(graphQL));
         router.route("/graphql").handler(GraphQLHandler.create(graphQL, new GraphQLHandlerOptions()));
-        router.route("/graphiql/*").handler(GraphiQLHandler.create(new GraphiQLHandlerOptions().setEnabled(true)));
-        router.route("/").handler(ctx -> ctx.response().putHeader("location", "/graphiql/").setStatusCode(302).end());
-        router.route().handler(LoggerHandler.create());
-        router.route().handler(StaticHandler.create());
-        router.route().handler(FaviconHandler.create());
-    }
-
-    public void authCheck(RoutingContext context) {
-
-        if (context.user() != null) {
-            context.user().isAuthorized(requiredRole,
-                                        res -> {
-                                            if (res.succeeded()) {
-                                                boolean hasAuthority = res.result();
-                                                if (!hasAuthority) {
-                                                    LOGGER.error("User does not have the authority");
-                                                    context.fail(403);
-                                                } else {
-                                                    context.next();
-                                                }
-                                            } else {
-                                                LOGGER.error("It was not able to retrieve user authorization ", res.cause());
-                                                context.fail(500);
-                                            }
-                                        });
-        } else {
-            LOGGER.error("Auth enabled but No user context found");
-            context.fail(401);
-        }
     }
 }

--- a/data-index/data-index-service/src/main/resources/application.properties
+++ b/data-index/data-index-service/src/main/resources/application.properties
@@ -41,4 +41,6 @@ quarkus.oidc.enabled=false
 %keycloak.quarkus.oidc.auth-server-url=http://localhost:8280/auth/realms/kogito
 %keycloak.quarkus.oidc.client-id=kogito-data-index-service
 %keycloak.quarkus.oidc.credentials.secret=secret
-%keycloak.kogito.dataindex.auth.requiredrole=confidential
+%keycloak.quarkus.http.auth.policy.role-policy1.roles-allowed=confidential
+%keycloak.quarkus.http.auth.permission.roles1.paths=/graphql
+%keycloak.quarkus.http.auth.permission.roles1.policy=role-policy1

--- a/data-index/data-index-service/src/test/java/org/kie/kogito/index/service/KeycloakIntegrationIndexingServiceTest.java
+++ b/data-index/data-index-service/src/test/java/org/kie/kogito/index/service/KeycloakIntegrationIndexingServiceTest.java
@@ -37,6 +37,9 @@ public class KeycloakIntegrationIndexingServiceTest {
     @BeforeAll
     public static void setup() {
         System.setProperty("quarkus.oidc.enabled", "true");
+        System.setProperty("quarkus.http.auth.policy.role-policy1.roles-allowed", "confidential");
+        System.setProperty("quarkus.http.auth.permission.roles1.paths", "/graphql");
+        System.setProperty("quarkus.http.auth.permission.roles1.policy", "role-policy1");
     }
 
     @Test
@@ -45,7 +48,7 @@ public class KeycloakIntegrationIndexingServiceTest {
         given().auth().oauth2(getAccessToken("alice"))
                 .when().get("/graphiql/")
                 .then()
-                .statusCode(403);
+                .statusCode(404);
 
         given().contentType(ContentType.JSON).body("{ \"query\" : \"{ProcessInstances{ id } }\" }")
                 .auth().oauth2(getAccessToken("alice"))
@@ -58,10 +61,9 @@ public class KeycloakIntegrationIndexingServiceTest {
     public void testNoTokenProvided() {
         given().when().get("/graphiql/")
                 .then()
-                .statusCode(401);
+                .statusCode(404);
 
-        given().contentType(ContentType.JSON)
-                .body("{ \"query\" : \"{ProcessInstances{ id } }\" }")
+        given().contentType(ContentType.JSON).body("{ \"query\" : \"{ProcessInstances{ id } }\" }")
                 .when().get("/graphql")
                 .then()
                 .statusCode(401);
@@ -73,7 +75,8 @@ public class KeycloakIntegrationIndexingServiceTest {
         given().auth().oauth2(getAccessToken("jdoe"))
                 .when().get("/graphiql/")
                 .then()
-                .statusCode(200);
+                .statusCode(404);
+
         given().auth().oauth2(getAccessToken("jdoe"))
                 .contentType(ContentType.JSON)
                 .body("{ \"query\" : \"{ProcessInstances{ id } }\" }")

--- a/data-index/data-index-service/src/test/resources/application.properties
+++ b/data-index/data-index-service/src/test/resources/application.properties
@@ -11,8 +11,6 @@ quarkus.log.category."graphql".level=DEBUG
 quarkus.infinispan-client.server-list=localhost:11232
 #keycloak
 quarkus.oidc.enabled=false
-#quarkus.oidc.enabled=true
 quarkus.oidc.auth-server-url=http://localhost:8281/auth/realms/kogito
 quarkus.oidc.client-id=kogito-data-index-service
 quarkus.oidc.credentials.secret=secret
-kogito.dataindex.auth.requiredrole=confidential


### PR DESCRIPTION
Add quarkus security configuration to manage data-index-service security
Disable graphiql UI when open id auth is enabled