### PR TITLE
KOGITO-639: kogito-runtimes pom should not depend on quarkus

### DIFF
--- a/addons/pom.xml
+++ b/addons/pom.xml
@@ -19,4 +19,18 @@
     <module>jobs</module>
   </modules>
 
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-bom</artifactId>
+        <version>${version.io.quarkus}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+
 </project>

--- a/addons/pom.xml
+++ b/addons/pom.xml
@@ -19,9 +19,32 @@
     <module>jobs</module>
   </modules>
 
-
   <dependencyManagement>
     <dependencies>
+      <!--
+        kogito-deps-bom and kogito-bom are duplicate in kogito-runtimes
+        we have to re-import it here, to override the versions in quarkus-bom.
+        Please notice this is only a partial fix, because kogito-extension
+        resides *inside* quarkus: if kogito-codegen changes some API,
+        then these submodules may break.
+
+        Solution would be to explicitly import all the quarkus dependencies here,
+        instead of importing them via bom.
+      -->
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-deps-bom</artifactId>
+        <version>${version.org.kie.kogito}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-bom</artifactId>
+        <version>${version.org.kie.kogito}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-bom</artifactId>

--- a/data-index/pom.xml
+++ b/data-index/pom.xml
@@ -21,6 +21,30 @@
 
   <dependencyManagement>
     <dependencies>
+      <!--
+        kogito-deps-bom and kogito-bom are duplicate in kogito-runtimes
+        we have to re-import it here, to override the versions in quarkus-bom.
+        Please notice this is only a partial fix, because kogito-extension
+        resides *inside* quarkus: if kogito-codegen changes some API,
+        then these submodules may break.
+
+        Solution would be to explicitly import all the quarkus dependencies here,
+        instead of importing them via bom.
+      -->
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-deps-bom</artifactId>
+        <version>${version.org.kie.kogito}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-bom</artifactId>
+        <version>${version.org.kie.kogito}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-bom</artifactId>

--- a/data-index/pom.xml
+++ b/data-index/pom.xml
@@ -19,4 +19,17 @@
   </modules>
 
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-bom</artifactId>
+        <version>${version.io.quarkus}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -77,13 +77,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <dependency>
-        <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-bom</artifactId>
-        <version>${version.io.quarkus}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
otherwise it will bring an older version of kogito-runtimes
as a transitive dependency