### PR TITLE
[KOGITO-612] - Add topics to image metadata

### DIFF
--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/ApplicationGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/ApplicationGenerator.java
@@ -32,6 +32,7 @@ import org.drools.modelcompiler.builder.BodyDeclarationComparator;
 import org.kie.kogito.Config;
 import org.kie.kogito.codegen.di.DependencyInjectionAnnotator;
 import org.kie.kogito.codegen.metadata.Labeler;
+import org.kie.kogito.codegen.metadata.MessagingLabeler;
 import org.kie.kogito.codegen.metadata.MetaDataWriter;
 import org.kie.kogito.codegen.metadata.PrometheusLabeler;
 import org.kie.kogito.event.EventPublisher;
@@ -92,6 +93,7 @@ public class ApplicationGenerator {
         this.sourceFilePath = targetCanonicalName.replace('.', '/') + ".java";
         this.factoryMethods = new ArrayList<>();
         this.configGenerator = new ConfigGenerator(packageName);
+        this.labelers.add(new MessagingLabeler(targetDirectory));
     }
 
     public String targetCanonicalName() {

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/metadata/MessagingLabeler.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/metadata/MessagingLabeler.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.codegen.metadata;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.StringJoiner;
+
+/**
+ * Generates labels for messaging add-ons.
+ * This {@link Labeler} will scan the target directory for the application.properties file
+ * and will read every property that starts with <code>mp.messaging.incoming.</code> or <code>mp.messaging.outcoming.</code>.
+ * Those properties values are going to be added to the image metadata to be read by cloud components.
+ *
+ * @see <a href="https://github.com/kiegroup/kogito-runtimes/wiki/Messaging">Kogito Runtimes - Messaging</a>
+ */
+public class MessagingLabeler implements Labeler {
+
+    static final String MESSAGING_LABEL_PREFIX = ImageMetaData.LABEL_PREFIX + "messaging/topics";
+    private static final String CLASSES_DIR = "classes";
+    private static final String PROPS_FILE = "application.properties";
+    private static final String KEY_REGEXP_PATTERN = "mp\\.messaging\\.(.+)\\.topic";
+    private static final Logger LOGGER = LoggerFactory.getLogger(MessagingLabeler.class);
+
+    private final File targetDirectory;
+    private final Map<String, String> labels = new HashMap<>();
+
+    public MessagingLabeler(File targetDirectory) {
+        this.targetDirectory = targetDirectory;
+    }
+
+    @Override
+    public Map<String, String> generateLabels() {
+        if (targetDirectory != null && targetDirectory.isDirectory()) {
+            final Path propertiesPath = Paths.get(targetDirectory.getPath(), CLASSES_DIR, PROPS_FILE);
+            if (propertiesPath.toFile().exists()) {
+                try (InputStream propsFile = Files.newInputStream(propertiesPath)) {
+                    StringJoiner sj = new StringJoiner(",");
+                    Properties applicationProperties = new Properties();
+                    applicationProperties.load(propsFile);
+                    applicationProperties
+                            .entrySet()
+                            .stream()
+                            .filter(p -> ((String) p.getKey()).matches(KEY_REGEXP_PATTERN))
+                            .forEach(p -> sj.add(p.getValue().toString()));
+                    if (sj.length() > 0) {
+                        LOGGER.debug("Adding topics to the labels: {}", sj);
+                        labels.put(MESSAGING_LABEL_PREFIX, sj.toString());
+                    }
+                } catch (IOException e) {
+                    throw new UncheckedIOException("Error while reading application.properties file", e);
+                }
+            }
+        }
+        return labels;
+    }
+
+}

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/metadata/MessagingLabelerTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/metadata/MessagingLabelerTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.codegen.metadata;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.net.URISyntaxException;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MessagingLabelerTest {
+
+    @Test
+    public void getLabelsFromApplicationWithTopics() throws URISyntaxException {
+        final MessagingLabeler labeler = new MessagingLabeler(new File(this.getClass().getResource("/labels/messaging/has_properties").toURI().getPath()));
+        final Map<String, String> labels = labeler.generateLabels();
+        final String topics[] = "kogito-usertaskinstances-events,kogito-processinstances-events,visasapproved,visasrejected,visaapplications".split(",");
+        assertThat(labels).isNotNull();
+        assertThat(labels).containsKey(MessagingLabeler.MESSAGING_LABEL_PREFIX);
+        assertThat(labels).hasSize(1);
+        assertThat(labels.get(MessagingLabeler.MESSAGING_LABEL_PREFIX).split(",")).contains(topics);
+    }
+
+    @Test
+    public void getLabelsFromApplicationNoClassDir() throws URISyntaxException {
+        // path doesn't exist
+        final MessagingLabeler labeler = new MessagingLabeler(new File(this.getClass().getResource("/labels").toURI().getPath()));
+        final Map<String, String> labels = labeler.generateLabels();
+        assertThat(labels).isNotNull();
+        assertThat(labels).hasSize(0);
+    }
+
+    @Test
+    public void getLabelsFromApplicationEmptyProperties() throws URISyntaxException {
+        // path doesn't exist
+        final MessagingLabeler labeler = new MessagingLabeler(new File(this.getClass().getResource("/labels/messaging/empty_properties").toURI().getPath()));
+        final Map<String, String> labels = labeler.generateLabels();
+        assertThat(labels).isNotNull();
+        assertThat(labels).hasSize(0);
+    }
+}

--- a/kogito-codegen/src/test/resources/labels/messaging/has_properties/classes/application.properties
+++ b/kogito-codegen/src/test/resources/labels/messaging/has_properties/classes/application.properties
@@ -1,0 +1,30 @@
+# Configuration file
+# key = value
+kogito.dataindex.url=localhost:8180/graphql
+
+quarkus.infinispan-client.server-list=localhost:11222
+
+mp.messaging.incoming.visasapproved.bootstrap.servers=localhost:9092
+mp.messaging.incoming.visasapproved.connector=smallrye-kafka
+mp.messaging.incoming.visasapproved.topic=visasapproved
+mp.messaging.incoming.visasapproved.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
+
+mp.messaging.incoming.visasrejected.bootstrap.servers=localhost:9092
+mp.messaging.incoming.visasrejected.connector=smallrye-kafka
+mp.messaging.incoming.visasrejected.topic=visasrejected
+mp.messaging.incoming.visasrejected.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
+
+mp.messaging.outgoing.visaapplications.bootstrap.servers=localhost:9092
+mp.messaging.outgoing.visaapplications.connector=smallrye-kafka
+mp.messaging.outgoing.visaapplications.topic=visaapplications
+mp.messaging.outgoing.visaapplications.value.serializer=org.apache.kafka.common.serialization.StringSerializer
+
+mp.messaging.outgoing.kogito-processinstances-events.bootstrap.servers=localhost:9092
+mp.messaging.outgoing.kogito-processinstances-events.connector=smallrye-kafka
+mp.messaging.outgoing.kogito-processinstances-events.topic=kogito-processinstances-events
+mp.messaging.outgoing.kogito-processinstances-events.value.serializer=org.apache.kafka.common.serialization.StringSerializer
+
+mp.messaging.outgoing.kogito-usertaskinstances-events.bootstrap.servers=localhost:9092
+mp.messaging.outgoing.kogito-usertaskinstances-events.connector=smallrye-kafka
+mp.messaging.outgoing.kogito-usertaskinstances-events.topic=kogito-usertaskinstances-events
+mp.messaging.outgoing.kogito-usertaskinstances-events.value.serializer=org.apache.kafka.common.serialization.StringSerializer


### PR DESCRIPTION
See:
https://issues.jboss.org/browse/KOGITO-612

In this PR we're adding the label `org.kie/messaging/topics` when the runtime defines Kafka topics:

```json
{
  "labels" : [ {
    "org.kie/messaging/topics" : "kogito-usertaskinstances-events,kogito-processinstances-events,visaapplications,visasrejected,visasapproved",
    "prometheus.io/path" : "/metrics",
    "prometheus.io/scheme" : "http",
    "prometheus.io/port" : "8080",
    "prometheus.io/scrape" : "true"
  } ]
}
```
