### PR TITLE
KOGITO-641: Build fails processing dtable, when no drools-decisiontables

### DIFF
--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
@@ -173,15 +173,7 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
         ReleaseIdImpl dummyReleaseId = new ReleaseIdImpl("dummy:dummy:0.0.0");
         if (!decisionTableSupported &&
                 resources.stream().anyMatch(r -> r.getResourceType() == ResourceType.DTABLE)) {
-            ApplicationGenerator.logger.error(
-                    "A Decision Table resource was found, but a necessary dependency is missing. \n" +
-                    "Verify you have added decision table support to your project dependencies: \n" +
-                    "\n" +
-                    "<dependency>\n" +
-                    "      <groupId>org.kie.kogito</groupId>\n" +
-                    "      <artifactId>drools-decisiontables</artifactId>\n" +
-                    "</dependency>");
-            throw new RuleCodegenError();
+            throw new MissingDecisionTableDependencyError();
         }
 
         moduleGenerator = new RuleUnitContainerGenerator();
@@ -197,8 +189,7 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
         batch.build();
 
         if (modelBuilder.hasErrors()) {
-            ApplicationGenerator.logger.error( modelBuilder.getErrors().toString() );
-            throw new RuleCodegenError();
+            throw new RuleCodegenError(modelBuilder.getErrors().getErrors());
         }
 
         boolean hasRuleUnits = false;

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
@@ -36,6 +36,8 @@ import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
 import org.drools.compiler.builder.impl.KnowledgeBuilderConfigurationImpl;
+import org.drools.compiler.compiler.DecisionTableFactory;
+import org.drools.compiler.compiler.DecisionTableProvider;
 import org.drools.compiler.kproject.ReleaseIdImpl;
 import org.drools.compiler.kproject.models.KieModuleModelImpl;
 import org.drools.core.io.impl.FileSystemResource;
@@ -69,8 +71,6 @@ import static org.drools.compiler.kie.builder.impl.KieBuilderImpl.setDefaultsfor
 import static org.kie.kogito.codegen.ApplicationGenerator.log;
 
 public class IncrementalRuleCodegen extends AbstractGenerator {
-
-    private String packageName;
 
     public static IncrementalRuleCodegen ofPath( Path basePath) {
         try {
@@ -138,6 +138,9 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
 
     private KieModuleModel kieModuleModel;
     private boolean hotReloadMode = false;
+    private String packageName;
+    private final boolean decisionTableSupported;
+
 
     @Deprecated
     public IncrementalRuleCodegen(Path basePath, Collection<File> files, ResourceType resourceType) {
@@ -149,6 +152,7 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
         this.kieModuleModel = new KieModuleModelImpl();
         setDefaultsforEmptyKieModule(kieModuleModel);
         this.contextClassLoader = getClass().getClassLoader();
+        this.decisionTableSupported = DecisionTableFactory.getDecisionTableProvider() != null;
     }
 
     @Override
@@ -167,6 +171,18 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
 
     public List<GeneratedFile> generate() {
         ReleaseIdImpl dummyReleaseId = new ReleaseIdImpl("dummy:dummy:0.0.0");
+        if (!decisionTableSupported &&
+                resources.stream().anyMatch(r -> r.getResourceType() == ResourceType.DTABLE)) {
+            ApplicationGenerator.logger.error(
+                    "A Decision Table resource was found, but a necessary dependency is missing. \n" +
+                    "Verify you have added decision table support to your project dependencies: \n" +
+                    "\n" +
+                    "<dependency>\n" +
+                    "      <groupId>org.kie.kogito</groupId>\n" +
+                    "      <artifactId>drools-decisiontables</artifactId>\n" +
+                    "</dependency>");
+            throw new RuleCodegenError();
+        }
 
         moduleGenerator = new RuleUnitContainerGenerator();
         moduleGenerator.withDependencyInjection(annotator);
@@ -182,7 +198,7 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
 
         if (modelBuilder.hasErrors()) {
             ApplicationGenerator.logger.error( modelBuilder.getErrors().toString() );
-            return Collections.emptyList();
+            throw new RuleCodegenError();
         }
 
         boolean hasRuleUnits = false;

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/MissingDecisionTableDependencyError.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/MissingDecisionTableDependencyError.java
@@ -15,24 +15,15 @@
 
 package org.kie.kogito.codegen.rules;
 
-import java.util.Arrays;
-import java.util.stream.Collectors;
+public class MissingDecisionTableDependencyError extends Error {
 
-import org.drools.compiler.compiler.DroolsError;
-
-public class RuleCodegenError extends Error {
-
-    private final DroolsError[] errors;
-
-    public RuleCodegenError(DroolsError... errors) {
-        super("Errors were generated during the code-generation process:\n" +
-                      Arrays.stream(errors)
-                              .map(DroolsError::toString)
-                              .collect(Collectors.joining("\n")));
-        this.errors = errors;
-    }
-
-    public DroolsError[] getErrors() {
-        return errors;
+    public MissingDecisionTableDependencyError() {
+        super("A Decision Table resource was found, but a necessary dependency is missing. \n" +
+                      "Verify you have added decision table support to your project dependencies: \n" +
+                      "\n" +
+                      "<dependency>\n" +
+                      "      <groupId>org.kie.kogito</groupId>\n" +
+                      "      <artifactId>drools-decisiontables</artifactId>\n" +
+                      "</dependency>");
     }
 }

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/RuleCodegenError.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/RuleCodegenError.java
@@ -1,0 +1,8 @@
+package org.kie.kogito.codegen.rules;
+
+public class RuleCodegenError extends Error {
+
+    public RuleCodegenError() {
+        super("Errors were generated during the code-generation process. Scroll up for details.");
+    }
+}

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegenTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegenTest.java
@@ -22,7 +22,11 @@ import java.util.Collections;
 import java.util.List;
 
 import org.drools.compiler.compiler.DecisionTableFactory;
+import org.drools.compiler.compiler.DecisionTableProvider;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.kie.api.internal.utils.ServiceRegistry;
 import org.kie.api.io.ResourceType;
 import org.kie.kogito.codegen.GeneratedFile;
 
@@ -30,6 +34,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class IncrementalRuleCodegenTest {
+
+    @BeforeEach
+    public void blah() {
+        DecisionTableFactory.setDecisionTableProvider(ServiceRegistry.getInstance().get(DecisionTableProvider.class));
+    }
+
 
     @Test
     public void generateSingleFile() {

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegenTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegenTest.java
@@ -21,11 +21,13 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.drools.compiler.compiler.DecisionTableFactory;
 import org.junit.jupiter.api.Test;
 import org.kie.api.io.ResourceType;
 import org.kie.kogito.codegen.GeneratedFile;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class IncrementalRuleCodegenTest {
 
@@ -101,6 +103,19 @@ public class IncrementalRuleCodegenTest {
         List<GeneratedFile> generatedFiles = incrementalRuleCodegen.withHotReloadMode().generate();
         assertRules(1, 1, generatedFiles.size());
     }
+
+    @Test
+    public void throwWhenDtableDependencyMissing() {
+        DecisionTableFactory.setDecisionTableProvider(null);
+        IncrementalRuleCodegen incrementalRuleCodegen =
+                IncrementalRuleCodegen.ofFiles(
+                        Collections.singleton(
+                                new File("src/test/resources/org/drools/simple/candrink/CanDrink.xls")));
+        incrementalRuleCodegen.setPackageName("com.acme");
+
+        assertThrows(RuleCodegenError.class, incrementalRuleCodegen.withHotReloadMode()::generate);
+    }
+
 
     private static void assertRules(int expectedRules, int expectedPackages, int expectedUnits, int actualGeneratedFiles) {
         assertEquals(expectedRules +

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegenTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegenTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class IncrementalRuleCodegenTest {
 
     @BeforeEach
-    public void blah() {
+    public void setup() {
         DecisionTableFactory.setDecisionTableProvider(ServiceRegistry.getInstance().get(DecisionTableProvider.class));
     }
 
@@ -115,6 +115,16 @@ public class IncrementalRuleCodegenTest {
     }
 
     @Test
+    public void raiseErrorOnSyntaxError() {
+        IncrementalRuleCodegen incrementalRuleCodegen =
+                IncrementalRuleCodegen.ofFiles(
+                        Collections.singleton(
+                                new File("src/test/resources/org/drools/simple/broken.drl")));
+        incrementalRuleCodegen.setPackageName("com.acme");
+        assertThrows(RuleCodegenError.class, incrementalRuleCodegen.withHotReloadMode()::generate);
+    }
+
+    @Test
     public void throwWhenDtableDependencyMissing() {
         DecisionTableFactory.setDecisionTableProvider(null);
         IncrementalRuleCodegen incrementalRuleCodegen =
@@ -122,8 +132,7 @@ public class IncrementalRuleCodegenTest {
                         Collections.singleton(
                                 new File("src/test/resources/org/drools/simple/candrink/CanDrink.xls")));
         incrementalRuleCodegen.setPackageName("com.acme");
-
-        assertThrows(RuleCodegenError.class, incrementalRuleCodegen.withHotReloadMode()::generate);
+        assertThrows(MissingDecisionTableDependencyError.class, incrementalRuleCodegen.withHotReloadMode()::generate);
     }
 
 

--- a/kogito-codegen/src/test/resources/org/drools/simple/broken.drl
+++ b/kogito-codegen/src/test/resources/org/drools/simple/broken.drl
@@ -1,0 +1,1 @@
+syntax error


### PR DESCRIPTION
An helpful error message is now printed when XLS are present, but the DTABLE dependency is missing

```
2019-11-26 10:56:33,120 [main] ERROR A Decision Table resource was found, but a necessary dependency is missing. 
Verify you have added decision table support to your project dependencies: 

<dependency>
      <groupId>org.kie.kogito</groupId>
      <artifactId>drools-decisiontables</artifactId>
</dependency>

```