### PR TITLE
Jobs service - publish the jobs-service-runner.jar on maven

### DIFF
--- a/addons/jobs/jobs-service/pom.xml
+++ b/addons/jobs/jobs-service/pom.xml
@@ -108,6 +108,9 @@
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
+        <configuration>
+          <uberJar>true</uberJar>
+        </configuration>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
@cristianonicolai the `runner` jar artifact was not being published on maven, see http://repo2.maven.org/maven2/org/kie/kogito/jobs-service/0.6.0/ and comparing to the data-index http://repo2.maven.org/maven2/org/kie/kogito/data-index-service/0.6.0/ that was published.
So, comparing the `quarkus-maven-plugin` I inserted the configuration for uberJar, and now it is being published.

