### PR TITLE
[KOGITO-336] Include DMN inside of Spring Boot archetype

### DIFF
--- a/archetypes/kogito-springboot-archetype/src/main/resources/archetype-resources/src/main/resources/application.properties
+++ b/archetypes/kogito-springboot-archetype/src/main/resources/archetype-resources/src/main/resources/application.properties
@@ -2,4 +2,4 @@ server.address=0.0.0.0
 
 spring.mvc.servlet.path=/docs
 
-resteasy.jaxrs.scan-packages=org.kie.**,\${groupId}
+resteasy.jaxrs.scan-packages=org.kie.**,\${groupId},http*

--- a/archetypes/kogito-springboot-starter/pom.xml
+++ b/archetypes/kogito-springboot-starter/pom.xml
@@ -54,6 +54,10 @@
       <artifactId>jbpm-flow</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-dmn</artifactId>
+    </dependency>
+    <dependency>
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
     </dependency>


### PR DESCRIPTION
I added "http*" for archetype application.properties so that generated DMN REST classes can be scanned. A package name of a DMN REST class is generated from its namespace. So this configuration works when DMN namespace starts from "http" or "https". According to DMN spec, namespace is anyURI. So it's not constrained to http/https but it's a reasonable default value for archetype?

> namespace: anyURI [1] | This attribute identifies the namespace associated with this Definitions and follows the convention established by XML Schema.

I manually tested by dropping TrafficViolation.dmn (https://github.com/kiegroup/kogito-runtimes/blob/master/drools/kogito-dmn/src/test/resources/org/kie/kogito/dmn/TrafficViolation.dmn) into the generated project and confirmed that the generated REST endpoint works.

```
$ curl -d '{ "Driver": { "Points": 2}, "Violation": { "Type": "speed", "Actual Speed": 120, "Speed Limit": 100 }}' -H "Content-Type: application/json" -X POST http://localhost:8080/Traffic%20Violation

{"Violation":{"Type":"speed","Speed Limit":100,"Actual Speed":120},"Driver":{"Points":2},"Fine":{"Points":3,"Amount":500},"Should the driver be suspended?":"No"}
```