### PR TITLE
KOGITO-831: NPE when cancelActivity is marked in editor

### DIFF
--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/BoundaryEventHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/BoundaryEventHandler.java
@@ -64,7 +64,10 @@ public class BoundaryEventHandler extends AbstractNodeHandler {
         Node node = (Node) parser.getCurrent();
         String attachedTo = element.getAttribute("attachedToRef");
         Attr cancelActivityAttr = element.getAttributeNode("cancelActivity");
-        boolean cancelActivity = Boolean.parseBoolean(cancelActivityAttr.getValue());
+        boolean cancelActivity = true;
+        if (cancelActivityAttr != null) {
+            cancelActivity = Boolean.parseBoolean(cancelActivityAttr.getValue());
+        }
 
         // determine type of event definition, so the correct type of node can be generated
         org.w3c.dom.Node xmlNode = element.getFirstChild();


### PR DESCRIPTION
For this PR I am following what I read in the BPMN XSD[1] for cancelActivity attribute:

~~~
<xsd:complexContent>
<xsd:extension base="tCatchEvent">
<xsd:attribute name="cancelActivity" type="xsd:boolean" default="true"/>
<xsd:attribute name="attachedToRef" type="xsd:QName" use="required"/>
</xsd:extension>
</xsd:complexContent>
</xsd:complexType>
~~~

Where:

* It is required (hence why the null checking)
* default is true

This solved the issue from KOGITO-831.

[1] https://www.omg.org/spec/BPMN/20100501/Semantic.xsd
