### PR TITLE
[Jobs Service] - disable quarkus log console color

### DIFF
--- a/addons/jobs/jobs-service/src/main/resources/application.properties
+++ b/addons/jobs/jobs-service/src/main/resources/application.properties
@@ -21,7 +21,7 @@ quarkus.log.category."org.kie.kogito.jobs".level=DEBUG
 ##Console
 quarkus.log.console.enable=true
 quarkus.log.console.format=%d{yyyy-MM-dd HH:mm:ss,SSS} %h %-5p [%c:%L] (%t) %s%e%n
-quarkus.log.console.color=true
+quarkus.log.console.color=false
 quarkus.log.console.async=true
 ##File
 quarkus.log.file.enable=true


### PR DESCRIPTION
@ricardozanini as we talk on the chat, this PR is disabling by default the log color on the console to follow the same pattern as the other services.
One other point that maybe it is worth to discuss is the log format, it could be the same pattern on all services.

@mswiderski ^