### PR TITLE
[Jobs Service] Refactoring events structure

### DIFF
--- a/addons/jobs/jobs-service/pom.xml
+++ b/addons/jobs/jobs-service/pom.xml
@@ -12,18 +12,6 @@
   <name>Jobs Service</name>
   <description>Jobs Service (Timers and Async Jobs)</description>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-bom</artifactId>
-        <version>${version.io.quarkus}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
     <dependency>
       <groupId>org.kie.kogito</groupId>

--- a/addons/jobs/jobs-service/src/main/java/org/kie/kogito/jobs/service/events/JobDataEvent.java
+++ b/addons/jobs/jobs-service/src/main/java/org/kie/kogito/jobs/service/events/JobDataEvent.java
@@ -16,68 +16,27 @@
 
 package org.kie.kogito.jobs.service.events;
 
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.Optional;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreType;
-import org.kie.kogito.event.DataEvent;
+import org.kie.kogito.event.AbstractDataEvent;
 import org.kie.kogito.jobs.service.model.ScheduledJob;
 
 /**
  * <a href="https://cloudevents.io">CloudEvent</a> to propagate job status information from Job Service.
  */
-public class JobDataEvent implements DataEvent<ScheduledJob> {
+public class JobDataEvent extends AbstractDataEvent<ScheduledJob> {
 
     public static final String JOB_EVENT_TYPE = "JobEvent";
-    public static final String DEFAULT_SPEC_VERSION = "0.3";
-    private String specversion;
-    private String id;
-    private String source;
-    private ZonedDateTime time;
-    private ScheduledJob data;
 
-    public JobDataEvent() {
-
-    }
-
-    public JobDataEvent(String specversion, String id, String source, ZonedDateTime time, ScheduledJob data) {
-        this.specversion = Optional.ofNullable(specversion).orElse(DEFAULT_SPEC_VERSION);
-        this.id = id;
-        this.source = source;
-        this.time = time;
-        this.data = data;
-    }
-
-    @Override
-    public String getSpecversion() {
-        return specversion;
-    }
-
-    @Override
-    public String getId() {
-        return id;
-    }
-
-    @Override
-    public String getType() {
-        return JOB_EVENT_TYPE;
-    }
-
-    @Override
-    public String getSource() {
-        return source;
-    }
-
-    @Override
-    public String getTime() {
-        return time.format(DateTimeFormatter.ISO_INSTANT);
-    }
-
-    @Override
-    public ScheduledJob getData() {
-        return data;
+    public JobDataEvent(String source, ScheduledJob data) {
+        super(JOB_EVENT_TYPE,
+              source,
+              data,
+              data.getProcessInstanceId(),
+              data.getRootProcessInstanceId(),
+              data.getProcessId(),
+              data.getRootProcessId(),
+              null);
     }
 
     @JsonIgnore
@@ -88,29 +47,11 @@ public class JobDataEvent implements DataEvent<ScheduledJob> {
     @JsonIgnoreType
     public static class JobDataEventBuilder {
 
-        private String specversion;
-        private String id;
         private String source;
-        private ZonedDateTime time;
         private ScheduledJob data;
-
-        public JobDataEventBuilder specversion(String specversion) {
-            this.specversion = specversion;
-            return this;
-        }
-
-        public JobDataEventBuilder id(String id) {
-            this.id = id;
-            return this;
-        }
 
         public JobDataEventBuilder source(String source) {
             this.source = source;
-            return this;
-        }
-
-        public JobDataEventBuilder time(ZonedDateTime time) {
-            this.time = time;
             return this;
         }
 
@@ -120,7 +61,7 @@ public class JobDataEvent implements DataEvent<ScheduledJob> {
         }
 
         public JobDataEvent build() {
-            return new JobDataEvent(specversion, id, source, time, data);
+            return new JobDataEvent(source, data);
         }
     }
 }

--- a/addons/jobs/jobs-service/src/main/resources/application.properties
+++ b/addons/jobs/jobs-service/src/main/resources/application.properties
@@ -57,6 +57,7 @@ quarkus.infinispan-client.sasl-mechanism=${infinispan_saslmechanism:}
 kogito.jobs-service.persistence=in-memory
 kogito.jobs-service.maxIntervalLimitToRetryMillis=60000
 kogito.jobs-service.backoffRetryMillis=1000
+kogito.service.url=http://localhost:8080
 
 #Configure Events Publishing on Job Service using profile
 #disabled by default

--- a/api/kogito-api/src/main/java/org/kie/kogito/event/AbstractDataEvent.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/event/AbstractDataEvent.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.event;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+/**
+ * This is an abstract implementation of the {@link DataEvent} that contains basic common attributes referring to
+ * kogito processes metadata. This class can be extended mainly by Services that need to publish events to be
+ * indexed by the Data-Index service.
+ *
+ * @param <T> the payload
+ */
+public abstract class AbstractDataEvent<T> implements DataEvent<T> {
+
+    private static final String SPEC_VERSION = "0.3";
+
+    private String specversion;
+    private String id;
+    private String source;
+    private String type;
+    private String time;
+    private T data;
+    private String kogitoProcessinstanceId;
+    private String kogitoRootProcessinstanceId;
+    private String kogitoProcessId;
+    private String kogitoRootProcessId;
+    private String kogitoAddons;
+
+    public AbstractDataEvent(String type,
+                             String source,
+                             T body,
+                             String kogitoProcessinstanceId,
+                             String kogitoRootProcessinstanceId,
+                             String kogitoProcessId,
+                             String kogitoRootProcessId,
+                             String kogitoAddons) {
+        this.specversion = SPEC_VERSION;
+        this.id = UUID.randomUUID().toString();
+        this.source = source;
+        this.type = type;
+        this.time = ZonedDateTime.now().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+        this.data = body;
+
+        this.kogitoProcessinstanceId = kogitoProcessinstanceId;
+        this.kogitoRootProcessinstanceId = kogitoRootProcessinstanceId;
+        this.kogitoProcessId = kogitoProcessId;
+        this.kogitoRootProcessId = kogitoRootProcessId;
+        this.kogitoAddons = kogitoAddons;
+    }
+
+    @Override
+    public String getSource() {
+        return source;
+    }
+
+    @Override
+    public String getSpecversion() {
+        return specversion;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+    @Override
+    public String getTime() {
+        return time;
+    }
+
+    @Override
+    public T getData() {
+        return data;
+    }
+
+    public String getKogitoProcessinstanceId() {
+        return kogitoProcessinstanceId;
+    }
+
+    public String getKogitoRootProcessinstanceId() {
+        return kogitoRootProcessinstanceId;
+    }
+
+    public String getKogitoProcessId() {
+        return kogitoProcessId;
+    }
+
+    public String getKogitoRootProcessId() {
+        return kogitoRootProcessId;
+    }
+
+    public String getKogitoAddons() {
+        return kogitoAddons;
+    }
+}

--- a/api/kogito-services/src/main/java/org/kie/kogito/services/event/AbstractProcessDataEvent.java
+++ b/api/kogito-services/src/main/java/org/kie/kogito/services/event/AbstractProcessDataEvent.java
@@ -15,34 +15,14 @@
 
 package org.kie.kogito.services.event;
 
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.UUID;
+import org.kie.kogito.event.AbstractDataEvent;
 
-import org.kie.kogito.event.DataEvent;
+public abstract class AbstractProcessDataEvent<T> extends AbstractDataEvent<T> {
 
-public abstract class AbstractProcessDataEvent<T> implements DataEvent<T> {
-    
-    private static final String SPEC_VERSION = "0.3";
-
-    protected String specversion;
-    protected String id;
-    protected String source;
-    protected String type;
-    protected String time;
-    protected T data;
-
-    protected String kogitoProcessinstanceId;
     protected String kogitoParentProcessinstanceId;
-    protected String kogitoRootProcessinstanceId;
-    protected String kogitoProcessId;
-    protected String kogitoRootProcessId;
     protected String kogitoProcessinstanceState;
-    
     protected String kogitoReferenceId;
-    
-    protected String kogitoAddons;
-    
+
     public AbstractProcessDataEvent(String source,
                                     T body,
                                     String kogitoProcessinstanceId,
@@ -52,97 +32,42 @@ public abstract class AbstractProcessDataEvent<T> implements DataEvent<T> {
                                     String kogitoRootProcessId,
                                     String kogitoProcessinstanceState,
                                     String kogitoAddons) {
-        
-        this.specversion = SPEC_VERSION;
-        this.id = UUID.randomUUID().toString();
-        this.source = source;        
-        this.type = this.getClass().getSimpleName();
-        this.time = ZonedDateTime.now().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
-        this.data = body;
-
-        this.kogitoProcessinstanceId = kogitoProcessinstanceId;
-        this.kogitoParentProcessinstanceId = kogitoParentProcessinstanceId;
-        this.kogitoRootProcessinstanceId = kogitoRootProcessinstanceId;
-        this.kogitoProcessId = kogitoProcessId;
-        this.kogitoRootProcessId = kogitoRootProcessId;
-        this.kogitoProcessinstanceState = kogitoProcessinstanceState; 
-        this.kogitoAddons = kogitoAddons;
+        this(null,
+             source,
+             body,
+             kogitoProcessinstanceId,
+             kogitoParentProcessinstanceId,
+             kogitoRootProcessinstanceId,
+             kogitoProcessId,
+             kogitoRootProcessId,
+             kogitoProcessinstanceState,
+             kogitoAddons);
     }
 
     public AbstractProcessDataEvent(String type,
-                             String source, 
-                             T body,
-                             String kogitoProcessinstanceId,
-                             String kogitoParentProcessinstanceId,
-                             String kogitoRootProcessinstanceId,
-                             String kogitoProcessId,
-                             String kogitoRootProcessId,
-                             String kogitoProcessinstanceState,
-                             String kogitoAddons) {
-        this.specversion = SPEC_VERSION;
-        this.id = UUID.randomUUID().toString();
-        this.source = source;
-        this.type = type;
-        this.time = ZonedDateTime.now().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
-        this.data = body;
-
-        this.kogitoProcessinstanceId = kogitoProcessinstanceId;
+                                    String source,
+                                    T body,
+                                    String kogitoProcessinstanceId,
+                                    String kogitoParentProcessinstanceId,
+                                    String kogitoRootProcessinstanceId,
+                                    String kogitoProcessId,
+                                    String kogitoRootProcessId,
+                                    String kogitoProcessinstanceState,
+                                    String kogitoAddons) {
+        super(type,
+              source,
+              body,
+              kogitoProcessinstanceId,
+              kogitoRootProcessinstanceId,
+              kogitoProcessId,
+              kogitoRootProcessId,
+              kogitoAddons);
         this.kogitoParentProcessinstanceId = kogitoParentProcessinstanceId;
-        this.kogitoRootProcessinstanceId = kogitoRootProcessinstanceId;
-        this.kogitoProcessId = kogitoProcessId;
-        this.kogitoRootProcessId = kogitoRootProcessId;
         this.kogitoProcessinstanceState = kogitoProcessinstanceState;
-        this.kogitoAddons = kogitoAddons;
-    }
-
-    @Override
-    public String getSource() {
-        return source;
-    }
-
-    @Override
-    public String getSpecversion() {
-        return specversion;
-    }
-
-    @Override
-    public String getId() {
-        return id;
-    }
-
-    @Override
-    public String getType() {
-        return type;
-    }
-
-    @Override
-    public String getTime() {
-        return time;
-    }
-
-    @Override
-    public T getData() {        
-        return data;
-    }
-
-    public String getKogitoProcessinstanceId() {
-        return kogitoProcessinstanceId;
     }
 
     public String getKogitoParentProcessinstanceId() {
         return kogitoParentProcessinstanceId;
-    }
-
-    public String getKogitoRootProcessinstanceId() {
-        return kogitoRootProcessinstanceId;
-    }
-
-    public String getKogitoProcessId() {
-        return kogitoProcessId;
-    }
-    
-    public String getKogitoRootProcessId() {
-        return kogitoRootProcessId;
     }
 
     public String getKogitoProcessinstanceState() {
@@ -152,12 +77,8 @@ public abstract class AbstractProcessDataEvent<T> implements DataEvent<T> {
     public String getKogitoReferenceId() {
         return this.kogitoReferenceId;
     }
-    
+
     public void setKogitoReferenceId(String kogitoReferenceId) {
         this.kogitoReferenceId = kogitoReferenceId;
-    }
-    
-    public String getKogitoAddons() {
-        return kogitoAddons;
     }
 }

--- a/api/kogito-services/src/main/java/org/kie/kogito/services/event/ProcessInstanceDataEvent.java
+++ b/api/kogito-services/src/main/java/org/kie/kogito/services/event/ProcessInstanceDataEvent.java
@@ -33,5 +33,4 @@ public class ProcessInstanceDataEvent extends AbstractProcessDataEvent<ProcessIn
               metaData.get(ProcessInstanceEventBody.STATE_META_DATA),
               addons);
     }
-
 }

--- a/api/kogito-services/src/main/java/org/kie/kogito/services/event/UserTaskInstanceDataEvent.java
+++ b/api/kogito-services/src/main/java/org/kie/kogito/services/event/UserTaskInstanceDataEvent.java
@@ -15,96 +15,31 @@
 
 package org.kie.kogito.services.event;
 
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Map;
-import java.util.UUID;
 
-import org.kie.kogito.event.DataEvent;
+import org.kie.kogito.event.AbstractDataEvent;
 import org.kie.kogito.services.event.impl.ProcessInstanceEventBody;
 import org.kie.kogito.services.event.impl.UserTaskInstanceEventBody;
 
-public class UserTaskInstanceDataEvent implements DataEvent<UserTaskInstanceEventBody> {
-
-    private final String specversion;
-    private final String id;
-    private final String source;
-    private final String type;
-    private final String time;
-    private final UserTaskInstanceEventBody data;
+public class UserTaskInstanceDataEvent extends AbstractDataEvent<UserTaskInstanceEventBody> {
 
     private final String kogitoUserTaskinstanceId;
-    private final String kogitoProcessinstanceId;
-    private final String kogitoRootProcessinstanceId;
-    private final String kogitoProcessId;
-    private final String kogitoRootProcessId;
     private final String kogitoUserTaskinstanceState;
-    
-    private String kogitoAddons;
 
     public UserTaskInstanceDataEvent(String source, String addons, Map<String, String> metaData, UserTaskInstanceEventBody body) {
-        this.specversion = "0.3";
-        this.id = UUID.randomUUID().toString();
-        this.source = source;
-        this.type = "UserTaskInstanceEvent";
-        this.time = ZonedDateTime.now().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
-        this.data = body;
 
-        this.kogitoProcessinstanceId = metaData.get(ProcessInstanceEventBody.ID_META_DATA);
-        this.kogitoRootProcessinstanceId = metaData.get(ProcessInstanceEventBody.ROOT_ID_META_DATA);
-        this.kogitoProcessId = metaData.get(ProcessInstanceEventBody.PROCESS_ID_META_DATA);
-        this.kogitoRootProcessId = metaData.get(ProcessInstanceEventBody.ROOT_PROCESS_ID_META_DATA);
+        super("UserTaskInstanceEvent",
+              source,
+              body,
+              metaData.get(ProcessInstanceEventBody.ID_META_DATA),
+              metaData.get(ProcessInstanceEventBody.ROOT_ID_META_DATA),
+              metaData.get(ProcessInstanceEventBody.PROCESS_ID_META_DATA),
+              metaData.get(ProcessInstanceEventBody.ROOT_PROCESS_ID_META_DATA),
+              addons
+        );
 
         this.kogitoUserTaskinstanceState = metaData.get(UserTaskInstanceEventBody.UT_STATE_META_DATA);
         this.kogitoUserTaskinstanceId = metaData.get(UserTaskInstanceEventBody.UT_ID_META_DATA);
-        
-        this.kogitoAddons = addons;
-    }
-
-    @Override
-    public String getSource() {
-        return source;
-    }
-
-    @Override
-    public UserTaskInstanceEventBody getData() {
-        return data;
-    }
-
-    @Override
-    public String getSpecversion() {
-        return specversion;
-    }
-
-    @Override
-    public String getId() {
-        return id;
-    }
-
-    @Override
-    public String getType() {
-        return type;
-    }
-
-    @Override
-    public String getTime() {
-        return time;
-    }
-
-    public String getKogitoProcessinstanceId() {
-        return kogitoProcessinstanceId;
-    }
-
-    public String getKogitoRootProcessinstanceId() {
-        return kogitoRootProcessinstanceId;
-    }
-
-    public String getKogitoProcessId() {
-        return kogitoProcessId;
-    }
-
-    public String getKogitoRootProcessId() {
-        return kogitoRootProcessId;
     }
 
     public String getKogitoUserTaskinstanceId() {
@@ -113,9 +48,5 @@ public class UserTaskInstanceDataEvent implements DataEvent<UserTaskInstanceEven
 
     public String getKogitoUserTaskinstanceState() {
         return kogitoUserTaskinstanceState;
-    }
-
-    public String getKogitoAddons() {
-        return kogitoAddons;
     }
 }


### PR DESCRIPTION
Modifications needed for the Jobs Service and Data Index integration.
- Unique event UUID
- Source based on the service URL configuration
-  Process metadata on the event attributes + refactoring on the `AbstractProcessDataEvent` to share the common attributes on all events.

@cristianonicolai here are the modifications we talked to regarding the jobs-service and data-index integration.
@mswiderski 