### PR TITLE
KOGITO-929: Fix mixed-up slashes in code generation

### DIFF
--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/AbstractResourceGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/AbstractResourceGenerator.java
@@ -89,7 +89,7 @@ public abstract class AbstractResourceGenerator {
         this.appCanonicalName = appCanonicalName;
         String classPrefix = StringUtils.capitalize(processName);
         this.resourceClazzName = classPrefix + "Resource";
-        this.relativePath = packageName.replace(".", File.separator) + File.separator + resourceClazzName + ".java";
+        this.relativePath = packageName.replace(".", "/") + "/" + resourceClazzName + ".java";
         this.modelfqcn = modelfqcn;
         this.dataClazzName = modelfqcn.substring(modelfqcn.lastIndexOf('.') + 1);
         this.processClazzName = processfqcn;


### PR DESCRIPTION
`org.kie.kogito.codegen.process.AbstractResourceGenerator` was refactored to use fileSeparator instead of forward slashes, causing windows build to break.

- compilation on quarkus extension goes through in-memory file system which assumes forward slashes
- if we do not mix forward and back-slashes it's ok, since Windows allows for forward slashes in paths

