### PR TITLE
[KOGITO-223] DMN review serialization annotations

### DIFF
--- a/drools/kogito-dmn/src/main/java/org/kie/kogito/dmn/rest/DMNDecisionInfo.java
+++ b/drools/kogito-dmn/src/main/java/org/kie/kogito/dmn/rest/DMNDecisionInfo.java
@@ -20,8 +20,6 @@ import java.io.Serializable;
 
 import org.kie.dmn.api.core.ast.DecisionNode;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 public class DMNDecisionInfo implements Serializable {
 
     private String id;
@@ -38,7 +36,6 @@ public class DMNDecisionInfo implements Serializable {
         return res;
     }
 
-    @JsonProperty("decision-id")
     public String getId() {
         return id;
     }
@@ -47,7 +44,6 @@ public class DMNDecisionInfo implements Serializable {
         this.id = id;
     }
 
-    @JsonProperty("decision-name")
     public String getName() {
         return name;
     }

--- a/drools/kogito-dmn/src/main/java/org/kie/kogito/dmn/rest/DMNDecisionResultSQ.java
+++ b/drools/kogito-dmn/src/main/java/org/kie/kogito/dmn/rest/DMNDecisionResultSQ.java
@@ -24,8 +24,6 @@ import org.kie.dmn.api.core.DMNDecisionResult;
 import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.core.internal.utils.MarshallingStubUtils;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 public class DMNDecisionResultSQ implements Serializable, DMNDecisionResult {
 
     private String decisionId;
@@ -52,7 +50,6 @@ public class DMNDecisionResultSQ implements Serializable, DMNDecisionResult {
         return res;
     }
 
-    @JsonProperty("decision-id")
     @Override
     public String getDecisionId() {
         return decisionId;
@@ -62,7 +59,6 @@ public class DMNDecisionResultSQ implements Serializable, DMNDecisionResult {
         this.decisionId = decisionId;
     }
 
-    @JsonProperty("decision-name")
     @Override
     public String getDecisionName() {
         return decisionName;
@@ -72,7 +68,6 @@ public class DMNDecisionResultSQ implements Serializable, DMNDecisionResult {
         this.decisionName = decisionName;
     }
 
-    @JsonProperty("status")
     @Override
     public DecisionEvaluationStatus getEvaluationStatus() {
         return status;
@@ -82,7 +77,6 @@ public class DMNDecisionResultSQ implements Serializable, DMNDecisionResult {
         this.status = status;
     }
 
-    @JsonProperty("result")
     @Override
     public Object getResult() {
         return result;
@@ -92,7 +86,6 @@ public class DMNDecisionResultSQ implements Serializable, DMNDecisionResult {
         this.result = MarshallingStubUtils.stubDMNResult(result, String::valueOf);
     }
 
-    @JsonProperty("messages")
     public List<DMNMessage> getMessages() {
         return (List) messages;
     }

--- a/drools/kogito-dmn/src/main/java/org/kie/kogito/dmn/rest/DMNDecisionServiceInfo.java
+++ b/drools/kogito-dmn/src/main/java/org/kie/kogito/dmn/rest/DMNDecisionServiceInfo.java
@@ -20,8 +20,6 @@ import java.io.Serializable;
 
 import org.kie.dmn.api.core.ast.DecisionServiceNode;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 public class DMNDecisionServiceInfo implements Serializable {
 
     private String id;
@@ -38,7 +36,6 @@ public class DMNDecisionServiceInfo implements Serializable {
         return res;
     }
 
-    @JsonProperty("decision-service-id")
     public String getId() {
         return id;
     }
@@ -47,7 +44,6 @@ public class DMNDecisionServiceInfo implements Serializable {
         this.id = id;
     }
 
-    @JsonProperty("decision-service-name")
     public String getName() {
         return name;
     }

--- a/drools/kogito-dmn/src/main/java/org/kie/kogito/dmn/rest/DMNInputDataInfo.java
+++ b/drools/kogito-dmn/src/main/java/org/kie/kogito/dmn/rest/DMNInputDataInfo.java
@@ -25,8 +25,6 @@ import org.kie.dmn.api.core.ast.InputDataNode;
 import org.kie.dmn.core.ast.InputDataNodeImpl;
 import org.kie.dmn.model.api.InputData;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 public class DMNInputDataInfo implements Serializable {
 
     private String id;
@@ -54,7 +52,6 @@ public class DMNInputDataInfo implements Serializable {
         return res;
     }
 
-    @JsonProperty("inputdata-id")
     public String getId() {
         return id;
     }
@@ -63,7 +60,6 @@ public class DMNInputDataInfo implements Serializable {
         this.id = id;
     }
 
-    @JsonProperty("inputdata-name")
     public String getName() {
         return name;
     }
@@ -72,7 +68,6 @@ public class DMNInputDataInfo implements Serializable {
         this.name = name;
     }
 
-    @JsonProperty("inputdata-typeRef")
     public String getTypeRef() {
         return typeRef;
     }

--- a/drools/kogito-dmn/src/main/java/org/kie/kogito/dmn/rest/DMNItemDefinitionInfo.java
+++ b/drools/kogito-dmn/src/main/java/org/kie/kogito/dmn/rest/DMNItemDefinitionInfo.java
@@ -23,8 +23,6 @@ import java.util.stream.Collectors;
 
 import org.kie.dmn.model.api.ItemDefinition;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 public class DMNItemDefinitionInfo implements Serializable {
 
     private String id;
@@ -61,7 +59,6 @@ public class DMNItemDefinitionInfo implements Serializable {
         return res;
     }
 
-    @JsonProperty("itemdefinition-id")
     public String getId() {
         return id;
     }
@@ -70,7 +67,6 @@ public class DMNItemDefinitionInfo implements Serializable {
         this.id = id;
     }
 
-    @JsonProperty("itemdefinition-name")
     public String getName() {
         return name;
     }
@@ -79,7 +75,6 @@ public class DMNItemDefinitionInfo implements Serializable {
         this.name = name;
     }
 
-    @JsonProperty("itemdefinition-typeRef")
     public String getTypeRef() {
         return typeRef;
     }
@@ -88,7 +83,6 @@ public class DMNItemDefinitionInfo implements Serializable {
         this.typeRef = typeRef;
     }
 
-    @JsonProperty("itemdefinition-allowedValues")
     public DMNUnaryTestsInfo getAllowedValues() {
         return allowedValues;
     }
@@ -97,7 +91,6 @@ public class DMNItemDefinitionInfo implements Serializable {
         this.allowedValues = allowedValues;
     }
 
-    @JsonProperty("itemdefinition-itemComponent")
     public List<DMNItemDefinitionInfo> getItemComponent() {
         return itemComponent;
     }
@@ -106,7 +99,6 @@ public class DMNItemDefinitionInfo implements Serializable {
         this.itemComponent = itemComponent;
     }
 
-    @JsonProperty("itemdefinition-typeLanguage")
     public String getTypeLanguage() {
         return typeLanguage;
     }
@@ -115,7 +107,6 @@ public class DMNItemDefinitionInfo implements Serializable {
         this.typeLanguage = typeLanguage;
     }
 
-    @JsonProperty("itemdefinition-isCollection")
     public Boolean getIsCollection() {
         return isCollection;
     }

--- a/drools/kogito-dmn/src/main/java/org/kie/kogito/dmn/rest/DMNMessageSQ.java
+++ b/drools/kogito-dmn/src/main/java/org/kie/kogito/dmn/rest/DMNMessageSQ.java
@@ -18,13 +18,11 @@ package org.kie.kogito.dmn.rest;
 
 import java.io.Serializable;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNMessageType;
 import org.kie.dmn.api.feel.runtime.events.FEELEvent;
 import org.kie.internal.builder.InternalMessage;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class DMNMessageSQ implements Serializable, DMNMessage {
 
@@ -62,16 +60,12 @@ public class DMNMessageSQ implements Serializable, DMNMessage {
         }
     }
 
-    @JsonProperty("dmn-message-severity")
     private DMNMessageSeverityKS severity;
 
-    @JsonProperty("message")
     private String message;
 
-    @JsonProperty("message-type")
     private DMNMessageType messageType;
 
-    @JsonProperty("source-id")
     private String sourceId;
 
     public DMNMessageSQ() {

--- a/drools/kogito-dmn/src/main/java/org/kie/kogito/dmn/rest/DMNModelInfo.java
+++ b/drools/kogito-dmn/src/main/java/org/kie/kogito/dmn/rest/DMNModelInfo.java
@@ -24,8 +24,6 @@ import java.util.stream.Collectors;
 import org.kie.dmn.api.core.DMNModel;
 import org.kie.dmn.core.ast.ItemDefNodeImpl;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 public class DMNModelInfo implements Serializable {
 
     private String namespace;
@@ -52,7 +50,6 @@ public class DMNModelInfo implements Serializable {
         return res;
     }
 
-    @JsonProperty("model-namespace")
     public String getNamespace() {
         return namespace;
     }
@@ -61,7 +58,6 @@ public class DMNModelInfo implements Serializable {
         this.namespace = namespace;
     }
 
-    @JsonProperty("model-name")
     public String getName() {
         return name;
     }
@@ -70,7 +66,6 @@ public class DMNModelInfo implements Serializable {
         this.name = name;
     }
 
-    @JsonProperty("model-id")
     public String getId() {
         return id;
     }
@@ -79,7 +74,6 @@ public class DMNModelInfo implements Serializable {
         this.id = id;
     }
 
-    @JsonProperty("decisions")
     public Collection<DMNDecisionInfo> getDecisions() {
         return decisions;
     }
@@ -88,7 +82,6 @@ public class DMNModelInfo implements Serializable {
         this.decisions = decisions;
     }
 
-    @JsonProperty("inputs")
     public Collection<DMNInputDataInfo> getInputs() {
         return inputs;
     }
@@ -97,7 +90,6 @@ public class DMNModelInfo implements Serializable {
         this.inputs = inputs;
     }
 
-    @JsonProperty("itemDefinitions")
     public Collection<DMNItemDefinitionInfo> getItemDefinitions() {
         return itemDefinitions;
     }
@@ -106,7 +98,6 @@ public class DMNModelInfo implements Serializable {
         this.itemDefinitions = itemDefinitions;
     }
 
-    @JsonProperty("decisionServices")
     public Collection<DMNDecisionServiceInfo> getDecisionServices() {
         return decisionServices;
     }

--- a/drools/kogito-dmn/src/main/java/org/kie/kogito/dmn/rest/DMNModelInfoList.java
+++ b/drools/kogito-dmn/src/main/java/org/kie/kogito/dmn/rest/DMNModelInfoList.java
@@ -20,8 +20,6 @@ import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 public class DMNModelInfoList implements Serializable {
 
     private DMNModelInfo[] models;
@@ -33,7 +31,6 @@ public class DMNModelInfoList implements Serializable {
         this.models = models.toArray(new DMNModelInfo[]{});
     }
 
-    @JsonProperty("models")
     public List<DMNModelInfo> getModels() {
         return Arrays.asList(models);
     }

--- a/drools/kogito-dmn/src/main/java/org/kie/kogito/dmn/rest/DMNResult.java
+++ b/drools/kogito-dmn/src/main/java/org/kie/kogito/dmn/rest/DMNResult.java
@@ -25,14 +25,13 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.kie.dmn.api.core.DMNContext;
 import org.kie.dmn.api.core.DMNDecisionResult;
 import org.kie.dmn.api.core.DMNMessage;
 import org.kie.dmn.api.core.DMNMessage.Severity;
 import org.kie.dmn.core.internal.utils.MapBackedDMNContext;
 import org.kie.dmn.core.internal.utils.MarshallingStubUtils;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class DMNResult implements Serializable, org.kie.dmn.api.core.DMNResult {
 
@@ -62,7 +61,6 @@ public class DMNResult implements Serializable, org.kie.dmn.api.core.DMNResult {
         this.modelName = modelName;
     }
 
-    @JsonProperty("model-namespace")
     public String getNamespace() {
         return namespace;
     }
@@ -71,7 +69,6 @@ public class DMNResult implements Serializable, org.kie.dmn.api.core.DMNResult {
         this.namespace = namespace;
     }
 
-    @JsonProperty("model-name")
     public String getModelName() {
         return modelName;
     }
@@ -80,7 +77,6 @@ public class DMNResult implements Serializable, org.kie.dmn.api.core.DMNResult {
         this.modelName = modelName;
     }
 
-    @JsonProperty("dmn-context")
     public Map<String, Object> getDmnContext() {
         return dmnContext;
     }
@@ -104,13 +100,12 @@ public class DMNResult implements Serializable, org.kie.dmn.api.core.DMNResult {
         }
     }
 
-    @JsonProperty
+    @JsonIgnore
     @Override
     public DMNContext getContext() {
         return MapBackedDMNContext.of(dmnContext);
     }
 
-    @JsonProperty("messages")
     @Override
     public List<DMNMessage> getMessages() {
         return (List) messages;
@@ -128,7 +123,6 @@ public class DMNResult implements Serializable, org.kie.dmn.api.core.DMNResult {
         return messages.stream().anyMatch(m -> DMNMessage.Severity.ERROR.equals(m.getSeverity()));
     }
 
-    @JsonProperty("decision-results")
     @Override
     public List<DMNDecisionResult> getDecisionResults() {
         return new ArrayList<>(decisionResults.values());

--- a/drools/kogito-dmn/src/main/java/org/kie/kogito/dmn/rest/DMNUnaryTestsInfo.java
+++ b/drools/kogito-dmn/src/main/java/org/kie/kogito/dmn/rest/DMNUnaryTestsInfo.java
@@ -18,8 +18,6 @@ package org.kie.kogito.dmn.rest;
 
 import java.io.Serializable;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 public class DMNUnaryTestsInfo implements Serializable {
 
     private String text;
@@ -29,7 +27,6 @@ public class DMNUnaryTestsInfo implements Serializable {
         // Intentionally blank.
     }
 
-    @JsonProperty("unarytests-text")
     public String getText() {
         return text;
     }
@@ -38,7 +35,6 @@ public class DMNUnaryTestsInfo implements Serializable {
         this.text = text;
     }
 
-    @JsonProperty("unarytests-expressionLanguage")
     public String getExpressionLanguage() {
         return expressionLanguage;
     }


### PR DESCRIPTION
Dropped all @JsonProperty from kogito-dmn classes to rely on field names. I think it's safe because:
- kogito-dmn is depended only by kogito-codegen for templating REST endpoint classes. Thus, dropping @JsonProperty doesn't affect kogito-codegen (and no other project).
- According to https://github.com/kiegroup/kogito-runtimes/pull/136 discussion, we don't/won't need to keep consistency between XML and JSON format. Indeed, Kogito consumes/produces only JSON at the moment.

I tested the change using dmn-quarkus-example:

~~~
$ curl -X POST -H 'Accept: application/json' -H 'Content-Type: application/json' -d '{"DriverXX":{"Points":2},"Violation":{"Type":"speed","Actual Speed":120,"Speed Limit":100}}' http://localhost:8080/Traffic%20Violation

{"namespace":null,"modelName":null,"dmnContext":{"Violation":{"Type":"speed","Speed Limit":100,"Actual Speed":120},"DriverXX":{"Points":2},"Fine":{"Points":3,"Amount":500}},"messages":[{"severity":"ERROR","message":"Required dependency 'Driver' not found on node 'Should the driver be suspended?'","messageType":"REQ_NOT_FOUND","sourceId":"_8A408366-D8E9-4626-ABF3-5F69AA01F880","level":"ERROR"}],"decisionResults":[{"decisionId":"_4055D956-1C47-479C-B3F4-BAEB61F1C929","decisionName":"Fine","result":{"Points":3,"Amount":500},"messages":[],"evaluationStatus":"SUCCEEDED"},{"decisionId":"_8A408366-D8E9-4626-ABF3-5F69AA01F880","decisionName":"Should the driver be suspended?","result":null,"messages":[{"severity":"ERROR","message":"Required dependency 'Driver' not found on node 'Should the driver be suspended?'","messageType":"REQ_NOT_FOUND","sourceId":"_8A408366-D8E9-4626-ABF3-5F69AA01F880","level":"ERROR"}],"evaluationStatus":"SKIPPED"}],"context":{"all":{"Violation":{"Type":"speed","Speed Limit":100,"Actual Speed":120},"DriverXX":{"Points":2},"Fine":{"Points":3,"Amount":500}}}}
~~~

We no longer see "-" in property names.
