### PR TITLE
KOGITO-894: Allow separate compilation of declared types

### DIFF
--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/ApplicationGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/ApplicationGenerator.java
@@ -165,6 +165,9 @@ public class ApplicationGenerator {
 
         for (Generator generator : generators) {
             ApplicationSection section = generator.section();
+            if (section == null) {
+                continue;
+            }
             cls.addMember(section.fieldDeclaration());
             cls.addMember(section.factoryMethod());
             cls.addMember(section.classDeclaration());
@@ -208,7 +211,8 @@ public class ApplicationGenerator {
         generatedFiles.add(generateApplicationDescriptor());
         generatedFiles.add(generateApplicationConfigDescriptor());
         if (useInjection()) {
-            generators.forEach(gen -> generateSectionClass(gen.section(), generatedFiles));
+            generators.stream().filter(gen -> gen.section() != null)
+                    .forEach(gen -> generateSectionClass(gen.section(), generatedFiles));
         }
         this.labelers.forEach(l -> MetaDataWriter.writeLabelsImageMetadata(targetDirectory, l.generateLabels()));
         

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/KogitoPackageSources.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/KogitoPackageSources.java
@@ -78,6 +78,24 @@ public class KogitoPackageSources extends PackageSources {
         return sources;
     }
 
+    public static KogitoPackageSources dumpPojos( PackageModel pkgModel) {
+        KogitoPackageSources sources = new KogitoPackageSources();
+
+        List<String> pojoClasses = new ArrayList<>();
+        PackageModelWriter packageModelWriter = new PackageModelWriter(pkgModel);
+        for (DeclaredTypeWriter declaredType : packageModelWriter.getDeclaredTypes()) {
+            sources.pojoSources.add(new GeneratedFile(declaredType.getName(), logSource( declaredType.getSource() )));
+            pojoClasses.add(declaredType.getClassName());
+        }
+
+        if (!pojoClasses.isEmpty()) {
+            sources.reflectConfigSource = new GeneratedFile("META-INF/native-image/" + pkgModel.getPathName() + "/reflect-config.json", reflectConfigSource(pojoClasses));
+        }
+
+        return sources;
+    }
+
+
     public Map<String, String> getModelsByUnit() {
         return modelsByUnit;
     }

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/DeclaredTypeCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/DeclaredTypeCodegen.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.codegen.rules;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.drools.compiler.builder.impl.KnowledgeBuilderConfigurationImpl;
+import org.drools.compiler.compiler.PackageRegistry;
+import org.drools.compiler.kproject.ReleaseIdImpl;
+import org.drools.compiler.lang.descr.CompositePackageDescr;
+import org.drools.compiler.lang.descr.PackageDescr;
+import org.drools.core.io.impl.FileSystemResource;
+import org.drools.modelcompiler.builder.GeneratedFile;
+import org.drools.modelcompiler.builder.ModelBuilderImpl;
+import org.kie.api.io.Resource;
+import org.kie.api.io.ResourceType;
+import org.kie.internal.builder.CompositeKnowledgeBuilder;
+import org.kie.kogito.codegen.AbstractGenerator;
+import org.kie.kogito.codegen.ApplicationSection;
+import org.kie.kogito.codegen.ConfigGenerator;
+import org.kie.kogito.codegen.KogitoPackageSources;
+import org.kie.kogito.codegen.di.DependencyInjectionAnnotator;
+import org.kie.kogito.codegen.rules.config.RuleConfigGenerator;
+
+import static java.util.stream.Collectors.toList;
+
+public class DeclaredTypeCodegen extends AbstractGenerator {
+
+    public static DeclaredTypeCodegen ofPath(Path basePath) {
+        try {
+            Stream<File> files = Files.walk(basePath).map(Path::toFile);
+            Set<Resource> resources = toResources(files);
+            return new DeclaredTypeCodegen(resources);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public static DeclaredTypeCodegen ofFiles(Collection<File> files) {
+        return new DeclaredTypeCodegen(toResources(files.stream()));
+    }
+
+    public static DeclaredTypeCodegen ofResources(Collection<Resource> resources) {
+        return new DeclaredTypeCodegen(resources);
+    }
+
+    private static Set<Resource> toResources(Stream<File> files) {
+        return files.map(FileSystemResource::new).peek(r -> r.setResourceType(typeOf(r))).filter(r -> r.getResourceType() != null).collect(Collectors.toSet());
+    }
+
+    private static ResourceType typeOf(FileSystemResource r) {
+        for (ResourceType rt : resourceTypes) {
+            if (rt.matchesExtension(r.getFile().getName())) {
+                return rt;
+            }
+        }
+        return null;
+    }
+
+    private static final ResourceType[] resourceTypes = {
+            ResourceType.DRL
+    };
+    private final Collection<Resource> resources;
+
+    /**
+     * used for type-resolving during codegen/type-checking
+     */
+    private ClassLoader contextClassLoader;
+
+    private DeclaredTypeCodegen(Collection<Resource> resources) {
+        this.resources = resources;
+        this.contextClassLoader = getClass().getClassLoader();
+    }
+
+    @Override
+    public void setPackageName(String packageName) {
+        // not used
+    }
+
+    public void setDependencyInjection(DependencyInjectionAnnotator annotator) {
+        // not used
+    }
+
+    @Override
+    public ApplicationSection section() {
+        return null;
+    }
+
+    public List<org.kie.kogito.codegen.GeneratedFile> generate() {
+        ReleaseIdImpl dummyReleaseId = new ReleaseIdImpl("dummy:dummy:0.0.0");
+
+        KnowledgeBuilderConfigurationImpl configuration =
+                new KnowledgeBuilderConfigurationImpl(contextClassLoader);
+
+        ModelBuilderImpl<KogitoPackageSources> modelBuilder = new ModelBuilderImpl<KogitoPackageSources>(
+                KogitoPackageSources::dumpPojos, configuration, dummyReleaseId, true, true) {
+
+            @Override
+            protected void buildOtherDeclarations(Collection<CompositePackageDescr> packages) {
+                // skip full processing
+            }
+
+            @Override
+            protected void compileKnowledgePackages(PackageDescr packageDescr, PackageRegistry pkgRegistry) {
+                // skip full processing
+            }
+        };
+
+        CompositeKnowledgeBuilder batch = modelBuilder.batch();
+        resources.forEach(f -> batch.add(f, f.getResourceType()));
+        batch.build();
+
+        if (modelBuilder.hasErrors()) {
+            throw new RuleCodegenError(modelBuilder.getErrors().getErrors());
+        }
+
+        List<GeneratedFile> modelFiles = new ArrayList<>();
+
+        for (KogitoPackageSources pkgSources : modelBuilder.getPackageSources()) {
+            pkgSources.collectGeneratedFiles(modelFiles);
+        }
+
+        return modelFiles.stream()
+                .filter(Objects::nonNull)
+                .map(f -> new org.kie.kogito.codegen.GeneratedFile(
+                        org.kie.kogito.codegen.GeneratedFile.Type.RULE,
+                        f.getPath(), f.getData())).collect(toList());
+    }
+
+    @Override
+    public void updateConfig(ConfigGenerator cfg) {
+        cfg.withRuleConfig(new RuleConfigGenerator());
+    }
+
+    public DeclaredTypeCodegen withClassLoader(ClassLoader projectClassLoader) {
+        this.contextClassLoader = projectClassLoader;
+        return this;
+    }
+}

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/rules/DeclaredTypeCodegenTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/rules/DeclaredTypeCodegenTest.java
@@ -1,0 +1,29 @@
+package org.kie.kogito.codegen.rules;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.kie.api.io.ResourceType;
+import org.kie.kogito.codegen.GeneratedFile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class DeclaredTypeCodegenTest {
+
+    @Test
+    void ofPath() {
+        DeclaredTypeCodegen incrementalRuleCodegen =
+                DeclaredTypeCodegen.ofFiles(
+                        Collections.singleton(
+                                new File("src/test/resources/org/kie/kogito/codegen/declared/declared.drl")));
+        incrementalRuleCodegen.setPackageName("com.acme");
+
+        List<GeneratedFile> generatedFiles = incrementalRuleCodegen.generate();
+
+        assertThat(generatedFiles).hasSize(1);
+
+    }
+}

--- a/kogito-codegen/src/test/resources/org/kie/kogito/codegen/declared/declared.drl
+++ b/kogito-codegen/src/test/resources/org/kie/kogito/codegen/declared/declared.drl
@@ -1,0 +1,13 @@
+package org.kie.kogito.codegen.declared;
+
+global InvalidType ignored;
+
+declare StringContainer
+    value: String
+end
+
+rule thisShouldBeIgnore when
+    FakeType( doesnotexists )
+then
+    ThisIs invalid = nobodyShouldCare();
+end

--- a/kogito-maven-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/kogito-maven-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -8,7 +8,7 @@
             <implementation>org.apache.maven.lifecycle.mapping.DefaultLifecycleMapping</implementation>
             <configuration>
                 <phases>
-                    <process-resources>org.apache.maven.plugins:maven-resources-plugin:resources</process-resources>
+                    <process-resources>org.apache.maven.plugins:maven-resources-plugin:resources,org.kie.kogito:kogito-maven-plugin:generateDeclaredTypes</process-resources>
                     <compile>org.apache.maven.plugins:maven-compiler-plugin:compile,org.kie.kogito:kogito-maven-plugin:generateModel,org.kie.kogito:kogito-maven-plugin:generateDMNModel,org.apache.maven.plugins:maven-compiler-plugin:compile</compile>
                     <!-- proces-classes does not have a default plug-in binding for JAR/KJAR, accordingly to https://maven.apache.org/ref/3-LATEST/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging
                          so can directly declare the inject reactive bytecode goal -->


### PR DESCRIPTION
add a new "generator" that processes declared types separately from the rest of the rules
note: this is sort-of a "hack". 

The same internal "knowledge builder" is used to first process the declared types, skipping the rest; then it processes the full rule base, now including rules as well. 

Declared Types are therefore processed *twice*: first by this processor, then by the "regular" processor. We can fix this later, by actually separating the two processing phases, but, because the operation is basically idempotent (even if it runs twice, it will produce the same results and overwrite) we can get the benefit of separate compilation with little effort.