### PR TITLE
KOGITO-888: Use properties to configure rules (wip)

### DIFF
--- a/api/kogito-api/src/main/java/org/kie/kogito/conf/Clock.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/conf/Clock.java
@@ -1,9 +1,8 @@
 /*
- * Copyright 2005 JBoss Inc
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -24,7 +23,6 @@ import java.lang.annotation.Target;
 @Retention(value = RetentionPolicy.RUNTIME)
 @Target(value = ElementType.TYPE)
 public @interface Clock {
-    enum Type { PSEUDO, REALTIME }
 
-    Type value();
+    ClockType value();
 }

--- a/api/kogito-api/src/main/java/org/kie/kogito/conf/ClockType.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/conf/ClockType.java
@@ -15,14 +15,7 @@
 
 package org.kie.kogito.conf;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-
-@Retention(value = RetentionPolicy.RUNTIME)
-@Target(value = ElementType.TYPE)
-public @interface EventProcessing {
-
-    EventProcessingType value();
+public enum ClockType {
+    PSEUDO,
+    REALTIME
 }

--- a/api/kogito-api/src/main/java/org/kie/kogito/conf/EventProcessingType.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/conf/EventProcessingType.java
@@ -15,14 +15,7 @@
 
 package org.kie.kogito.conf;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-
-@Retention(value = RetentionPolicy.RUNTIME)
-@Target(value = ElementType.TYPE)
-public @interface EventProcessing {
-
-    EventProcessingType value();
+public enum EventProcessingType {
+    CLOUD,
+    STREAM
 }

--- a/api/kogito-api/src/main/java/org/kie/kogito/rules/RuleConfig.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/rules/RuleConfig.java
@@ -15,14 +15,7 @@
 
 package org.kie.kogito.rules;
 
-import org.kie.api.conf.EventProcessingOption;
-import org.kie.api.runtime.conf.ClockTypeOption;
-
 public interface RuleConfig {
 
     RuleEventListenerConfig ruleEventListeners();
-
-    EventProcessingOption eventProcessingMode();
-
-    ClockTypeOption clockType();
 }

--- a/api/kogito-api/src/main/java/org/kie/kogito/rules/RuleUnitConfig.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/rules/RuleUnitConfig.java
@@ -1,0 +1,34 @@
+package org.kie.kogito.rules;
+
+import java.util.OptionalInt;
+
+import org.kie.kogito.conf.ClockType;
+import org.kie.kogito.conf.EventProcessingType;
+
+public final class RuleUnitConfig {
+
+    public static final RuleUnitConfig Default =
+            new RuleUnitConfig(EventProcessingType.CLOUD, ClockType.REALTIME, null);
+
+    private final EventProcessingType eventProcessingType;
+    private final ClockType clockType;
+    private final Integer sessionPool;
+
+    public RuleUnitConfig(EventProcessingType eventProcessingType, ClockType clockType, Integer sessionPool) {
+        this.eventProcessingType = eventProcessingType;
+        this.clockType = clockType;
+        this.sessionPool = sessionPool;
+    }
+
+    public EventProcessingType getEventProcessingType() {
+        return eventProcessingType;
+    }
+
+    public ClockType getClockType() {
+        return clockType;
+    }
+
+    public OptionalInt getSessionPool() {
+        return (sessionPool == null) ? OptionalInt.empty() : OptionalInt.of(sessionPool);
+    }
+}

--- a/api/kogito-internal/src/main/java/org/kie/internal/ruleunit/RuleUnitDescription.java
+++ b/api/kogito-internal/src/main/java/org/kie/internal/ruleunit/RuleUnitDescription.java
@@ -19,6 +19,8 @@ package org.kie.internal.ruleunit;
 import java.util.Collection;
 import java.util.Optional;
 
+import org.kie.kogito.rules.RuleUnitConfig;
+
 public interface RuleUnitDescription {
 
     /**
@@ -53,5 +55,7 @@ public interface RuleUnitDescription {
     Collection<? extends RuleUnitVariable> getUnitVarDeclarations();
 
     boolean hasDataSource( String name );
+
+    RuleUnitConfig getConfig();
 
 }

--- a/drools/drools-core/src/main/java/org/drools/core/config/StaticRuleConfig.java
+++ b/drools/drools-core/src/main/java/org/drools/core/config/StaticRuleConfig.java
@@ -41,13 +41,4 @@ public class StaticRuleConfig implements RuleConfig {
         return ruleEventListenerConfig;
     }
 
-    @Override
-    public EventProcessingOption eventProcessingMode() {
-        return eventProcessing;
-    }
-
-    @Override
-    public ClockTypeOption clockType() {
-        return clockType;
-    }
 }

--- a/drools/kogito-ruleunits/src/main/java/org/kie/kogito/rules/units/AbstractRuleUnitDescription.java
+++ b/drools/kogito-ruleunits/src/main/java/org/kie/kogito/rules/units/AbstractRuleUnitDescription.java
@@ -23,10 +23,12 @@ import java.util.Optional;
 
 import org.kie.internal.ruleunit.RuleUnitDescription;
 import org.kie.internal.ruleunit.RuleUnitVariable;
+import org.kie.kogito.rules.RuleUnitConfig;
 
 public abstract class AbstractRuleUnitDescription implements RuleUnitDescription {
 
     private final Map<String, RuleUnitVariable> varDeclarations = new HashMap<>();
+    private RuleUnitConfig config;
 
     @Override
     public Optional<Class<?>> getDatasourceType(String name) {
@@ -70,4 +72,12 @@ public abstract class AbstractRuleUnitDescription implements RuleUnitDescription
         varDeclarations.put(varDeclaration.getName(), varDeclaration);
     }
 
+    protected void setConfig(RuleUnitConfig config) {
+        this.config = config;
+    }
+
+    @Override
+    public RuleUnitConfig getConfig() {
+        return config;
+    }
 }

--- a/drools/kogito-ruleunits/src/main/java/org/kie/kogito/rules/units/GeneratedRuleUnitDescription.java
+++ b/drools/kogito-ruleunits/src/main/java/org/kie/kogito/rules/units/GeneratedRuleUnitDescription.java
@@ -23,6 +23,7 @@ import java.util.function.Function;
 
 import org.drools.core.addon.TypeResolver;
 import org.kie.kogito.rules.DataSource;
+import org.kie.kogito.rules.RuleUnitConfig;
 
 public class GeneratedRuleUnitDescription extends AbstractRuleUnitDescription {
 
@@ -30,12 +31,14 @@ public class GeneratedRuleUnitDescription extends AbstractRuleUnitDescription {
     private final String name;
     private final String packageName;
     private final String simpleName;
+    private RuleUnitConfig config;
 
     public GeneratedRuleUnitDescription(String name, Function<String, Class<?>> typeResolver) {
         this.typeResolver = typeResolver;
         this.name = name;
         this.simpleName = name.substring(name.lastIndexOf('.') + 1);
         this.packageName = name.substring(0, name.lastIndexOf('.'));
+        this.config = RuleUnitConfig.Default;
     }
 
     public GeneratedRuleUnitDescription(String name, TypeResolver typeResolver) {
@@ -126,5 +129,14 @@ public class GeneratedRuleUnitDescription extends AbstractRuleUnitDescription {
         return returnType instanceof ParameterizedType ?
                 (Class<?>) ((ParameterizedType) returnType).getActualTypeArguments()[0] :
                 Object.class;
+    }
+
+    public void setConfig(RuleUnitConfig config) {
+        this.config = config;
+    }
+
+    @Override
+    public RuleUnitConfig getConfig() {
+        return this.config;
     }
 }

--- a/drools/kogito-ruleunits/src/main/java/org/kie/kogito/rules/units/GeneratedRuleUnitDescription.java
+++ b/drools/kogito-ruleunits/src/main/java/org/kie/kogito/rules/units/GeneratedRuleUnitDescription.java
@@ -31,14 +31,13 @@ public class GeneratedRuleUnitDescription extends AbstractRuleUnitDescription {
     private final String name;
     private final String packageName;
     private final String simpleName;
-    private RuleUnitConfig config;
 
     public GeneratedRuleUnitDescription(String name, Function<String, Class<?>> typeResolver) {
         this.typeResolver = typeResolver;
         this.name = name;
         this.simpleName = name.substring(name.lastIndexOf('.') + 1);
         this.packageName = name.substring(0, name.lastIndexOf('.'));
-        this.config = RuleUnitConfig.Default;
+        setConfig(RuleUnitConfig.Default);
     }
 
     public GeneratedRuleUnitDescription(String name, TypeResolver typeResolver) {
@@ -102,6 +101,7 @@ public class GeneratedRuleUnitDescription extends AbstractRuleUnitDescription {
             throw new IllegalArgumentException(e);
         }
     }
+
     private static Class<?> uncheckedLoadClass(ClassLoader classLoader, String fqcn) {
         try {
             return classLoader.loadClass(fqcn);
@@ -129,14 +129,5 @@ public class GeneratedRuleUnitDescription extends AbstractRuleUnitDescription {
         return returnType instanceof ParameterizedType ?
                 (Class<?>) ((ParameterizedType) returnType).getActualTypeArguments()[0] :
                 Object.class;
-    }
-
-    public void setConfig(RuleUnitConfig config) {
-        this.config = config;
-    }
-
-    @Override
-    public RuleUnitConfig getConfig() {
-        return this.config;
     }
 }

--- a/drools/kogito-ruleunits/src/main/java/org/kie/kogito/rules/units/ReflectiveRuleUnitDescription.java
+++ b/drools/kogito-ruleunits/src/main/java/org/kie/kogito/rules/units/ReflectiveRuleUnitDescription.java
@@ -19,17 +19,18 @@ package org.kie.kogito.rules.units;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 
 import org.drools.core.definitions.InternalKnowledgePackage;
-import org.drools.core.rule.EntryPointId;
+import org.kie.kogito.conf.Clock;
+import org.kie.kogito.conf.ClockType;
+import org.kie.kogito.conf.EventProcessing;
+import org.kie.kogito.conf.EventProcessingType;
+import org.kie.kogito.conf.SessionsPool;
 import org.kie.kogito.rules.DataSource;
 import org.kie.kogito.rules.RuleUnit;
+import org.kie.kogito.rules.RuleUnitConfig;
 import org.kie.kogito.rules.RuleUnitData;
-import org.kie.kogito.rules.units.AbstractRuleUnitDescription;
 
 import static org.drools.reflective.util.ClassUtils.getter2property;
 
@@ -105,5 +106,17 @@ public class ReflectiveRuleUnitDescription extends AbstractRuleUnitDescription {
         return returnType instanceof ParameterizedType ?
                 (Class<?>) ((ParameterizedType) returnType).getActualTypeArguments()[0] :
                 Object.class;
+    }
+
+    @Override
+    public RuleUnitConfig getConfig() {
+        Optional<EventProcessing> eventAnn = Optional.ofNullable(ruleUnitClass.getAnnotation(EventProcessing.class));
+        Optional<Clock> clockAnn = Optional.ofNullable(ruleUnitClass.getAnnotation(Clock.class));
+        Optional<SessionsPool> sessionsPoolAnn = Optional.ofNullable(ruleUnitClass.getAnnotation(SessionsPool.class));
+
+        return new RuleUnitConfig(
+                eventAnn.map(EventProcessing::value).orElse(EventProcessingType.CLOUD),
+                clockAnn.map(Clock::value).orElse(ClockType.REALTIME),
+                sessionsPoolAnn.map(SessionsPool::value).orElse(null));
     }
 }

--- a/drools/kogito-ruleunits/src/main/java/org/kie/kogito/rules/units/ReflectiveRuleUnitDescription.java
+++ b/drools/kogito-ruleunits/src/main/java/org/kie/kogito/rules/units/ReflectiveRuleUnitDescription.java
@@ -41,6 +41,7 @@ public class ReflectiveRuleUnitDescription extends AbstractRuleUnitDescription {
     public ReflectiveRuleUnitDescription(InternalKnowledgePackage pkg, Class<? extends RuleUnitData> ruleUnitClass) {
         this.ruleUnitClass = ruleUnitClass;
         indexUnitVars();
+        setConfig(loadConfig(ruleUnitClass));
     }
 
     @Override
@@ -108,8 +109,7 @@ public class ReflectiveRuleUnitDescription extends AbstractRuleUnitDescription {
                 Object.class;
     }
 
-    @Override
-    public RuleUnitConfig getConfig() {
+    private static RuleUnitConfig loadConfig(Class<? extends RuleUnitData> ruleUnitClass) {
         Optional<EventProcessing> eventAnn = Optional.ofNullable(ruleUnitClass.getAnnotation(EventProcessing.class));
         Optional<Clock> clockAnn = Optional.ofNullable(ruleUnitClass.getAnnotation(Clock.class));
         Optional<SessionsPool> sessionsPoolAnn = Optional.ofNullable(ruleUnitClass.getAnnotation(SessionsPool.class));

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
@@ -58,6 +58,7 @@ import org.kie.kogito.codegen.ApplicationSection;
 import org.kie.kogito.codegen.ConfigGenerator;
 import org.kie.kogito.codegen.KogitoPackageSources;
 import org.kie.kogito.codegen.di.DependencyInjectionAnnotator;
+import org.kie.kogito.codegen.rules.config.NamedRuleUnitConfig;
 import org.kie.kogito.codegen.rules.config.RuleConfigGenerator;
 import org.kie.kogito.conf.ClockType;
 import org.kie.kogito.conf.EventProcessingType;
@@ -70,7 +71,7 @@ import static org.kie.kogito.codegen.ApplicationGenerator.log;
 
 public class IncrementalRuleCodegen extends AbstractGenerator {
 
-    public static IncrementalRuleCodegen ofPath( Path basePath) {
+    public static IncrementalRuleCodegen ofPath(Path basePath) {
         try {
             Stream<File> files = Files.walk(basePath).map(Path::toFile);
             Set<Resource> resources = toResources(files);
@@ -144,6 +145,7 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
     private boolean hotReloadMode = false;
     private String packageName;
     private final boolean decisionTableSupported;
+    private final Map<String, RuleUnitConfig> configs;
 
 
     @Deprecated
@@ -157,6 +159,7 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
         setDefaultsforEmptyKieModule(kieModuleModel);
         this.contextClassLoader = getClass().getClassLoader();
         this.decisionTableSupported = DecisionTableFactory.getDecisionTableProvider() != null;
+        this.configs = new HashMap<>();
     }
 
     @Override
@@ -338,6 +341,14 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
 
     public void setDependencyInjection(boolean di) {
         this.dependencyInjection = di;
+    }
+
+    public IncrementalRuleCodegen withRuleUnitConfigs(Collection<NamedRuleUnitConfig> configs) {
+        this.configs.clear();
+        for (NamedRuleUnitConfig cfg : configs) {
+            this.configs.put(cfg.getCanonicalName(), cfg.getConfig());
+        }
+        return this;
     }
 
     public IncrementalRuleCodegen withKModule(KieModuleModel model) {

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/config/NamedRuleUnitConfig.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/config/NamedRuleUnitConfig.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.codegen.rules.config;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+
+import org.kie.kogito.conf.ClockType;
+import org.kie.kogito.conf.EventProcessingType;
+import org.kie.kogito.rules.RuleUnitConfig;
+
+public final class NamedRuleUnitConfig {
+
+    private static String CONFIG_PREFIX = "kogito.rules.";
+    private static String CONFIG_EVENT_PROCESSING_TYPE = CONFIG_PREFIX + "\"%s\".event-processing-type";
+    private static String CONFIG_CLOCK_TYPE = CONFIG_PREFIX + "\"%s\".clock-type";
+    private static String CONFIG_SESSIONS_POOL = CONFIG_PREFIX + "\"%s\".sessions-pool";
+
+    public static List<NamedRuleUnitConfig> fromProperties(Properties props) {
+        HashSet<String> canonicalNames = new HashSet<>();
+        for (String k : props.stringPropertyNames()) {
+            if (k.startsWith(CONFIG_PREFIX)) {
+                String rest = k.substring(CONFIG_PREFIX.length());
+                Optional<String> unitCanonicalName = parseQuotedIdentifier(rest);
+                unitCanonicalName.ifPresent(canonicalNames::add);
+            }
+        }
+
+        ArrayList<NamedRuleUnitConfig> configs = new ArrayList<>();
+        for (String canonicalName : canonicalNames) {
+            String ept = props.getOrDefault(
+                    String.format(CONFIG_EVENT_PROCESSING_TYPE, canonicalName), EventProcessingType.CLOUD.name())
+                    .toString().toUpperCase();
+            EventProcessingType eventProcessingType = EventProcessingType.valueOf(ept);
+
+            String ct = props.getOrDefault(
+                    String.format(CONFIG_CLOCK_TYPE, canonicalName), ClockType.REALTIME.name())
+                    .toString().toUpperCase();
+            ClockType clockType = ClockType.valueOf(ct);
+
+            String sp = props.getProperty(
+                    String.format(CONFIG_SESSIONS_POOL, canonicalName));
+            Integer sessionPool = sp == null ? null : Integer.parseInt(sp);
+
+            configs.add(new NamedRuleUnitConfig(
+                    canonicalName,
+                    new RuleUnitConfig(
+                            eventProcessingType,
+                            clockType,
+                            sessionPool)));
+        }
+
+        return configs;
+    }
+
+    private static Optional<String> parseQuotedIdentifier(String key) {
+        if (key.startsWith("\"")) {
+            int endIndex = key.substring(1).indexOf('"');
+            if (endIndex == -1) {
+                return Optional.empty();
+            } else {
+                return Optional.of(key.substring(1, endIndex + 1));
+            }
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    private final String canonicalName;
+    private final RuleUnitConfig config;
+
+    public NamedRuleUnitConfig(String canonicalName, RuleUnitConfig config) {
+        this.canonicalName = canonicalName;
+        this.config = config;
+    }
+
+    public String getCanonicalName() {
+        return canonicalName;
+    }
+
+    public RuleUnitConfig getConfig() {
+        return config;
+    }
+}

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/rules/config/NamedRuleUnitConfigTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/rules/config/NamedRuleUnitConfigTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.codegen.rules.config;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+import org.kie.kogito.conf.ClockType;
+import org.kie.kogito.conf.EventProcessingType;
+import org.kie.kogito.rules.RuleUnitConfig;
+
+import static java.util.stream.Collectors.toMap;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NamedRuleUnitConfigTest {
+
+    @Test
+    public void singleUnit() {
+        Properties properties = new Properties();
+        properties.put("kogito.rules.\"my.rule.Unit\".event-processing-type", EventProcessingType.CLOUD.name());
+        properties.put("kogito.rules.\"my.rule.Unit\".clock-type", ClockType.REALTIME.name());
+        properties.put("kogito.rules.\"my.rule.Unit\".sessions-pool", "10");
+
+        List<NamedRuleUnitConfig> namedRuleUnitConfigs = NamedRuleUnitConfig.fromProperties(properties);
+        assertThat(namedRuleUnitConfigs).hasSize(1);
+        NamedRuleUnitConfig namedRuleUnitConfig = namedRuleUnitConfigs.get(0);
+        assertThat(namedRuleUnitConfig.getCanonicalName()).isEqualTo("my.rule.Unit");
+        assertThat(namedRuleUnitConfig.getConfig().getEventProcessingType()).isEqualTo(EventProcessingType.CLOUD);
+        assertThat(namedRuleUnitConfig.getConfig().getClockType()).isEqualTo(ClockType.REALTIME);
+        assertThat(namedRuleUnitConfig.getConfig().getSessionPool().getAsInt()).isEqualTo(10);
+    }
+
+    @Test
+    public void multiUnit() {
+        Properties properties = new Properties();
+        properties.put("kogito.rules.some.other.config", "ignore me");
+
+        properties.put("kogito.rules.\"my.rule.Unit\".event-processing-type", EventProcessingType.CLOUD.name());
+        properties.put("kogito.rules.\"my.rule.Unit\".clock-type", ClockType.PSEUDO.name());
+        properties.put("kogito.rules.\"my.rule.Unit\".sessions-pool", "10");
+
+        properties.put("kogito.rules.\"my.rule.Unit2\".event-processing-type", EventProcessingType.STREAM.name());
+
+        List<NamedRuleUnitConfig> namedRuleUnitConfigs = NamedRuleUnitConfig.fromProperties(properties);
+        assertThat(namedRuleUnitConfigs).hasSize(2);
+
+        Map<String, RuleUnitConfig> map =
+                namedRuleUnitConfigs.stream()
+                        .collect(toMap(NamedRuleUnitConfig::getCanonicalName, NamedRuleUnitConfig::getConfig));
+
+        RuleUnitConfig myRuleUnitConfig = map.get("my.rule.Unit");
+        assertThat(myRuleUnitConfig).isNotNull();
+        assertThat(myRuleUnitConfig.getEventProcessingType()).isEqualTo(EventProcessingType.CLOUD);
+        assertThat(myRuleUnitConfig.getClockType()).isEqualTo(ClockType.PSEUDO);
+        assertThat(myRuleUnitConfig.getSessionPool().getAsInt()).isEqualTo(10);
+
+        RuleUnitConfig myRuleUnit2Config = map.get("my.rule.Unit2");
+        assertThat(myRuleUnit2Config).isNotNull();
+
+        assertThat(myRuleUnit2Config.getEventProcessingType()).isEqualTo(EventProcessingType.STREAM);
+        assertThat(myRuleUnit2Config.getClockType()).isEqualTo(ClockType.REALTIME);
+        assertThat(myRuleUnit2Config.getSessionPool()).isEmpty();
+    }
+
+    @Test
+    public void unbalancedParentheses() {
+        Properties properties = new Properties();
+        properties.put("kogito.rules.some.other.config", "ignore me");
+
+        properties.put("kogito.rules.\"my.rule.Unit", EventProcessingType.CLOUD.name());
+        List<NamedRuleUnitConfig> namedRuleUnitConfigs = NamedRuleUnitConfig.fromProperties(properties);
+
+        assertThat(namedRuleUnitConfigs).isEmpty();
+    }
+}

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/unit/AdultUnit.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/unit/AdultUnit.java
@@ -19,13 +19,14 @@ package org.kie.kogito.codegen.unit;
 import org.kie.kogito.codegen.data.Person;
 import org.kie.kogito.codegen.data.Results;
 import org.kie.kogito.conf.Clock;
+import org.kie.kogito.conf.ClockType;
 import org.kie.kogito.conf.SessionsPool;
 import org.kie.kogito.rules.DataSource;
 import org.kie.kogito.rules.DataStore;
 import org.kie.kogito.rules.RuleUnitData;
 
 @SessionsPool(1)
-@Clock( Clock.Type.PSEUDO )
+@Clock( ClockType.PSEUDO )
 public class AdultUnit implements RuleUnitData {
     private int adultAge = 18;
     private DataStore<Person> persons = DataSource.createStore();

--- a/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
+++ b/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
@@ -2,6 +2,8 @@ package org.kie.kogito.maven.plugin;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URL;
@@ -14,9 +16,11 @@ import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -36,6 +40,7 @@ import org.kie.kogito.codegen.GeneratorContext;
 import org.kie.kogito.codegen.decision.DecisionCodegen;
 import org.kie.kogito.codegen.process.ProcessCodegen;
 import org.kie.kogito.codegen.rules.IncrementalRuleCodegen;
+import org.kie.kogito.codegen.rules.config.NamedRuleUnitConfig;
 import org.kie.kogito.maven.plugin.util.MojoUtil;
 
 @Mojo(name = "generateModel",
@@ -98,7 +103,7 @@ public class GenerateModelMojo extends AbstractKieMojo {
 
     @Parameter(property = "kogito.di.enabled", defaultValue = "true")
     private boolean dependencyInjection;
-    
+
     @Parameter(property = "kogito.persistence.enabled", defaultValue = "false")
     private boolean persistence;
 
@@ -169,21 +174,21 @@ public class GenerateModelMojo extends AbstractKieMojo {
 
     private ApplicationGenerator createApplicationGenerator(boolean generateRuleUnits, boolean generateProcesses, boolean generateDecisions) throws IOException, MojoExecutionException {
         String appPackageName = project.getGroupId();
-        
+
         // safe guard to not generate application classes that would clash with interfaces
         if (appPackageName.equals(ApplicationGenerator.DEFAULT_GROUP_ID)) {
             appPackageName = ApplicationGenerator.DEFAULT_PACKAGE_NAME;
         }
         boolean usePersistence = persistence || hasClassOnClasspath("org.kie.kogito.persistence.KogitoProcessInstancesFactory");
-        boolean useMonitoring = hasClassOnClasspath("org.kie.addons.monitoring.rest.MetricsResource"); 
-        
-        
+        boolean useMonitoring = hasClassOnClasspath("org.kie.addons.monitoring.rest.MetricsResource");
+
+
 
         ClassLoader projectClassLoader = MojoUtil.createProjectClassLoader(this.getClass().getClassLoader(),
                                                                            project,
                                                                            outputDirectory,
                                                                            null);
-        
+
         GeneratorContext context = GeneratorContext.ofResourcePath(kieSourcesDirectory);
         context.withBuildContext(discoverKogitoRuntimeContext(project));
 
@@ -194,15 +199,16 @@ public class GenerateModelMojo extends AbstractKieMojo {
                         .withMonitoring(useMonitoring)
                         .withClassLoader(projectClassLoader)
                         .withGeneratorContext(context);
-        
+
         if (generateRuleUnits) {
             appGen.withGenerator(IncrementalRuleCodegen.ofPath(kieSourcesDirectory.toPath()))
                     .withKModule(getKModuleModel())
-                    .withClassLoader(projectClassLoader);
+                    .withClassLoader(projectClassLoader)
+                    .withRuleUnitConfigs(getRuleUnitConfigs());
         }
 
         if (generateProcesses) {
-            appGen.withGenerator(ProcessCodegen.ofPath(kieSourcesDirectory.toPath())) 
+            appGen.withGenerator(ProcessCodegen.ofPath(kieSourcesDirectory.toPath()))
                     .withPersistence(usePersistence)
                     .withClassLoader(projectClassLoader)
             ;
@@ -232,6 +238,17 @@ public class GenerateModelMojo extends AbstractKieMojo {
         }
     }
 
+    private List<NamedRuleUnitConfig> getRuleUnitConfigs() throws IOException {
+        if (!project.getResources().isEmpty()) {
+            Path filePath = Paths.get(project.getResources().get(0).getDirectory()).resolve("application.conf");
+            FileReader fileReader = new FileReader(filePath.toFile());
+            Properties properties = new Properties();
+            properties.load(fileReader);
+            return NamedRuleUnitConfig.fromProperties(properties);
+        }
+        return Collections.emptyList();
+    }
+
     private void writeGeneratedFile(GeneratedFile f) throws IOException {
         Files.write(
                 pathOf(f.relativePath()),
@@ -259,17 +276,17 @@ public class GenerateModelMojo extends AbstractKieMojo {
         }
     }
 
-    
+
     protected boolean hasClassOnClasspath(String className) {
         try {
             Set<Artifact> elements = project.getDependencyArtifacts();
             URL[] urls = new URL[elements.size()];
-            
+
             int i = 0;
             Iterator<Artifact> it = elements.iterator();
             while (it.hasNext()) {
                 Artifact artifact = it.next();
-                
+
                 urls[i] = artifact.getFile().toURI().toURL();
                 i++;
             }


### PR DESCRIPTION
add support for config properties in `application.conf`

```
kogito.rules."my.rule.Unit".event-processing-type = [CLOUD | STREAM] # default = CLOUD
kogito.rules."my.rule.Unit".clock-type" = [REALTIME | PSEUDO] # default = REALTIME
kogito.rules."my.rule.Unit".sessions-pool = [>1] # default = null
```

