### PR TITLE
KOGITO-1015: Fix usages of javax.annotation.{PostConstruct, ...}

### DIFF
--- a/kogito-codegen/pom.xml
+++ b/kogito-codegen/pom.xml
@@ -106,6 +106,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/kogito-codegen/src/main/resources/class-templates/MessageConsumerTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/MessageConsumerTemplate.java
@@ -25,9 +25,13 @@ public class $Type$MessageConsumer {
     Optional<Boolean> useCloudEvents = Optional.of(true);
     
     private ObjectMapper json = new ObjectMapper();
-        
+
     {
         json.setDateFormat(new StdDateFormat().withColonInTimeZone(true).withTimeZone(TimeZone.getDefault()));
+    }
+
+    public void configure() {
+
     }
     
 	public void consume(String payload) {

--- a/kogito-codegen/src/main/resources/class-templates/MessageConsumerTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/MessageConsumerTemplate.java
@@ -3,8 +3,6 @@ package com.myspace.demo;
 import java.util.TimeZone;
 import java.util.Optional;
 
-import javax.annotation.PostConstruct;
-
 import org.kie.kogito.Application;
 import org.kie.kogito.event.DataEvent;
 import org.kie.kogito.process.Process;
@@ -28,7 +26,7 @@ public class $Type$MessageConsumer {
     
     private ObjectMapper json = new ObjectMapper();
         
-    public void configure() {
+    {
         json.setDateFormat(new StdDateFormat().withColonInTimeZone(true).withTimeZone(TimeZone.getDefault()));
     }
     

--- a/kogito-codegen/src/main/resources/class-templates/MessageProducerTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/MessageProducerTemplate.java
@@ -17,9 +17,13 @@ public class MessageProducer {
     
     Optional<Boolean> useCloudEvents = Optional.of(true);
     private ObjectMapper json = new ObjectMapper();
-    
-    {
-        json.setDateFormat(new StdDateFormat().withColonInTimeZone(true).withTimeZone(TimeZone.getDefault()));
+
+	{
+		json.setDateFormat(new StdDateFormat().withColonInTimeZone(true).withTimeZone(TimeZone.getDefault()));
+	}
+
+    public void configure() {
+		
     }
     
 	public void produce(ProcessInstance pi, $Type$ eventData) {

--- a/kogito-codegen/src/main/resources/class-templates/MessageProducerTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/MessageProducerTemplate.java
@@ -18,8 +18,7 @@ public class MessageProducer {
     Optional<Boolean> useCloudEvents = Optional.of(true);
     private ObjectMapper json = new ObjectMapper();
     
-    
-    public void configure() {
+    {
         json.setDateFormat(new StdDateFormat().withColonInTimeZone(true).withTimeZone(TimeZone.getDefault()));
     }
     

--- a/kogito-codegen/src/main/resources/class-templates/ProcessesTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/ProcessesTemplate.java
@@ -13,8 +13,9 @@ public class ApplicationProcesses implements Processes {
     Object processes;
         
     private Map<String, Process<? extends Model>> mappedProcesses = new HashMap<>();
-    
-    public ApplicationProcesses() {
+
+    @javax.annotation.PostConstruct
+    public void setup() {
         
         for (Process<? extends Model> process : processes) {
             mappedProcesses.put(process.id(), process);

--- a/kogito-codegen/src/main/resources/class-templates/ProcessesTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/ProcessesTemplate.java
@@ -4,8 +4,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.annotation.PostConstruct;
-
 import org.kie.kogito.Model;
 import org.kie.kogito.process.Process;
 import org.kie.kogito.process.Processes;
@@ -16,8 +14,7 @@ public class ApplicationProcesses implements Processes {
         
     private Map<String, Process<? extends Model>> mappedProcesses = new HashMap<>();
     
-    @PostConstruct
-    public void setup() {
+    public ApplicationProcesses() {
         
         for (Process<? extends Model> process : processes) {
             mappedProcesses.put(process.id(), process);

--- a/kogito-codegen/src/main/resources/class-templates/ReactiveRestResourceTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/ReactiveRestResourceTemplate.java
@@ -6,8 +6,6 @@ import java.util.stream.Collectors;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;

--- a/kogito-codegen/src/main/resources/class-templates/RestResourceTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/RestResourceTemplate.java
@@ -4,8 +4,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;


### PR DESCRIPTION
master is currently broken (not sure why), this change also removes usages of such annotations in some places where it's not necessary (e.g. PostConstruct can be usually substituted by a generated constructor)