### PR TITLE
KOGITO-458 Add health check for Data Index service

### DIFF
--- a/data-index/data-index-service/pom.xml
+++ b/data-index/data-index-service/pom.xml
@@ -52,6 +52,12 @@
       <artifactId>quarkus-oidc</artifactId>
     </dependency>
 
+    <!-- Health Check -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-smallrye-health</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>

--- a/data-index/data-index-service/src/main/resources/application.properties
+++ b/data-index/data-index-service/src/main/resources/application.properties
@@ -15,6 +15,9 @@ quarkus.http.cors=true
 quarkus.infinispan-client.server-list=localhost:11222
 
 # Kafka
+quarkus.kafka.health.enabled=true
+quarkus.kafka.bootstrap-servers=localhost:9092
+
 mp.messaging.incoming.kogito-processinstances-events.connector=smallrye-kafka
 mp.messaging.incoming.kogito-processinstances-events.topic=kogito-processinstances-events
 mp.messaging.incoming.kogito-processinstances-events.value.deserializer=org.kie.kogito.index.messaging.KogitoProcessCloudEventDeserializer

--- a/data-index/data-index-storage/data-index-storage-infinispan/pom.xml
+++ b/data-index/data-index-storage/data-index-storage-infinispan/pom.xml
@@ -25,6 +25,13 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-infinispan-client</artifactId>
     </dependency>
+
+    <!-- Health Check -->
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>infinispan-quarkus-health-addon</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>

--- a/data-index/data-index-storage/data-index-storage-infinispan/src/main/java/org/kie/kogito/index/infinispan/InfinispanHealthCheckProducer.java
+++ b/data-index/data-index-storage/data-index-storage-infinispan/src/main/java/org/kie/kogito/index/infinispan/InfinispanHealthCheckProducer.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.index.infinispan;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.Produces;
+
+import org.eclipse.microprofile.health.Readiness;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.kie.kogito.infinispan.health.InfinispanHealthCheck;
+
+@ApplicationScoped
+public class InfinispanHealthCheckProducer {
+
+    @Produces
+    @Readiness
+    public InfinispanHealthCheck infinispanHealthCheck(Instance<RemoteCacheManager> cacheManagerInstance) {
+        return new InfinispanHealthCheck(cacheManagerInstance);
+    }
+}


### PR DESCRIPTION
Adding the health check for kafka and infinispan in the same way as the jobs-service.