### PR TITLE
KOGITO-855 - [Jobs Service] improve persisted jobs loading

### DIFF
--- a/addons/jobs/jobs-service/src/main/java/org/kie/kogito/jobs/service/model/ScheduledJob.java
+++ b/addons/jobs/jobs-service/src/main/java/org/kie/kogito/jobs/service/model/ScheduledJob.java
@@ -92,6 +92,7 @@ public class ScheduledJob extends Job {
                 .add("lastUpdate=" + lastUpdate)
                 .add("executionResponse=" + executionResponse)
                 .add("executionCounter=" + executionCounter)
+                .add("job=" + super.toString())
                 .toString();
     }
 

--- a/addons/jobs/jobs-service/src/main/java/org/kie/kogito/jobs/service/repository/ReactiveJobRepository.java
+++ b/addons/jobs/jobs-service/src/main/java/org/kie/kogito/jobs/service/repository/ReactiveJobRepository.java
@@ -16,6 +16,7 @@
 
 package org.kie.kogito.jobs.service.repository;
 
+import java.time.ZonedDateTime;
 import java.util.concurrent.CompletionStage;
 
 import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
@@ -38,4 +39,5 @@ public interface ReactiveJobRepository {
 
     PublisherBuilder<ScheduledJob> findAll();
 
+    PublisherBuilder<ScheduledJob> findByStatusBetweenDatesOrderByPriority(ZonedDateTime from, ZonedDateTime to, JobStatus... status);
 }

--- a/addons/jobs/jobs-service/src/main/java/org/kie/kogito/jobs/service/repository/impl/JobRepositoryDelegate.java
+++ b/addons/jobs/jobs-service/src/main/java/org/kie/kogito/jobs/service/repository/impl/JobRepositoryDelegate.java
@@ -16,6 +16,7 @@
 
 package org.kie.kogito.jobs.service.repository.impl;
 
+import java.time.ZonedDateTime;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
@@ -87,5 +88,10 @@ public class JobRepositoryDelegate implements ReactiveJobRepository {
     @Override
     public PublisherBuilder<ScheduledJob> findAll() {
         return delegate.findAll();
+    }
+
+    @Override
+    public PublisherBuilder<ScheduledJob> findByStatusBetweenDatesOrderByPriority(ZonedDateTime from, ZonedDateTime to, JobStatus... status) {
+        return delegate.findByStatusBetweenDatesOrderByPriority(from, to, status);
     }
 }

--- a/addons/jobs/jobs-service/src/main/java/org/kie/kogito/jobs/service/repository/infinispan/marshaller/BaseMarshaller.java
+++ b/addons/jobs/jobs-service/src/main/java/org/kie/kogito/jobs/service/repository/infinispan/marshaller/BaseMarshaller.java
@@ -16,12 +16,7 @@
 
 package org.kie.kogito.jobs.service.repository.infinispan.marshaller;
 
-import java.time.Instant;
-import java.time.ZonedDateTime;
-import java.util.Optional;
-
 import org.infinispan.protostream.MessageMarshaller;
-import org.kie.kogito.jobs.service.utils.DateUtil;
 
 public abstract class BaseMarshaller<T> implements MessageMarshaller<T> {
 
@@ -29,15 +24,5 @@ public abstract class BaseMarshaller<T> implements MessageMarshaller<T> {
 
     public String getPackage() {
         return JOB_SERVICE_PKG;
-    }
-
-    protected Instant zonedDateTimeToInstant(ZonedDateTime dateTime) {
-        return Optional.ofNullable(dateTime).map(ZonedDateTime::toInstant).orElse(null);
-    }
-
-    protected ZonedDateTime instantToZonedDateTime(Instant instant){
-        return Optional.ofNullable(instant)
-                .map(i -> ZonedDateTime.ofInstant(i, DateUtil.DEFAULT_ZONE))
-                .orElse(null);
     }
 }

--- a/addons/jobs/jobs-service/src/main/java/org/kie/kogito/jobs/service/repository/infinispan/marshaller/ScheduledJobMarshaller.java
+++ b/addons/jobs/jobs-service/src/main/java/org/kie/kogito/jobs/service/repository/infinispan/marshaller/ScheduledJobMarshaller.java
@@ -18,11 +18,16 @@ package org.kie.kogito.jobs.service.repository.infinispan.marshaller;
 
 import java.io.IOException;
 import java.time.ZonedDateTime;
+import java.util.Optional;
 
+import org.apache.commons.lang3.StringUtils;
 import org.kie.kogito.jobs.api.Job;
 import org.kie.kogito.jobs.api.JobBuilder;
 import org.kie.kogito.jobs.service.model.JobStatus;
 import org.kie.kogito.jobs.service.model.ScheduledJob;
+
+import static org.kie.kogito.jobs.service.utils.DateUtil.instantToZonedDateTime;
+import static org.kie.kogito.jobs.service.utils.DateUtil.zonedDateTimeToInstant;
 
 public class ScheduledJobMarshaller extends BaseMarshaller<ScheduledJob> {
 
@@ -51,7 +56,7 @@ public class ScheduledJobMarshaller extends BaseMarshaller<ScheduledJob> {
 
         writer.writeString("scheduledId", job.getScheduledId());
         writer.writeInt("retries", job.getRetries());
-        writer.writeString("status", job.getStatus().name());
+        writer.writeString("status", Optional.ofNullable(job.getStatus()).map(Enum::name).orElse(""));
         writer.writeInstant("lastUpdate", zonedDateTimeToInstant(job.getLastUpdate()));
         writer.writeInt("executionCounter", job.getExecutionCounter());
     }
@@ -83,7 +88,10 @@ public class ScheduledJobMarshaller extends BaseMarshaller<ScheduledJob> {
 
         String scheduledId = reader.readString("scheduledId");
         Integer retries = reader.readInt("retries");
-        JobStatus status = JobStatus.valueOf(reader.readString("status"));
+        JobStatus status = Optional.ofNullable(reader.readString("status"))
+                .filter(StringUtils::isNotBlank)
+                .map(JobStatus::valueOf)
+                .orElse(null);
         ZonedDateTime lastUpdate = instantToZonedDateTime(reader.readInstant("lastUpdate"));
         Integer executionCounter = reader.readInt("executionCounter");
         return ScheduledJob.builder()

--- a/addons/jobs/jobs-service/src/main/java/org/kie/kogito/jobs/service/scheduler/JobScheduler.java
+++ b/addons/jobs/jobs-service/src/main/java/org/kie/kogito/jobs/service/scheduler/JobScheduler.java
@@ -16,6 +16,9 @@
 
 package org.kie.kogito.jobs.service.scheduler;
 
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
 import org.kie.kogito.jobs.api.Job;
 
 public interface JobScheduler<T, C> {
@@ -23,4 +26,6 @@ public interface JobScheduler<T, C> {
     T schedule(Job job);
 
     C cancel(String jobId);
+
+    Optional<ZonedDateTime> scheduled(String jobId);
 }

--- a/addons/jobs/jobs-service/src/main/java/org/kie/kogito/jobs/service/scheduler/ReactiveJobScheduler.java
+++ b/addons/jobs/jobs-service/src/main/java/org/kie/kogito/jobs/service/scheduler/ReactiveJobScheduler.java
@@ -33,5 +33,4 @@ public interface ReactiveJobScheduler<T> extends JobScheduler<Publisher<T>, Comp
     PublisherBuilder<ScheduledJob> handleJobExecutionError(JobExecutionResponse errorResponse);
 
     PublisherBuilder<ScheduledJob> handleJobExecutionSuccess(JobExecutionResponse errorResponse);
-
 }

--- a/addons/jobs/jobs-service/src/main/java/org/kie/kogito/jobs/service/scheduler/impl/VertxJobScheduler.java
+++ b/addons/jobs/jobs-service/src/main/java/org/kie/kogito/jobs/service/scheduler/impl/VertxJobScheduler.java
@@ -48,7 +48,7 @@ public class VertxJobScheduler extends BaseTimerJobScheduler {
     @Inject
     Vertx vertx;
 
-    public VertxJobScheduler() {
+    protected VertxJobScheduler() {
     }
 
     public VertxJobScheduler(Vertx vertx, JobExecutor jobExecutor, ReactiveJobRepository jobRepository,

--- a/addons/jobs/jobs-service/src/main/java/org/kie/kogito/jobs/service/utils/DateUtil.java
+++ b/addons/jobs/jobs-service/src/main/java/org/kie/kogito/jobs/service/utils/DateUtil.java
@@ -16,18 +16,36 @@
 
 package org.kie.kogito.jobs.service.utils;
 
+import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
 
 public class DateUtil {
 
     public static final ZoneId DEFAULT_ZONE = ZoneId.of("UTC");
 
     private DateUtil() {
-        
+
     }
-    
+
     public static ZonedDateTime now() {
-        return ZonedDateTime.now(DEFAULT_ZONE);
+        return ZonedDateTime.now(DEFAULT_ZONE).truncatedTo(ChronoUnit.MILLIS);
+    }
+
+    public static Instant zonedDateTimeToInstant(ZonedDateTime dateTime) {
+        return Optional.ofNullable(dateTime)
+                .map(t -> t.withZoneSameLocal(DEFAULT_ZONE))
+                .map(t -> t.truncatedTo(ChronoUnit.MILLIS))
+                .map(ZonedDateTime::toInstant)
+                .orElse(null);
+    }
+
+    public static ZonedDateTime instantToZonedDateTime(Instant instant) {
+        return Optional.ofNullable(instant)
+                .map(i -> ZonedDateTime.ofInstant(i, DateUtil.DEFAULT_ZONE))
+                .map(i -> i.truncatedTo(ChronoUnit.MILLIS))
+                .orElse(null);
     }
 }

--- a/addons/jobs/jobs-service/src/main/resources/application.properties
+++ b/addons/jobs/jobs-service/src/main/resources/application.properties
@@ -58,6 +58,8 @@ kogito.jobs-service.persistence=in-memory
 kogito.jobs-service.maxIntervalLimitToRetryMillis=60000
 kogito.jobs-service.backoffRetryMillis=1000
 kogito.service.url=http://localhost:8080
+kogito.jobs-service.schedulerChunkInMinutes=10
+kogito.jobs-service.loadJobIntervalInMinutes=10
 
 #Configure Events Publishing on Job Service using profile
 #disabled by default

--- a/addons/jobs/jobs-service/src/test/java/org/kie/kogito/jobs/service/repository/impl/BaseJobRepositoryTest.java
+++ b/addons/jobs/jobs-service/src/test/java/org/kie/kogito/jobs/service/repository/impl/BaseJobRepositoryTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.jobs.service.repository.impl;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import org.junit.jupiter.api.Test;
+import org.kie.kogito.jobs.api.JobBuilder;
+import org.kie.kogito.jobs.service.model.JobStatus;
+import org.kie.kogito.jobs.service.model.ScheduledJob;
+import org.kie.kogito.jobs.service.repository.ReactiveJobRepository;
+import org.kie.kogito.jobs.service.stream.JobStreams;
+import org.kie.kogito.jobs.service.utils.DateUtil;
+import org.mockito.Mock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+
+public abstract class BaseJobRepositoryTest {
+
+    public static final String ID = UUID.randomUUID().toString();
+
+    @Mock
+    public Vertx vertx;
+
+    @Mock
+    public JobStreams jobStreams;
+
+    private ScheduledJob job;
+
+    public void setUp() {
+        lenient().doAnswer(a -> {
+                               a.getArgument(0, Handler.class).handle(null);
+                               return null;
+                           }
+        ).when(vertx).runOnContext(any());
+
+        createAndSaveJob(ID);
+    }
+
+    public abstract ReactiveJobRepository tested();
+
+    @Test
+    void testSaveAndGet() throws ExecutionException, InterruptedException {
+        ScheduledJob scheduledJob = tested().get(ID).toCompletableFuture().get();
+        assertThat(scheduledJob).isEqualTo(job);
+        ScheduledJob notFound = tested().get(UUID.randomUUID().toString()).toCompletableFuture().get();
+        assertThat(notFound).isNull();
+    }
+
+    private void createAndSaveJob(String id) {
+        job = ScheduledJob.builder()
+                .job(JobBuilder.builder()
+                             .id(id)
+                             .expirationTime(DateUtil.now())
+                             .priority(1)
+                             .callbackEndpoint("url")
+                             .build())
+                .build();
+        tested().save(job);
+    }
+
+    @Test
+    void testExists() throws ExecutionException, InterruptedException {
+        Boolean exists = tested().exists(ID).toCompletableFuture().get();
+        assertThat(exists).isTrue();
+        Boolean notFound = tested().exists(UUID.randomUUID().toString()).toCompletableFuture().get();
+        assertThat(notFound).isFalse();
+    }
+
+    @Test
+    void testDelete() throws ExecutionException, InterruptedException {
+        ScheduledJob scheduledJob = tested().delete(ID).toCompletableFuture().get();
+        assertThat(scheduledJob).isEqualTo(job);
+        ScheduledJob notFound = tested().get(ID).toCompletableFuture().get();
+        assertThat(notFound).isNull();
+    }
+
+    @Test
+    void testFindAll() throws ExecutionException, InterruptedException {
+        List<ScheduledJob> jobs = tested().findAll().toList().run().toCompletableFuture().get();
+        assertThat(jobs.size()).isEqualTo(1);
+        assertThat(jobs.get(0)).isEqualTo(job);
+    }
+
+    @Test
+    void testFindByStatusBetweenDates() throws ExecutionException, InterruptedException {
+        List<ScheduledJob> jobs = IntStream.rangeClosed(1, 10).boxed()
+                .map(id -> ScheduledJob.builder()
+                        .status(JobStatus.SCHEDULED)
+                        .job(JobBuilder.builder()
+                                     .id(String.valueOf(id))
+                                     .expirationTime(DateUtil.now().plusMinutes(id))
+                                     .priority(id)
+                                     .build())
+                        .build())
+                .peek(tested()::save)
+                .collect(Collectors.toList());
+
+        final List<ScheduledJob> fetched = tested().findByStatusBetweenDatesOrderByPriority(DateUtil.now(),
+                                                                                            DateUtil.now().plusMinutes(5).plusSeconds(1),
+                                                                                            JobStatus.SCHEDULED)
+                .toList()
+                .run()
+                .toCompletableFuture()
+                .get();
+
+        assertThat(fetched.size()).isEqualTo(5);
+
+        IntStream.rangeClosed(0, 4).forEach(
+                i -> assertThat(fetched.get(i)).isEqualTo(jobs.get(fetched.size() - 1 - i))
+        );
+
+        //not found test
+        List<ScheduledJob> fetchedNotFound = tested().findByStatusBetweenDatesOrderByPriority(DateUtil.now(),
+                                                                                              DateUtil.now().plusMinutes(5).plusSeconds(1),
+                                                                                              JobStatus.CANCELED)
+                .toList()
+                .run()
+                .toCompletableFuture()
+                .get();
+
+        assertThat(fetchedNotFound.size()).isEqualTo(0);
+
+        fetchedNotFound = tested().findByStatusBetweenDatesOrderByPriority(DateUtil.now().plusDays(1),
+                                                                           DateUtil.now().plusDays(2),
+                                                                           JobStatus.SCHEDULED)
+                .toList()
+                .run()
+                .toCompletableFuture()
+                .get();
+
+        assertThat(fetchedNotFound.size()).isEqualTo(0);
+    }
+}

--- a/addons/jobs/jobs-service/src/test/java/org/kie/kogito/jobs/service/repository/impl/InMemoryJobRepositoryTest.java
+++ b/addons/jobs/jobs-service/src/test/java/org/kie/kogito/jobs/service/repository/impl/InMemoryJobRepositoryTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.jobs.service.repository.impl;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.kie.kogito.jobs.service.repository.ReactiveJobRepository;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class InMemoryJobRepositoryTest extends BaseJobRepositoryTest {
+
+    @InjectMocks
+    private InMemoryJobRepository tested;
+
+    @BeforeEach
+    public void setUp() {
+        super.setUp();
+    }
+
+    @Override
+    public ReactiveJobRepository tested() {
+        return tested;
+    }
+}

--- a/addons/jobs/jobs-service/src/test/java/org/kie/kogito/jobs/service/repository/infinispan/InfinispanJobRepositoryTest.java
+++ b/addons/jobs/jobs-service/src/test/java/org/kie/kogito/jobs/service/repository/infinispan/InfinispanJobRepositoryTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.jobs.service.repository.infinispan;
+
+import javax.inject.Inject;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.kie.kogito.jobs.service.repository.ReactiveJobRepository;
+import org.kie.kogito.jobs.service.repository.impl.BaseJobRepositoryTest;
+import org.kie.kogito.jobs.service.resource.InfinispanServerTestResource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@QuarkusTest
+@QuarkusTestResource(InfinispanServerTestResource.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(MockitoExtension.class)
+class InfinispanJobRepositoryTest extends BaseJobRepositoryTest {
+
+    private InfinispanJobRepository tested;
+
+    @Inject
+    RemoteCacheManager remoteCacheManager;
+
+    @BeforeEach
+    public void setUp() {
+        remoteCacheManager
+                .administration()
+                .getOrCreateCache(InfinispanConfiguration.Caches.SCHEDULED_JOBS, (String) null)
+                .clear();
+        tested = new InfinispanJobRepository(vertx, jobStreams, remoteCacheManager);
+        super.setUp();
+    }
+
+    @Override
+    public ReactiveJobRepository tested() {
+        return tested;
+    }
+}

--- a/addons/jobs/jobs-service/src/test/java/org/kie/kogito/jobs/service/resource/InfinispanServerTestResource.java
+++ b/addons/jobs/jobs-service/src/test/java/org/kie/kogito/jobs/service/resource/InfinispanServerTestResource.java
@@ -18,6 +18,7 @@ package org.kie.kogito.jobs.service.resource;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import org.slf4j.Logger;
@@ -25,10 +26,11 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.FixedHostPortGenericContainer;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
 
 public class InfinispanServerTestResource implements QuarkusTestResourceLifecycleManager {
 
-    private static final String INFINISPAN_VERSION = System.getProperty("infinispan.version");
+    private static final String INFINISPAN_VERSION = Optional.ofNullable(System.getProperty("infinispan.version")).orElse("latest");
     private static final Logger LOGGER = LoggerFactory.getLogger(InfinispanServerTestResource.class);
     private GenericContainer infinispan;
 
@@ -40,6 +42,8 @@ public class InfinispanServerTestResource implements QuarkusTestResourceLifecycl
         LOGGER.info("Using Infinispan image version: {}", INFINISPAN_VERSION);
         infinispan = new FixedHostPortGenericContainer("quay.io/infinispan/server:" + INFINISPAN_VERSION)
                 .withFixedExposedPort(11232, 11222)
+                //wait for the server to be  fully started
+                .waitingFor(Wait.forLogMessage(".*\\bstarted\\b.*", 1))
                 .withEnv("USER", "admin")
                 .withEnv("PASS", "admin")
                 .withLogConsumer(new Slf4jLogConsumer(LOGGER));

--- a/addons/jobs/jobs-service/src/test/java/org/kie/kogito/jobs/service/scheduler/JobSchedulerManagerTest.java
+++ b/addons/jobs/jobs-service/src/test/java/org/kie/kogito/jobs/service/scheduler/JobSchedulerManagerTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.jobs.service.scheduler;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+import io.quarkus.runtime.StartupEvent;
+import io.vertx.axle.core.Vertx;
+import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.kie.kogito.jobs.api.JobBuilder;
+import org.kie.kogito.jobs.service.model.JobStatus;
+import org.kie.kogito.jobs.service.model.ScheduledJob;
+import org.kie.kogito.jobs.service.repository.ReactiveJobRepository;
+import org.kie.kogito.jobs.service.scheduler.impl.VertxJobScheduler;
+import org.kie.kogito.jobs.service.utils.DateUtil;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class JobSchedulerManagerTest {
+
+    public static final String JOB_ID = UUID.randomUUID().toString();
+
+    @Mock
+    VertxJobScheduler scheduler;
+
+    @Mock
+    ReactiveJobRepository repository;
+
+    @Mock
+    Vertx vertx;
+
+    @Spy
+    @InjectMocks
+    private JobSchedulerManager tested;
+
+    @Captor
+    private ArgumentCaptor<Consumer<Void>> captorFirstExecution;
+
+    @Captor
+    private ArgumentCaptor<Consumer<Long>> captorPeriodic;
+
+    private ScheduledJob scheduledJob;
+
+    @BeforeEach
+    void setUp() {
+        this.scheduledJob = ScheduledJob
+                .builder()
+                .job(JobBuilder
+                             .builder()
+                             .id(JOB_ID)
+                             .expirationTime(DateUtil.now())
+                             .build())
+                .build();
+
+        lenient().when(repository.findByStatusBetweenDatesOrderByPriority(any(ZonedDateTime.class),
+                                                                          any(ZonedDateTime.class),
+                                                                          any(JobStatus.class),
+                                                                          any(JobStatus.class)))
+                .thenReturn(ReactiveStreams.of(scheduledJob));
+        lenient().when(scheduler.scheduled(JOB_ID))
+                .thenReturn(Optional.empty());
+        lenient().when(scheduler.schedule(scheduledJob))
+                .thenReturn(ReactiveStreams.of(scheduledJob).buildRs());
+    }
+
+    @Test
+    void testOnStartup(@Mock StartupEvent event) {
+        tested.onStartup(event);
+        verify(vertx).runOnContext(captorFirstExecution.capture());
+        verify(vertx).setPeriodic(eq(tested.loadJobIntervalInMinutes), captorPeriodic.capture());
+    }
+
+    @Test
+    void testOnStartupInvalidInterval(@Mock StartupEvent event) {
+        tested.schedulerChunkInMinutes = 10;
+        tested.loadJobIntervalInMinutes = 20;
+
+        tested.onStartup(event);
+
+        assertThat(tested.loadJobIntervalInMinutes).isEqualTo(tested.schedulerChunkInMinutes);
+    }
+
+    @Test
+    void testLoadScheduledJobs() {
+        tested.loadScheduledJobs();
+        verify(scheduler).schedule(scheduledJob);
+    }
+
+    @Test
+    void testLoadAlreadyScheduledJobs() {
+        when(scheduler.scheduled(JOB_ID)).thenReturn(Optional.of(DateUtil.now()));
+
+        tested.loadScheduledJobs();
+        verify(scheduler, never()).schedule(scheduledJob);
+    }
+}

--- a/addons/jobs/jobs-service/src/test/java/org/kie/kogito/jobs/service/scheduler/impl/VertxJobSchedulerTest.java
+++ b/addons/jobs/jobs-service/src/test/java/org/kie/kogito/jobs/service/scheduler/impl/VertxJobSchedulerTest.java
@@ -73,7 +73,6 @@ class VertxJobSchedulerTest extends BaseTimerJobSchedulerTest {
         super.setUp();
         lenient().when(vertx.setTimer(anyLong(), any())).thenReturn(Long.valueOf(SCHEDULED_ID));
         lenient().when(vertx.setPeriodic(anyLong(), any())).thenReturn(Long.valueOf(SCHEDULED_ID));
-
     }
 
     @Override

--- a/addons/jobs/jobs-service/src/test/resources/application.properties
+++ b/addons/jobs/jobs-service/src/test/resources/application.properties
@@ -22,8 +22,11 @@ quarkus.infinispan-client.auth-password=admin
 quarkus.infinispan-client.auth-realm=default
 quarkus.infinispan-client.auth-server-name=infinispan
 
+kogito.jobs-service.persistence=in-memory
+kogito.jobs-service.maxIntervalLimitToRetryMillis=60000
+kogito.jobs-service.backoffRetryMillis=1000
+kogito.service.url=http://localhost:8080
+kogito.jobs-service.schedulerChunkInMinutes=10
+kogito.jobs-service.loadJobIntervalInMinutes=10
+
 kogito.jobs-service.data-index.enabled=false
-
-#mp.messaging.outgoing.kogito-job-service-job-events.connector=smallrye-in-memory
-
-#mp.messaging.outgoing.kogito-job-service-job-status-events.connector=smallrye-in-memory


### PR DESCRIPTION
Schedule and load jobs in chunks, expressed in a period of time that can be configured, for instance, next 10 minutes, 30 minutes,  60 minutes...
The scheduler just handles the jobs in the current chunk in this way it is not necessary to schedule jobs that are supposed to be executed in a long time in the future.

Besides, it was added the jobs load prioritization.