### PR TITLE
BAQE-1054 Enable cross-module coverage for XML reports

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,7 +60,7 @@ pipeline {
         stage('Analyze kogito-runtimes') {
             steps {
                 script {
-                    maven.runMavenWithSubmarineSettings('-e -nsu generate-resources -Psonarcloud-analysis', false)
+                    maven.runMavenWithSubmarineSettings('-e -nsu validate -Psonarcloud-analysis', false)
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,6 +26,11 @@ pipeline {
             steps {
                 script {
                     maven.runMavenWithSubmarineSettings('clean install -Prun-code-coverage', false)
+                    /*
+                       The analysis must happen before the other stages as these clone different projects into a root
+                       directory of kogito-runtimes and are by mistake incorporated in a test coverage report.
+                     */
+                    maven.runMavenWithSubmarineSettings('-e -nsu validate -Psonarcloud-analysis', false)
                 }
             }
         }
@@ -54,13 +59,6 @@ pipeline {
                         // Don't run with tests so far, see: https://github.com/quarkusio/quarkus/issues/6885
                         maven.runMavenWithSubmarineSettings('clean install -Ppersistence', true)
                     }
-                }
-            }
-        }
-        stage('Analyze kogito-runtimes') {
-            steps {
-                script {
-                    maven.runMavenWithSubmarineSettings('-e -nsu validate -Psonarcloud-analysis', false)
                 }
             }
         }

--- a/Jenkinsfile-sonarcloud-daily
+++ b/Jenkinsfile-sonarcloud-daily
@@ -35,7 +35,7 @@ pipeline {
         stage('Analyze kogito-runtimes') {
             steps {
                 script {
-                    maven.runMavenWithSubmarineSettings('-e -nsu generate-resources -Psonarcloud-analysis', false)
+                    maven.runMavenWithSubmarineSettings('-e -nsu validate -Psonarcloud-analysis', false)
                 }
             }
         }

--- a/pom.xml
+++ b/pom.xml
@@ -34,13 +34,13 @@
     <checkstyle.header.template>.*</checkstyle.header.template>
     <checkstyle.header.extensions>java</checkstyle.header.extensions>
 
+    <jacoco.agent.argLine/>
     <!--
       JaCoCo coverage data file location. Using a single file for appending in the project's root directory makes it
       possible to measure cross-module test coverage -->
+    <jacoco.exec.file>${project.root.dir}/target/jacoco.exec</jacoco.exec.file>
     <!--suppress UnresolvedMavenProperty -->
-    <version.org.jacoco.agent>0.8.4</version.org.jacoco.agent>
-    <version.jacoco.plugin>${version.org.jacoco.agent}</version.jacoco.plugin>
-    <jacoco.exec.file>${maven.multiModuleProjectDirectory}/target/jacoco.exec</jacoco.exec.file>
+    <project.root.dir>${maven.multiModuleProjectDirectory}</project.root.dir>
 
     <!-- plugin versions -->
     <version.antapacheregexp>1.8.2</version.antapacheregexp>
@@ -57,6 +57,7 @@
     <version.findbugs.plugin>3.0.5</version.findbugs.plugin>
     <version.install.plugin>2.5.2</version.install.plugin>
     <version.invoker.plugin>2.0.0</version.invoker.plugin>
+    <version.jacoco.plugin>0.8.5</version.jacoco.plugin>
     <version.jandex.plugin>1.0.6</version.jandex.plugin>
     <version.jar.plugin>3.1.0</version.jar.plugin>
     <version.javadoc.plugin>3.0.1</version.javadoc.plugin>
@@ -689,12 +690,6 @@
       </dependency>
 
       <dependency>
-        <groupId>org.jacoco</groupId>
-        <artifactId>org.jacoco.agent</artifactId>
-        <version>${version.org.jacoco.agent}</version>
-      </dependency>
-
-      <dependency>
         <groupId>org.reflections</groupId>
         <artifactId>reflections</artifactId>
         <version>${version.org.reflections}</version>
@@ -719,51 +714,23 @@
 
     <profile>
       <id>run-code-coverage</id>
-      <properties>
-        <jacoco.excludes>*Lexer:org.kie.kogito.codegen.data.*</jacoco.excludes>
-        <jacoco.agent.line>-javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${version.org.jacoco.agent}/org.jacoco.agent-${version.org.jacoco.agent}-runtime.jar=destfile=${jacoco.exec.file},append=true,excludes=${jacoco.excludes}</jacoco.agent.line>
-        <surefire.argLine>
-          -Dfile.encoding=${project.build.sourceEncoding}
-          ${jacoco.agent.line}
-        </surefire.argLine>
-      </properties>
       <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>org.codehaus.cargo</groupId>
-              <artifactId>cargo-maven2-plugin</artifactId>
-              <configuration>
-                <configuration>
-                  <properties>
-                    <cargo.start.jvmargs>${jacoco.agent.line}</cargo.start.jvmargs>
-                  </properties>
-                </configuration>
-              </configuration>
-            </plugin>
-            <plugin>
-              <artifactId>maven-surefire-plugin</artifactId>
-              <configuration>
-                <argLine>${surefire.argLine}</argLine>
-              </configuration>
-              <dependencies>
-                <dependency>
-                  <groupId>org.jacoco</groupId>
-                  <artifactId>org.jacoco.agent</artifactId>
-                  <version>${version.org.jacoco.agent}</version>
-                  <classifier>runtime</classifier>
-                </dependency>
-              </dependencies>
-            </plugin>
-          </plugins>
-        </pluginManagement>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
       </build>
     </profile>
 
+    <!--
+      Creates JaCoCo XML reports and invokes the Sonar scanner, which uploads code quality data into the SonarCloud.
+    -->
     <profile>
       <id>sonarcloud-analysis</id>
       <properties>
-        <sonar.jacoco.reportPaths>${jacoco.exec.file}</sonar.jacoco.reportPaths>
+        <sonar.coverage.jacoco.xmlReportPaths>${project.reporting.outputDirectory}/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.organization>kiegroup</sonar.organization>
         <!--suppress UnresolvedMavenProperty -->
@@ -772,6 +739,79 @@
       <build>
         <plugins>
           <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>validate</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <!--
+                    Jacoco ant "report" task provides control over scope of the generated report. The report task
+                    requires access to sources, classes and .exec file containing coverage data. The configuration
+                    below uses sources and classes of the entire project (each of its modules) and a single jacoco.exec
+                    file placed in project root directory.
+                    Jacoco maven plugin does not provide such a level of control and requires an artificial module that
+                    depends on all modules in the project to generate an aggregated report for all the modules.
+                    This necessity of creating a reporting module in every project is rather intrusive.
+                    See:
+                    https://www.jacoco.org/jacoco/trunk/doc/report-aggregate-mojo.html and
+                    https://groups.google.com/forum/#!topic/jacoco/oMxNZs_DNII
+                  -->
+                  <target>
+                    <echo message="Generating JaCoCo Reports"/>
+                    <taskdef name="report" classname="org.jacoco.ant.ReportTask"/>
+                    <mkdir dir="${project.reporting.outputDirectory}/jacoco"/>
+                    <report>
+                      <executiondata>
+                        <fileset dir="${project.root.dir}/target">
+                          <!--
+                            Include a single jacoco.exec file, which should be used in append mode by every module.
+                          -->
+                          <include name="jacoco.exec"/>
+                        </fileset>
+                      </executiondata>
+                      <structure name="Coverage Report">
+                        <group name="${project.artifactId}">
+                          <classfiles>
+                            <fileset dir="${project.root.dir}">
+                              <!--
+                                Include class files from every module.
+                              -->
+                              <include name="**/target/classes/**/*.class"/>
+                              <!-- To avoid a complaint about duplicate classes from archetypes. -->
+                              <exclude name="**/target/test-classes/**/*.class"/>
+                            </fileset>
+                          </classfiles>
+                          <sourcefiles encoding="UTF-8">
+                            <fileset dir="${project.root.dir}">
+                              <!--
+                                Include source files from every module.
+                              -->
+                              <include name="**/src/main/**/*.java"/>
+                            </fileset>
+                          </sourcefiles>
+                        </group>
+                      </structure>
+                      <!-- The same report is generated in each module -->
+                      <xml destfile="${project.reporting.outputDirectory}/jacoco/jacoco.xml"/>
+                    </report>
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+            <dependencies>
+              <dependency>
+                <groupId>org.jacoco</groupId>
+                <artifactId>org.jacoco.ant</artifactId>
+                <!-- Keep the version in sync with jacoco-maven-plugin -->
+                <version>${version.jacoco.plugin}</version>
+              </dependency>
+            </dependencies>
+          </plugin>
+          <plugin>
             <groupId>org.sonarsource.scanner.maven</groupId>
             <artifactId>sonar-maven-plugin</artifactId>
             <executions>
@@ -779,7 +819,7 @@
                 <goals>
                   <goal>sonar</goal>
                 </goals>
-                <phase>generate-resources</phase>
+                <phase>validate</phase>
               </execution>
             </executions>
           </plugin>
@@ -995,7 +1035,8 @@
             <excludes>
               <exclude>**/*IntegrationTest.java</exclude>
             </excludes>
-            <argLine>-Xmx1024m -Dfile.encoding=UTF-8</argLine>
+            <!-- Append jacoco.agent.argLine property populated by JaCoCo's prepare-agent goal. -->
+            <argLine>@{jacoco.agent.argLine} -Xmx1024m -Dfile.encoding=UTF-8</argLine>
             <systemPropertyVariables>
               <apple.awt.UIElement>true</apple.awt.UIElement>
               <org.uberfire.nio.git.daemon.enabled>false</org.uberfire.nio.git.daemon.enabled>
@@ -1243,11 +1284,6 @@
           <version>${version.swagger.plugin}</version>
         </plugin>
         <plugin>
-          <groupId>org.jacoco</groupId>
-          <artifactId>jacoco-maven-plugin</artifactId>
-          <version>${version.jacoco.plugin}</version>
-        </plugin>
-        <plugin>
           <groupId>org.jboss.jandex</groupId>
           <artifactId>jandex-maven-plugin</artifactId>
           <version>${version.jandex.plugin}</version>
@@ -1257,6 +1293,28 @@
               <goals>
                 <goal>jandex</goal>
               </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>${version.jacoco.plugin}</version>
+          <executions>
+            <execution>
+              <id>jacoco-prepare-agent</id>
+              <goals>
+                <goal>prepare-agent</goal>
+              </goals>
+              <configuration>
+                <append>true</append>
+                <destFile>${jacoco.exec.file}</destFile>
+                <excludes>
+                  <exclude>*Lexer</exclude>
+                  <exclude>org.kie.kogito.codegen.data.*</exclude>
+                </excludes>
+                <propertyName>jacoco.agent.argLine</propertyName>
+              </configuration>
             </execution>
           </executions>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
     <version.resources.plugin>3.1.0</version.resources.plugin>
     <version.site.plugin>3.7.1</version.site.plugin>
     <version.shade.plugin>3.0.0</version.shade.plugin>
+    <version.sonar.plugin>3.6.1.1688</version.sonar.plugin>
     <version.source.plugin>3.0.1</version.source.plugin>
     <version.surefire>2.22.1</version.surefire> <!-- minimum required by JUnit 5 -->
     <version.surefire.report.plugin>2.6</version.surefire.report.plugin>
@@ -877,6 +878,11 @@
                   </configuration>
                 </execution>
               </executions>
+            </plugin>
+            <plugin>
+              <groupId>org.sonarsource.scanner.maven</groupId>
+              <artifactId>sonar-maven-plugin</artifactId>
+              <version>${version.sonar.plugin}</version>
             </plugin>
           </plugins>
         </pluginManagement>


### PR DESCRIPTION
The change in reporting coverage is similar to https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1186.

Other than that, this PR also:
- redefines how the code coverage is measured - by using jacoco maven plugin to construct an argument line for surefire instead of defining it manually
- binds the reporting to an earlier phase (validate) to avoid unnecessarily triggering some other maven plugins