### PR TITLE
Add support for Start Signal Catch Events.

### DIFF
--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/StartNodeVisitor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/StartNodeVisitor.java
@@ -16,9 +16,11 @@
 
 package org.jbpm.compiler.canonical;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.jbpm.process.core.context.variable.VariableScope;
+import org.jbpm.ruleflow.core.factory.EventNodeFactory;
 import org.jbpm.ruleflow.core.factory.StartNodeFactory;
 import org.jbpm.workflow.core.node.StartNode;
 import org.kie.api.definition.process.Node;
@@ -32,28 +34,56 @@ public class StartNodeVisitor extends AbstractVisitor {
     @Override
     public void visitNode(String factoryField, Node node, BlockStmt body, VariableScope variableScope, ProcessMetaData metadata) {
         StartNode startNode = (StartNode) node;
-        
-        addFactoryMethodWithArgsWithAssignment(factoryField, body, StartNodeFactory.class, "startNode" + node.getId(), "startNode", new LongLiteralExpr(startNode.getId()));
-        addFactoryMethodWithArgs(body, "startNode" + node.getId(), "name", new StringLiteralExpr(getOrDefault(startNode.getName(), "Start")));
-        
-        visitMetaData(startNode.getMetaData(), body, "startNode" + node.getId());
-        
-        addFactoryMethodWithArgs(body, "startNode" + node.getId(), "done");
-        
-        if (startNode.getTriggers() != null && !startNode.getTriggers().isEmpty()) {
+
+        if ("Signal".equals(startNode.getMetaData("TriggerType"))) {
             Map<String, Object> nodeMetaData = startNode.getMetaData();
-            metadata.getTriggers().add(new TriggerMetaData((String)nodeMetaData.get("TriggerRef"), 
-                                                           (String)nodeMetaData.get("TriggerType"), 
-                                                           (String)nodeMetaData.get("MessageType"), 
-                                                           (String)nodeMetaData.get("TriggerMapping"),
-                                                           String.valueOf(node.getId())).validate());
-            
-            addFactoryMethodWithArgs(body, "startNode" + node.getId(), "trigger", new StringLiteralExpr((String)nodeMetaData.get("TriggerRef")),
-                                                                                  new StringLiteralExpr(getOrDefault((String)nodeMetaData.get("TriggerMapping"), "")));
+            String variableName = "eventNode" + node.getId();
+            String signalName = (String) nodeMetaData.get("MessageType");
+            String triggerMapping = (String) nodeMetaData.get("TriggerMapping");
+
+            addFactoryMethodWithArgsWithAssignment(factoryField, body, EventNodeFactory.class, variableName, "eventNode", new LongLiteralExpr(startNode.getId()));
+
+            if (triggerMapping != null) {
+                metadata.getSignals().put(signalName, variableScope.findVariable(triggerMapping).getType().getStringType());
+                addFactoryMethodWithArgs(body, variableName, "variableName", new StringLiteralExpr(triggerMapping));
+            } else {
+                metadata.getSignals().put(signalName, null);
+            }
+
+            addFactoryMethodWithArgs(body, variableName, "name", new StringLiteralExpr(getOrDefault(startNode.getName(), "Event")));
+            addFactoryMethodWithArgs(body, variableName, "eventType", new StringLiteralExpr(signalName));
+
+            Map<String, Object> newMetaData = new HashMap<>(nodeMetaData);
+            newMetaData.put("EventType", "signal");
+            visitMetaData(newMetaData, body, variableName);
+            addFactoryMethodWithArgs(body, variableName, "done");
         } else {
-            // since there is start node without trigger then make sure it is startable
-            metadata.setStartable(true);
+            addFactoryMethodWithArgsWithAssignment(factoryField, body, StartNodeFactory.class, "startNode" + node.getId(), "startNode", new LongLiteralExpr(startNode.getId()));
+            addFactoryMethodWithArgs(body, "startNode" + node.getId(), "name", new StringLiteralExpr(getOrDefault(startNode.getName(), "Start")));
+
+            visitMetaData(startNode.getMetaData(), body, "startNode" + node.getId());
+
+            addFactoryMethodWithArgs(body, "startNode" + node.getId(), "done");
+
+            if (startNode.getTriggers() != null && !startNode.getTriggers().isEmpty()) {
+                Map<String, Object> nodeMetaData = startNode.getMetaData();
+                String name = (String) nodeMetaData.get("TriggerRef");
+                String type = (String) nodeMetaData.get("TriggerType");
+                String messageType = (String) nodeMetaData.get("MessageType");
+                String triggerMapping = (String) nodeMetaData.get("TriggerMapping");
+
+                metadata.getTriggers().add(new TriggerMetaData(name,
+                                                               type,
+                                                               messageType,
+                                                               triggerMapping,
+                                                               String.valueOf(node.getId())).validate());
+                addFactoryMethodWithArgs(body, "startNode" + node.getId(), "trigger", new StringLiteralExpr(name),
+                                         new StringLiteralExpr(getOrDefault(triggerMapping, "")));
+            } else {
+                // since there is start node without trigger then make sure it is startable
+                metadata.setStartable(true);
+            }
         }
-        
+
     }
 }


### PR DESCRIPTION
This PR add support for Start Signal Catch Events. Before, an error was thrown since the code expected Messages to be the only Start Node kind with Triggers. I am guessing tests will revolve around creating BPMN diagrams and asserting the correct code is generated and is executed correctly?

(Why is this useful? It allows one to handle requests as they come in for a particular process without needing to creating a signal loop or use persistence with messages).