### PR TITLE
KOGITO-893: Use Singleton DataSource in processes+rules

### DIFF
--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/AbstractVisitor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/AbstractVisitor.java
@@ -154,11 +154,11 @@ public abstract class AbstractVisitor {
         }
     }
 
-    protected void addNodeMappings(Mappable workItemNode, BlockStmt body, String variableName) {
-        for (Entry<String, String> entry : workItemNode.getInMappings().entrySet()) {
+    protected void addNodeMappings(Mappable node, BlockStmt body, String variableName) {
+        for (Entry<String, String> entry : node.getInMappings().entrySet()) {
             addFactoryMethodWithArgs(body, variableName, "inMapping", new StringLiteralExpr(entry.getKey()), new StringLiteralExpr(entry.getValue()));
         }
-        for (Entry<String, String> entry : workItemNode.getOutMappings().entrySet()) {
+        for (Entry<String, String> entry : node.getOutMappings().entrySet()) {
             addFactoryMethodWithArgs(body, variableName, "outMapping", new StringLiteralExpr(entry.getKey()), new StringLiteralExpr(entry.getValue()));
         }
     }

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/AbstractVisitor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/AbstractVisitor.java
@@ -23,6 +23,7 @@ import java.util.Map.Entry;
 
 import org.drools.core.util.StringUtils;
 import org.jbpm.process.core.Work;
+import org.jbpm.process.core.context.variable.Mappable;
 import org.jbpm.process.core.context.variable.Variable;
 import org.jbpm.process.core.context.variable.VariableScope;
 import org.jbpm.workflow.core.node.WorkItemNode;
@@ -153,8 +154,7 @@ public abstract class AbstractVisitor {
         }
     }
 
-    protected void addWorkItemMappings(WorkItemNode workItemNode, BlockStmt body, String variableName) {
-
+    protected void addNodeMappings(Mappable workItemNode, BlockStmt body, String variableName) {
         for (Entry<String, String> entry : workItemNode.getInMappings().entrySet()) {
             addFactoryMethodWithArgs(body, variableName, "inMapping", new StringLiteralExpr(entry.getKey()), new StringLiteralExpr(entry.getValue()));
         }

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/HumanTaskNodeVisitor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/HumanTaskNodeVisitor.java
@@ -37,7 +37,7 @@ public class HumanTaskNodeVisitor extends AbstractVisitor {
         addFactoryMethodWithArgs(body, "humanTaskNode" + node.getId(), "name", new StringLiteralExpr(getOrDefault(humanTaskNode.getName(), "Task")));            
         
         addWorkItemParameters(work, body, "humanTaskNode" + node.getId());
-        addWorkItemMappings(humanTaskNode, body, "humanTaskNode" + node.getId());
+        addNodeMappings(humanTaskNode, body, "humanTaskNode" + node.getId());
         
         addFactoryMethodWithArgs(body, "humanTaskNode" + node.getId(), "done");
         

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/RuleUnitHandler.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/RuleUnitHandler.java
@@ -35,6 +35,19 @@ import org.slf4j.LoggerFactory;
 
 import static com.github.javaparser.StaticJavaParser.parse;
 
+/*
+ *
+ * Input/Output mapping with Rule Units:
+ *
+ * | Mapping | Process Variable | Rule Unit field   | Action
+ * | IN      | scalar           | scalar            | Assignment
+ * | IN      | scalar           | data source 	    | Add to (i.e. insert into) data source
+ * | IN      | collection       | data source 	    | Add all contents from data source
+ * | OUT     | scalar           | scalar 	        | Assignment
+ * | OUT     | scalar           | data source 	    | get 1 value off the data source
+ * | OUT     | collection       | data source 	    | Add all contents to the data source
+ *
+ */
 public class RuleUnitHandler {
 
     public static final Logger logger = LoggerFactory.getLogger(ProcessToExecModelGenerator.class);

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/RuleUnitMetaModel.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/RuleUnitMetaModel.java
@@ -33,6 +33,7 @@ import org.kie.internal.ruleunit.RuleUnitVariable;
 import org.kie.kogito.rules.DataObserver;
 import org.kie.kogito.rules.DataStore;
 import org.kie.kogito.rules.DataStream;
+import org.kie.kogito.rules.SingletonStore;
 
 import static com.github.javaparser.StaticJavaParser.parseExpression;
 
@@ -144,6 +145,8 @@ public class RuleUnitMetaModel {
             appendMethod = "append";
         } else if (type.isAssignableFrom(DataStore.class)) {
             appendMethod = "add";
+        } else if (type.isAssignableFrom(SingletonStore.class)) {
+            appendMethod = "set";
         } else {
             throw new IllegalArgumentException("Unknown data source type " + type.getCanonicalName());
         }

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/WorkItemNodeVisitor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/WorkItemNodeVisitor.java
@@ -72,7 +72,7 @@ public class WorkItemNodeVisitor extends AbstractVisitor {
         addFactoryMethodWithArgs(body, "workItemNode" + node.getId(), "workName", new StringLiteralExpr(workName));
 
         addWorkItemParameters(work, body, "workItemNode" + node.getId());
-        addWorkItemMappings(workItemNode, body, "workItemNode" + node.getId());
+        addNodeMappings(workItemNode, body, "workItemNode" + node.getId());
         
         addFactoryMethodWithArgs(body, "workItemNode" + node.getId(), "done");
         

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/RuleSetNode.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/RuleSetNode.java
@@ -28,6 +28,7 @@ import java.util.function.Supplier;
 import org.jbpm.process.core.Context;
 import org.jbpm.process.core.ContextContainer;
 import org.jbpm.process.core.context.AbstractContext;
+import org.jbpm.process.core.context.variable.Mappable;
 import org.jbpm.process.core.impl.ContextContainerImpl;
 import org.kie.api.definition.process.Connection;
 import org.kie.api.runtime.KieRuntime;
@@ -37,7 +38,8 @@ import org.kie.kogito.rules.RuleUnitData;
 /**
  * Default implementation of a RuleSet node.
  */
-public class RuleSetNode extends StateBasedNode implements ContextContainer {
+public class RuleSetNode extends StateBasedNode implements ContextContainer,
+                                                           Mappable {
 
 
     public static abstract class RuleType implements Serializable {

--- a/kogito-codegen/src/test/resources/ruletask/Generated.drl
+++ b/kogito-codegen/src/test/resources/ruletask/Generated.drl
@@ -16,8 +16,8 @@ rule singlePerson_add_note when
     s: /singleString[ this == "hello" ]
 then
     p.setAdult(true);
-    singleString.remove(s);
-	singleString.add("Now the life starts again");
+    singleString.clear();
+	singleString.set("Now the life starts again");
 end
 
 rule singlePerson_clear_note when
@@ -25,5 +25,5 @@ rule singlePerson_clear_note when
     s: /singleString
 then
     p.setAdult(true);
-	singleString.remove(s);
+	singleString.clear();
 end

--- a/kogito-codegen/src/test/resources/ruletask/Generated.drl
+++ b/kogito-codegen/src/test/resources/ruletask/Generated.drl
@@ -16,7 +16,6 @@ rule singlePerson_add_note when
     s: /singleString[ this == "hello" ]
 then
     p.setAdult(true);
-    singleString.clear();
 	singleString.set("Now the life starts again");
 end
 


### PR DESCRIPTION
We have introduced the SingletonStore: a data store for single-values. In this PR we use it for workflow-generated rule units; i.e. rule units that transparently "see" process variables