### PR TITLE
KOGITO-1264 - Allow to use Validation API to enhance generated REST api

### DIFF
--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ModelMetaData.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ModelMetaData.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.drools.core.util.StringUtils;
+import org.jbpm.process.core.context.variable.Variable;
 import org.kie.api.definition.process.WorkflowProcess;
 import org.kie.internal.kogito.codegen.Generated;
 import org.kie.internal.kogito.codegen.VariableInfo;
@@ -68,6 +69,8 @@ public class ModelMetaData {
     private String visibility;
     private boolean hidden;
     private String templateName;
+    
+    private boolean supportsValidation;
 
     public ModelMetaData(String processId, String packageName, String modelClassSimpleName, String visibility, VariableDeclarations variableScope, boolean hidden) {
         this(processId, packageName, modelClassSimpleName, visibility, variableScope, hidden, "/class-templates/ModelTemplate.java");
@@ -181,6 +184,8 @@ public class ModelMetaData {
             List<String> tags = variableScope.getTags(vname);
             fd.addAnnotation(new NormalAnnotationExpr(new Name(VariableInfo.class.getCanonicalName()), NodeList.nodeList(new MemberValuePair("tags", new StringLiteralExpr(tags.stream().collect(Collectors.joining(",")))))));
 
+            applyValidation(fd, tags);
+            
             fd.createGetter();
             fd.createSetter();
 
@@ -214,6 +219,18 @@ public class ModelMetaData {
         return compilationUnit;
     }
 
+    private void applyValidation(FieldDeclaration fd, List<String> tags) {
+
+        if (supportsValidation) {
+            fd.addAnnotation("javax.validation.Valid");
+            
+            if (tags != null && tags.contains(Variable.REQUIRED_TAG)) {
+                fd.addAnnotation("javax.validation.constraints.NotNull");
+            }
+        }
+        
+    }
+
     private FieldDeclaration declareField(String name, String type) {
         return new FieldDeclaration().addVariable(
                 new VariableDeclarator()
@@ -233,6 +250,15 @@ public class ModelMetaData {
     public String getGeneratedClassModel() {
         return generate();
     }
+    
+    public boolean isSupportsValidation() {
+        return supportsValidation;
+    }
+    
+    public void setSupportsValidation(boolean supportsValidation) {
+        this.supportsValidation = supportsValidation;
+    }
+
 
     @Override
     public String toString() {

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/KogitoCodeGenConstants.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/KogitoCodeGenConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,15 +13,14 @@
  * limitations under the License.
  */
 
-package org.kie.kogito.codegen.context;
+package org.kie.kogito.codegen;
 
-import org.kie.kogito.codegen.KogitoCodeGenConstants;
 
-public interface KogitoBuildContext {    
-
-    boolean hasClassAvailable(String fqcn);
+public class KogitoCodeGenConstants {
     
-    default boolean isValidationSupported() {
-        return hasClassAvailable(KogitoCodeGenConstants.VALIDATION_CLASS);
+    private KogitoCodeGenConstants() {
+        
     }
+
+    public static final String VALIDATION_CLASS = "javax.validation.constraints.NotNull";
 }

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/context/QuarkusKogitoBuildContext.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/context/QuarkusKogitoBuildContext.java
@@ -15,6 +15,18 @@
 
 package org.kie.kogito.codegen.context;
 
+import java.util.function.Predicate;
+
 public class QuarkusKogitoBuildContext implements KogitoBuildContext {
-    
+
+    private Predicate<String> classAvailabilityResolver;
+
+    public QuarkusKogitoBuildContext(Predicate<String> classAvailabilityResolver) {
+        this.classAvailabilityResolver = classAvailabilityResolver;
+    }
+
+    @Override
+    public boolean hasClassAvailable(String fqcn) {
+        return classAvailabilityResolver.test(fqcn);
+    }
 }

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/context/SpringBootKogitoBuildContext.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/context/SpringBootKogitoBuildContext.java
@@ -15,6 +15,19 @@
 
 package org.kie.kogito.codegen.context;
 
+import java.util.function.Predicate;
+
 public class SpringBootKogitoBuildContext implements KogitoBuildContext {
+    
+    private Predicate<String> classAvailabilityResolver;
+
+    public SpringBootKogitoBuildContext(Predicate<String> classAvailabilityResolver) {
+        this.classAvailabilityResolver = classAvailabilityResolver;
+    }
+
+    @Override
+    public boolean hasClassAvailable(String fqcn) {
+        return classAvailabilityResolver.test(fqcn);
+    }
     
 }

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/AbstractResourceGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/AbstractResourceGenerator.java
@@ -32,6 +32,7 @@ import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.Parameter;
 import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.expr.BinaryExpr;
 import com.github.javaparser.ast.expr.BinaryExpr.Operator;
@@ -51,6 +52,7 @@ import org.drools.core.util.StringUtils;
 import org.jbpm.compiler.canonical.UserTaskModelMetaData;
 import org.kie.api.definition.process.WorkflowProcess;
 import org.kie.kogito.codegen.BodyDeclarationComparator;
+import org.kie.kogito.codegen.GeneratorContext;
 import org.kie.kogito.codegen.di.DependencyInjectionAnnotator;
 import org.kie.kogito.process.ProcessInstance;
 import org.kie.kogito.process.impl.Sig;
@@ -62,6 +64,7 @@ public abstract class AbstractResourceGenerator {
 
     private final String relativePath;
 
+    private final GeneratorContext context;
     private WorkflowProcess process;
     private final String packageName;
     private final String resourceClazzName;
@@ -78,10 +81,12 @@ public abstract class AbstractResourceGenerator {
     private Map<String, String> signals;
 
     public AbstractResourceGenerator(
+            GeneratorContext context, 
             WorkflowProcess process,
             String modelfqcn,
             String processfqcn,
             String appCanonicalName) {
+        this.context = context;
         this.process = process;
         this.packageName = process.getPackageName();
         this.processId = process.getId();
@@ -247,6 +252,8 @@ public abstract class AbstractResourceGenerator {
             annotator.withApplicationComponent(template);
         }
         
+        enableValidation(template);
+        
         template.getMembers().sort(new BodyDeclarationComparator());
         return clazz.toString();
     }
@@ -265,6 +272,15 @@ public abstract class AbstractResourceGenerator {
                 md.getAnnotationByName("GET").isPresent() ||
                 md.getAnnotationByName("PUT").isPresent() ||
                 md.getAnnotationByName("DELETE").isPresent();           
+    }
+    
+    private void enableValidation(ClassOrInterfaceDeclaration template) {
+        if (context.getBuildContext().isValidationSupported()) {
+            template.findAll(Parameter.class).stream().filter(param -> param.getTypeAsString().equals(dataClazzName+"Input")).forEach(param -> {
+                param.addAnnotation("javax.validation.Valid");
+                param.addAnnotation("javax.validation.constraints.NotNull");
+                });
+        }
     }
 
     private void initializeProcessField(FieldDeclaration fd) {

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/InputModelClassGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/InputModelClassGenerator.java
@@ -21,20 +21,23 @@ import org.jbpm.compiler.canonical.ProcessToExecModelGenerator;
 import org.jbpm.compiler.canonical.VariableDeclarations;
 import org.jbpm.process.core.context.variable.VariableScope;
 import org.kie.api.definition.process.WorkflowProcess;
+import org.kie.kogito.codegen.GeneratorContext;
 
 public class InputModelClassGenerator {
-
+    
+    private final GeneratorContext context;
     private final WorkflowProcess workFlowProcess;
     private String className;
     private String modelFileName;
     private ModelMetaData modelMetaData;
     private String modelClassName;
 
-    public InputModelClassGenerator(WorkflowProcess workFlowProcess) {
+    public InputModelClassGenerator(GeneratorContext context, WorkflowProcess workFlowProcess) {
         String pid = workFlowProcess.getId();
         className = StringUtils.capitalize(ProcessToExecModelGenerator.extractProcessId(pid) + "ModelInput");
         this.modelClassName = workFlowProcess.getPackageName() + "." + className;
 
+        this.context = context;
         this.workFlowProcess = workFlowProcess;
     }
 
@@ -45,6 +48,7 @@ public class InputModelClassGenerator {
         modelMetaData = new ModelMetaData(workFlowProcess.getId(), packageName, className, workFlowProcess.getVisibility(),
                                  VariableDeclarations.ofInput((VariableScope) ((org.jbpm.process.core.Process) workFlowProcess).getDefaultContext(VariableScope.VARIABLE_SCOPE)),
                                  true, "/class-templates/ModelNoIDTemplate.java");
+        modelMetaData.setSupportsValidation(context.getBuildContext().isValidationSupported());
                 
         modelFileName = modelMetaData.getModelClassName().replace('.', '/') + ".java";
         return modelMetaData;

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ModelClassGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ModelClassGenerator.java
@@ -19,20 +19,23 @@ import org.drools.core.util.StringUtils;
 import org.jbpm.compiler.canonical.ModelMetaData;
 import org.jbpm.compiler.canonical.ProcessToExecModelGenerator;
 import org.kie.api.definition.process.WorkflowProcess;
+import org.kie.kogito.codegen.GeneratorContext;
 
 public class ModelClassGenerator {
 
+    private final GeneratorContext context;
     private final WorkflowProcess workFlowProcess;
     private String modelFileName;
     private ModelMetaData modelMetaData;
     private String modelClassName;
 
-    public ModelClassGenerator(WorkflowProcess workFlowProcess) {
+    public ModelClassGenerator(GeneratorContext context, WorkflowProcess workFlowProcess) {
         String pid = workFlowProcess.getId();
         String name = ProcessToExecModelGenerator.extractProcessId(pid);
         this.modelClassName = workFlowProcess.getPackageName() + "." +
                 StringUtils.capitalize(name) + "Model";
 
+        this.context = context;
         this.workFlowProcess = workFlowProcess;
     }
 
@@ -40,6 +43,9 @@ public class ModelClassGenerator {
         // create model class for all variables
         modelMetaData = ProcessToExecModelGenerator.INSTANCE.generateModel(workFlowProcess);        
         modelFileName = modelMetaData.getModelClassName().replace('.', '/') + ".java";
+        
+        modelMetaData.setSupportsValidation(context.getBuildContext().isValidationSupported());
+        
         return modelMetaData;
     }
 

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/OutputModelClassGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/OutputModelClassGenerator.java
@@ -21,20 +21,23 @@ import org.jbpm.compiler.canonical.ProcessToExecModelGenerator;
 import org.jbpm.compiler.canonical.VariableDeclarations;
 import org.jbpm.process.core.context.variable.VariableScope;
 import org.kie.api.definition.process.WorkflowProcess;
+import org.kie.kogito.codegen.GeneratorContext;
 
 public class OutputModelClassGenerator {
 
+    private final GeneratorContext context;
     private final WorkflowProcess workFlowProcess;
     private String className;
     private String modelFileName;
     private ModelMetaData modelMetaData;
     private String modelClassName;
 
-    public OutputModelClassGenerator(WorkflowProcess workFlowProcess) {
+    public OutputModelClassGenerator(GeneratorContext context, WorkflowProcess workFlowProcess) {
         String pid = workFlowProcess.getId();
         className = StringUtils.capitalize(ProcessToExecModelGenerator.extractProcessId(pid) + "ModelOutput");
         this.modelClassName = workFlowProcess.getPackageName() + "." + className;
 
+        this.context = context;
         this.workFlowProcess = workFlowProcess;
     }
 
@@ -46,6 +49,7 @@ public class OutputModelClassGenerator {
                                  VariableDeclarations.ofOutput((VariableScope) ((org.jbpm.process.core.Process) workFlowProcess).getDefaultContext(VariableScope.VARIABLE_SCOPE)),
                                  true);       
         modelFileName = modelMetaData.getModelClassName().replace('.', '/') + ".java";
+        modelMetaData.setSupportsValidation(context.getBuildContext().isValidationSupported());
         return modelMetaData;
     }
 

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ProcessCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ProcessCodegen.java
@@ -208,15 +208,15 @@ public class ProcessCodegen extends AbstractGenerator {
 
         // first we generate all the data classes from variable declarations
         for (WorkflowProcess workFlowProcess : processes.values()) {
-            ModelClassGenerator mcg = new ModelClassGenerator(workFlowProcess);
+            ModelClassGenerator mcg = new ModelClassGenerator(context(), workFlowProcess);
             processIdToModelGenerator.put(workFlowProcess.getId(), mcg);
             processIdToModel.put(workFlowProcess.getId(), mcg.generate());
             
-            InputModelClassGenerator imcg = new InputModelClassGenerator(workFlowProcess);
+            InputModelClassGenerator imcg = new InputModelClassGenerator(context(), workFlowProcess);
             processIdToInputModelGenerator.put(workFlowProcess.getId(), imcg);
             
-            OutputModelClassGenerator omcg = new OutputModelClassGenerator(workFlowProcess);
-            processIdToOutputModelGenerator.put(workFlowProcess.getId(), omcg);
+            OutputModelClassGenerator omcg = new OutputModelClassGenerator(context(), workFlowProcess);
+            processIdToOutputModelGenerator.put( workFlowProcess.getId(), omcg);
         }
         
 
@@ -288,7 +288,7 @@ public class ProcessCodegen extends AbstractGenerator {
 
                 LOGGER.debug("Generating Reactive REST Resources.");
                 // create REST resource class for process
-                resourceGenerator = new ReactiveResourceGenerator(
+                resourceGenerator = new ReactiveResourceGenerator(context(),
                                             workFlowProcess,
                                             modelClassGenerator.className(),
                                             execModelGen.className(),
@@ -296,7 +296,7 @@ public class ProcessCodegen extends AbstractGenerator {
             } else {
                 LOGGER.debug("Generating REST Resources.");
                 // create REST resource class for process
-                resourceGenerator = new ResourceGenerator(
+                resourceGenerator = new ResourceGenerator(context(),
                                             workFlowProcess,
                                             modelClassGenerator.className(),
                                             execModelGen.className(),

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ReactiveResourceGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ReactiveResourceGenerator.java
@@ -16,17 +16,19 @@
 package org.kie.kogito.codegen.process;
 
 import org.kie.api.definition.process.WorkflowProcess;
+import org.kie.kogito.codegen.GeneratorContext;
 
 public class ReactiveResourceGenerator extends AbstractResourceGenerator {
 
     private static final String REACTIVE_RESOURCE_TEMPLATE = "/class-templates/ReactiveRestResourceTemplate.java";
 
     public ReactiveResourceGenerator(
+            GeneratorContext context, 
             WorkflowProcess process,
             String modelfqcn,
             String processfqcn,
             String appCanonicalName) {
-        super(process, modelfqcn, processfqcn, appCanonicalName);
+        super(context, process, modelfqcn, processfqcn, appCanonicalName);
     }
 
     @Override

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ResourceGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ResourceGenerator.java
@@ -16,17 +16,19 @@
 package org.kie.kogito.codegen.process;
 
 import org.kie.api.definition.process.WorkflowProcess;
+import org.kie.kogito.codegen.GeneratorContext;
 
 public class ResourceGenerator extends AbstractResourceGenerator {
 
     private static final String RESOURCE_TEMPLATE = "/class-templates/RestResourceTemplate.java";
 
     public ResourceGenerator(
+            GeneratorContext context,
             WorkflowProcess process,
             String modelfqcn,
             String processfqcn,
             String appCanonicalName) {
-        super(process, modelfqcn, processfqcn, appCanonicalName);
+        super(context, process, modelfqcn, processfqcn, appCanonicalName);
     }
 
     @Override

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/AbstractCodegenTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/AbstractCodegenTest.java
@@ -36,6 +36,7 @@ import org.drools.compiler.commons.jci.compilers.JavaCompilerFactory;
 import org.drools.compiler.compiler.io.memory.MemoryFileSystem;
 import org.drools.compiler.rule.builder.dialect.java.JavaDialectConfiguration;
 import org.kie.kogito.Application;
+import org.kie.kogito.codegen.context.KogitoBuildContext;
 import org.kie.kogito.codegen.decision.DecisionCodegen;
 import org.kie.kogito.codegen.process.ProcessCodegen;
 import org.kie.kogito.codegen.rules.IncrementalRuleCodegen;
@@ -75,6 +76,13 @@ public class AbstractCodegenTest {
             List<String> javaRulesResources,
             boolean hasRuleUnit) throws Exception {
         GeneratorContext context = GeneratorContext.ofResourcePath(new File("src/test/resources"));
+        context.withBuildContext(new KogitoBuildContext() {
+            
+            @Override
+            public boolean hasClassAvailable(String fqcn) {
+                return false;
+            }
+        });
         ApplicationGenerator appGen =
                 new ApplicationGenerator(this.getClass().getPackage().getName(), new File("target/codegen-tests"))
                         .withGeneratorContext(context)

--- a/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
+++ b/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
@@ -2,12 +2,8 @@ package org.kie.kogito.maven.plugin;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.net.URL;
-import java.net.URLClassLoader;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
@@ -16,15 +12,10 @@ import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
 import java.util.stream.Stream;
 
-import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -39,13 +30,11 @@ import org.kie.kogito.codegen.GeneratedFile;
 import org.kie.kogito.codegen.GeneratorContext;
 import org.kie.kogito.codegen.decision.DecisionCodegen;
 import org.kie.kogito.codegen.process.ProcessCodegen;
-import org.kie.kogito.codegen.rules.DeclaredTypeCodegen;
 import org.kie.kogito.codegen.rules.IncrementalRuleCodegen;
-import org.kie.kogito.codegen.rules.config.NamedRuleUnitConfig;
 import org.kie.kogito.maven.plugin.util.MojoUtil;
 
 @Mojo(name = "generateModel",
-        requiresDependencyResolution = ResolutionScope.NONE,
+        requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME,
         requiresProject = true,
         defaultPhase = LifecyclePhase.COMPILE)
 public class GenerateModelMojo extends AbstractKieMojo {
@@ -183,8 +172,8 @@ public class GenerateModelMojo extends AbstractKieMojo {
         if (appPackageName.equals(ApplicationGenerator.DEFAULT_GROUP_ID)) {
             appPackageName = ApplicationGenerator.DEFAULT_PACKAGE_NAME;
         }
-        boolean usePersistence = persistence || hasClassOnClasspath("org.kie.kogito.persistence.KogitoProcessInstancesFactory");
-        boolean useMonitoring = hasClassOnClasspath("org.kie.addons.monitoring.rest.MetricsResource");
+        boolean usePersistence = persistence || hasClassOnClasspath(project, "org.kie.kogito.persistence.KogitoProcessInstancesFactory");
+        boolean useMonitoring = hasClassOnClasspath(project, "org.kie.addons.monitoring.rest.MetricsResource");
 
 
 
@@ -268,25 +257,5 @@ public class GenerateModelMojo extends AbstractKieMojo {
     }
 
 
-    protected boolean hasClassOnClasspath(String className) {
-        try {
-            Set<Artifact> elements = project.getDependencyArtifacts();
-            URL[] urls = new URL[elements.size()];
 
-            int i = 0;
-            Iterator<Artifact> it = elements.iterator();
-            while (it.hasNext()) {
-                Artifact artifact = it.next();
-
-                urls[i] = artifact.getFile().toURI().toURL();
-                i++;
-            }
-            try (URLClassLoader cl = new URLClassLoader(urls)) {
-                cl.loadClass(className);
-            }
-            return true;
-        } catch (Exception e) {
-            return false;
-        }
-    }
 }

--- a/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/KogitoAssetsProcessor.java
+++ b/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/KogitoAssetsProcessor.java
@@ -323,7 +323,11 @@ public class KogitoAssetsProcessor {
                 .getClassByName(createDotName(persistenceFactoryClass)) != null;
 
         GeneratorContext context = GeneratorContext.ofResourcePath(projectPath.resolve("src/main/resources").toFile());
-        context.withBuildContext(new QuarkusKogitoBuildContext());
+        context.withBuildContext(new QuarkusKogitoBuildContext(className -> {
+                DotName classDotName = createDotName(className);
+                return !combinedIndexBuildItem.getIndex().getAnnotations(classDotName).isEmpty() || combinedIndexBuildItem.getIndex().getClassByName(classDotName) != null;
+                
+        }));
 
         ApplicationGenerator appGen = new ApplicationGenerator(appPackageName, new File(projectPath.toFile(), "target"))
                 .withDependencyInjection(new CDIDependencyInjectionAnnotator())


### PR DESCRIPTION
This PR brings support for validation api to enhance the generated REST api

In general it allows to use validation api annotations on model classes and then the generated api will enforce this validation. See some details in jira

So an example here could be to use following model

```
import javax.validation.constraints.Email;
import javax.validation.constraints.Min;
import javax.validation.constraints.NotNull;
import javax.validation.constraints.Size;

public class Person {

    @NotNull
    @Size(min = 2, max = 30)
    private String name;

    @NotNull
    @Min(value = 2, message = "Age must be higher than 5")
    private int age;

    @NotNull
    @Email
    private String email;

    private boolean adult;
```

and this will then generated following input data model for process that references this type as variable

```
public class PersonsModelInput implements org.kie.kogito.Model {


    @org.kie.internal.kogito.codegen.VariableInfo(tags = "")
    @javax.validation.Valid()
    private org.acme.travels.Person person;

    public org.acme.travels.Person getPerson() {
        return person;
    }

    public void setPerson(org.acme.travels.Person person) {
        this.person = person;
    }
}
```

And then the REST resource for creating new instances of the process

```
 @POST()
    @Produces(MediaType.APPLICATION_JSON)
    @Consumes(MediaType.APPLICATION_JSON)
    public PersonsModelOutput createResource_persons(@Context HttpHeaders httpHeaders, 
@QueryParam("businessKey") String businessKey,
 @javax.validation.Valid() @javax.validation.constraints.NotNull() PersonsModelInput resource) {     
```

whenever user attempts to send invalid data such as following

```
curl -X POST -H 'Content-Type:application/json' -H 'Accept:application/json' -d '{"person" : {"name" : "john", "age" : 3, "email" : "user"}}' http://localhost:8080/persons
```

it will produce `400 Bad Request` response with following message (this can actually be configured)

```
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8080 (#0)
> POST /persons HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.54.0
> Content-Type:application/json
> Accept:application/json
> Content-Length: 59
>
* upload completely sent off: 59 out of 59 bytes
< HTTP/1.1 400 Bad Request
< Content-Length: 262
< validation-exception: true
< Content-Type: application/json
<
* Connection #0 to host localhost left intact
{"exception":null,"propertyViolations":[],"classViolations":[],"parameterViolations":[{"constraintType":"PARAMETER","path":"createResource_persons.resource.person.email","message":"must be a well-formed email address","value":"user"}],"returnValueViolations":[]}
```

this could be nice addition not only to processes but also to decision and rules 

In addition this also is exposed via the OpenAPI/swagger

![image](https://user-images.githubusercontent.com/904474/75253806-9194e800-57df-11ea-91ea-919b6c9a4ad0.png)


@tarilabs @evacchi in case you would be interested