### PR TITLE
fix hasClassOnClasspath (getDependencyArtifacts is deprecated)

### DIFF
--- a/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
+++ b/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
@@ -6,6 +6,7 @@ import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.FileSystems;
@@ -14,6 +15,7 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -267,26 +269,23 @@ public class GenerateModelMojo extends AbstractKieMojo {
         }
     }
 
-
     protected boolean hasClassOnClasspath(String className) {
-        try {
-            Set<Artifact> elements = project.getDependencyArtifacts();
-            URL[] urls = new URL[elements.size()];
+        Set<Artifact> elements = project.getArtifacts();
 
-            int i = 0;
-            Iterator<Artifact> it = elements.iterator();
-            while (it.hasNext()) {
-                Artifact artifact = it.next();
+        List<URL> urls = new ArrayList<>();
 
-                urls[i] = artifact.getFile().toURI().toURL();
-                i++;
+        for(Artifact artifact : elements){
+            try {
+                urls.add(artifact.getFile().toURI().toURL());
             }
-            try (URLClassLoader cl = new URLClassLoader(urls)) {
-                cl.loadClass(className);
-            }
-            return true;
+            catch(MalformedURLException e){}
+        }
+
+        try (URLClassLoader cl = new URLClassLoader(urls.toArray(new URL[urls.size()]))) {
+            cl.loadClass(className);
         } catch (Exception e) {
             return false;
         }
+        return true;
     }
 }

--- a/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
+++ b/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
@@ -47,7 +47,7 @@ import org.kie.kogito.codegen.rules.config.NamedRuleUnitConfig;
 import org.kie.kogito.maven.plugin.util.MojoUtil;
 
 @Mojo(name = "generateModel",
-        requiresDependencyResolution = ResolutionScope.NONE,
+        requiresDependencyResolution = ResolutionScope.COMPILE,
         requiresProject = true,
         defaultPhase = LifecyclePhase.COMPILE)
 public class GenerateModelMojo extends AbstractKieMojo {

--- a/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
+++ b/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
@@ -270,11 +270,11 @@ public class GenerateModelMojo extends AbstractKieMojo {
     }
 
     protected boolean hasClassOnClasspath(String className) {
-        Set<Artifact> elements = project.getArtifacts();
+        Set<Artifact> artifacts = project.getArtifacts();
 
         List<URL> urls = new ArrayList<>();
 
-        for(Artifact artifact : elements){
+        for(Artifact artifact : artifacts){
             try {
                 urls.add(artifact.getFile().toURI().toURL());
             }

--- a/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
+++ b/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
@@ -278,7 +278,9 @@ public class GenerateModelMojo extends AbstractKieMojo {
             try {
                 urls.add(artifact.getFile().toURI().toURL());
             }
-            catch(MalformedURLException e){}
+            catch(MalformedURLException e){
+                getLog().debug("Artifact has malformed URL: skipping the artifact.", e);
+            }
         }
 
         try (URLClassLoader cl = new URLClassLoader(urls.toArray(new URL[urls.size()]))) {


### PR DESCRIPTION
`getDependencyArtifacts` is currently deprecated. In addition to that if a URL is malformed the current implementation will return `false`, but actually the class might be in the classpath -> with the new implementation even if a URL is malformed all the others are taken into consideration to provide a result.