### PR TITLE
KOGITO-1266: Fix hot reload for rule units

### DIFF
--- a/drools/kogito-ruleunits/src/main/java/org/kie/kogito/rules/units/DataSourceTypes.java
+++ b/drools/kogito-ruleunits/src/main/java/org/kie/kogito/rules/units/DataSourceTypes.java
@@ -1,0 +1,29 @@
+package org.kie.kogito.rules.units;
+
+import org.kie.kogito.rules.DataSource;
+import org.kie.kogito.rules.DataStore;
+import org.kie.kogito.rules.DataStream;
+import org.kie.kogito.rules.SingletonStore;
+
+public final class DataSourceTypes {
+
+    public final Class<DataSource> DataSource;
+    public final Class<DataStore> DataStore;
+    public final Class<DataStream> DataStream;
+    public final Class<SingletonStore> SingletonStore;
+
+    public static DataSourceTypes getInstance(ClassLoader cl) {
+        try {
+            return new DataSourceTypes(cl);
+        } catch (ClassNotFoundException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    private DataSourceTypes(ClassLoader classLoader) throws ClassNotFoundException {
+        this.DataSource = (Class<DataSource>) classLoader.loadClass(DataSource.class.getCanonicalName());
+        this.DataStore = (Class<DataStore>) classLoader.loadClass(DataStore.class.getCanonicalName());
+        this.DataStream = (Class<DataStream>) classLoader.loadClass(DataStream.class.getCanonicalName());
+        this.SingletonStore = (Class<SingletonStore>) classLoader.loadClass(SingletonStore.class.getCanonicalName());
+    }
+}

--- a/drools/kogito-ruleunits/src/main/java/org/kie/kogito/rules/units/GeneratedRuleUnitDescription.java
+++ b/drools/kogito-ruleunits/src/main/java/org/kie/kogito/rules/units/GeneratedRuleUnitDescription.java
@@ -16,13 +16,9 @@
 
 package org.kie.kogito.rules.units;
 
-import java.lang.reflect.Method;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
 import java.util.function.Function;
 
 import org.drools.core.addon.TypeResolver;
-import org.kie.kogito.rules.DataSource;
 import org.kie.kogito.rules.RuleUnitConfig;
 
 public class GeneratedRuleUnitDescription extends AbstractRuleUnitDescription {
@@ -108,26 +104,5 @@ public class GeneratedRuleUnitDescription extends AbstractRuleUnitDescription {
         } catch (ClassNotFoundException e) {
             throw new IllegalArgumentException(e);
         }
-    }
-
-    private Class<?> getUnitVarType(Method m) {
-        Class<?> returnClass = m.getReturnType();
-        if (returnClass.isArray()) {
-            return returnClass.getComponentType();
-        }
-        if (DataSource.class.isAssignableFrom(returnClass)) {
-            return getParametricType(m);
-        }
-        if (Iterable.class.isAssignableFrom(returnClass)) {
-            return getParametricType(m);
-        }
-        return returnClass;
-    }
-
-    private Class<?> getParametricType(Method m) {
-        Type returnType = m.getGenericReturnType();
-        return returnType instanceof ParameterizedType ?
-                (Class<?>) ((ParameterizedType) returnType).getActualTypeArguments()[0] :
-                Object.class;
     }
 }

--- a/drools/kogito-ruleunits/src/main/java/org/kie/kogito/rules/units/ReflectiveRuleUnitDescription.java
+++ b/drools/kogito-ruleunits/src/main/java/org/kie/kogito/rules/units/ReflectiveRuleUnitDescription.java
@@ -38,9 +38,11 @@ import static org.drools.reflective.util.ClassUtils.getter2property;
 public class ReflectiveRuleUnitDescription extends AbstractRuleUnitDescription {
 
     private final Class<? extends RuleUnitData> ruleUnitClass;
+    private final DataSourceTypes dataSourceTypes;
 
     public ReflectiveRuleUnitDescription(InternalKnowledgePackage pkg, Class<? extends RuleUnitData> ruleUnitClass) {
         this.ruleUnitClass = ruleUnitClass;
+        this.dataSourceTypes = DataSourceTypes.getInstance(ruleUnitClass.getClassLoader());
         indexUnitVars();
         setConfig(loadConfig(ruleUnitClass));
     }
@@ -95,7 +97,7 @@ public class ReflectiveRuleUnitDescription extends AbstractRuleUnitDescription {
         if (returnClass.isArray()) {
             return returnClass.getComponentType();
         }
-        if (DataSource.class.isAssignableFrom(returnClass)) {
+        if (dataSourceTypes.DataSource.isAssignableFrom(returnClass)) {
             return getParametricType(m);
         }
         if (Iterable.class.isAssignableFrom(returnClass)) {

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/RuleSetNodeVisitor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/RuleSetNodeVisitor.java
@@ -38,7 +38,7 @@ import org.kie.api.definition.process.Node;
 import org.kie.internal.ruleunit.RuleUnitComponentFactory;
 import org.kie.internal.ruleunit.RuleUnitDescription;
 import org.kie.kogito.rules.RuleUnitData;
-import org.kie.kogito.rules.SingletonStore;
+import org.kie.kogito.rules.units.DataSourceTypes;
 import org.kie.kogito.rules.units.GeneratedRuleUnitDescription;
 import org.kie.kogito.rules.units.ReflectiveRuleUnitDescription;
 import org.kie.kogito.rules.units.impl.RuleUnitComponentFactoryImpl;
@@ -51,9 +51,11 @@ public class RuleSetNodeVisitor extends AbstractVisitor {
     public static final Logger logger = LoggerFactory.getLogger(ProcessToExecModelGenerator.class);
 
     private final ClassLoader contextClassLoader;
+    private final DataSourceTypes dataSourceTypes;
 
     public RuleSetNodeVisitor(ClassLoader contextClassLoader) {
         this.contextClassLoader = contextClassLoader;
+        this.dataSourceTypes = DataSourceTypes.getInstance(contextClassLoader);
     }
 
     @Override
@@ -137,7 +139,7 @@ public class RuleSetNodeVisitor extends AbstractVisitor {
             description = d;
         }
 
-        RuleUnitHandler handler = new RuleUnitHandler(description, processContext, ruleSetNode);
+        RuleUnitHandler handler = new RuleUnitHandler(description, processContext, ruleSetNode, dataSourceTypes);
         Expression ruleUnitFactory = handler.invoke();
 
         return new MethodCallExpr("ruleUnit")
@@ -151,7 +153,7 @@ public class RuleSetNodeVisitor extends AbstractVisitor {
         for (Variable variable : processContext.getVariables()) {
             d.putDatasourceVar(
                     variable.getName(),
-                    SingletonStore.class.getCanonicalName(),
+                    dataSourceTypes.SingletonStore.getCanonicalName(),
                     variable.getType().getStringType());
         }
         return d;

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/RuleUnitHandler.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/RuleUnitHandler.java
@@ -99,7 +99,7 @@ public class RuleUnitHandler {
      */
     private BlockStmt bind(ProcessContextMetaModel variableScope, RuleSetNode node, RuleUnitDescription unitDescription) {
         RuleUnitMetaModel unit =
-                new RuleUnitMetaModel(unitDescription, "unit");
+                new RuleUnitMetaModel(unitDescription, "unit", dataSourceTypes);
 
         BlockStmt actionBody = new BlockStmt();
 
@@ -163,7 +163,7 @@ public class RuleUnitHandler {
 
     private BlockStmt unbind(ProcessContextMetaModel variableScope, RuleSetNode node, RuleUnitDescription unitDescription) {
         RuleUnitMetaModel unit =
-                new RuleUnitMetaModel(unitDescription, "unit");
+                new RuleUnitMetaModel(unitDescription, "unit", dataSourceTypes);
 
         BlockStmt actionBody = new BlockStmt();
 

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/RuleUnitHandler.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/RuleUnitHandler.java
@@ -30,6 +30,7 @@ import com.github.javaparser.ast.stmt.ReturnStmt;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import org.jbpm.workflow.core.node.RuleSetNode;
 import org.kie.internal.ruleunit.RuleUnitDescription;
+import org.kie.kogito.rules.units.DataSourceTypes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,14 +53,16 @@ public class RuleUnitHandler {
 
     public static final Logger logger = LoggerFactory.getLogger(ProcessToExecModelGenerator.class);
 
-    RuleUnitDescription ruleUnit;
-    ProcessContextMetaModel variableScope;
-    RuleSetNode ruleSetNode;
+    private final RuleUnitDescription ruleUnit;
+    private final ProcessContextMetaModel variableScope;
+    private final RuleSetNode ruleSetNode;
+    private final DataSourceTypes dataSourceTypes;
 
-    public RuleUnitHandler(RuleUnitDescription ruleUnit, ProcessContextMetaModel variableScope, RuleSetNode ruleSetNode) {
+    public RuleUnitHandler(RuleUnitDescription ruleUnit, ProcessContextMetaModel variableScope, RuleSetNode ruleSetNode, DataSourceTypes dataSourceTypes) {
         this.ruleUnit = ruleUnit;
         this.variableScope = variableScope;
         this.ruleSetNode = ruleSetNode;
+        this.dataSourceTypes = dataSourceTypes;
     }
 
     public Expression invoke() {

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/RuleUnitMetaModel.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/RuleUnitMetaModel.java
@@ -31,9 +31,7 @@ import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import org.kie.internal.ruleunit.RuleUnitDescription;
 import org.kie.internal.ruleunit.RuleUnitVariable;
 import org.kie.kogito.rules.DataObserver;
-import org.kie.kogito.rules.DataStore;
-import org.kie.kogito.rules.DataStream;
-import org.kie.kogito.rules.SingletonStore;
+import org.kie.kogito.rules.units.DataSourceTypes;
 
 import static com.github.javaparser.StaticJavaParser.parseExpression;
 
@@ -43,11 +41,13 @@ public class RuleUnitMetaModel {
     private final String modelClassName;
 
     private final String instanceVarName;
+    private final DataSourceTypes dataSourceTypes;
 
-    public RuleUnitMetaModel(RuleUnitDescription ruleUnitDescription, String instanceVarName) {
+    public RuleUnitMetaModel(RuleUnitDescription ruleUnitDescription, String instanceVarName, DataSourceTypes dataSourceTypes) {
         this.ruleUnitDescription = ruleUnitDescription;
         this.modelClassName = ruleUnitDescription.getCanonicalName();
         this.instanceVarName = instanceVarName;
+        this.dataSourceTypes = dataSourceTypes;
     }
 
     public String instanceVarName() {
@@ -141,11 +141,11 @@ public class RuleUnitMetaModel {
 
     private String appendMethodOf(Class<?> type) {
         String appendMethod;
-        if (type.isAssignableFrom(DataStream.class)) {
+        if (dataSourceTypes.DataStream.isAssignableFrom(type)) {
             appendMethod = "append";
-        } else if (type.isAssignableFrom(DataStore.class)) {
+        } else if (dataSourceTypes.DataStore.isAssignableFrom(type)) {
             appendMethod = "add";
-        } else if (type.isAssignableFrom(SingletonStore.class)) {
+        } else if (dataSourceTypes.SingletonStore.isAssignableFrom(type)) {
             appendMethod = "set";
         } else {
             throw new IllegalArgumentException("Unknown data source type " + type.getCanonicalName());

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/GeneratedFile.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/GeneratedFile.java
@@ -21,6 +21,8 @@ public class GeneratedFile {
 
     public enum Type {
         APPLICATION,
+        APPLICATION_SECTION,
+        APPLICATION_CONFIG,
         PROCESS,
         PROCESS_INSTANCE,
         REST,

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
@@ -261,7 +261,7 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
 
                 List<QueryEndpointGenerator> queries = ruleUnit.queries();
                 if (!queries.isEmpty()) {
-                    generatedFiles.add( new RuleUnitDTOSourceClass( ruleUnit.getRuleUnitDescription() ).generateFile(org.kie.kogito.codegen.GeneratedFile.Type.RULE) );
+                    generatedFiles.add( new RuleUnitDTOSourceClass( ruleUnit.getRuleUnitDescription(), contextClassLoader ).generateFile(org.kie.kogito.codegen.GeneratedFile.Type.RULE) );
                     for (QueryEndpointGenerator query : queries) {
                         generatedFiles.add( query.generateFile( org.kie.kogito.codegen.GeneratedFile.Type.QUERY ) );
                     }

--- a/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/KogitoCompilationProvider.java
+++ b/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/KogitoCompilationProvider.java
@@ -52,8 +52,10 @@ public abstract class KogitoCompilationProvider extends JavaCompilationProvider 
             Set<File> generatedSourceFiles = new HashSet<>();
             for (GeneratedFile file : generatedFiles) {
                 Path path = pathOf(outputDirectory.getPath(), file.relativePath());
-                Files.write(path, file.contents());
-                generatedSourceFiles.add(path.toFile());
+                if (file.getType() != GeneratedFile.Type.APPLICATION && file.getType() != GeneratedFile.Type.APPLICATION_CONFIG) {
+                    Files.write(path, file.contents());
+                    generatedSourceFiles.add(path.toFile());
+                }
             }
             super.compile(generatedSourceFiles, context);
         } catch (IOException e) {


### PR DESCRIPTION
Not the greatest of fix, but for now it will make do.
We don't use class literals for type-testing (e.g. DataSource.class), but we create a class holding all these types in the correct classloader (DataSourceTypes), then we use those to do such checks.

also, let's make sure these examples are not broken, especially the BPMN one:
https://github.com/evacchi/kogito-rules-example