### PR TITLE
KOGITO-1298: Update quarkus archetype to use our new bom (fix properties)

### DIFF
--- a/archetypes/kogito-quarkus-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/kogito-quarkus-archetype/src/main/resources/archetype-resources/pom.xml
@@ -10,6 +10,7 @@
   <properties>
     <quarkus.version>${version.io.quarkus}</quarkus.version>
     <kogito.version>${project.version}</kogito.version>
+    <surefire.version>${version.surefire}</surefire.version>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.11</maven.compiler.source>
@@ -62,11 +63,18 @@
     </dependency>
   </dependencies>
 
+
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${surefire.version}</version>
+      </plugin>
+      <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
+        <version>${version.io.quarkus}</version>
         <executions>
           <execution>
             <goals>
@@ -74,9 +82,6 @@
             </goals>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/archetypes/pom.xml
+++ b/archetypes/pom.xml
@@ -10,6 +10,10 @@
   <name>Kogito Maven Archetypes</name>
   <description>Various Kogito Maven archetypes for project generation</description>
 
+  <properties>
+    <version.io.quarkus>1.3.0.Alpha2</version.io.quarkus>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>


### PR DESCRIPTION
apparently last PR broke (at least locally) the archetype installation in some cases.
This should fix everything and bring in the correct dependencies