### PR TITLE
KOGITO-1216 Bump services to Quarkus 1.3.0.CR2

### DIFF
--- a/addons/events/kogito-events-reactive-messaging-addon/pom.xml
+++ b/addons/events/kogito-events-reactive-messaging-addon/pom.xml
@@ -29,7 +29,11 @@
       <groupId>io.smallrye.reactive</groupId>
       <artifactId>smallrye-reactive-messaging-provider</artifactId>
     </dependency>
-    
+    <dependency>
+      <groupId>org.eclipse.microprofile.config</groupId>
+      <artifactId>microprofile-config-api</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>

--- a/addons/jobs/jobs-management-springboot-addon/pom.xml
+++ b/addons/jobs/jobs-management-springboot-addon/pom.xml
@@ -29,28 +29,21 @@
       <artifactId>jobs-management-common</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-context</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-web</artifactId>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-springboot-starter</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
     </dependency>
-
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
-
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
     </dependency>
-
     <dependency>
       <groupId>org.jboss.spec.javax.ws.rs</groupId>
       <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>

--- a/addons/persistence/infinispan-quarkus-health-addon/src/test/resources/application.properties
+++ b/addons/persistence/infinispan-quarkus-health-addon/src/test/resources/application.properties
@@ -21,3 +21,5 @@ quarkus.infinispan-client.auth-username=admin
 quarkus.infinispan-client.auth-password=admin
 quarkus.infinispan-client.auth-realm=default
 quarkus.infinispan-client.auth-server-name=infinispan
+quarkus.infinispan-client.client-intelligence=BASIC
+quarkus.infinispan-client.sasl-mechanism=DIGEST-MD5

--- a/archetypes/pom.xml
+++ b/archetypes/pom.xml
@@ -10,10 +10,6 @@
   <name>Kogito Maven Archetypes</name>
   <description>Various Kogito Maven archetypes for project generation</description>
 
-  <properties>
-    <version.io.quarkus>1.3.0.Alpha2</version.io.quarkus>
-  </properties>
-
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/kogito-quarkus-extension/bom/pom.xml
+++ b/kogito-quarkus-extension/bom/pom.xml
@@ -17,16 +17,6 @@
 
   <dependencyManagement>
     <dependencies>
-      <!-- FIXME: temporary workaround for infinispan buffer overflow, remove when quarkus is updated; see KOGITO-1315 -->
-      <!-- Netty dependencies, imported as a BOM -->
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-bom</artifactId>
-        <version>${netty.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
       <dependency>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-bom</artifactId>

--- a/kogito-quarkus-extension/bom/pom.xml
+++ b/kogito-quarkus-extension/bom/pom.xml
@@ -15,13 +15,18 @@
 
   <name>Kogito - Quarkus - Extension BOM</name>
 
-  <properties>
-    <version.io.quarkus>1.3.0.Alpha2</version.io.quarkus>
-    <version.com.fasterxml.jackson>2.10.2</version.com.fasterxml.jackson>
-  </properties>
-
   <dependencyManagement>
     <dependencies>
+      <!-- FIXME: temporary workaround for infinispan buffer overflow, remove when quarkus is updated; see KOGITO-1315 -->
+      <!-- Netty dependencies, imported as a BOM -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${netty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
       <dependency>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-bom</artifactId>
@@ -36,22 +41,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-
-      <!-- FIXME: temporary workaround for infinispan buffer overflow, remove when quarkus is updated; see KOGITO-1315 -->
-
-      <dependency><groupId>io.netty</groupId><artifactId>netty-codec</artifactId><version>4.1.45.Final</version></dependency>
-      <dependency><groupId>io.netty</groupId><artifactId>netty-handler</artifactId><version>4.1.45.Final</version></dependency>
-      <dependency><groupId>io.netty</groupId><artifactId>netty-common</artifactId><version>4.1.45.Final</version></dependency>
-      <dependency><groupId>io.netty</groupId><artifactId>netty-buffer</artifactId><version>4.1.45.Final</version></dependency>
-      <dependency><groupId>io.netty</groupId><artifactId>netty-transport</artifactId><version>4.1.45.Final</version></dependency>
-      <dependency><groupId>io.netty</groupId><artifactId>netty-handler-proxy</artifactId><version>4.1.45.Final</version></dependency>
-      <dependency><groupId>io.netty</groupId><artifactId>netty-codec-socks</artifactId><version>4.1.45.Final</version></dependency>
-      <dependency><groupId>io.netty</groupId><artifactId>netty-codec-http</artifactId><version>4.1.45.Final</version></dependency>
-      <dependency><groupId>io.netty</groupId><artifactId>netty-codec-http2</artifactId><version>4.1.45.Final</version></dependency>
-      <dependency><groupId>io.netty</groupId><artifactId>netty-resolver</artifactId><version>4.1.45.Final</version></dependency>
-      <dependency><groupId>io.netty</groupId><artifactId>netty-resolver-dns</artifactId><version>4.1.45.Final</version></dependency>
-      <dependency><groupId>io.netty</groupId><artifactId>netty-codec-dns</artifactId><version>4.1.45.Final</version></dependency>
-
     </dependencies>
   </dependencyManagement>
 

--- a/kogito-quarkus-extension/pom.xml
+++ b/kogito-quarkus-extension/pom.xml
@@ -13,11 +13,6 @@
   <artifactId>kogito-quarkus-parent</artifactId>
   <name>Kogito - Quarkus Extension</name>
 
-  <properties>
-    <version.io.quarkus>1.3.0.Alpha2</version.io.quarkus>
-    <version.com.fasterxml.jackson>2.10.2</version.com.fasterxml.jackson>
-  </properties>
-
   <packaging>pom</packaging>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
     <version.io.fabric8.kubernetes-client>4.6.2</version.io.fabric8.kubernetes-client>
     <version.io.prometheus>0.5.0</version.io.prometheus>
     <version.io.quarkus>1.3.0.Alpha2</version.io.quarkus>
-    <netty.version>4.1.46.Final</netty.version>
+    <netty.version>4.1.45.Final</netty.version>
     <version.io.restassured>4.1.2</version.io.restassured>
     <version.io.smallrye.reactive>1.0.8</version.io.smallrye.reactive>
 
@@ -117,9 +117,9 @@
     <version.org.assertj>3.13.2</version.org.assertj>
     <version.org.eclipse.jdt>3.19.0</version.org.eclipse.jdt>
     <version.org.hamcrest>1.3</version.org.hamcrest> <!-- else old version coming from Mockito wins and breaks tests -->
-    <version.org.infinispan>10.1.3.Final</version.org.infinispan>
-    <version.org.infinispan.image>10.1.3.Final</version.org.infinispan.image>
-    <version.org.infinispan.protostream>4.3.0.Final</version.org.infinispan.protostream>
+    <version.org.infinispan>10.1.2.Final</version.org.infinispan>
+    <version.org.infinispan.image>10.1.2.Final</version.org.infinispan.image>
+    <version.org.infinispan.protostream>4.3.1.Final</version.org.infinispan.protostream>
     <version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>1.0.1.Final</version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>
     <version.org.junit.minor>6.0</version.org.junit.minor> <!-- so that org.junit.platform and org.junit can share the same minor version -->
     <version.org.junit>5.${version.org.junit.minor}</version.org.junit>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
 
     <!-- dependencies versions -->
     <version.ch.obermuhlner>2.0.1</version.ch.obermuhlner>
-    <version.com.fasterxml.jackson>2.9.10</version.com.fasterxml.jackson>
+    <version.com.fasterxml.jackson>2.10.3</version.com.fasterxml.jackson>
     <version.com.github.haifengl.smile>1.5.2</version.com.github.haifengl.smile>
     <version.com.github.javaparser>3.13.10</version.com.github.javaparser>
     <version.com.google.protobuf>3.6.1</version.com.google.protobuf>
@@ -107,7 +107,8 @@
 
     <version.io.fabric8.kubernetes-client>4.6.2</version.io.fabric8.kubernetes-client>
     <version.io.prometheus>0.5.0</version.io.prometheus>
-    <version.io.quarkus>1.1.0.Final</version.io.quarkus>
+    <version.io.quarkus>1.3.0.Alpha2</version.io.quarkus>
+    <netty.version>4.1.46.Final</netty.version>
     <version.io.restassured>4.1.2</version.io.restassured>
     <version.io.smallrye.reactive>1.0.8</version.io.smallrye.reactive>
 
@@ -116,8 +117,8 @@
     <version.org.assertj>3.13.2</version.org.assertj>
     <version.org.eclipse.jdt>3.19.0</version.org.eclipse.jdt>
     <version.org.hamcrest>1.3</version.org.hamcrest> <!-- else old version coming from Mockito wins and breaks tests -->
-    <version.org.infinispan>10.0.0.Final</version.org.infinispan>
-    <version.org.infinispan.image>10.0.0.Final-1</version.org.infinispan.image>
+    <version.org.infinispan>10.1.3.Final</version.org.infinispan>
+    <version.org.infinispan.image>10.1.3.Final</version.org.infinispan.image>
     <version.org.infinispan.protostream>4.3.0.Final</version.org.infinispan.protostream>
     <version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>1.0.1.Final</version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>
     <version.org.junit.minor>6.0</version.org.junit.minor> <!-- so that org.junit.platform and org.junit can share the same minor version -->

--- a/pom.xml
+++ b/pom.xml
@@ -107,10 +107,9 @@
 
     <version.io.fabric8.kubernetes-client>4.6.2</version.io.fabric8.kubernetes-client>
     <version.io.prometheus>0.5.0</version.io.prometheus>
-    <version.io.quarkus>1.3.0.Alpha2</version.io.quarkus>
-    <netty.version>4.1.45.Final</netty.version>
+    <version.io.quarkus>1.3.0.CR2</version.io.quarkus>
     <version.io.restassured>4.1.2</version.io.restassured>
-    <version.io.smallrye.reactive>1.0.8</version.io.smallrye.reactive>
+    <version.io.smallrye.reactive>1.1.0</version.io.smallrye.reactive>
 
     <version.org.antlr>3.5.2</version.org.antlr>
     <version.org.antlr4>4.7.2</version.org.antlr4>


### PR DESCRIPTION
Unifying quarkus version , jackson on kogito-runtimes. In this way all kogito will use this version.
Adding the bom to specify netty version on all dependencies, change was made on kogito-quarkus-bom replacing the explicit dependencies that were added to fix the issue.

Related https://github.com/kiegroup/kogito-apps/pull/91

@evacchi 
@mariofusco 
@cristianonicolai 