### PR TITLE
KOGITO-1262: Unclear error message when using oopath + units

### DIFF
--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
@@ -70,9 +70,8 @@ import org.kie.kogito.conf.EventProcessingType;
 import org.kie.kogito.rules.RuleUnitConfig;
 import org.kie.kogito.rules.units.AssignableChecker;
 
-import static java.util.stream.Collectors.toList;
-
 import static com.github.javaparser.StaticJavaParser.parse;
+import static java.util.stream.Collectors.toList;
 import static org.drools.compiler.kie.builder.impl.KieBuilderImpl.setDefaultsforEmptyKieModule;
 import static org.drools.core.util.IoUtils.readBytesFromInputStream;
 import static org.kie.api.io.ResourceType.determineResourceType;
@@ -233,7 +232,12 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
 
         CompositeKnowledgeBuilder batch = modelBuilder.batch();
         resources.forEach(f -> batch.add(f, f.getResourceType()));
-        batch.build();
+
+        try {
+            batch.build();
+        } catch (RuntimeException e) {
+            throw new RuleCodegenError(e, modelBuilder.getErrors().getErrors());
+        }
 
         if (modelBuilder.hasErrors()) {
             throw new RuleCodegenError(modelBuilder.getErrors().getErrors());

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/RuleCodegenError.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/RuleCodegenError.java
@@ -32,6 +32,15 @@ public class RuleCodegenError extends Error {
         this.errors = errors;
     }
 
+    public RuleCodegenError(Exception ex, DroolsError... errors) {
+        super("Errors were generated during the code-generation process:\n" +
+                      ex.getMessage() + "\n" +
+                      Arrays.stream(errors)
+                              .map(DroolsError::toString)
+                              .collect(Collectors.joining("\n")));
+        this.errors = errors;
+    }
+
     public DroolsError[] getErrors() {
         return errors;
     }

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegenTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegenTest.java
@@ -29,7 +29,6 @@ import org.kie.api.io.ResourceType;
 import org.kie.kogito.codegen.GeneratedFile;
 
 import static java.util.Arrays.asList;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -138,6 +137,17 @@ public class IncrementalRuleCodegenTest {
         incrementalRuleCodegen.setPackageName("com.acme");
         assertThrows(RuleCodegenError.class, incrementalRuleCodegen.withHotReloadMode()::generate);
     }
+
+    @Test
+    public void raiseErrorOnBadOOPath() {
+        IncrementalRuleCodegen incrementalRuleCodegen =
+                IncrementalRuleCodegen.ofFiles(
+                        Collections.singleton(
+                                new File("src/test/resources/org/kie/kogito/codegen/brokenrules/brokenunit/ABrokenUnit.drl")));
+        incrementalRuleCodegen.setPackageName("com.acme");
+        assertThrows(RuleCodegenError.class, incrementalRuleCodegen.withHotReloadMode()::generate);
+    }
+
 
     @Test
     public void throwWhenDtableDependencyMissing() {

--- a/kogito-codegen/src/test/resources/org/kie/kogito/codegen/brokenrules/brokenunit/ABrokenUnit.drl
+++ b/kogito-codegen/src/test/resources/org/kie/kogito/codegen/brokenrules/brokenunit/ABrokenUnit.drl
@@ -1,0 +1,8 @@
+package org.kie.kogito.codegen.brokenrules.brokenunit;
+unit ABrokenUnit;
+
+rule invalidRule when
+    invalidOOPath: /values
+then
+    System.out.println("this cannot work");
+end


### PR DESCRIPTION
see ticket for details https://issues.redhat.com/browse/KOGITO-1262
the problem was in Drools core we are throwing an exception, but really we should stop building earlier because earlier errors prevent the rest of the DRL from being processed meaningfully.
I have implemented a workaround to collect exceptions and print them as errors, but we should probably fix this in Drools core as well.