### PR TITLE
added trigger for deploying kogito

### DIFF
--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -8,6 +8,9 @@ pipeline {
         maven 'kie-maven-3.5.4'
         jdk 'kie-jdk1.8'
     }
+    triggers {
+        cron ('H 9 * * *')
+    }
     options {
         buildDiscarder logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '5')
         timeout(time: 90, unit: 'MINUTES')


### PR DESCRIPTION
the deploy job for kogito (maybe not at the best place here in kogito-runtimes) is triggered right now so it doesn't have to be fired manually. When our Jenkins is upgraded to a version >= 2.176.1 wo shoudl use ciBuildTrigger instead the cron. Right now it is not supported.