### PR TITLE
KOGITO-1534: Better error messages when unit variables are undefined

### DIFF
--- a/drools/kogito-ruleunits/src/main/java/org/kie/kogito/rules/units/AbstractRuleUnitDescription.java
+++ b/drools/kogito-ruleunits/src/main/java/org/kie/kogito/rules/units/AbstractRuleUnitDescription.java
@@ -49,7 +49,11 @@ public abstract class AbstractRuleUnitDescription implements RuleUnitDescription
 
     @Override
     public RuleUnitVariable getVar(String name) {
-        return varDeclarations.get(name);
+        RuleUnitVariable ruleUnitVariable = varDeclarations.get(name);
+        if (ruleUnitVariable == null) {
+            throw new UndefinedRuleUnitVariable(name, this.getCanonicalName());
+        }
+        return ruleUnitVariable;
     }
 
     @Override

--- a/drools/kogito-ruleunits/src/main/java/org/kie/kogito/rules/units/GeneratedRuleUnitDescription.java
+++ b/drools/kogito-ruleunits/src/main/java/org/kie/kogito/rules/units/GeneratedRuleUnitDescription.java
@@ -19,6 +19,7 @@ package org.kie.kogito.rules.units;
 import java.util.function.Function;
 
 import org.drools.core.addon.TypeResolver;
+import org.kie.internal.ruleunit.RuleUnitVariable;
 import org.kie.kogito.rules.RuleUnitConfig;
 
 public class GeneratedRuleUnitDescription extends AbstractRuleUnitDescription {
@@ -27,12 +28,21 @@ public class GeneratedRuleUnitDescription extends AbstractRuleUnitDescription {
     private final String name;
     private final String packageName;
     private final String simpleName;
+    private final String canonicalName;
 
     public GeneratedRuleUnitDescription(String name, Function<String, Class<?>> typeResolver) {
         this.typeResolver = typeResolver;
         this.name = name;
-        this.simpleName = name.substring(name.lastIndexOf('.') + 1);
-        this.packageName = name.substring(0, name.lastIndexOf('.'));
+        int width = name.lastIndexOf('.');
+        if (width > -1) {
+            this.simpleName = name.substring(width + 1);
+            this.packageName = name.substring(0, width);
+            this.canonicalName = packageName + '.' + simpleName;
+        } else {
+            this.simpleName = name;
+            this.packageName = "";
+            this.canonicalName = simpleName;
+        }
         setConfig(RuleUnitConfig.Default);
     }
 
@@ -52,7 +62,7 @@ public class GeneratedRuleUnitDescription extends AbstractRuleUnitDescription {
 
     @Override
     public String getCanonicalName() {
-        return getPackageName() + '.' + getSimpleName();
+        return canonicalName;
     }
 
     @Override
@@ -68,6 +78,15 @@ public class GeneratedRuleUnitDescription extends AbstractRuleUnitDescription {
     @Override
     public String getRuleUnitName() {
         return name;
+    }
+
+    @Override
+    public RuleUnitVariable getVar(String name) {
+         try {
+             return super.getVar(name);
+         } catch (UndefinedRuleUnitVariable e) {
+             throw new UndefinedGeneratedRuleUnitVariable(e.getVariable(), e.getUnit());
+         }
     }
 
     public void putSimpleVar(String name, String varTypeFQCN) {

--- a/drools/kogito-ruleunits/src/main/java/org/kie/kogito/rules/units/UndefinedGeneratedRuleUnitVariable.java
+++ b/drools/kogito-ruleunits/src/main/java/org/kie/kogito/rules/units/UndefinedGeneratedRuleUnitVariable.java
@@ -1,0 +1,21 @@
+package org.kie.kogito.rules.units;
+
+public class UndefinedGeneratedRuleUnitVariable extends IllegalArgumentException {
+
+    private final String variable;
+    private final String unit;
+
+    public UndefinedGeneratedRuleUnitVariable(String varName, String unitName) {
+        super(String.format("Unknown variable '%s' for generated rule unit '%s'", varName, unitName));
+        variable = varName;
+        unit = unitName;
+    }
+
+    public String getVariable() {
+        return variable;
+    }
+
+    public String getUnit() {
+        return unit;
+    }
+}

--- a/drools/kogito-ruleunits/src/main/java/org/kie/kogito/rules/units/UndefinedRuleUnitVariable.java
+++ b/drools/kogito-ruleunits/src/main/java/org/kie/kogito/rules/units/UndefinedRuleUnitVariable.java
@@ -1,0 +1,21 @@
+package org.kie.kogito.rules.units;
+
+public class UndefinedRuleUnitVariable extends IllegalArgumentException {
+
+    private final String variable;
+    private final String unit;
+
+    public UndefinedRuleUnitVariable(String varName, String unitName) {
+        super(String.format("Unknown variable '%s' for rule unit '%s'", varName, unitName));
+        variable = varName;
+        unit = unitName;
+    }
+
+    public String getVariable() {
+        return variable;
+    }
+
+    public String getUnit() {
+        return unit;
+    }
+}

--- a/drools/kogito-ruleunits/src/test/java/org/drools/core/ruleunit/RuleUnitDescriptionTest.java
+++ b/drools/kogito-ruleunits/src/test/java/org/drools/core/ruleunit/RuleUnitDescriptionTest.java
@@ -27,8 +27,8 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.kie.internal.ruleunit.RuleUnitVariable;
 import org.kie.kogito.rules.units.ReflectiveRuleUnitDescription;
+import org.kie.kogito.rules.units.UndefinedRuleUnitVariable;
 
-@Disabled
 public class RuleUnitDescriptionTest {
 
     private ReflectiveRuleUnitDescription ruleUnitDescr;
@@ -49,6 +49,13 @@ public class RuleUnitDescriptionTest {
     }
 
     @Test
+    public void getRuleUnitVariable() {
+        Assertions.assertThat(ruleUnitDescr.getVar("number")).isNotNull();
+        Assertions.assertThatThrownBy(() -> ruleUnitDescr.getVar("undefinedField")).isInstanceOf(UndefinedRuleUnitVariable.class);
+    }
+
+
+    @Test
     public void getEntryPointId() {
         final String entryPointId = ruleUnitDescr.getEntryPointName("nonexisting");
         Assertions.assertThat(entryPointId).isNotNull();
@@ -59,7 +66,7 @@ public class RuleUnitDescriptionTest {
         assertEntryPointIdExists("simpleFactList");
     }
 
-    @Test
+    @Disabled
     public void getDatasourceType() {
         final Optional<Class<?>> dataSourceType = ruleUnitDescr.getDatasourceType("nonexisting");
         Assertions.assertThat(dataSourceType).isNotPresent();
@@ -109,7 +116,7 @@ public class RuleUnitDescriptionTest {
                 .containsExactlyInAnyOrder("bound", "number", "numbersArray", "stringList", "simpleFactList");
     }
 
-    @Test
+    @Disabled
     public void hasDataSource() {
         Assertions.assertThat(ruleUnitDescr.hasDataSource("nonexisting")).isFalse();
         Assertions.assertThat(ruleUnitDescr.hasDataSource("numbers")).isFalse();

--- a/drools/kogito-ruleunits/src/test/java/org/drools/core/ruleunit/RuleUnitDescriptionTest.java
+++ b/drools/kogito-ruleunits/src/test/java/org/drools/core/ruleunit/RuleUnitDescriptionTest.java
@@ -66,7 +66,7 @@ public class RuleUnitDescriptionTest {
         assertEntryPointIdExists("simpleFactList");
     }
 
-    @Disabled
+    @Test
     public void getDatasourceType() {
         final Optional<Class<?>> dataSourceType = ruleUnitDescr.getDatasourceType("nonexisting");
         Assertions.assertThat(dataSourceType).isNotPresent();
@@ -116,7 +116,7 @@ public class RuleUnitDescriptionTest {
                 .containsExactlyInAnyOrder("bound", "number", "numbersArray", "stringList", "simpleFactList");
     }
 
-    @Disabled
+    @Test
     public void hasDataSource() {
         Assertions.assertThat(ruleUnitDescr.hasDataSource("nonexisting")).isFalse();
         Assertions.assertThat(ruleUnitDescr.hasDataSource("numbers")).isFalse();

--- a/drools/kogito-ruleunits/src/test/java/org/drools/core/ruleunit/RuleUnitDescriptionTest.java
+++ b/drools/kogito-ruleunits/src/test/java/org/drools/core/ruleunit/RuleUnitDescriptionTest.java
@@ -71,10 +71,7 @@ public class RuleUnitDescriptionTest {
         final Optional<Class<?>> dataSourceType = ruleUnitDescr.getDatasourceType("nonexisting");
         Assertions.assertThat(dataSourceType).isNotPresent();
 
-        assertDataSourceType("number", BigDecimal.class);
-        assertDataSourceType("numbersArray", Integer.class);
-        assertDataSourceType("stringList", String.class);
-        assertDataSourceType("simpleFactList", SimpleFact.class);
+        assertDataSourceType("strings", String.class);
     }
 
     @Test
@@ -102,28 +99,25 @@ public class RuleUnitDescriptionTest {
     public void getUnitVars() {
         final Collection<String> unitVars = ruleUnitDescr.getUnitVars();
         Assertions.assertThat(unitVars).isNotEmpty();
-        Assertions.assertThat(unitVars).hasSize(5);
-        Assertions.assertThat(unitVars).containsExactlyInAnyOrder("bound", "number", "numbersArray", "stringList", "simpleFactList");
+        Assertions.assertThat(unitVars).hasSize(6);
+        Assertions.assertThat(unitVars).containsExactlyInAnyOrder("strings", "bound", "number", "numbersArray", "stringList", "simpleFactList");
     }
 
     @Test
     public void getUnitVarAccessors() {
         final Collection<? extends RuleUnitVariable> unitVarAccessors = ruleUnitDescr.getUnitVarDeclarations();
         Assertions.assertThat(unitVarAccessors).isNotEmpty();
-        Assertions.assertThat(unitVarAccessors).hasSize(5);
+        Assertions.assertThat(unitVarAccessors).hasSize(6);
         Assertions.assertThat(unitVarAccessors)
                 .extracting("name", String.class)
-                .containsExactlyInAnyOrder("bound", "number", "numbersArray", "stringList", "simpleFactList");
+                .containsExactlyInAnyOrder("strings", "bound", "number", "numbersArray", "stringList", "simpleFactList");
     }
 
     @Test
     public void hasDataSource() {
         Assertions.assertThat(ruleUnitDescr.hasDataSource("nonexisting")).isFalse();
         Assertions.assertThat(ruleUnitDescr.hasDataSource("numbers")).isFalse();
-        Assertions.assertThat(ruleUnitDescr.hasDataSource("number")).isTrue();
-        Assertions.assertThat(ruleUnitDescr.hasDataSource("numbersArray")).isTrue();
-        Assertions.assertThat(ruleUnitDescr.hasDataSource("stringList")).isTrue();
-        Assertions.assertThat(ruleUnitDescr.hasDataSource("simpleFactList")).isTrue();
+        Assertions.assertThat(ruleUnitDescr.hasDataSource("strings")).isTrue();
     }
 
     private void assertEntryPointIdExists(final String entryPointIdName) {

--- a/drools/kogito-ruleunits/src/test/java/org/drools/core/ruleunit/TestRuleUnit.java
+++ b/drools/kogito-ruleunits/src/test/java/org/drools/core/ruleunit/TestRuleUnit.java
@@ -20,15 +20,17 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.kie.api.definition.rule.UnitVar;
+import org.kie.kogito.rules.DataSource;
+import org.kie.kogito.rules.DataStream;
 import org.kie.kogito.rules.RuleUnitData;
 
 public class TestRuleUnit implements RuleUnitData {
 
     private final Integer[] numbersArray;
 
-    @UnitVar("numberVariable")
     private BigDecimal number;
+
+    private final DataStream<String> strings = DataSource.createStream();
 
     private final List<String> stringList;
     private final List<SimpleFact> simpleFactList;
@@ -47,6 +49,10 @@ public class TestRuleUnit implements RuleUnitData {
         this.number = number;
         this.stringList = new ArrayList<>();
         this.simpleFactList = new ArrayList<>();
+    }
+
+    public DataStream<String> getStrings() {
+        return strings;
     }
 
     public Integer[] getNumbersArray() {

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/RuleUnitHandler.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/RuleUnitHandler.java
@@ -200,7 +200,8 @@ public class RuleUnitHandler {
 
     private Map<String, String> getOutputMappings(ProcessContextMetaModel variableScope, RuleSetNode node) {
         Map<String, String> entries = node.getOutMappings();
-        if (entries.isEmpty()) {
+        // if both are empty we use automatic binding, otherwise we do nothing
+        if (node.getInMappings().isEmpty() && entries.isEmpty()) {
             entries = new HashMap<>();
             for (String varName : variableScope.getVariableNames()) {
                 entries.put(varName, varName);

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ProcessCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ProcessCodegen.java
@@ -63,6 +63,7 @@ import org.kie.kogito.codegen.GeneratorConfig;
 import org.kie.kogito.codegen.context.QuarkusKogitoBuildContext;
 import org.kie.kogito.codegen.di.DependencyInjectionAnnotator;
 import org.kie.kogito.codegen.process.config.ProcessConfigGenerator;
+import org.kie.kogito.rules.units.UndefinedGeneratedRuleUnitVariable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
@@ -70,6 +71,7 @@ import org.xml.sax.SAXException;
 import static org.drools.core.util.IoUtils.readBytesFromInputStream;
 import static org.kie.api.io.ResourceType.determineResourceType;
 import static org.kie.kogito.codegen.ApplicationGenerator.log;
+import static org.kie.kogito.codegen.ApplicationGenerator.logger;
 
 /**
  * Entry point to process code generation
@@ -271,7 +273,11 @@ public class ProcessCodegen extends AbstractGenerator {
                 ProcessMetaData generate = execModelGen.generate();
                 processIdToMetadata.put(id, generate);
                 processExecutableModelGenerators.add(execModelGen);
+            } catch (UndefinedGeneratedRuleUnitVariable e) {
+                LOGGER.error(e.getMessage() + "\nRemember: in this case rule unit variables are usually named after process variables.");
+                throw new ProcessCodegenException(id, packageName, e);
             } catch (RuntimeException e) {
+                LOGGER.error(e.getMessage());
                 throw new ProcessCodegenException(id, packageName, e);
             }
         }

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
@@ -40,6 +40,7 @@ import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
 import org.drools.compiler.builder.impl.KnowledgeBuilderConfigurationImpl;
 import org.drools.compiler.compiler.DecisionTableFactory;
+import org.drools.compiler.compiler.DroolsError;
 import org.drools.compiler.kproject.ReleaseIdImpl;
 import org.drools.compiler.kproject.models.KieModuleModelImpl;
 import org.drools.core.io.impl.ByteArrayResource;
@@ -76,6 +77,7 @@ import static org.drools.compiler.kie.builder.impl.KieBuilderImpl.setDefaultsfor
 import static org.drools.core.util.IoUtils.readBytesFromInputStream;
 import static org.kie.api.io.ResourceType.determineResourceType;
 import static org.kie.kogito.codegen.ApplicationGenerator.log;
+import static org.kie.kogito.codegen.ApplicationGenerator.logger;
 
 public class IncrementalRuleCodegen extends AbstractGenerator {
 
@@ -236,10 +238,17 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
         try {
             batch.build();
         } catch (RuntimeException e) {
+            for (DroolsError error : modelBuilder.getErrors().getErrors()) {
+                logger.error(error.toString());
+            }
+            logger.error(e.getMessage());
             throw new RuleCodegenError(e, modelBuilder.getErrors().getErrors());
         }
 
         if (modelBuilder.hasErrors()) {
+            for (DroolsError error : modelBuilder.getErrors().getErrors()) {
+                logger.error(error.toString());
+            }
             throw new RuleCodegenError(modelBuilder.getErrors().getErrors());
         }
 

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/tests/BusinessRuleUnitTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/tests/BusinessRuleUnitTest.java
@@ -41,10 +41,12 @@ import org.kie.kogito.codegen.process.ProcessCodegenException;
 import org.kie.kogito.process.Process;
 import org.kie.kogito.process.ProcessInstance;
 import org.kie.kogito.process.impl.DefaultProcessEventListenerConfig;
+import org.kie.kogito.rules.units.UndefinedGeneratedRuleUnitVariable;
 import org.kie.kogito.uow.UnitOfWork;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -279,6 +281,15 @@ public class BusinessRuleUnitTest extends AbstractCodegenTest {
         assertEquals(john, result.get("singlePerson"));
         assertNull(result.get("singleString"));
 
+    }
+
+
+    @Test
+    public void wrongVariableNameInGeneratedRuleUnit() {
+        assertThatExceptionOfType(ProcessCodegenException.class).isThrownBy(() -> {
+            Application app = generateCode(Collections.singletonList("ruletask/ExampleGeneratedWrong.bpmn"),
+                                           Collections.singletonList("ruletask/Generated.drl"));
+        }).withCauseInstanceOf(UndefinedGeneratedRuleUnitVariable.class);
     }
 
     @Test

--- a/kogito-codegen/src/test/resources/ruletask/ExampleGeneratedWrong.bpmn
+++ b/kogito-codegen/src/test/resources/ruletask/ExampleGeneratedWrong.bpmn
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" id="_Kd7psU8cEDijEJ-Gu4czCw" exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
+  <bpmn2:itemDefinition id="_singleStringItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="_singlePersonItem" structureRef="org.kie.kogito.codegen.data.Person"/>
+  <bpmn2:itemDefinition id="__5E0A1111-5D38-4B9F-AFDE-F55CC99B9952_namespaceInputXItem" structureRef="java.lang.String"/>
+  <bpmn2:itemDefinition id="__5E0A1111-5D38-4B9F-AFDE-F55CC99B9952_modelInputXItem" structureRef="java.lang.String"/>
+  <bpmn2:itemDefinition id="__5E0A1111-5D38-4B9F-AFDE-F55CC99B9952_decisionInputXItem" structureRef="java.lang.String"/>
+  <bpmn2:itemDefinition id="__5E0A1111-5D38-4B9F-AFDE-F55CC99B9952_singleInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__5293F325-A06A-469B-8C31-1E79EE36A3E2_namespaceInputXItem" structureRef="java.lang.String"/>
+  <bpmn2:itemDefinition id="__5293F325-A06A-469B-8C31-1E79EE36A3E2_modelInputXItem" structureRef="java.lang.String"/>
+  <bpmn2:itemDefinition id="__5293F325-A06A-469B-8C31-1E79EE36A3E2_decisionInputXItem" structureRef="java.lang.String"/>
+  <bpmn2:process id="ruletask.ExampleGenerated" drools:packageName="ruletask" xmlns:drools="http://www.jboss.org/drools" drools:version="1.0" drools:adHoc="false" name="ExampleGenerated" isExecutable="true" processType="Public">
+    <bpmn2:property id="singleString" itemSubjectRef="_singleStringItem" name="singleString"/>
+    <bpmn2:property id="singlePerson" itemSubjectRef="_singlePersonItem" name="singlePerson"/>
+    <bpmn2:sequenceFlow id="_D8A8D35C-3BBE-461E-8C67-682A3CEE6ACD" sourceRef="_5293F325-A06A-469B-8C31-1E79EE36A3E2" targetRef="_B89C98A9-F577-4B07-BB72-52283EE38A77">
+      <bpmn2:extensionElements>
+        <drools:metaData name="isAutoConnection.source">
+          <drools:metaValue>true</drools:metaValue>
+        </drools:metaData>
+        <drools:metaData name="isAutoConnection.target">
+          <drools:metaValue>true</drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+    </bpmn2:sequenceFlow>
+    <bpmn2:sequenceFlow id="_587C3E93-D988-4692-AAD3-954FD9254EEC" sourceRef="_5E0A1111-5D38-4B9F-AFDE-F55CC99B9952" targetRef="_5293F325-A06A-469B-8C31-1E79EE36A3E2">
+      <bpmn2:extensionElements>
+        <drools:metaData name="isAutoConnection.source">
+          <drools:metaValue>true</drools:metaValue>
+        </drools:metaData>
+        <drools:metaData name="isAutoConnection.target">
+          <drools:metaValue>true</drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+    </bpmn2:sequenceFlow>
+    <bpmn2:sequenceFlow id="_0390D294-D66C-4ED6-89CB-C22BE74B6ACD" sourceRef="_AB221175-4773-4CD7-96FF-867312DAA65D" targetRef="_5E0A1111-5D38-4B9F-AFDE-F55CC99B9952">
+      <bpmn2:extensionElements>
+        <drools:metaData name="isAutoConnection.source">
+          <drools:metaValue>true</drools:metaValue>
+        </drools:metaData>
+        <drools:metaData name="isAutoConnection.target">
+          <drools:metaValue>true</drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+    </bpmn2:sequenceFlow>
+    <bpmn2:endEvent id="_B89C98A9-F577-4B07-BB72-52283EE38A77">
+      <bpmn2:incoming>_D8A8D35C-3BBE-461E-8C67-682A3CEE6ACD</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:businessRuleTask id="_5293F325-A06A-469B-8C31-1E79EE36A3E2" drools:ruleFlowGroup="unit:ruletask.Generated" name="Rule2" implementation="http://www.jboss.org/drools/rule">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue>Rule2</drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_587C3E93-D988-4692-AAD3-954FD9254EEC</bpmn2:incoming>
+      <bpmn2:outgoing>_D8A8D35C-3BBE-461E-8C67-682A3CEE6ACD</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_KeNWgE8cEDijEJ-Gu4czCw"/>
+    </bpmn2:businessRuleTask>
+    <bpmn2:businessRuleTask id="_5E0A1111-5D38-4B9F-AFDE-F55CC99B9952" drools:ruleFlowGroup="unit:ruletask.Generated" name="Rule1" implementation="http://www.jboss.org/drools/rule">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue>Rule1</drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_0390D294-D66C-4ED6-89CB-C22BE74B6ACD</bpmn2:incoming>
+      <bpmn2:outgoing>_587C3E93-D988-4692-AAD3-954FD9254EEC</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_KePLsE8cEDijEJ-Gu4czCw">
+        <bpmn2:dataInput id="_5E0A1111-5D38-4B9F-AFDE-F55CC99B9952_singleInputX" drools:dtype="String" itemSubjectRef="__5E0A1111-5D38-4B9F-AFDE-F55CC99B9952_singleInputXItem" name="single"/>
+        <bpmn2:inputSet id="_KePywE8cEDijEJ-Gu4czCw">
+          <bpmn2:dataInputRefs>_5E0A1111-5D38-4B9F-AFDE-F55CC99B9952_singleInputX</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="_KeRA4E8cEDijEJ-Gu4czCw">
+        <bpmn2:sourceRef>singleString</bpmn2:sourceRef>
+        <bpmn2:targetRef>_5E0A1111-5D38-4B9F-AFDE-F55CC99B9952_singleInputX</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+    </bpmn2:businessRuleTask>
+    <bpmn2:startEvent id="_AB221175-4773-4CD7-96FF-867312DAA65D">
+      <bpmn2:outgoing>_0390D294-D66C-4ED6-89CB-C22BE74B6ACD</bpmn2:outgoing>
+    </bpmn2:startEvent>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI">
+    <bpmndi:BPMNPlane bpmnElement="ruletask.ExampleGenerated">
+      <bpmndi:BPMNShape id="shape__AB221175-4773-4CD7-96FF-867312DAA65D" bpmnElement="_AB221175-4773-4CD7-96FF-867312DAA65D">
+        <dc:Bounds xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" height="56" width="56" x="100" y="100"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__5E0A1111-5D38-4B9F-AFDE-F55CC99B9952" bpmnElement="_5E0A1111-5D38-4B9F-AFDE-F55CC99B9952">
+        <dc:Bounds xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" height="102" width="154" x="236" y="77"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__5293F325-A06A-469B-8C31-1E79EE36A3E2" bpmnElement="_5293F325-A06A-469B-8C31-1E79EE36A3E2">
+        <dc:Bounds xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" height="102" width="154" x="470" y="77"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__B89C98A9-F577-4B07-BB72-52283EE38A77" bpmnElement="_B89C98A9-F577-4B07-BB72-52283EE38A77">
+        <dc:Bounds xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" height="56" width="56" x="704" y="100"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="edge_shape__AB221175-4773-4CD7-96FF-867312DAA65D_to_shape__5E0A1111-5D38-4B9F-AFDE-F55CC99B9952" bpmnElement="_0390D294-D66C-4ED6-89CB-C22BE74B6ACD">
+        <di:waypoint xmlns:di="http://www.omg.org/spec/DD/20100524/DI" x="156" y="128"/>
+        <di:waypoint xmlns:di="http://www.omg.org/spec/DD/20100524/DI" x="236" y="128"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_shape__5E0A1111-5D38-4B9F-AFDE-F55CC99B9952_to_shape__5293F325-A06A-469B-8C31-1E79EE36A3E2" bpmnElement="_587C3E93-D988-4692-AAD3-954FD9254EEC">
+        <di:waypoint xmlns:di="http://www.omg.org/spec/DD/20100524/DI" x="390" y="128"/>
+        <di:waypoint xmlns:di="http://www.omg.org/spec/DD/20100524/DI" x="470" y="128"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_shape__5293F325-A06A-469B-8C31-1E79EE36A3E2_to_shape__B89C98A9-F577-4B07-BB72-52283EE38A77" bpmnElement="_D8A8D35C-3BBE-461E-8C67-682A3CEE6ACD">
+        <di:waypoint xmlns:di="http://www.omg.org/spec/DD/20100524/DI" x="624" y="128"/>
+        <di:waypoint xmlns:di="http://www.omg.org/spec/DD/20100524/DI" x="704" y="128"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship id="_KeYVoE8cEDijEJ-Gu4czCw" type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData xmlns:bpsim="http://www.bpsim.org/schemas/1.0">
+        <bpsim:Scenario id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters/>
+          <bpsim:ElementParameters elementRef="_AB221175-4773-4CD7-96FF-867312DAA65D">
+            <bpsim:TimeParameters>
+              <bpsim:ProcessingTime>
+                <bpsim:NormalDistribution mean="0" standardDeviation="0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters elementRef="_5E0A1111-5D38-4B9F-AFDE-F55CC99B9952">
+            <bpsim:TimeParameters>
+              <bpsim:ProcessingTime>
+                <bpsim:NormalDistribution mean="0" standardDeviation="0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters>
+              <bpsim:Availability>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:Availability>
+              <bpsim:Quantity>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters>
+              <bpsim:UnitCost>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters elementRef="_5293F325-A06A-469B-8C31-1E79EE36A3E2">
+            <bpsim:TimeParameters>
+              <bpsim:ProcessingTime>
+                <bpsim:NormalDistribution mean="0" standardDeviation="0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters>
+              <bpsim:Availability>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:Availability>
+              <bpsim:Quantity>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters>
+              <bpsim:UnitCost>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_Kd7psU8cEDijEJ-Gu4czCw</bpmn2:source>
+    <bpmn2:target>_Kd7psU8cEDijEJ-Gu4czCw</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>

--- a/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/KogitoAssetsProcessor.java
+++ b/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/KogitoAssetsProcessor.java
@@ -13,6 +13,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.BiFunction;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import io.quarkus.arc.deployment.GeneratedBeanBuildItem;
@@ -50,7 +51,9 @@ import org.jboss.jandex.Index;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.Indexer;
 import org.jboss.jandex.MethodInfo;
+import org.jboss.logmanager.Level;
 import org.kie.api.builder.model.KieModuleModel;
+import org.kie.internal.jci.CompilationProblem;
 import org.kie.internal.kogito.codegen.Generated;
 import org.kie.internal.kogito.codegen.VariableInfo;
 import org.kie.kogito.Model;
@@ -66,6 +69,7 @@ import org.kie.kogito.codegen.rules.IncrementalRuleCodegen;
 
 public class KogitoAssetsProcessor {
 
+    private static final Logger log = Logger.getLogger("KogitoAssetsProcessor");
     private final transient String generatedClassesDir = System.getProperty("quarkus.debug.generated-classes-dir");
     private final transient String appPackageName = "org.kie.kogito.app";
     private final transient String persistenceFactoryClass = "org.kie.kogito.persistence.KogitoProcessInstancesFactory";
@@ -275,6 +279,11 @@ public class KogitoAssetsProcessor {
             CompilationResult result, Path projectPath) throws IOException {
         if (result.getErrors().length > 0) {
             StringBuilder errorInfo = new StringBuilder();
+            for (CompilationProblem compilationProblem : result.getErrors()) {
+                errorInfo.append(compilationProblem.toString());
+                errorInfo.append("\n");
+                log.log(Level.ERROR, compilationProblem.toString());
+            }
             Arrays.stream(result.getErrors()).forEach(cp -> errorInfo.append(cp.toString()));
             throw new IllegalStateException(errorInfo.toString());
         }


### PR DESCRIPTION
Current error messages are misleading or side-effects from other errors (e.g. NPEs)
- a process tries to use a wrong variable input in a generated rule unit (e.g. declared process var Foo, io Map Foo to Bar -> NPE); it should say something useful
- a process tries to use a wrong variable *output* in a generated rule unit (e.g. declared process var Foo, io Map Foo to Bar -> NPE); if there is some input mapping, then we should *not* do automatic mapping
- we should also *log* to ERROR in case of exception, instead of just throwing