### PR TITLE
KOGITO-1557: Remove --allow-incomplete-classpath from examples and archetypes

### DIFF
--- a/archetypes/kogito-quarkus-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/kogito-quarkus-archetype/src/main/resources/archetype-resources/pom.xml
@@ -99,9 +99,6 @@
                 <goals>
                   <goal>native-image</goal>
                 </goals>
-                <configuration>
-                  <additionalBuildArgs>--allow-incomplete-classpath</additionalBuildArgs>
-                </configuration>
               </execution>
             </executions>
           </plugin>


### PR DESCRIPTION
remove --allow-incomplete-classpath from archetype