### PR TITLE
A set of improvements and enhancements for working with bpmn2 processes

### DIFF
--- a/addons/predictions/kogito-predictions-api/src/test/java/org/kie/kogito/prediction/api/PredictionAwareHumanTaskLifeCycleTest.java
+++ b/addons/predictions/kogito-predictions-api/src/test/java/org/kie/kogito/prediction/api/PredictionAwareHumanTaskLifeCycleTest.java
@@ -78,7 +78,7 @@ public class PredictionAwareHumanTaskLifeCycleTest {
     public void testUserTaskWithPredictionService() {
         predictNow.set(true);
         
-        BpmnProcess process = (BpmnProcess) BpmnProcess.from(new ClassPathResource("BPMN2-UserTask.bpmn2"), config).get(0);        
+        BpmnProcess process = (BpmnProcess) BpmnProcess.from(config, new ClassPathResource("BPMN2-UserTask.bpmn2")).get(0);        
         process.configure();
                                      
         ProcessInstance<BpmnVariables> processInstance = process.createInstance(BpmnVariables.create(Collections.singletonMap("test", "test")));
@@ -97,7 +97,7 @@ public class PredictionAwareHumanTaskLifeCycleTest {
     @Test
     public void testUserTaskWithoutPredictionService() {
 
-        BpmnProcess process = (BpmnProcess) BpmnProcess.from(new ClassPathResource("BPMN2-UserTask.bpmn2"), config).get(0);        
+        BpmnProcess process = (BpmnProcess) BpmnProcess.from(config, new ClassPathResource("BPMN2-UserTask.bpmn2")).get(0);        
         process.configure();
                                      
         ProcessInstance<BpmnVariables> processInstance = process.createInstance(BpmnVariables.create(Collections.singletonMap("test", "test")));

--- a/addons/predictions/kogito-predictions-smile-addon/src/test/java/org/kie/kogito/predictions/smile/SmileRandomForestPredictionTest.java
+++ b/addons/predictions/kogito-predictions-smile-addon/src/test/java/org/kie/kogito/predictions/smile/SmileRandomForestPredictionTest.java
@@ -61,7 +61,7 @@ public class SmileRandomForestPredictionTest {
     public void testUserTaskWithPredictionService() {
         
         
-        BpmnProcess process = (BpmnProcess) BpmnProcess.from(new ClassPathResource("BPMN2-UserTask.bpmn2"), config).get(0);        
+        BpmnProcess process = (BpmnProcess) BpmnProcess.from(config, new ClassPathResource("BPMN2-UserTask.bpmn2")).get(0);        
         process.configure();
                                      
         ProcessInstance<BpmnVariables> processInstance = process.createInstance(BpmnVariables.create(Collections.singletonMap("test", "test")));

--- a/api/kogito-api/src/main/java/org/kie/api/runtime/process/WorkItem.java
+++ b/api/kogito-api/src/main/java/org/kie/api/runtime/process/WorkItem.java
@@ -141,6 +141,22 @@ public interface WorkItem {
     Date getCompleteDate(); 
     
     /**
+     * The node instance that is associated with this
+     * work item
+     *
+     * @return the related node instance
+     */
+    NodeInstance getNodeInstance();
+    
+    /**
+     * The process instance that requested the execution of this
+     * work item
+     *
+     * @return the related process instance
+     */
+    ProcessInstance getProcessInstance();
+    
+    /**
      * Enforces given policies on this work item. It must false in case of any policy 
      * violations. 
      * @param policies optional policies to be enforced

--- a/api/kogito-api/src/main/java/org/kie/kogito/jobs/ProcessJobDescription.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/jobs/ProcessJobDescription.java
@@ -20,54 +20,69 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.UUID;
 
+import org.kie.kogito.process.Process;
+
 public class ProcessJobDescription implements JobDescription {
 
-    public static final Integer DEFAULT_PRIORITY = 5;
+	public static final Integer DEFAULT_PRIORITY = 5;
 
-    private final String id;
+	private final String id;
 
-    private final ExpirationTime expirationTime;
+	private final ExpirationTime expirationTime;
 
-    private final Integer priority;
+	private final Integer priority;
 
-    private final String processId;
+	private String processId;
 
-    private ProcessJobDescription(ExpirationTime expirationTime, Integer priority, String processId) {
-        this.id = UUID.randomUUID().toString();
-        this.expirationTime = requireNonNull(expirationTime);
-        this.priority = requireNonNull(priority);
-        this.processId = requireNonNull(processId);
-    }
+	private Process<?> process;
 
-    @Override
-    public String id() {
-        return id;
-    }
+	private ProcessJobDescription(ExpirationTime expirationTime, Integer priority, String processId) {
+		this.id = UUID.randomUUID().toString();
+		this.expirationTime = requireNonNull(expirationTime);
+		this.priority = requireNonNull(priority);
+		this.processId = requireNonNull(processId);
+	}
 
-    @Override
-    public ExpirationTime expirationTime() {
-        return expirationTime;
-    }
+	public ProcessJobDescription(ExpirationTime expirationTime, Integer priority, Process<?> process) {
+		this.id = UUID.randomUUID().toString();
+		this.expirationTime = requireNonNull(expirationTime);
+		this.priority = requireNonNull(priority);
+		this.process = requireNonNull(process);
+	}
 
-    @Override
-    public Integer priority() {
-        return priority;
-    }
+	@Override
+	public String id() {
+		return id;
+	}
 
-    public String processId() {
-        return processId;
-    }
-    
-    public static ProcessJobDescription of(ExpirationTime expirationTime,
-                                                String processId) {
-        return of(expirationTime, DEFAULT_PRIORITY, processId);
-    }
-   
+	@Override
+	public ExpirationTime expirationTime() {
+		return expirationTime;
+	}
 
-    public static ProcessJobDescription of(ExpirationTime expirationTime,
-                                                Integer priority,
-                                                String processId) {
+	@Override
+	public Integer priority() {
+		return priority;
+	}
 
-        return new ProcessJobDescription(expirationTime, priority, processId);
-    }
+	public String processId() {
+		return processId;
+	}
+
+	public Process<?> process() {
+		return process;
+	}
+
+	public static ProcessJobDescription of(ExpirationTime expirationTime, Process<?> process) {
+		return new ProcessJobDescription(expirationTime, DEFAULT_PRIORITY, process);
+	}
+
+	public static ProcessJobDescription of(ExpirationTime expirationTime, String processId) {
+		return of(expirationTime, DEFAULT_PRIORITY, processId);
+	}
+
+	public static ProcessJobDescription of(ExpirationTime expirationTime, Integer priority, String processId) {
+
+		return new ProcessJobDescription(expirationTime, priority, processId);
+	}
 }

--- a/api/kogito-api/src/main/java/org/kie/kogito/jobs/ProcessJobDescription.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/jobs/ProcessJobDescription.java
@@ -73,16 +73,16 @@ public class ProcessJobDescription implements JobDescription {
 		return process;
 	}
 
-	public static ProcessJobDescription of(ExpirationTime expirationTime, Process<?> process) {
-		return new ProcessJobDescription(expirationTime, DEFAULT_PRIORITY, process);
-	}
+    public static ProcessJobDescription of(ExpirationTime expirationTime, Process<?> process) {
+        return new ProcessJobDescription(expirationTime, DEFAULT_PRIORITY, process);
+    }
 
-	public static ProcessJobDescription of(ExpirationTime expirationTime, String processId) {
-		return of(expirationTime, DEFAULT_PRIORITY, processId);
-	}
+    public static ProcessJobDescription of(ExpirationTime expirationTime, String processId) {
+        return of(expirationTime, DEFAULT_PRIORITY, processId);
+    }
 
-	public static ProcessJobDescription of(ExpirationTime expirationTime, Integer priority, String processId) {
+    public static ProcessJobDescription of(ExpirationTime expirationTime, Integer priority, String processId) {
 
-		return new ProcessJobDescription(expirationTime, priority, processId);
-	}
+        return new ProcessJobDescription(expirationTime, priority, processId);
+    }
 }

--- a/api/kogito-api/src/main/java/org/kie/kogito/process/Process.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/process/Process.java
@@ -34,4 +34,8 @@ public interface Process<T> {
     ProcessInstance<? extends Model> createInstance(String businessKey, Model m);
     
     String id();
+
+	void activate();
+
+	void deactivate();
 }

--- a/api/kogito-api/src/main/java/org/kie/kogito/process/Process.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/process/Process.java
@@ -35,7 +35,7 @@ public interface Process<T> {
     
     String id();
 
-	void activate();
+    void activate();
 
-	void deactivate();
+    void deactivate();
 }

--- a/api/kogito-api/src/main/java/org/kie/kogito/process/Processes.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/process/Processes.java
@@ -24,4 +24,12 @@ public interface Processes {
     Process<? extends Model> processById(String processId);
     
     Collection<String> processIds();
+
+	default void activate() {
+		
+	}
+
+	default void deactivate() {
+		
+	}
 }

--- a/api/kogito-api/src/main/java/org/kie/kogito/process/Processes.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/process/Processes.java
@@ -25,11 +25,11 @@ public interface Processes {
     
     Collection<String> processIds();
 
-	default void activate() {
-		
-	}
+    default void activate() {
 
-	default void deactivate() {
-		
-	}
+    }
+
+    default void deactivate() {
+
+    }
 }

--- a/api/kogito-api/src/main/java/org/kie/kogito/process/workitem/WorkItemExecutionError.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/process/workitem/WorkItemExecutionError.java
@@ -1,28 +1,43 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.kogito.process.workitem;
 
 public class WorkItemExecutionError extends RuntimeException {
 
-	private static final long serialVersionUID = 4739415822214766299L;
+    private static final long serialVersionUID = 4739415822214766299L;
 
-	private final String errorCode;
-	
-	public WorkItemExecutionError(String errorCode) {
-		super("WorkItem execution failed with error code " + errorCode);
-		this.errorCode = errorCode;
-	}
+    private final String errorCode;
 
-	public WorkItemExecutionError(String errorCode, Throwable e) {
-		super("WorkItem execution failed with error code " + errorCode, e);
-		this.errorCode = errorCode;
-	}
+    public WorkItemExecutionError(String errorCode) {
+        super("WorkItem execution failed with error code " + errorCode);
+        this.errorCode = errorCode;
+    }
 
-	public String getErrorCode() {
-		return errorCode;
-	}
+    public WorkItemExecutionError(String errorCode, Throwable e) {
+        super("WorkItem execution failed with error code " + errorCode, e);
+        this.errorCode = errorCode;
+    }
 
-	@Override
-	public String toString() {
-		return "WorkItemExecutionError [errorCode=" + errorCode + "]";
-	}
-	
+    public String getErrorCode() {
+        return errorCode;
+    }
+
+    @Override
+    public String toString() {
+        return "WorkItemExecutionError [errorCode=" + errorCode + "]";
+    }
+
 }

--- a/api/kogito-api/src/main/java/org/kie/kogito/process/workitem/WorkItemExecutionError.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/process/workitem/WorkItemExecutionError.java
@@ -1,0 +1,28 @@
+package org.kie.kogito.process.workitem;
+
+public class WorkItemExecutionError extends RuntimeException {
+
+	private static final long serialVersionUID = 4739415822214766299L;
+
+	private final String errorCode;
+	
+	public WorkItemExecutionError(String errorCode) {
+		super("WorkItem execution failed with error code " + errorCode);
+		this.errorCode = errorCode;
+	}
+
+	public WorkItemExecutionError(String errorCode, Throwable e) {
+		super("WorkItem execution failed with error code " + errorCode, e);
+		this.errorCode = errorCode;
+	}
+
+	public String getErrorCode() {
+		return errorCode;
+	}
+
+	@Override
+	public String toString() {
+		return "WorkItemExecutionError [errorCode=" + errorCode + "]";
+	}
+	
+}

--- a/api/kogito-services/src/main/java/org/kie/services/jobs/impl/InMemoryJobService.java
+++ b/api/kogito-services/src/main/java/org/kie/services/jobs/impl/InMemoryJobService.java
@@ -59,10 +59,10 @@ public class InMemoryJobService implements JobsService {
     public String scheduleProcessJob(ProcessJobDescription description) {
         ScheduledFuture<?> future = null;
         if (description.expirationTime().repeatInterval() != null) {
-            future = scheduler.scheduleAtFixedRate(new StartProcessOnExpiredTimer(description.id(), description.processId(), false, description.expirationTime().repeatLimit()), calculateDelay(description), description.expirationTime().repeatInterval(), TimeUnit.MILLISECONDS);
+            future = scheduler.scheduleAtFixedRate(repeatableProcessJobByDescription(description), calculateDelay(description), description.expirationTime().repeatInterval(), TimeUnit.MILLISECONDS);
         } else {
         
-            future = scheduler.schedule(new StartProcessOnExpiredTimer(description.id(), description.processId(), true, -1), calculateDelay(description), TimeUnit.MILLISECONDS);
+            future = scheduler.schedule(processJobByDescription(description), calculateDelay(description), TimeUnit.MILLISECONDS);
         }
         scheduledJobs.put(description.id(), future);
         return description.id();
@@ -91,8 +91,23 @@ public class InMemoryJobService implements JobsService {
     }
     
     protected long calculateDelay(JobDescription description) {
-        return Duration.between(ZonedDateTime.now(), description.expirationTime().get()).toMillis();
-        
+        return Duration.between(ZonedDateTime.now(), description.expirationTime().get()).toMillis();       
+    }
+    
+    protected Runnable processJobByDescription(ProcessJobDescription description) {
+    	if (description.process() != null) {
+    		return new StartProcessOnExpiredTimer(description.id(), description.process(), true, -1);
+    	} else {
+    		return new LegacyStartProcessOnExpiredTimer(description.id(), description.processId(), true, -1);
+    	}
+    }
+    
+    protected Runnable repeatableProcessJobByDescription(ProcessJobDescription description) {
+    	if (description.process() != null) {
+    		return new StartProcessOnExpiredTimer(description.id(), description.process(), false, description.expirationTime().repeatLimit());
+    	} else {
+    		return new LegacyStartProcessOnExpiredTimer(description.id(), description.processId(), false, description.expirationTime().repeatLimit());
+    	}
     }
 
     private class SignalProcessInstanceOnExpiredTimer implements Runnable {
@@ -141,23 +156,63 @@ public class InMemoryJobService implements JobsService {
         private final String id;
         
         private boolean removeAtExecution;
+        @SuppressWarnings("rawtypes")
+		private org.kie.kogito.process.Process process;
+
+        private Integer limit;
+        
+        private StartProcessOnExpiredTimer(String id, org.kie.kogito.process.Process<?> process, boolean removeAtExecution, Integer limit) {
+            this.id = id;
+            this.process = process;
+            this.removeAtExecution = removeAtExecution;
+            this.limit = limit;
+        }
+        @SuppressWarnings("unchecked")
+		@Override
+        public void run() {
+            try {
+                UnitOfWorkExecutor.executeInUnitOfWork(unitOfWorkManager, () -> {
+                	org.kie.kogito.process.ProcessInstance<?> pi = process.createInstance(process.createModel());
+                    if (pi != null) {
+                        pi.start("timer", null);
+                    }
+                    
+                    return null;
+                });
+                limit--;
+                if (limit == 0) {
+                    scheduledJobs.remove(id).cancel(false);
+                }
+            } finally {
+                if (removeAtExecution) {
+                    scheduledJobs.remove(id);
+                }
+            }
+        }
+    }
+    
+    private class LegacyStartProcessOnExpiredTimer implements Runnable {
+        private final String id;
+        
+        private boolean removeAtExecution;
         private String processId;
 
         private Integer limit;
         
-        private StartProcessOnExpiredTimer(String id, String processId, boolean removeAtExecution, Integer limit) {
+        private LegacyStartProcessOnExpiredTimer(String id, String processId, boolean removeAtExecution, Integer limit) {
             this.id = id;
             this.processId = processId;
             this.removeAtExecution = removeAtExecution;
             this.limit = limit;
         }
-        @Override
+
+		@Override
         public void run() {
             try {
                 UnitOfWorkExecutor.executeInUnitOfWork(unitOfWorkManager, () -> {
-                    ProcessInstance pi = processRuntime.createProcessInstance(processId, null);
+                	ProcessInstance pi = processRuntime.createProcessInstance(processId, null);
                     if (pi != null) {
-                        processRuntime.startProcessInstance(pi.getId(), "timer");
+                    	processRuntime.startProcessInstance(pi.getId(), "timer");
                     }
                     
                     return null;

--- a/api/kogito-services/src/main/java/org/kie/services/jobs/impl/InMemoryJobService.java
+++ b/api/kogito-services/src/main/java/org/kie/services/jobs/impl/InMemoryJobService.java
@@ -93,21 +93,21 @@ public class InMemoryJobService implements JobsService {
     protected long calculateDelay(JobDescription description) {
         return Duration.between(ZonedDateTime.now(), description.expirationTime().get()).toMillis();       
     }
-    
+
     protected Runnable processJobByDescription(ProcessJobDescription description) {
-    	if (description.process() != null) {
-    		return new StartProcessOnExpiredTimer(description.id(), description.process(), true, -1);
-    	} else {
-    		return new LegacyStartProcessOnExpiredTimer(description.id(), description.processId(), true, -1);
-    	}
+        if (description.process() != null) {
+            return new StartProcessOnExpiredTimer(description.id(), description.process(), true, -1);
+        } else {
+            return new LegacyStartProcessOnExpiredTimer(description.id(), description.processId(), true, -1);
+        }
     }
-    
+
     protected Runnable repeatableProcessJobByDescription(ProcessJobDescription description) {
-    	if (description.process() != null) {
-    		return new StartProcessOnExpiredTimer(description.id(), description.process(), false, description.expirationTime().repeatLimit());
-    	} else {
-    		return new LegacyStartProcessOnExpiredTimer(description.id(), description.processId(), false, description.expirationTime().repeatLimit());
-    	}
+        if (description.process() != null) {
+            return new StartProcessOnExpiredTimer(description.id(), description.process(), false, description.expirationTime().repeatLimit());
+        } else {
+            return new LegacyStartProcessOnExpiredTimer(description.id(), description.processId(), false, description.expirationTime().repeatLimit());
+        }
     }
 
     private class SignalProcessInstanceOnExpiredTimer implements Runnable {
@@ -153,30 +153,32 @@ public class InMemoryJobService implements JobsService {
     }
 
     private class StartProcessOnExpiredTimer implements Runnable {
+
         private final String id;
-        
+
         private boolean removeAtExecution;
         @SuppressWarnings("rawtypes")
-		private org.kie.kogito.process.Process process;
+        private org.kie.kogito.process.Process process;
 
         private Integer limit;
-        
+
         private StartProcessOnExpiredTimer(String id, org.kie.kogito.process.Process<?> process, boolean removeAtExecution, Integer limit) {
             this.id = id;
             this.process = process;
             this.removeAtExecution = removeAtExecution;
             this.limit = limit;
         }
+
         @SuppressWarnings("unchecked")
-		@Override
+        @Override
         public void run() {
             try {
                 UnitOfWorkExecutor.executeInUnitOfWork(unitOfWorkManager, () -> {
-                	org.kie.kogito.process.ProcessInstance<?> pi = process.createInstance(process.createModel());
+                    org.kie.kogito.process.ProcessInstance<?> pi = process.createInstance(process.createModel());
                     if (pi != null) {
                         pi.start("timer", null);
                     }
-                    
+
                     return null;
                 });
                 limit--;
@@ -190,15 +192,16 @@ public class InMemoryJobService implements JobsService {
             }
         }
     }
-    
+
     private class LegacyStartProcessOnExpiredTimer implements Runnable {
+
         private final String id;
-        
+
         private boolean removeAtExecution;
         private String processId;
 
         private Integer limit;
-        
+
         private LegacyStartProcessOnExpiredTimer(String id, String processId, boolean removeAtExecution, Integer limit) {
             this.id = id;
             this.processId = processId;
@@ -206,15 +209,15 @@ public class InMemoryJobService implements JobsService {
             this.limit = limit;
         }
 
-		@Override
+        @Override
         public void run() {
             try {
                 UnitOfWorkExecutor.executeInUnitOfWork(unitOfWorkManager, () -> {
-                	ProcessInstance pi = processRuntime.createProcessInstance(processId, null);
+                    ProcessInstance pi = processRuntime.createProcessInstance(processId, null);
                     if (pi != null) {
-                    	processRuntime.startProcessInstance(pi.getId(), "timer");
+                        processRuntime.startProcessInstance(pi.getId(), "timer");
                     }
-                    
+
                     return null;
                 });
                 limit--;

--- a/drools/drools-core/src/main/java/org/drools/core/process/instance/WorkItem.java
+++ b/drools/drools-core/src/main/java/org/drools/core/process/instance/WorkItem.java
@@ -55,8 +55,8 @@ public interface WorkItem extends org.kie.api.runtime.process.WorkItem {
     void setStartDate(Date date);
     
     void setCompleteDate(Date date);
-    
+
     void setNodeInsstance(NodeInstance nodeInstance);
-    
+
     void setProcessInstance(ProcessInstance processInstance);
 }

--- a/drools/drools-core/src/main/java/org/drools/core/process/instance/WorkItem.java
+++ b/drools/drools-core/src/main/java/org/drools/core/process/instance/WorkItem.java
@@ -19,6 +19,9 @@ package org.drools.core.process.instance;
 import java.util.Date;
 import java.util.Map;
 
+import org.kie.api.runtime.process.NodeInstance;
+import org.kie.api.runtime.process.ProcessInstance;
+
 public interface WorkItem extends org.kie.api.runtime.process.WorkItem {
 
     void setName(String name);
@@ -52,4 +55,8 @@ public interface WorkItem extends org.kie.api.runtime.process.WorkItem {
     void setStartDate(Date date);
     
     void setCompleteDate(Date date);
+    
+    void setNodeInsstance(NodeInstance nodeInstance);
+    
+    void setProcessInstance(ProcessInstance processInstance);
 }

--- a/drools/drools-core/src/main/java/org/drools/core/process/instance/impl/WorkItemImpl.java
+++ b/drools/drools-core/src/main/java/org/drools/core/process/instance/impl/WorkItemImpl.java
@@ -23,6 +23,8 @@ import java.util.Iterator;
 import java.util.Map;
 
 import org.drools.core.process.instance.WorkItem;
+import org.kie.api.runtime.process.NodeInstance;
+import org.kie.api.runtime.process.ProcessInstance;
 
 public class WorkItemImpl implements WorkItem, Serializable {
 
@@ -43,6 +45,9 @@ public class WorkItemImpl implements WorkItem, Serializable {
 
     private Date startDate;
     private Date completeDate;
+    
+    private transient ProcessInstance processInstance;
+    private transient NodeInstance nodeInstance;
 
     public void setId(String id) {
         this.id = id;
@@ -192,4 +197,24 @@ public class WorkItemImpl implements WorkItem, Serializable {
         b.append("}]");
         return b.toString();
     }
+
+	@Override
+	public NodeInstance getNodeInstance() {
+		return this.nodeInstance;
+	}
+
+	@Override
+	public ProcessInstance getProcessInstance() {
+		return this.processInstance;
+	}
+
+	@Override
+	public void setNodeInsstance(NodeInstance nodeInstance) {
+		this.nodeInstance = nodeInstance;
+	}
+
+	@Override
+	public void setProcessInstance(ProcessInstance processInstance) {
+		this.processInstance = processInstance;
+	}
 }

--- a/drools/drools-core/src/main/java/org/drools/core/process/instance/impl/WorkItemImpl.java
+++ b/drools/drools-core/src/main/java/org/drools/core/process/instance/impl/WorkItemImpl.java
@@ -45,7 +45,7 @@ public class WorkItemImpl implements WorkItem, Serializable {
 
     private Date startDate;
     private Date completeDate;
-    
+
     private transient ProcessInstance processInstance;
     private transient NodeInstance nodeInstance;
 
@@ -198,23 +198,23 @@ public class WorkItemImpl implements WorkItem, Serializable {
         return b.toString();
     }
 
-	@Override
-	public NodeInstance getNodeInstance() {
-		return this.nodeInstance;
-	}
+    @Override
+    public NodeInstance getNodeInstance() {
+        return this.nodeInstance;
+    }
 
-	@Override
-	public ProcessInstance getProcessInstance() {
-		return this.processInstance;
-	}
+    @Override
+    public ProcessInstance getProcessInstance() {
+        return this.processInstance;
+    }
 
-	@Override
-	public void setNodeInsstance(NodeInstance nodeInstance) {
-		this.nodeInstance = nodeInstance;
-	}
+    @Override
+    public void setNodeInsstance(NodeInstance nodeInstance) {
+        this.nodeInstance = nodeInstance;
+    }
 
-	@Override
-	public void setProcessInstance(ProcessInstance processInstance) {
-		this.processInstance = processInstance;
-	}
+    @Override
+    public void setProcessInstance(ProcessInstance processInstance) {
+        this.processInstance = processInstance;
+    }
 }

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/DataObjectHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/DataObjectHandler.java
@@ -77,6 +77,7 @@ public class DataObjectHandler extends BaseAbstractHandler implements Handler {
 			List variables = variableScope.getVariables();
 			Variable variable = new Variable();
 			variable.setMetaData("DataObject", "true");
+			variable.setId(id);
 			variable.setName(id);
             variable.setMetaData(id, variable.getName());
 			// retrieve type from item definition

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/PropertyHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/PropertyHandler.java
@@ -76,6 +76,7 @@ public class PropertyHandler extends BaseAbstractHandler implements Handler {
                 contextContainer.getDefaultContext(VariableScope.VARIABLE_SCOPE);
 			List variables = variableScope.getVariables();
 			Variable variable = new Variable();
+			variable.setId(id);
 			// if name is given use it as variable name instead of id
 			if (name != null && name.length() > 0) {
 			    variable.setName(name);

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/ScriptTaskHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/ScriptTaskHandler.java
@@ -16,16 +16,30 @@
 
 package org.jbpm.bpmn2.xml;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.drools.compiler.rule.builder.dialect.java.JavaDialect;
 import org.drools.core.xml.ExtensibleXmlParser;
+import org.jbpm.process.core.impl.DataTransformerRegistry;
 import org.jbpm.workflow.core.Node;
 import org.jbpm.workflow.core.impl.DroolsConsequenceAction;
 import org.jbpm.workflow.core.node.ActionNode;
+import org.jbpm.workflow.core.node.Assignment;
+import org.jbpm.workflow.core.node.DataAssociation;
+import org.jbpm.workflow.core.node.Transformation;
+import org.kie.api.runtime.process.DataTransformer;
 import org.w3c.dom.Element;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 
 public class ScriptTaskHandler extends AbstractNodeHandler {
+	
+	private DataTransformerRegistry transformerRegistry = DataTransformerRegistry.get();
     
     protected Node createNode(Attributes attrs) {
         ActionNode result = new ActionNode();
@@ -53,15 +67,33 @@ public class ScriptTaskHandler extends AbstractNodeHandler {
 			action.setDialect(JavaDialect.ID);
 		} else if (XmlBPMNProcessDumper.JAVASCRIPT_LANGUAGE.equals(language)) {
 		    action.setDialect("JavaScript");
+		} else if (XmlBPMNProcessDumper.FEEL_LANGUAGE.equals(language) || XmlBPMNProcessDumper.FEEL_LANGUAGE_SHORT.equals(language)) {
+		    action.setDialect("FEEL");
 		}
 		action.setConsequence("");
+	    
+        dataInputs.clear();
+        dataOutputs.clear();
+        
         org.w3c.dom.Node xmlNode = element.getFirstChild();
         while (xmlNode != null) {
-        	if (xmlNode instanceof Element && "script".equals(xmlNode.getNodeName())) {
+        	
+        	String nodeName = xmlNode.getNodeName();
+        	if (xmlNode instanceof Element && "script".equals(nodeName)) {
         		action.setConsequence(xmlNode.getTextContent());
-        	}
-        	xmlNode = xmlNode.getNextSibling();
+        	} else if ("ioSpecification".equals(nodeName)) {
+                readIoSpecification(xmlNode, dataInputs, dataOutputs, dataInputTypes, dataOutputTypes);
+            } else if ("dataInputAssociation".equals(nodeName)) {
+                readDataInputAssociation(xmlNode, actionNode, dataInputs);
+            } else if ("dataOutputAssociation".equals(nodeName)) {
+                readDataOutputAssociation(xmlNode, actionNode, dataOutputs);
+            }
+            xmlNode = xmlNode.getNextSibling();
         }
+    
+
+        actionNode.setMetaData("DataInputs", new HashMap<String, String>(dataInputs));
+        actionNode.setMetaData("DataOutputs", new HashMap<String, String>(dataOutputs));
         
         String compensation = element.getAttribute("isForCompensation");
         if( compensation != null ) {
@@ -75,5 +107,97 @@ public class ScriptTaskHandler extends AbstractNodeHandler {
 	public void writeNode(Node node, StringBuilder xmlDump, int metaDataType) {
 	    throw new IllegalArgumentException("Writing out should be handled by action node handler");
 	}
+	
+	protected void readDataInputAssociation(org.w3c.dom.Node xmlNode, ActionNode actionNode, Map<String, String> dataInputs) {
+        // sourceRef
+        org.w3c.dom.Node subNode = xmlNode.getFirstChild();
+        if ("sourceRef".equals(subNode.getNodeName())) {
+        	List<String> sources = new ArrayList<>();
+    		sources.add(subNode.getTextContent());
+    		
+    		subNode = subNode.getNextSibling();
+    		
+    		while ("sourceRef".equals(subNode.getNodeName())) {
+    			sources.add(subNode.getTextContent());
+    			subNode = subNode.getNextSibling();
+    		}
+            // targetRef
+            String target = subNode.getTextContent();
+            // transformation
+    		Transformation transformation = null;
+    		subNode = subNode.getNextSibling();
+    		if (subNode != null && "transformation".equals(subNode.getNodeName())) {
+    			String lang = subNode.getAttributes().getNamedItem("language").getNodeValue();
+    			String expression = subNode.getTextContent();
+    			
+    			DataTransformer transformer = transformerRegistry.find(lang);
+    			if (transformer == null) {
+    				throw new IllegalArgumentException("No transformer registered for language " + lang);
+    			}    			
+    			transformation = new Transformation(lang, expression);    			
+    			
+    			subNode = subNode.getNextSibling();
+    		}
+    		// assignments  
+            List<Assignment> assignments = new LinkedList<Assignment>();
+            while(subNode != null){
+            	String expressionLang = ((Element)subNode).getAttribute("expressionLanguage");
+            	if (expressionLang == null || expressionLang.trim().isEmpty()) {
+            		expressionLang = "XPath";
+            	}
+                org.w3c.dom.Node ssubNode = subNode.getFirstChild();
+                String from = ssubNode.getTextContent();
+                String to = ssubNode.getNextSibling().getTextContent();
+                assignments.add(new Assignment(expressionLang, from, to));
+                subNode = subNode.getNextSibling();
+            }
+            actionNode.addInAssociation(new DataAssociation(
+                    sources,
+                    dataInputs.get(target), assignments, transformation));
+        }
+    }
+    
+    protected void readDataOutputAssociation(org.w3c.dom.Node xmlNode, ActionNode actionNode, Map<String, String> dataOutputs) {
+        // sourceRef
+        org.w3c.dom.Node subNode = xmlNode.getFirstChild();
+        List<String> sources = new ArrayList<>();
+		sources.add(subNode.getTextContent());
+		
+		subNode = subNode.getNextSibling();
+		
+		while ("sourceRef".equals(subNode.getNodeName())) {
+			sources.add(subNode.getTextContent());
+			subNode = subNode.getNextSibling();
+		}
+        // targetRef
+        String target = subNode.getTextContent();
+        // transformation
+ 		Transformation transformation = null;
+ 		subNode = subNode.getNextSibling();
+ 		if (subNode != null && "transformation".equals(subNode.getNodeName())) {
+ 			String lang = subNode.getAttributes().getNamedItem("language").getNodeValue();
+ 			String expression = subNode.getTextContent();
+ 			DataTransformer transformer = transformerRegistry.find(lang);
+ 			if (transformer == null) {
+ 				throw new IllegalArgumentException("No transformer registered for language " + lang);
+ 			}    			
+ 			transformation = new Transformation(lang, expression); 		
+ 			subNode = subNode.getNextSibling();
+ 		}
+ 		// assignments 
+        List<Assignment> assignments = new LinkedList<Assignment>();
+        while(subNode != null){
+        	String expressionLang = ((Element)subNode).getAttribute("expressionLanguage");
+        	if (expressionLang == null || expressionLang.trim().isEmpty()) {
+        		expressionLang = "XPath";
+        	}
+            org.w3c.dom.Node ssubNode = subNode.getFirstChild();
+            String from = ssubNode.getTextContent();
+            String to = ssubNode.getNextSibling().getTextContent();
+            assignments.add(new Assignment(expressionLang, from, to));
+            subNode = subNode.getNextSibling();
+        }
+        actionNode.addOutAssociation(new DataAssociation(sources.stream().map(source -> dataOutputs.get(source)).collect(Collectors.toList()), target, assignments, transformation));
+    }
 
 }

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/ScriptTaskHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/ScriptTaskHandler.java
@@ -107,44 +107,44 @@ public class ScriptTaskHandler extends AbstractNodeHandler {
 	public void writeNode(Node node, StringBuilder xmlDump, int metaDataType) {
 	    throw new IllegalArgumentException("Writing out should be handled by action node handler");
 	}
-	
-	protected void readDataInputAssociation(org.w3c.dom.Node xmlNode, ActionNode actionNode, Map<String, String> dataInputs) {
+
+    protected void readDataInputAssociation(org.w3c.dom.Node xmlNode, ActionNode actionNode, Map<String, String> dataInputs) {
         // sourceRef
         org.w3c.dom.Node subNode = xmlNode.getFirstChild();
         if ("sourceRef".equals(subNode.getNodeName())) {
-        	List<String> sources = new ArrayList<>();
-    		sources.add(subNode.getTextContent());
-    		
-    		subNode = subNode.getNextSibling();
-    		
-    		while ("sourceRef".equals(subNode.getNodeName())) {
-    			sources.add(subNode.getTextContent());
-    			subNode = subNode.getNextSibling();
-    		}
+            List<String> sources = new ArrayList<>();
+            sources.add(subNode.getTextContent());
+
+            subNode = subNode.getNextSibling();
+
+            while ("sourceRef".equals(subNode.getNodeName())) {
+                sources.add(subNode.getTextContent());
+                subNode = subNode.getNextSibling();
+            }
             // targetRef
             String target = subNode.getTextContent();
             // transformation
-    		Transformation transformation = null;
-    		subNode = subNode.getNextSibling();
-    		if (subNode != null && "transformation".equals(subNode.getNodeName())) {
-    			String lang = subNode.getAttributes().getNamedItem("language").getNodeValue();
-    			String expression = subNode.getTextContent();
-    			
-    			DataTransformer transformer = transformerRegistry.find(lang);
-    			if (transformer == null) {
-    				throw new IllegalArgumentException("No transformer registered for language " + lang);
-    			}    			
-    			transformation = new Transformation(lang, expression);    			
-    			
-    			subNode = subNode.getNextSibling();
-    		}
-    		// assignments  
+            Transformation transformation = null;
+            subNode = subNode.getNextSibling();
+            if (subNode != null && "transformation".equals(subNode.getNodeName())) {
+                String lang = subNode.getAttributes().getNamedItem("language").getNodeValue();
+                String expression = subNode.getTextContent();
+
+                DataTransformer transformer = transformerRegistry.find(lang);
+                if (transformer == null) {
+                    throw new IllegalArgumentException("No transformer registered for language " + lang);
+                }
+                transformation = new Transformation(lang, expression);
+
+                subNode = subNode.getNextSibling();
+            }
+            // assignments  
             List<Assignment> assignments = new LinkedList<Assignment>();
-            while(subNode != null){
-            	String expressionLang = ((Element)subNode).getAttribute("expressionLanguage");
-            	if (expressionLang == null || expressionLang.trim().isEmpty()) {
-            		expressionLang = "XPath";
-            	}
+            while (subNode != null) {
+                String expressionLang = ((Element) subNode).getAttribute("expressionLanguage");
+                if (expressionLang == null || expressionLang.trim().isEmpty()) {
+                    expressionLang = "XPath";
+                }
                 org.w3c.dom.Node ssubNode = subNode.getFirstChild();
                 String from = ssubNode.getTextContent();
                 String to = ssubNode.getNextSibling().getTextContent();
@@ -152,45 +152,45 @@ public class ScriptTaskHandler extends AbstractNodeHandler {
                 subNode = subNode.getNextSibling();
             }
             actionNode.addInAssociation(new DataAssociation(
-                    sources,
-                    dataInputs.get(target), assignments, transformation));
+                                                            sources,
+                                                            dataInputs.get(target), assignments, transformation));
         }
     }
-    
+
     protected void readDataOutputAssociation(org.w3c.dom.Node xmlNode, ActionNode actionNode, Map<String, String> dataOutputs) {
         // sourceRef
         org.w3c.dom.Node subNode = xmlNode.getFirstChild();
         List<String> sources = new ArrayList<>();
-		sources.add(subNode.getTextContent());
-		
-		subNode = subNode.getNextSibling();
-		
-		while ("sourceRef".equals(subNode.getNodeName())) {
-			sources.add(subNode.getTextContent());
-			subNode = subNode.getNextSibling();
-		}
+        sources.add(subNode.getTextContent());
+
+        subNode = subNode.getNextSibling();
+
+        while ("sourceRef".equals(subNode.getNodeName())) {
+            sources.add(subNode.getTextContent());
+            subNode = subNode.getNextSibling();
+        }
         // targetRef
         String target = subNode.getTextContent();
         // transformation
- 		Transformation transformation = null;
- 		subNode = subNode.getNextSibling();
- 		if (subNode != null && "transformation".equals(subNode.getNodeName())) {
- 			String lang = subNode.getAttributes().getNamedItem("language").getNodeValue();
- 			String expression = subNode.getTextContent();
- 			DataTransformer transformer = transformerRegistry.find(lang);
- 			if (transformer == null) {
- 				throw new IllegalArgumentException("No transformer registered for language " + lang);
- 			}    			
- 			transformation = new Transformation(lang, expression); 		
- 			subNode = subNode.getNextSibling();
- 		}
- 		// assignments 
+        Transformation transformation = null;
+        subNode = subNode.getNextSibling();
+        if (subNode != null && "transformation".equals(subNode.getNodeName())) {
+            String lang = subNode.getAttributes().getNamedItem("language").getNodeValue();
+            String expression = subNode.getTextContent();
+            DataTransformer transformer = transformerRegistry.find(lang);
+            if (transformer == null) {
+                throw new IllegalArgumentException("No transformer registered for language " + lang);
+            }
+            transformation = new Transformation(lang, expression);
+            subNode = subNode.getNextSibling();
+        }
+        // assignments 
         List<Assignment> assignments = new LinkedList<Assignment>();
-        while(subNode != null){
-        	String expressionLang = ((Element)subNode).getAttribute("expressionLanguage");
-        	if (expressionLang == null || expressionLang.trim().isEmpty()) {
-        		expressionLang = "XPath";
-        	}
+        while (subNode != null) {
+            String expressionLang = ((Element) subNode).getAttribute("expressionLanguage");
+            if (expressionLang == null || expressionLang.trim().isEmpty()) {
+                expressionLang = "XPath";
+            }
             org.w3c.dom.Node ssubNode = subNode.getFirstChild();
             String from = ssubNode.getTextContent();
             String to = ssubNode.getNextSibling().getTextContent();

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/SequenceFlowHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/SequenceFlowHandler.java
@@ -137,7 +137,7 @@ public class SequenceFlowHandler extends BaseAbstractHandler implements Handler 
                         sequenceFlow.setLanguage("XPath");
                     } else if (XmlBPMNProcessDumper.JAVASCRIPT_LANGUAGE.equals(language)) {
                         sequenceFlow.setLanguage("JavaScript");
-                    } else if (XmlBPMNProcessDumper.FEEL_LANGUAGE.equals(language)) {
+                    } else if (XmlBPMNProcessDumper.FEEL_LANGUAGE.equals(language) || XmlBPMNProcessDumper.DMN_FEEL_LANGUAGE.equals(language)) {
                         sequenceFlow.setLanguage("FEEL");
                     } else {
                         throw new IllegalArgumentException("Unknown language " + language);

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/TaskHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/TaskHandler.java
@@ -185,7 +185,7 @@ public class TaskHandler extends AbstractNodeHandler {
             String target = subNode.getTextContent();
             // transformation
             Transformation transformation = null;
-    		subNode = subNode.getNextSibling();
+            subNode = subNode.getNextSibling();
     		if (subNode != null && "transformation".equals(subNode.getNodeName())) {
     			String lang = subNode.getAttributes().getNamedItem("language").getNodeValue();
     			String expression = subNode.getTextContent();
@@ -202,10 +202,10 @@ public class TaskHandler extends AbstractNodeHandler {
     		// assignments    	
     		List<Assignment> assignments = new LinkedList<Assignment>();
     		while(subNode != null){
-    			String expressionLang = ((Element)subNode).getAttribute("expressionLanguage");
-            	if (expressionLang == null || expressionLang.trim().isEmpty()) {
-            		expressionLang = "XPath";
-            	}
+                String expressionLang = ((Element) subNode).getAttribute("expressionLanguage");
+                if (expressionLang == null || expressionLang.trim().isEmpty()) {
+                    expressionLang = "XPath";
+                }
     			org.w3c.dom.Node ssubNode = subNode.getFirstChild();
     			String from = ssubNode.getTextContent();
     			String to = ssubNode.getNextSibling().getTextContent();
@@ -249,7 +249,7 @@ public class TaskHandler extends AbstractNodeHandler {
     }
     
     protected void readDataOutputAssociation(org.w3c.dom.Node xmlNode, WorkItemNode workItemNode, Map<String, String> dataOutputs) {
-		// sourceRef
+        // sourceRef
         org.w3c.dom.Node subNode = xmlNode.getFirstChild();
         List<String> sources = new ArrayList<>();
         sources.add(subNode.getTextContent());
@@ -279,10 +279,10 @@ public class TaskHandler extends AbstractNodeHandler {
 		// assignments  
 		List<Assignment> assignments = new LinkedList<Assignment>();
 		while(subNode != null){
-			String expressionLang = ((Element)subNode).getAttribute("expressionLanguage");
-        	if (expressionLang == null || expressionLang.trim().isEmpty()) {
-        		expressionLang = "XPath";
-        	}
+            String expressionLang = ((Element) subNode).getAttribute("expressionLanguage");
+            if (expressionLang == null || expressionLang.trim().isEmpty()) {
+                expressionLang = "XPath";
+            }
 			org.w3c.dom.Node ssubNode = subNode.getFirstChild();
 			String from = ssubNode.getTextContent();
 			String to = ssubNode.getNextSibling().getTextContent();

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/TaskHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/TaskHandler.java
@@ -16,12 +16,14 @@
 
 package org.jbpm.bpmn2.xml;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.stream.Collectors;
 
 import org.jbpm.process.core.ParameterDefinition;
 import org.jbpm.process.core.Work;
@@ -168,13 +170,21 @@ public class TaskHandler extends AbstractNodeHandler {
     protected void readDataInputAssociation(org.w3c.dom.Node xmlNode, WorkItemNode workItemNode, Map<String, String> dataInputs) {
 		// sourceRef
 		org.w3c.dom.Node subNode = xmlNode.getFirstChild();
-		if ("sourceRef".equals(subNode.getNodeName())) {
-    		String source = subNode.getTextContent();    		
-    		// targetRef
-    		subNode = subNode.getNextSibling();
-    		String target = subNode.getTextContent();
-    		// transformation
-    		Transformation transformation = null;
+		if ("sourceRef".equals(subNode.getNodeName())) {			    		
+            List<String> sources = new ArrayList<>();
+            sources.add(subNode.getTextContent());
+
+            subNode = subNode.getNextSibling();
+
+            while ("sourceRef".equals(subNode.getNodeName())) {
+                sources.add(subNode.getTextContent());
+                subNode = subNode.getNextSibling();
+            }
+
+            // targetRef    		
+            String target = subNode.getTextContent();
+            // transformation
+            Transformation transformation = null;
     		subNode = subNode.getNextSibling();
     		if (subNode != null && "transformation".equals(subNode.getNodeName())) {
     			String lang = subNode.getAttributes().getNamedItem("language").getNodeValue();
@@ -192,15 +202,19 @@ public class TaskHandler extends AbstractNodeHandler {
     		// assignments    	
     		List<Assignment> assignments = new LinkedList<Assignment>();
     		while(subNode != null){
+    			String expressionLang = ((Element)subNode).getAttribute("expressionLanguage");
+            	if (expressionLang == null || expressionLang.trim().isEmpty()) {
+            		expressionLang = "XPath";
+            	}
     			org.w3c.dom.Node ssubNode = subNode.getFirstChild();
     			String from = ssubNode.getTextContent();
     			String to = ssubNode.getNextSibling().getTextContent();
-    			assignments.add(new Assignment("XPath", from, to));
+    			assignments.add(new Assignment(expressionLang, from, to));
         		subNode = subNode.getNextSibling();
     		}
     		    		
     		workItemNode.addInAssociation(new DataAssociation(
-    				source,
+    				sources,
     				dataInputs.get(target), assignments, transformation));
 		} else {
 			// targetRef
@@ -236,13 +250,20 @@ public class TaskHandler extends AbstractNodeHandler {
     
     protected void readDataOutputAssociation(org.w3c.dom.Node xmlNode, WorkItemNode workItemNode, Map<String, String> dataOutputs) {
 		// sourceRef
-		org.w3c.dom.Node subNode = xmlNode.getFirstChild();
-		String source = subNode.getTextContent();
-		// targetRef
-		subNode = subNode.getNextSibling();
-		String target = subNode.getTextContent();
-		// transformation
-		Transformation transformation = null;
+        org.w3c.dom.Node subNode = xmlNode.getFirstChild();
+        List<String> sources = new ArrayList<>();
+        sources.add(subNode.getTextContent());
+
+        subNode = subNode.getNextSibling();
+
+        while ("sourceRef".equals(subNode.getNodeName())) {
+            sources.add(subNode.getTextContent());
+            subNode = subNode.getNextSibling();
+        }
+        // targetRef
+        String target = subNode.getTextContent();
+        // transformation
+        Transformation transformation = null;
 		subNode = subNode.getNextSibling();
 		if (subNode != null && "transformation".equals(subNode.getNodeName())) {
 			String lang = subNode.getAttributes().getNamedItem("language").getNodeValue();
@@ -251,20 +272,24 @@ public class TaskHandler extends AbstractNodeHandler {
 			if (transformer == null) {
 				throw new IllegalArgumentException("No transformer registered for language " + lang);
 			}    			
-			transformation = new Transformation(lang, expression, source);
+			transformation = new Transformation(lang, expression);
 //			transformation.setCompiledExpression(transformer.compile(expression));
 			subNode = subNode.getNextSibling();
 		}
 		// assignments  
 		List<Assignment> assignments = new LinkedList<Assignment>();
 		while(subNode != null){
+			String expressionLang = ((Element)subNode).getAttribute("expressionLanguage");
+        	if (expressionLang == null || expressionLang.trim().isEmpty()) {
+        		expressionLang = "XPath";
+        	}
 			org.w3c.dom.Node ssubNode = subNode.getFirstChild();
 			String from = ssubNode.getTextContent();
 			String to = ssubNode.getNextSibling().getTextContent();
-			assignments.add(new Assignment("XPath", from, to));
+			assignments.add(new Assignment(expressionLang, from, to));
     		subNode = subNode.getNextSibling();
 		}
-		workItemNode.addOutAssociation(new DataAssociation(dataOutputs.get(source), target, assignments, transformation));
+		workItemNode.addOutAssociation(new DataAssociation(sources.stream().map(source -> dataOutputs.get(source)).collect(Collectors.toList()), target, assignments, transformation));
     }
 
     @Override

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/XmlBPMNProcessDumper.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/XmlBPMNProcessDumper.java
@@ -80,6 +80,8 @@ public class XmlBPMNProcessDumper implements XmlProcessDumper {
     public static final String XPATH_LANGUAGE = "http://www.w3.org/1999/XPath";
     public static final String JAVASCRIPT_LANGUAGE = "http://www.javascript.com/javascript";
     public static final String FEEL_LANGUAGE = "http://www.omg.org/spec/FEEL/20140401";
+    public static final String DMN_FEEL_LANGUAGE = "http://www.omg.org/spec/DMN/20180521/FEEL/";
+    public static final String FEEL_LANGUAGE_SHORT = "application/feel";
 
     public static final int NO_META_DATA = 0;
     public static final int META_DATA_AS_NODE_PROPERTY = 1;

--- a/jbpm/jbpm-bpmn2/src/main/java/org/kie/kogito/process/bpmn2/BpmnProcess.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/kie/kogito/process/bpmn2/BpmnProcess.java
@@ -36,7 +36,6 @@ public class BpmnProcess extends AbstractProcess<BpmnVariables> {
         process = p;
     }
 
-
     public BpmnProcess(Process p, ProcessConfig config) {
         super(config);
         process = p;
@@ -61,7 +60,6 @@ public class BpmnProcess extends AbstractProcess<BpmnVariables> {
         return process;
     }
 
-
     @Override
     public BpmnVariables createModel() {
         return BpmnVariables.create(new HashMap<String, Object>());
@@ -71,7 +69,7 @@ public class BpmnProcess extends AbstractProcess<BpmnVariables> {
      *
      */
     public static void overrideCompiler(BpmnProcessCompiler compiler) {
-    	COMPILER = Objects.requireNonNull(compiler);
+        COMPILER = Objects.requireNonNull(compiler);
     }
 
     public static List<BpmnProcess> from(Resource... resource) {

--- a/jbpm/jbpm-bpmn2/src/main/java/org/kie/kogito/process/bpmn2/BpmnProcess.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/kie/kogito/process/bpmn2/BpmnProcess.java
@@ -17,13 +17,8 @@ package org.kie.kogito.process.bpmn2;
 
 import java.util.HashMap;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Objects;
 
-import org.drools.core.xml.SemanticModules;
-import org.jbpm.bpmn2.xml.BPMNDISemanticModule;
-import org.jbpm.bpmn2.xml.BPMNExtensionsSemanticModule;
-import org.jbpm.bpmn2.xml.BPMNSemanticModule;
-import org.jbpm.compiler.xml.XmlProcessReader;
 import org.kie.api.definition.process.Process;
 import org.kie.api.io.Resource;
 import org.kie.kogito.Model;
@@ -33,26 +28,20 @@ import org.kie.kogito.process.impl.AbstractProcess;
 
 public class BpmnProcess extends AbstractProcess<BpmnVariables> {
 
-    private static final SemanticModules BPMN_SEMANTIC_MODULES = new SemanticModules();
-
-    static {
-        BPMN_SEMANTIC_MODULES.addSemanticModule(new BPMNSemanticModule());
-        BPMN_SEMANTIC_MODULES.addSemanticModule(new BPMNExtensionsSemanticModule());
-        BPMN_SEMANTIC_MODULES.addSemanticModule(new BPMNDISemanticModule());
-    }
+    private static BpmnProcessCompiler COMPILER = new BpmnProcessCompiler();
 
     private final Process process;
 
     public BpmnProcess(Process p) {
         process = p;
     }
-    
-    
+
+
     public BpmnProcess(Process p, ProcessConfig config) {
         super(config);
         process = p;
     }
-    
+
     @Override
     public ProcessInstance<BpmnVariables> createInstance(Model m) {
         return new BpmnProcessInstance(this, BpmnVariables.create(m.toMap()), this.createLegacyProcessRuntime());
@@ -66,23 +55,6 @@ public class BpmnProcess extends AbstractProcess<BpmnVariables> {
     public ProcessInstance<BpmnVariables> createInstance(BpmnVariables variables) {
         return new BpmnProcessInstance(this, variables, this.createLegacyProcessRuntime());
     }
-    
-    public static List<BpmnProcess> from(Resource resource) {
-        return from(resource, null);
-    }
-
-    public static List<BpmnProcess> from(Resource resource, ProcessConfig config) {
-        try {
-            XmlProcessReader xmlReader = new XmlProcessReader(
-                    BPMN_SEMANTIC_MODULES,
-                    Thread.currentThread().getContextClassLoader());
-            List<Process> processes = xmlReader.read(resource.getReader());
-            return processes.stream().map(p -> (config == null ? new BpmnProcess(p) : new BpmnProcess(p, config))).collect(Collectors.toList());
-        } catch (Exception e) {
-            throw new BpmnProcessReaderException(e);
-        }
-    }
-    
 
     @Override
     public Process legacyProcess() {
@@ -91,7 +63,23 @@ public class BpmnProcess extends AbstractProcess<BpmnVariables> {
 
 
     @Override
-    public BpmnVariables createModel() {        
+    public BpmnVariables createModel() {
         return BpmnVariables.create(new HashMap<String, Object>());
     }
+
+    /**
+     *
+     */
+    public static void overrideCompiler(BpmnProcessCompiler compiler) {
+    	COMPILER = Objects.requireNonNull(compiler);
+    }
+
+    public static List<BpmnProcess> from(Resource... resource) {
+        return from(null, resource);
+    }
+
+    public static List<BpmnProcess> from(ProcessConfig config, Resource... resources) {
+        return COMPILER.from(config, resources);
+    }
+
 }

--- a/jbpm/jbpm-bpmn2/src/main/java/org/kie/kogito/process/bpmn2/BpmnProcessCompiler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/kie/kogito/process/bpmn2/BpmnProcessCompiler.java
@@ -1,0 +1,73 @@
+package org.kie.kogito.process.bpmn2;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.drools.core.xml.SemanticModule;
+import org.drools.core.xml.SemanticModules;
+import org.jbpm.bpmn2.xml.BPMNDISemanticModule;
+import org.jbpm.bpmn2.xml.BPMNExtensionsSemanticModule;
+import org.jbpm.bpmn2.xml.BPMNSemanticModule;
+import org.jbpm.compiler.xml.XmlProcessReader;
+import org.jbpm.workflow.core.WorkflowProcess;
+import org.kie.api.definition.process.Node;
+import org.kie.api.definition.process.Process;
+import org.kie.api.io.Resource;
+import org.kie.kogito.process.ProcessConfig;
+
+public class BpmnProcessCompiler {
+
+    private final SemanticModules bpmnSemanticModules;
+
+    public BpmnProcessCompiler(SemanticModule... modules) {
+        this.bpmnSemanticModules = new SemanticModules();
+
+        if (modules.length == 0) {
+            // add default
+            this.bpmnSemanticModules.addSemanticModule(new BPMNSemanticModule());
+            this.bpmnSemanticModules.addSemanticModule(new BPMNExtensionsSemanticModule());
+            this.bpmnSemanticModules.addSemanticModule(new BPMNDISemanticModule());
+        } else {
+            for (SemanticModule module : modules) {
+                this.bpmnSemanticModules.addSemanticModule(module);
+            }
+        }
+    }
+
+    protected SemanticModules getSemanticModules() {
+        return bpmnSemanticModules;
+    }
+
+    public List<BpmnProcess> from(ProcessConfig config, Resource... resources) {
+        try {
+            List<Process> processes = new ArrayList<>();
+            XmlProcessReader xmlReader = new XmlProcessReader(
+                                                              getSemanticModules(),
+                                                              Thread.currentThread().getContextClassLoader());
+
+            for (Resource resource : resources) {
+                processes.addAll(xmlReader.read(resource.getReader()));
+            }
+            List<BpmnProcess> bpmnProcesses = processes.stream()
+                                                       .map(p -> (config == null ? new BpmnProcess(p) : new BpmnProcess(p, config)))
+                                                       .collect(Collectors.toList());
+
+            bpmnProcesses.forEach(p -> {
+
+                for (Node node : ((WorkflowProcess) p.legacyProcess()).getNodesRecursively()) {
+
+                    processNode(node, bpmnProcesses);
+                }
+            });
+
+            return (List<BpmnProcess>) bpmnProcesses;
+        } catch (Exception e) {
+            throw new BpmnProcessReaderException(e);
+        }
+    }
+
+    protected void processNode(Node node, List<BpmnProcess> bpmnProcesses) {
+
+    }
+}

--- a/jbpm/jbpm-bpmn2/src/main/java/org/kie/kogito/process/bpmn2/BpmnProcessCompiler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/kie/kogito/process/bpmn2/BpmnProcessCompiler.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.kogito.process.bpmn2;
 
 import java.util.ArrayList;

--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/ActivityTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/ActivityTest.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.drools.compiler.rule.builder.PackageBuildContext;
 import org.jbpm.bpmn2.handler.ReceiveTaskHandler;
 import org.jbpm.bpmn2.handler.SendTaskHandler;
 import org.jbpm.bpmn2.handler.ServiceTaskHandler;
@@ -40,14 +41,26 @@ import org.jbpm.bpmn2.objects.HelloService;
 import org.jbpm.bpmn2.objects.Person;
 import org.jbpm.bpmn2.objects.TestWorkItemHandler;
 import org.jbpm.bpmn2.test.RequirePersistence;
+import org.jbpm.process.builder.ActionBuilder;
+import org.jbpm.process.builder.AssignmentBuilder;
+import org.jbpm.process.builder.ProcessBuildContext;
+import org.jbpm.process.builder.ProcessClassBuilder;
+import org.jbpm.process.builder.ReturnValueEvaluatorBuilder;
+import org.jbpm.process.builder.dialect.ProcessDialect;
+import org.jbpm.process.builder.dialect.ProcessDialectRegistry;
+import org.jbpm.process.core.ContextResolver;
 import org.jbpm.process.core.context.variable.VariableScope;
 import org.jbpm.process.core.impl.DataTransformerRegistry;
 import org.jbpm.process.instance.event.listeners.RuleAwareProcessEventListener;
 import org.jbpm.process.instance.event.listeners.TriggerRulesEventListener;
+import org.jbpm.process.instance.impl.AssignmentAction;
 import org.jbpm.process.instance.impl.demo.DoNothingWorkItemHandler;
 import org.jbpm.process.instance.impl.demo.SystemOutWorkItemHandler;
 import org.jbpm.test.util.NodeLeftCountDownProcessEventListener;
 import org.jbpm.workflow.core.node.ActionNode;
+import org.jbpm.workflow.core.node.Assignment;
+import org.jbpm.workflow.core.node.DataAssociation;
+import org.jbpm.workflow.core.node.WorkItemNode;
 import org.jbpm.workflow.instance.WorkflowRuntimeException;
 import org.jbpm.workflow.instance.impl.WorkflowProcessInstanceImpl;
 import org.jbpm.workflow.instance.node.DynamicNodeInstance;
@@ -75,6 +88,7 @@ import org.kie.api.runtime.Context;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.process.DataTransformer;
 import org.kie.api.runtime.process.NodeInstance;
+import org.kie.api.runtime.process.ProcessContext;
 import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.api.runtime.process.WorkItem;
 import org.kie.api.runtime.process.WorkItemManager;
@@ -1971,5 +1985,97 @@ public class ActivityTest extends JbpmBpmn2TestCase {
         
         Account account = (Account) processInstance.getVariables().get("account");
         assertNotNull(account.getPerson());
+    }
+    
+    @Test
+    public void testUserTaskWithAssignment() throws Exception {
+ProcessDialectRegistry.setDialect("custom", new ProcessDialect() {
+            
+            @Override
+            public ReturnValueEvaluatorBuilder getReturnValueEvaluatorBuilder() {
+                // TODO Auto-generated method stub
+                return null;
+            }
+            
+            @Override
+            public ProcessClassBuilder getProcessClassBuilder() {
+                return null;
+            }
+            
+            @Override
+            public AssignmentBuilder getAssignmentBuilder() {
+                return new AssignmentBuilder() {
+                    
+                    @Override
+                    public void build(PackageBuildContext context, Assignment assignment, String sourceExpr, String targetExpr, ContextResolver contextResolver, boolean isInput) {
+                        assignment.setMetaData("Action", new AssignmentAction() {
+                            
+                            @Override
+                            public void execute(org.drools.core.process.instance.WorkItem workItem, ProcessContext context) throws Exception {
+                                assertEquals("from_expression", assignment.getFrom());
+                                assertEquals("to_expression", assignment.getTo());
+                            }
+                        });
+                        
+                    }
+                };
+            }
+            
+            @Override
+            public ActionBuilder getActionBuilder() {
+                return null;
+            }
+            
+            @Override
+            public void addProcess(ProcessBuildContext context) {
+                
+            }
+        });
+        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-DataOutputAssignmentCustomExpressionLang.bpmn2");
+        
+        Process scriptProcess = kbase.getProcess("process");
+        assertThat(scriptProcess).isNotNull();
+        Node[] nodes = ((NodeContainer)scriptProcess).getNodes();
+        assertThat(nodes).hasSize(3);
+        assertThat(nodes).filteredOn(n -> n instanceof WorkItemNode).allMatch(n -> matchExpectedAssociationSetup(n));
+        ksession = createKnowledgeSession(kbase);
+        TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
+        ksession.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
+
+        Map<String, Object> params = new HashMap<>();                
+        params.put("name", "John");
+        ProcessInstance processInstance = ksession.startProcess("process", params);
+        
+        ksession.abortProcessInstance(processInstance.getId());
+        
+        assertProcessInstanceAborted(processInstance);
+    }
+    
+    protected boolean matchExpectedAssociationSetup(Node node) {
+        List<DataAssociation> inputs = ((WorkItemNode) node).getInAssociations();
+        List<DataAssociation> outputs = ((WorkItemNode) node).getOutAssociations();
+        
+        assertThat(inputs).hasSize(1);
+        assertThat(outputs).hasSize(1);
+        
+        DataAssociation association = inputs.get(0);        
+        assertThat(association.getAssignments()).hasSize(1);
+        assertThat(association.getSources()).hasSize(2);
+        
+        Assignment assignment = association.getAssignments().get(0);
+        assertThat(assignment.getDialect()).isEqualTo("custom");
+        assertThat(assignment.getFrom()).isEqualTo("from_expression");
+        assertThat(assignment.getTo()).isEqualTo("to_expression");
+        
+        association = outputs.get(0);        
+        assertThat(association.getAssignments()).hasSize(1);
+        assertThat(association.getSources()).hasSize(2);
+        
+        assignment = association.getAssignments().get(0);
+        assertThat(assignment.getDialect()).isEqualTo("custom");
+        assertThat(assignment.getFrom()).isEqualTo("from_expression");
+        assertThat(assignment.getTo()).isEqualTo("to_expression");
+        
+        return true;
     }
 }

--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/ActivityTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/ActivityTest.java
@@ -988,6 +988,29 @@ public class ActivityTest extends JbpmBpmn2TestCase {
         assertProcessInstanceFinished(processInstance, ksession);
         assertEquals("Hello john!", processInstance.getVariable("s"));
     }
+    
+    @Test
+    public void testServiceTaskWithAccessoWorkItemInfo() throws Exception {
+        KieBase kbase = createKnowledgeBase("BPMN2-ServiceProcess.bpmn2");
+        ksession = createKnowledgeSession(kbase);
+        ksession.getWorkItemManager().registerWorkItemHandler("Service Task",
+                new ServiceTaskHandler() {
+
+                    @Override
+                    public void executeWorkItem(WorkItem workItem, WorkItemManager manager) {
+                        assertThat(workItem.getProcessInstance()).isNotNull();
+                        assertThat(workItem.getNodeInstance()).isNotNull();
+                        super.executeWorkItem(workItem, manager);
+                    }
+            
+        });
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("s", "john");
+        WorkflowProcessInstance processInstance = (WorkflowProcessInstance) ksession
+                .startProcess("ServiceProcess", params);
+        assertProcessInstanceFinished(processInstance, ksession);
+        assertEquals("Hello john!", processInstance.getVariable("s"));
+    }
 
     @Test
     @Disabled("Transfomer has been disabled")

--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/ErrorEventTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/ErrorEventTest.java
@@ -404,7 +404,7 @@ public class ErrorEventTest extends JbpmBpmn2TestCase {
 		ProcessInstance processInstance = ksession .startProcess("com.sample.bpmn.hello");
 		assertEquals(ProcessInstance.STATE_ERROR, processInstance.getState());
     }
-    
+
     @Test
     public void testBoundaryErrorEventDefaultHandlerWithWorkItemExecutionError() throws Exception {
         KieBase kbase = createKnowledgeBase("BPMN2-BoundaryErrorEventDefaultHandlerByErrorCode.bpmn2");
@@ -412,8 +412,7 @@ public class ErrorEventTest extends JbpmBpmn2TestCase {
         WorkItemExecutionErrorWorkItemHandler handler = new WorkItemExecutionErrorWorkItemHandler();
         ksession.getWorkItemManager().registerWorkItemHandler("Human Task", handler);
 
-        
-        ProcessInstance processInstance = ksession .startProcess("com.sample.bpmn.hello");
+        ProcessInstance processInstance = ksession.startProcess("com.sample.bpmn.hello");
         assertEquals(ProcessInstance.STATE_COMPLETED, processInstance.getState());
     }
 
@@ -493,7 +492,7 @@ public class ErrorEventTest extends JbpmBpmn2TestCase {
 		}
 
     }
-    
+
     class WorkItemExecutionErrorWorkItemHandler implements WorkItemHandler {
 
         @Override
@@ -502,8 +501,7 @@ public class ErrorEventTest extends JbpmBpmn2TestCase {
         }
 
         @Override
-        public void abortWorkItem(WorkItem workItem, WorkItemManager manager) {
-        }
+        public void abortWorkItem(WorkItem workItem, WorkItemManager manager) {}
 
     }
 }

--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/ErrorEventTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/ErrorEventTest.java
@@ -44,6 +44,7 @@ import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.api.runtime.process.WorkItem;
 import org.kie.api.runtime.process.WorkItemHandler;
 import org.kie.api.runtime.process.WorkItemManager;
+import org.kie.kogito.process.workitem.WorkItemExecutionError;
 
 public class ErrorEventTest extends JbpmBpmn2TestCase {
 
@@ -403,6 +404,18 @@ public class ErrorEventTest extends JbpmBpmn2TestCase {
 		ProcessInstance processInstance = ksession .startProcess("com.sample.bpmn.hello");
 		assertEquals(ProcessInstance.STATE_ERROR, processInstance.getState());
     }
+    
+    @Test
+    public void testBoundaryErrorEventDefaultHandlerWithWorkItemExecutionError() throws Exception {
+        KieBase kbase = createKnowledgeBase("BPMN2-BoundaryErrorEventDefaultHandlerByErrorCode.bpmn2");
+        ksession = createKnowledgeSession(kbase);
+        WorkItemExecutionErrorWorkItemHandler handler = new WorkItemExecutionErrorWorkItemHandler();
+        ksession.getWorkItemManager().registerWorkItemHandler("Human Task", handler);
+
+        
+        ProcessInstance processInstance = ksession .startProcess("com.sample.bpmn.hello");
+        assertEquals(ProcessInstance.STATE_COMPLETED, processInstance.getState());
+    }
 
     @Test
     public void testBoundaryErrorEventDefaultHandlerWithErrorCodeWithoutStructureRef() throws Exception {
@@ -478,6 +491,19 @@ public class ErrorEventTest extends JbpmBpmn2TestCase {
 		@Override
 		public void abortWorkItem(WorkItem workItem, WorkItemManager manager) {
 		}
+
+    }
+    
+    class WorkItemExecutionErrorWorkItemHandler implements WorkItemHandler {
+
+        @Override
+        public void executeWorkItem(WorkItem workItem, WorkItemManager manager) {
+            throw new WorkItemExecutionError("500");
+        }
+
+        @Override
+        public void abortWorkItem(WorkItem workItem, WorkItemManager manager) {
+        }
 
     }
 }

--- a/jbpm/jbpm-bpmn2/src/test/resources/BPMN2-BoundaryErrorEventDefaultHandlerByErrorCode.bpmn2
+++ b/jbpm/jbpm-bpmn2/src/test/resources/BPMN2-BoundaryErrorEventDefaultHandlerByErrorCode.bpmn2
@@ -1,0 +1,268 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- origin at X=0.0 Y=0.0 -->
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:g="http://www.jboss.org/drools/flow/gpd" xmlns:java="http://www.java.com/javaTypes" xmlns:tns="http://www.jboss.org/drools" xmlns="http://www.jboss.org/drools" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" id="Definition" exporter="org.eclipse.bpmn2.modeler.core" exporterVersion="1.5.1.Final-v20190425-2005-B1" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.jboss.org/drools" typeLanguage="http://www.java.com/javaTypes">
+  <bpmn2:itemDefinition id="_applicationIdItem" isCollection="false" structureRef="String"/>
+  <bpmn2:itemDefinition id="_ItemDefinition_3" isCollection="false" structureRef="java.lang.String"/>
+  <bpmn2:itemDefinition id="ItemDefinition_1" isCollection="false" structureRef="Integer"/>
+  <bpmn2:itemDefinition id="ItemDefinition_2" isCollection="false" structureRef="Boolean"/>
+  <bpmn2:itemDefinition id="ItemDefinition_3" isCollection="false" structureRef="java.lang.Exception"/>
+  <bpmn2:error id="Error_1" errorCode="500" name="Error_1"/>
+  <bpmn2:process id="com.sample.bpmn.hello" tns:version="1" tns:packageName="defaultPackage" tns:adHoc="false" name="Hello World" isExecutable="true" processType="Private">
+    <bpmn2:extensionElements>
+      <tns:import name="java.lang.IllegalArgumentException"/>
+    </bpmn2:extensionElements>
+    <bpmn2:property id="var1" name="var1"/>
+    <bpmn2:startEvent id="_1" name="Start">
+      <bpmn2:extensionElements>
+        <tns:metaData name="elementname">
+          <tns:metaValue><![CDATA[Start]]></tns:metaValue>
+        </tns:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:outgoing>SequenceFlow_3</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:subProcess id="SubProcess_1" name="Sub Process 1">
+      <bpmn2:extensionElements>
+        <tns:metaData name="elementname">
+          <tns:metaValue><![CDATA[Sub Process 1]]></tns:metaValue>
+        </tns:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>SequenceFlow_3</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_4</bpmn2:outgoing>
+      <bpmn2:userTask id="UserTask_1" name="User Task">
+        <bpmn2:extensionElements>
+          <tns:metaData name="elementname">
+            <tns:metaValue><![CDATA[User Task]]></tns:metaValue>
+          </tns:metaData>
+        </bpmn2:extensionElements>
+        <bpmn2:incoming>SequenceFlow_5</bpmn2:incoming>
+        <bpmn2:outgoing>SequenceFlow_6</bpmn2:outgoing>
+        <bpmn2:ioSpecification id="_InputOutputSpecification_3">
+          <bpmn2:dataInput id="_DataInput_9" itemSubjectRef="_applicationIdItem" name="TaskName"/>
+          <bpmn2:dataInput id="_DataInput_10" itemSubjectRef="ItemDefinition_1" name="Priority"/>
+          <bpmn2:dataInput id="_DataInput_11" itemSubjectRef="_applicationIdItem" name="Comment"/>
+          <bpmn2:dataInput id="_DataInput_12" itemSubjectRef="_applicationIdItem" name="GroupId"/>
+          <bpmn2:dataInput id="_DataInput_13" itemSubjectRef="ItemDefinition_2" name="Skippable"/>
+          <bpmn2:dataInput id="_DataInput_14" itemSubjectRef="_applicationIdItem" name="Content"/>
+          <bpmn2:dataInput id="_DataInput_15" itemSubjectRef="_applicationIdItem" name="Locale"/>
+          <bpmn2:inputSet id="_InputSet_4"/>
+          <bpmn2:inputSet id="_InputSet_5" name="New Input Set">
+            <bpmn2:dataInputRefs>_DataInput_9</bpmn2:dataInputRefs>
+            <bpmn2:dataInputRefs>_DataInput_10</bpmn2:dataInputRefs>
+            <bpmn2:dataInputRefs>_DataInput_11</bpmn2:dataInputRefs>
+            <bpmn2:dataInputRefs>_DataInput_12</bpmn2:dataInputRefs>
+            <bpmn2:dataInputRefs>_DataInput_13</bpmn2:dataInputRefs>
+            <bpmn2:dataInputRefs>_DataInput_14</bpmn2:dataInputRefs>
+            <bpmn2:dataInputRefs>_DataInput_15</bpmn2:dataInputRefs>
+          </bpmn2:inputSet>
+          <bpmn2:outputSet id="_OutputSet_4"/>
+          <bpmn2:outputSet id="_OutputSet_5" name="Output Set"/>
+        </bpmn2:ioSpecification>
+        <bpmn2:dataInputAssociation id="_DataInputAssociation_9">
+          <bpmn2:targetRef>_DataInput_9</bpmn2:targetRef>
+        </bpmn2:dataInputAssociation>
+        <bpmn2:dataInputAssociation id="_DataInputAssociation_10">
+          <bpmn2:targetRef>_DataInput_10</bpmn2:targetRef>
+        </bpmn2:dataInputAssociation>
+        <bpmn2:dataInputAssociation id="_DataInputAssociation_11">
+          <bpmn2:targetRef>_DataInput_11</bpmn2:targetRef>
+        </bpmn2:dataInputAssociation>
+        <bpmn2:dataInputAssociation id="_DataInputAssociation_12">
+          <bpmn2:targetRef>_DataInput_12</bpmn2:targetRef>
+        </bpmn2:dataInputAssociation>
+        <bpmn2:dataInputAssociation id="_DataInputAssociation_13">
+          <bpmn2:targetRef>_DataInput_13</bpmn2:targetRef>
+        </bpmn2:dataInputAssociation>
+        <bpmn2:dataInputAssociation id="_DataInputAssociation_14">
+          <bpmn2:targetRef>_DataInput_14</bpmn2:targetRef>
+        </bpmn2:dataInputAssociation>
+        <bpmn2:dataInputAssociation id="_DataInputAssociation_15">
+          <bpmn2:targetRef>_DataInput_15</bpmn2:targetRef>
+        </bpmn2:dataInputAssociation>
+      </bpmn2:userTask>
+      <bpmn2:startEvent id="StartEvent_1" name="">
+        <bpmn2:extensionElements>
+          <tns:metaData name="elementname">
+            <tns:metaValue><![CDATA[]]></tns:metaValue>
+          </tns:metaData>
+        </bpmn2:extensionElements>
+        <bpmn2:outgoing>SequenceFlow_5</bpmn2:outgoing>
+      </bpmn2:startEvent>
+      <bpmn2:sequenceFlow id="SequenceFlow_5" tns:priority="1" name="" sourceRef="StartEvent_1" targetRef="UserTask_1"/>
+      <bpmn2:endEvent id="EndEvent_1" name="">
+        <bpmn2:extensionElements>
+          <tns:metaData name="elementname">
+            <tns:metaValue><![CDATA[]]></tns:metaValue>
+          </tns:metaData>
+        </bpmn2:extensionElements>
+        <bpmn2:incoming>SequenceFlow_6</bpmn2:incoming>
+      </bpmn2:endEvent>
+      <bpmn2:sequenceFlow id="SequenceFlow_6" tns:priority="1" name="" sourceRef="UserTask_1" targetRef="EndEvent_1"/>
+    </bpmn2:subProcess>
+    <bpmn2:sequenceFlow id="SequenceFlow_3" tns:priority="1" name="" sourceRef="_1" targetRef="SubProcess_1"/>
+    <bpmn2:sequenceFlow id="SequenceFlow_4" tns:priority="1" name="" sourceRef="SubProcess_1" targetRef="ScriptTask_2"/>
+    <bpmn2:boundaryEvent id="BoundaryEvent_1" name="MyBoundaryErrorEvent" attachedToRef="SubProcess_1">
+      <bpmn2:extensionElements>
+        <tns:metaData name="elementname">
+          <tns:metaValue><![CDATA[MyBoundaryErrorEvent]]></tns:metaValue>
+        </tns:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:outgoing>SequenceFlow_7</bpmn2:outgoing>
+      <bpmn2:dataOutput id="DataOutput_1" name="Error_2_Output"/>
+      <bpmn2:dataOutputAssociation id="DataOutputAssociation_1">
+        <bpmn2:sourceRef>DataOutput_1</bpmn2:sourceRef>
+        <bpmn2:targetRef>var1</bpmn2:targetRef>
+      </bpmn2:dataOutputAssociation>
+      <bpmn2:outputSet id="OutputSet_1" name="Output Set 1">
+        <bpmn2:dataOutputRefs>DataOutput_1</bpmn2:dataOutputRefs>
+      </bpmn2:outputSet>
+      <bpmn2:errorEventDefinition id="ErrorEventDefinition_2" errorRef="Error_1"/>
+    </bpmn2:boundaryEvent>
+    <bpmn2:scriptTask id="ScriptTask_1" name="Script Task 1" scriptFormat="http://www.java.com/java">
+      <bpmn2:extensionElements>
+        <tns:metaData name="elementname">
+          <tns:metaValue><![CDATA[Script Task 1]]></tns:metaValue>
+        </tns:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>SequenceFlow_7</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_8</bpmn2:outgoing>
+      <bpmn2:script>System.out.println(&quot;Error is handled : var1 = &quot; + var1);</bpmn2:script>
+    </bpmn2:scriptTask>
+    <bpmn2:sequenceFlow id="SequenceFlow_7" tns:priority="1" name="" sourceRef="BoundaryEvent_1" targetRef="ScriptTask_1"/>
+    <bpmn2:endEvent id="EndEvent_3" name="">
+      <bpmn2:extensionElements>
+        <tns:metaData name="elementname">
+          <tns:metaValue><![CDATA[]]></tns:metaValue>
+        </tns:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>SequenceFlow_8</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="SequenceFlow_8" tns:priority="1" name="" sourceRef="ScriptTask_1" targetRef="EndEvent_3"/>
+    <bpmn2:scriptTask id="ScriptTask_2" name="Script Task 2" scriptFormat="http://www.java.com/java">
+      <bpmn2:extensionElements>
+        <tns:metaData name="elementname">
+          <tns:metaValue><![CDATA[Script Task 2]]></tns:metaValue>
+        </tns:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>SequenceFlow_4</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_9</bpmn2:outgoing>
+      <bpmn2:script>System.out.println(&quot;Process is finishing&quot;);</bpmn2:script>
+    </bpmn2:scriptTask>
+    <bpmn2:endEvent id="_3" name="End">
+      <bpmn2:extensionElements>
+        <tns:metaData name="elementname">
+          <tns:metaValue><![CDATA[End]]></tns:metaValue>
+        </tns:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>SequenceFlow_9</bpmn2:incoming>
+      <bpmn2:terminateEventDefinition id="TerminateEventDefinition_1"/>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="SequenceFlow_9" tns:priority="1" name="" sourceRef="ScriptTask_2" targetRef="_3"/>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_Process_1" bpmnElement="com.sample.bpmn.hello">
+      <bpmndi:BPMNShape id="BPMNShape_SubProcess_1" bpmnElement="SubProcess_1" isExpanded="true">
+        <dc:Bounds height="300.0" width="431.0" x="200.0" y="0.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_1">
+          <dc:Bounds height="11.0" width="59.0" x="206.0" y="3.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_StartEvent_1" bpmnElement="_1">
+        <dc:Bounds height="48.0" width="48.0" x="16.0" y="16.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_2" labelStyle="#//@definitions/@diagrams.0/@labelStyle.0">
+          <dc:Bounds height="14.0" width="25.0" x="27.0" y="64.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_EndEvent_1" bpmnElement="_3">
+        <dc:Bounds height="48.0" width="48.0" x="940.0" y="126.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_3" labelStyle="#//@definitions/@diagrams.0/@labelStyle.0">
+          <dc:Bounds height="14.0" width="22.0" x="953.0" y="174.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_UserTask_1" bpmnElement="UserTask_1">
+        <dc:Bounds height="50.0" width="110.0" x="361.0" y="140.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_4" labelStyle="#//@definitions/@diagrams.0/@labelStyle.0">
+          <dc:Bounds height="11.0" width="40.0" x="396.0" y="159.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds height="36.0" width="36.0" x="252.0" y="112.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_5" labelStyle="#//@definitions/@diagrams.0/@labelStyle.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_EndEvent_2" bpmnElement="EndEvent_1">
+        <dc:Bounds height="36.0" width="36.0" x="522.0" y="132.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_6" labelStyle="#//@definitions/@diagrams.0/@labelStyle.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_BoundaryEvent_1" bpmnElement="BoundaryEvent_1">
+        <dc:Bounds height="36.0" width="36.0" x="292.0" y="282.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_7">
+          <dc:Bounds height="28.0" width="123.0" x="249.0" y="318.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_ScriptTask_1" bpmnElement="ScriptTask_1">
+        <dc:Bounds height="50.0" width="110.0" x="425.0" y="335.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_8" labelStyle="#//@definitions/@diagrams.0/@labelStyle.0">
+          <dc:Bounds height="14.0" width="70.0" x="445.0" y="353.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_EndEvent_4" bpmnElement="EndEvent_3">
+        <dc:Bounds height="36.0" width="36.0" x="603.0" y="342.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_9" labelStyle="#//@definitions/@diagrams.0/@labelStyle.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_ScriptTask_2" bpmnElement="ScriptTask_2">
+        <dc:Bounds height="50.0" width="110.0" x="767.0" y="125.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_10" labelStyle="#//@definitions/@diagrams.0/@labelStyle.0">
+          <dc:Bounds height="14.0" width="70.0" x="787.0" y="143.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_1" bpmnElement="SequenceFlow_3" sourceElement="BPMNShape_StartEvent_1" targetElement="BPMNShape_SubProcess_1">
+        <di:waypoint xsi:type="dc:Point" x="40.0" y="64.0"/>
+        <di:waypoint xsi:type="dc:Point" x="40.0" y="150.0"/>
+        <di:waypoint xsi:type="dc:Point" x="200.0" y="150.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_11"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_2" bpmnElement="SequenceFlow_4" sourceElement="BPMNShape_SubProcess_1" targetElement="BPMNShape_ScriptTask_2">
+        <di:waypoint xsi:type="dc:Point" x="631.0" y="150.0"/>
+        <di:waypoint xsi:type="dc:Point" x="741.0" y="150.0"/>
+        <di:waypoint xsi:type="dc:Point" x="741.0" y="150.0"/>
+        <di:waypoint xsi:type="dc:Point" x="767.0" y="150.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_12"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_3" bpmnElement="SequenceFlow_5" sourceElement="BPMNShape_StartEvent_2" targetElement="BPMNShape_UserTask_1">
+        <di:waypoint xsi:type="dc:Point" x="270.0" y="148.0"/>
+        <di:waypoint xsi:type="dc:Point" x="270.0" y="165.0"/>
+        <di:waypoint xsi:type="dc:Point" x="361.0" y="165.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_13"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_6" bpmnElement="SequenceFlow_6" sourceElement="BPMNShape_UserTask_1" targetElement="BPMNShape_EndEvent_2">
+        <di:waypoint xsi:type="dc:Point" x="471.0" y="165.0"/>
+        <di:waypoint xsi:type="dc:Point" x="510.0" y="165.0"/>
+        <di:waypoint xsi:type="dc:Point" x="510.0" y="150.0"/>
+        <di:waypoint xsi:type="dc:Point" x="522.0" y="150.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_14"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_7" bpmnElement="SequenceFlow_7" sourceElement="BPMNShape_BoundaryEvent_1" targetElement="BPMNShape_ScriptTask_1">
+        <di:waypoint xsi:type="dc:Point" x="310.0" y="318.0"/>
+        <di:waypoint xsi:type="dc:Point" x="310.0" y="360.0"/>
+        <di:waypoint xsi:type="dc:Point" x="425.0" y="360.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_15"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_8" bpmnElement="SequenceFlow_8" sourceElement="BPMNShape_ScriptTask_1" targetElement="BPMNShape_EndEvent_4">
+        <di:waypoint xsi:type="dc:Point" x="535.0" y="360.0"/>
+        <di:waypoint xsi:type="dc:Point" x="583.0" y="360.0"/>
+        <di:waypoint xsi:type="dc:Point" x="583.0" y="360.0"/>
+        <di:waypoint xsi:type="dc:Point" x="603.0" y="360.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_16"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_9" bpmnElement="SequenceFlow_9" sourceElement="BPMNShape_ScriptTask_2" targetElement="BPMNShape_EndEvent_1">
+        <di:waypoint xsi:type="dc:Point" x="877.0" y="150.0"/>
+        <di:waypoint xsi:type="dc:Point" x="926.0" y="150.0"/>
+        <di:waypoint xsi:type="dc:Point" x="926.0" y="150.0"/>
+        <di:waypoint xsi:type="dc:Point" x="940.0" y="150.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_17"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+    <bpmndi:BPMNLabelStyle>
+      <dc:Font name="arial" size="9.0"/>
+    </bpmndi:BPMNLabelStyle>
+  </bpmndi:BPMNDiagram>
+</bpmn2:definitions>

--- a/jbpm/jbpm-bpmn2/src/test/resources/BPMN2-DataOutputAssignmentCustomExpressionLang.bpmn2
+++ b/jbpm/jbpm-bpmn2/src/test/resources/BPMN2-DataOutputAssignmentCustomExpressionLang.bpmn2
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<definitions id="Definition"
+             targetNamespace=""
+             typeLanguage="http://www.java.com/javaTypes"
+             expressionLanguage="http://www.mvel.org/2.0"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd"
+             xmlns:g="http://www.jboss.org/drools/flow/gpd"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+             xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+             xmlns:tns="http://www.jboss.org/drools">
+
+  <itemDefinition id="_stringItem" structureRef="String" />
+
+  <process processType="Private" isExecutable="true" id="process" name="process" >
+  
+    <!-- process variables -->
+    <property id="name" itemSubjectRef="_stringItem"/>
+    <property id="address" itemSubjectRef="_stringItem"/>
+
+    <!-- nodes -->
+    <startEvent id="_1" name="" />
+    <userTask id="_2" name="Task">
+      <ioSpecification>
+        <dataInput id='input' name='input'/>
+        <dataOutput id='output' name='output'/>
+        <inputSet>
+          <dataInputRefs>input</dataInputRefs>
+        </inputSet>
+        <outputSet>
+          <dataOutputRefs>output</dataOutputRefs>
+        </outputSet>
+      </ioSpecification>
+      <dataInputAssociation>
+        <sourceRef>name</sourceRef>
+        <sourceRef>name</sourceRef>
+        <targetRef>input</targetRef>
+        <assignment expressionLanguage="custom">
+          <from>from_expression</from>
+          <to>to_expression</to>
+        </assignment>
+      </dataInputAssociation>
+      <dataOutputAssociation>
+        <sourceRef>output</sourceRef>
+        <sourceRef>output</sourceRef>
+        <targetRef>name</targetRef>
+        <assignment expressionLanguage="custom">
+          <from>from_expression</from>
+          <to>to_expression</to>
+        </assignment>
+      </dataOutputAssociation>
+    </userTask>
+    <endEvent id="_3" name="" />
+
+    <!-- connections -->
+    <sequenceFlow id="_1-_2" sourceRef="_1" targetRef="_2" />
+    <sequenceFlow id="_2-_3" sourceRef="_2" targetRef="_3" />
+
+  </process>
+
+</definitions>

--- a/jbpm/jbpm-bpmn2/src/test/resources/BPMN2-ScriptTaskWithIO.bpmn2
+++ b/jbpm/jbpm-bpmn2/src/test/resources/BPMN2-ScriptTaskWithIO.bpmn2
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<definitions id="Definition"
+             targetNamespace="http://www.example.org/MinimalExample"
+             typeLanguage="http://www.java.com/javaTypes"
+             expressionLanguage="http://www.mvel.org/2.0"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+             xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+             xmlns:tns="http://www.jboss.org/drools">
+
+  <itemDefinition id="_sItem" structureRef="String" />
+  <process processType="Private" isExecutable="true" id="ScriptTask" name="ScriptTask Process" tns:packageName="com.sample" >
+
+    <property id="_name" name="name" itemSubjectRef="_sItem"/>
+    <!-- nodes -->
+    <startEvent id="_1" name="StartProcess" />
+    <scriptTask id="_2" name="Hello" scriptFormat="http://www.java.com/java" >
+     <ioSpecification>
+        <dataInput id="_067D221E-E8BD-4AD5-9A90-FB204A0E89F9_UrlInputX" name="Name"/>
+        <dataOutput id="_067D221E-E8BD-4AD5-9A90-FB204A0E89F9_UrlInputY" name="Result"/>
+        <inputSet>
+         <dataInputRefs>_067D221E-E8BD-4AD5-9A90-FB204A0E89F9_UrlInputX</dataInputRefs>
+        </inputSet>
+        <outputSet>
+          <dataOutputRefs>_067D221E-E8BD-4AD5-9A90-FB204A0E89F9_UrlInputY</dataOutputRefs>
+        </outputSet>
+      </ioSpecification>
+      <dataInputAssociation id="_mZWjtlOZEeSBDLLXGrwEZw">
+        <sourceRef>_name</sourceRef>
+        <targetRef>_067D221E-E8BD-4AD5-9A90-FB204A0E89F9_UrlInputX</targetRef>
+      </dataInputAssociation>
+      <dataOutputAssociation id="_mZWjtlOZEeSBDLLXGrwEZw">
+        <sourceRef>_067D221E-E8BD-4AD5-9A90-FB204A0E89F9_UrlInputY</sourceRef>
+        <targetRef>_name</targetRef>
+      </dataOutputAssociation>
+      <script>System.out.println("Hello World " + name);</script>
+    </scriptTask>
+    <endEvent id="_3" name="EndProcess" >
+        <terminateEventDefinition/>
+    </endEvent>
+
+    <!-- connections -->
+    <sequenceFlow id="_1-_2" sourceRef="_1" targetRef="_2" />
+    <sequenceFlow id="_2-_3" sourceRef="_2" targetRef="_3" />
+
+  </process>
+
+  <bpmndi:BPMNDiagram>
+    <bpmndi:BPMNPlane bpmnElement="ScriptTask" >
+      <bpmndi:BPMNShape bpmnElement="_1" >
+        <dc:Bounds x="16" y="16" width="48" height="48" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_2" >
+        <dc:Bounds x="96" y="16" width="80" height="48" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_3" >
+        <dc:Bounds x="208" y="16" width="48" height="48" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="_1-_2" >
+        <di:waypoint x="40" y="40" />
+        <di:waypoint x="136" y="40" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="_2-_3" >
+        <di:waypoint x="136" y="40" />
+        <di:waypoint x="232" y="40" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+
+</definitions>

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/AbstractVisitor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/AbstractVisitor.java
@@ -26,7 +26,6 @@ import org.jbpm.process.core.Work;
 import org.jbpm.process.core.context.variable.Mappable;
 import org.jbpm.process.core.context.variable.Variable;
 import org.jbpm.process.core.context.variable.VariableScope;
-import org.jbpm.workflow.core.node.WorkItemNode;
 import org.kie.api.definition.process.Node;
 
 import com.github.javaparser.ast.expr.AssignExpr;
@@ -37,6 +36,7 @@ import com.github.javaparser.ast.expr.IntegerLiteralExpr;
 import com.github.javaparser.ast.expr.LongLiteralExpr;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.expr.NullLiteralExpr;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
 import com.github.javaparser.ast.expr.VariableDeclarationExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
@@ -142,7 +142,13 @@ public abstract class AbstractVisitor {
         return value;
     }
 
+    protected Expression getOrNullExpr(String value) {
+        if (value == null) {
+            return new NullLiteralExpr();
+        }
 
+        return new StringLiteralExpr(value);
+    }
 
     protected void addWorkItemParameters(Work work, BlockStmt body, String variableName) {
 

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/StartNodeVisitor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/StartNodeVisitor.java
@@ -58,7 +58,7 @@ public class StartNodeVisitor extends AbstractVisitor {
                                      getOrNullExpr(timer.getPeriod()),
                                      getOrNullExpr(timer.getDate()),
                                      new IntegerLiteralExpr(startNode.getTimer().getTimeType()));
-                                     
+
         } else if (startNode.getTriggers() != null && !startNode.getTriggers().isEmpty()) {
             Map<String, Object> nodeMetaData = startNode.getMetaData();
             metadata.getTriggers().add(new TriggerMetaData((String)nodeMetaData.get(TRIGGER_REF), 

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/StartNodeVisitor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/StartNodeVisitor.java
@@ -21,11 +21,13 @@ import java.util.Map.Entry;
 
 import org.jbpm.process.core.context.variable.Variable;
 import org.jbpm.process.core.context.variable.VariableScope;
+import org.jbpm.process.core.timer.Timer;
 import org.jbpm.ruleflow.core.factory.StartNodeFactory;
 import org.jbpm.workflow.core.node.StartNode;
 import org.kie.api.definition.process.Node;
 
 import com.github.javaparser.ast.expr.BooleanLiteralExpr;
+import com.github.javaparser.ast.expr.IntegerLiteralExpr;
 import com.github.javaparser.ast.expr.LongLiteralExpr;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
@@ -50,7 +52,14 @@ public class StartNodeVisitor extends AbstractVisitor {
         
         addFactoryMethodWithArgs(body, "startNode" + node.getId(), "done");
         
-        if (startNode.getTriggers() != null && !startNode.getTriggers().isEmpty()) {
+        if (startNode.getTimer() != null) {
+            Timer timer = startNode.getTimer();
+            addFactoryMethodWithArgs(body, "startNode" + node.getId(), "timer", getOrNullExpr(timer.getDelay()),
+                                     getOrNullExpr(timer.getPeriod()),
+                                     getOrNullExpr(timer.getDate()),
+                                     new IntegerLiteralExpr(startNode.getTimer().getTimeType()));
+                                     
+        } else if (startNode.getTriggers() != null && !startNode.getTriggers().isEmpty()) {
             Map<String, Object> nodeMetaData = startNode.getMetaData();
             metadata.getTriggers().add(new TriggerMetaData((String)nodeMetaData.get(TRIGGER_REF), 
                                                            (String)nodeMetaData.get(TRIGGER_TYPE), 

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/context/variable/Variable.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/context/variable/Variable.java
@@ -67,12 +67,12 @@ public class Variable implements TypeObject, ValueObject, Serializable {
     }
 
     public String getId() {
-		return id;
-	}
+        return id;
+    }
 
-	public void setId(String id) {
-		this.id = id;
-	}
+    public void setId(String id) {
+        this.id = id;
+    }
 
 	public DataType getType() {
         return this.type;

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/context/variable/Variable.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/context/variable/Variable.java
@@ -46,6 +46,7 @@ public class Variable implements TypeObject, ValueObject, Serializable {
     public static final String BUSINESS_RELEVANT = "business-relevant";
     public static final String TRACKED = "tracked";
 
+    private String id;
     private String name;
     private DataType type;
     private Object value;
@@ -65,7 +66,15 @@ public class Variable implements TypeObject, ValueObject, Serializable {
         this.name = name;
     }
 
-    public DataType getType() {
+    public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public DataType getType() {
         return this.type;
     }
 

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/RuleFlowProcess.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/RuleFlowProcess.java
@@ -145,21 +145,7 @@ public class RuleFlowProcess extends WorkflowProcessImpl {
         return null;
     }
 
-    public List<StartNode> getTimerStart() {
-        Node[] nodes = getNodes();
 
-        List<StartNode> timerStartNodes = new ArrayList<StartNode>();
-        for (int i = 0; i < nodes.length; i++) {
-            if (nodes[i] instanceof StartNode) {
-                // return start node that is not event based node
-                if (((StartNode) nodes[i]).getTimer() != null) {
-                    timerStartNodes.add((StartNode) nodes[i]);
-                }
-            }
-        }
-
-        return timerStartNodes;
-    }
 
     public List<Node> getAutoStartNodes() {
         if (!isDynamic()) {

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/factory/StartNodeFactory.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/factory/StartNodeFactory.java
@@ -17,6 +17,7 @@
 package org.jbpm.ruleflow.core.factory;
 
 import org.jbpm.process.core.event.EventTypeFilter;
+import org.jbpm.process.core.timer.Timer;
 import org.jbpm.ruleflow.core.RuleFlowNodeContainerFactory;
 import org.jbpm.workflow.core.Node;
 import org.jbpm.workflow.core.NodeContainer;
@@ -44,6 +45,7 @@ public class StartNodeFactory extends NodeFactory {
         getNode().setName(name);
         return this;
     } 
+    
     public StartNodeFactory interrupting(boolean interrupting) {
         getStartNode().setInterrupting(interrupting);
         return this;
@@ -61,6 +63,17 @@ public class StartNodeFactory extends NodeFactory {
 
         getStartNode().addTrigger(trigger);
         
+        return this;
+    }
+    
+    public StartNodeFactory timer(String delay, String period, String date, int timeType) {
+        Timer timer = new Timer();
+        timer.setDate(date);
+        timer.setDelay(delay);
+        timer.setPeriod(period);
+        timer.setTimeType(timeType);
+        
+        getStartNode().setTimer(timer);
         return this;
     }
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/factory/StartNodeFactory.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/factory/StartNodeFactory.java
@@ -65,14 +65,14 @@ public class StartNodeFactory extends NodeFactory {
         
         return this;
     }
-    
+
     public StartNodeFactory timer(String delay, String period, String date, int timeType) {
         Timer timer = new Timer();
         timer.setDate(date);
         timer.setDelay(delay);
         timer.setPeriod(period);
         timer.setTimeType(timeType);
-        
+
         getStartNode().setTimer(timer);
         return this;
     }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/WorkflowProcess.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/WorkflowProcess.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.jbpm.process.core.Process;
+import org.kie.api.definition.process.Node;
 
 /**
  * Represents a RuleFlow process. 
@@ -93,6 +94,8 @@ public interface WorkflowProcess extends org.kie.api.definition.process.Workflow
     
     boolean isDynamic();
 
-    Integer getProcessType();       
+    Integer getProcessType();
+    
+    List<Node> getNodesRecursively();
     
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/impl/WorkflowProcessImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/impl/WorkflowProcessImpl.java
@@ -24,35 +24,38 @@ import java.util.List;
 
 import org.jbpm.process.core.impl.ProcessImpl;
 import org.jbpm.workflow.core.WorkflowProcess;
+import org.jbpm.workflow.core.node.StartNode;
+import org.kie.api.definition.process.Node;
+import org.kie.api.definition.process.NodeContainer;
 
 /**
  * Default implementation of a RuleFlow process.
- * 
+ *
  */
 public class WorkflowProcessImpl extends ProcessImpl implements WorkflowProcess, org.jbpm.workflow.core.NodeContainer {
 
     private static final long serialVersionUID = 510l;
-    
+
     private boolean autoComplete = false;
     private boolean dynamic = false;
     private org.jbpm.workflow.core.NodeContainer nodeContainer;
-    
+
     public WorkflowProcessImpl() {
         nodeContainer = (org.jbpm.workflow.core.NodeContainer) createNodeContainer();
     }
-    
+
     protected NodeContainer createNodeContainer() {
         return new NodeContainerImpl();
     }
-    
+
     public Node[] getNodes() {
         return nodeContainer.getNodes();
-    }    
+    }
 
     public Node getNode(final long id) {
         return nodeContainer.getNode(id);
     }
-    
+
     public Node internalGetNode(long id) {
     	try {
     		return getNode(id);
@@ -74,11 +77,11 @@ public class WorkflowProcessImpl extends ProcessImpl implements WorkflowProcess,
         nodeContainer.addNode(node);
         ((org.jbpm.workflow.core.Node) node).setNodeContainer(this);
     }
-    
+
     public boolean isAutoComplete() {
         return autoComplete;
     }
-    
+
     public void setAutoComplete(boolean autoComplete) {
         this.autoComplete = autoComplete;
     }
@@ -100,15 +103,15 @@ public class WorkflowProcessImpl extends ProcessImpl implements WorkflowProcess,
     }
 
     public List<Node> getNodesRecursively() {
-        List<Node> nodes = new ArrayList<>(); 
-        
+        List<Node> nodes = new ArrayList<>();
+
         processNodeContainer(nodeContainer, nodes);
-                
-        return nodes;        
+
+        return nodes;
     }
-    
+
     protected void processNodeContainer(org.jbpm.workflow.core.NodeContainer nodeContainer, List<Node> nodes) {
-        
+
         for (Node node : nodeContainer.getNodes()){
             nodes.add(node);
             if (node instanceof org.jbpm.workflow.core.NodeContainer) {
@@ -116,7 +119,7 @@ public class WorkflowProcessImpl extends ProcessImpl implements WorkflowProcess,
             }
         }
     }
-    
+
     protected Node getContainerNode(Node currentNode, org.jbpm.workflow.core.NodeContainer nodeContainer, long nodeId) {
         for (Node node : nodeContainer.getNodes()) {
             if (nodeId == node.getId()) {
@@ -132,5 +135,21 @@ public class WorkflowProcessImpl extends ProcessImpl implements WorkflowProcess,
 
     public Node getParentNode(long nodeId) {
         return getContainerNode(null, nodeContainer, nodeId);
+    }
+
+    public List<StartNode> getTimerStart() {
+        Node[] nodes = getNodes();
+
+        List<StartNode> timerStartNodes = new ArrayList<StartNode>();
+        for (int i = 0; i < nodes.length; i++) {
+            if (nodes[i] instanceof StartNode) {
+                // return start node that is not event based node
+                if (((StartNode) nodes[i]).getTimer() != null) {
+                    timerStartNodes.add((StartNode) nodes[i]);
+                }
+            }
+        }
+
+        return timerStartNodes;
     }
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/impl/WorkflowProcessImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/impl/WorkflowProcessImpl.java
@@ -16,9 +16,6 @@
 
 package org.jbpm.workflow.core.impl;
 
-import org.kie.api.definition.process.Node;
-import org.kie.api.definition.process.NodeContainer;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -142,11 +139,8 @@ public class WorkflowProcessImpl extends ProcessImpl implements WorkflowProcess,
 
         List<StartNode> timerStartNodes = new ArrayList<StartNode>();
         for (int i = 0; i < nodes.length; i++) {
-            if (nodes[i] instanceof StartNode) {
-                // return start node that is not event based node
-                if (((StartNode) nodes[i]).getTimer() != null) {
-                    timerStartNodes.add((StartNode) nodes[i]);
-                }
+            if (nodes[i] instanceof StartNode && ((StartNode) nodes[i]).getTimer() != null) {
+                timerStartNodes.add((StartNode) nodes[i]);                
             }
         }
 

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/ActionNode.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/ActionNode.java
@@ -34,8 +34,8 @@ public class ActionNode extends ExtendedNodeImpl {
 
 	private static final long serialVersionUID = 510l;
 	
-	private DroolsAction action;
-	private List<DataAssociation> inMapping = new LinkedList<DataAssociation>();
+    private DroolsAction action;
+    private List<DataAssociation> inMapping = new LinkedList<DataAssociation>();
     private List<DataAssociation> outMapping = new LinkedList<DataAssociation>();
 
 	public DroolsAction getAction() {
@@ -73,7 +73,7 @@ public class ActionNode extends ExtendedNodeImpl {
                 + "] cannot have more than one outgoing connection!");
         }
     }
-    
+
     public void addInAssociation(DataAssociation dataAssociation) {
         inMapping.add(dataAssociation);
     }
@@ -81,7 +81,7 @@ public class ActionNode extends ExtendedNodeImpl {
     public List<DataAssociation> getInAssociations() {
         return Collections.unmodifiableList(inMapping);
     }
-    
+
     public void addOutAssociation(DataAssociation dataAssociation) {
         outMapping.add(dataAssociation);
     }
@@ -89,5 +89,5 @@ public class ActionNode extends ExtendedNodeImpl {
     public List<DataAssociation> getOutAssociations() {
         return Collections.unmodifiableList(outMapping);
     }
-    
+
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/ActionNode.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/ActionNode.java
@@ -17,6 +17,11 @@
 package org.jbpm.workflow.core.node;
 
 import org.kie.api.definition.process.Connection;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
 import org.jbpm.workflow.core.DroolsAction;
 import org.jbpm.workflow.core.impl.ExtendedNodeImpl;
 
@@ -30,6 +35,8 @@ public class ActionNode extends ExtendedNodeImpl {
 	private static final long serialVersionUID = 510l;
 	
 	private DroolsAction action;
+	private List<DataAssociation> inMapping = new LinkedList<DataAssociation>();
+    private List<DataAssociation> outMapping = new LinkedList<DataAssociation>();
 
 	public DroolsAction getAction() {
 		return action;
@@ -65,6 +72,22 @@ public class ActionNode extends ExtendedNodeImpl {
                 "This type of node [" + connection.getFrom().getMetaData().get("UniqueId") + ", " + connection.getFrom().getName() 
                 + "] cannot have more than one outgoing connection!");
         }
+    }
+    
+    public void addInAssociation(DataAssociation dataAssociation) {
+        inMapping.add(dataAssociation);
+    }
+
+    public List<DataAssociation> getInAssociations() {
+        return Collections.unmodifiableList(inMapping);
+    }
+    
+    public void addOutAssociation(DataAssociation dataAssociation) {
+        outMapping.add(dataAssociation);
+    }
+
+    public List<DataAssociation> getOutAssociations() {
+        return Collections.unmodifiableList(outMapping);
     }
     
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/ForEachNode.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/ForEachNode.java
@@ -194,6 +194,7 @@ public class ForEachNode extends CompositeContextNode {
         	variableScope.setVariables(variables);
         }
         Variable variable = new Variable();
+        variable.setId(variableName);
         variable.setName(variableName);
         variable.setType(type);
         variables.add(variable);
@@ -208,11 +209,13 @@ public class ForEachNode extends CompositeContextNode {
             variableScope.setVariables(variables);
         }
         Variable variable = new Variable();
+        variable.setId(variableName);
         variable.setName(variableName);
         variable.setType(type);
         variables.add(variable);
         
         Variable tmpvariable = new Variable();
+        variable.setId("foreach_output");
         tmpvariable.setName("foreach_output");
         tmpvariable.setType(type);
         variables.add(tmpvariable);

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/ActionNodeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/ActionNodeInstance.java
@@ -17,12 +17,23 @@
 package org.jbpm.workflow.instance.node;
 
 import java.util.Date;
+import java.util.List;
+import java.util.Map;
 
+import org.drools.core.addon.MVELEvaluator;
+import org.drools.core.addon.RawMVELEvaluator;
 import org.drools.core.spi.ProcessContext;
+import org.drools.core.util.MVELSafeHelper;
+import org.jbpm.process.core.context.variable.Variable;
+import org.jbpm.process.core.context.variable.VariableScope;
+import org.jbpm.process.instance.context.variable.VariableScopeInstance;
 import org.jbpm.process.instance.impl.Action;
+import org.jbpm.workflow.core.impl.DroolsConsequenceAction;
 import org.jbpm.workflow.core.node.ActionNode;
+import org.jbpm.workflow.core.node.DataAssociation;
 import org.jbpm.workflow.instance.WorkflowRuntimeException;
 import org.jbpm.workflow.instance.impl.NodeInstanceImpl;
+import org.jbpm.workflow.instance.impl.NodeInstanceResolverFactory;
 import org.kie.api.runtime.process.NodeInstance;
 
 /**
@@ -57,6 +68,24 @@ public class ActionNodeInstance extends NodeInstanceImpl {
 		    throw new WorkflowRuntimeException(this, getProcessInstance(), "Unable to execute Action: " + e.getMessage(), e);
 		} 
     	triggerCompleted();
+    }
+    
+    public void setOutputVariable(Object variable) {
+        List<DataAssociation> outputs = getActionNode().getOutAssociations();
+        if (outputs != null && !outputs.isEmpty()) {
+
+            for (DataAssociation output : outputs) {
+
+                VariableScopeInstance variableScopeInstance = (VariableScopeInstance) getProcessInstance().getContextInstance(VariableScope.VARIABLE_SCOPE);
+                if (variableScopeInstance != null) {
+
+                    Variable var = variableScopeInstance.getVariableScope().getVariables().stream().filter(v -> v.getId().equals(output.getTarget())).findFirst().orElse(null);
+                    if (var != null) {
+                        variableScopeInstance.setVariable(var.getName(), variable);
+                    }
+                }
+            }
+        }
     }
 
     public void triggerCompleted() {

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/ActionNodeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/ActionNodeInstance.java
@@ -18,22 +18,16 @@ package org.jbpm.workflow.instance.node;
 
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 
-import org.drools.core.addon.MVELEvaluator;
-import org.drools.core.addon.RawMVELEvaluator;
 import org.drools.core.spi.ProcessContext;
-import org.drools.core.util.MVELSafeHelper;
 import org.jbpm.process.core.context.variable.Variable;
 import org.jbpm.process.core.context.variable.VariableScope;
 import org.jbpm.process.instance.context.variable.VariableScopeInstance;
 import org.jbpm.process.instance.impl.Action;
-import org.jbpm.workflow.core.impl.DroolsConsequenceAction;
 import org.jbpm.workflow.core.node.ActionNode;
 import org.jbpm.workflow.core.node.DataAssociation;
 import org.jbpm.workflow.instance.WorkflowRuntimeException;
 import org.jbpm.workflow.instance.impl.NodeInstanceImpl;
-import org.jbpm.workflow.instance.impl.NodeInstanceResolverFactory;
 import org.kie.api.runtime.process.NodeInstance;
 
 /**
@@ -69,7 +63,7 @@ public class ActionNodeInstance extends NodeInstanceImpl {
 		} 
     	triggerCompleted();
     }
-    
+
     public void setOutputVariable(Object variable) {
         List<DataAssociation> outputs = getActionNode().getOutAssociations();
         if (outputs != null && !outputs.isEmpty()) {

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/RuleSetNodeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/RuleSetNodeInstance.java
@@ -438,7 +438,7 @@ public class RuleSetNodeInstance extends StateBasedNodeInstance implements Event
                 }
             }
             if (parameterValue != null) {
-                parameters.put(association.getTarget(), parameterValue);
+                parameters.put(sourceParam, parameterValue);
             }
         }
 

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/WorkItemNodeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/WorkItemNodeInstance.java
@@ -149,8 +149,8 @@ public class WorkItemNodeInstance extends StateBasedNodeInstance implements Even
         ((WorkItem) workItem).setDeploymentId(deploymentId);
         ((WorkItem) workItem).setNodeInstanceId(this.getId());
         ((WorkItem) workItem).setNodeId(getNodeId());
-        ((WorkItem) workItem).setNodeInsstance(this);
-        ((WorkItem) workItem).setProcessInstance(getProcessInstance());
+        workItem.setNodeInsstance(this);
+        workItem.setProcessInstance(getProcessInstance());
         if (isInversionOfControl()) {
             ((ProcessInstance) getProcessInstance()).getKnowledgeRuntime()
                                                     .update(((ProcessInstance) getProcessInstance()).getKnowledgeRuntime().getFactHandle(this), this);
@@ -166,8 +166,8 @@ public class WorkItemNodeInstance extends StateBasedNodeInstance implements Even
                 this.workItemId = workItem.getId();
                 handleWorkItemHandlerException(handlerException, workItem);
             } catch (WorkItemExecutionError e) {
-            	handleException(e.getErrorCode(), e);
-			} catch (Exception e) {
+                handleException(e.getErrorCode(), e);
+            } catch (Exception e) {
                 String exceptionName = e.getClass().getName();
                 handleException(exceptionName, e);
             }
@@ -177,9 +177,9 @@ public class WorkItemNodeInstance extends StateBasedNodeInstance implements Even
         }
         this.workItemId = workItem.getId();
     }
-    
+
     protected void handleException(String exceptionName, Exception e) {
-    	ExceptionScopeInstance exceptionScopeInstance = (ExceptionScopeInstance) resolveContextInstance(ExceptionScope.EXCEPTION_SCOPE, exceptionName);
+        ExceptionScopeInstance exceptionScopeInstance = (ExceptionScopeInstance) resolveContextInstance(ExceptionScope.EXCEPTION_SCOPE, exceptionName);
         if (exceptionScopeInstance == null) {
             throw new WorkflowRuntimeException(this, getProcessInstance(), "Unable to execute Action: " + e.getMessage(), e);
         }
@@ -187,7 +187,7 @@ public class WorkItemNodeInstance extends StateBasedNodeInstance implements Even
         this.workItemId = workItem.getId();
         exceptionScopeInstance.handleException(exceptionName, e);
     }
-    
+
     protected WorkItem newWorkItem() {
         return new WorkItemImpl();
     }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/WorkItemNodeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/WorkItemNodeInstance.java
@@ -113,6 +113,8 @@ public class WorkItemNodeInstance extends StateBasedNodeInstance implements Even
 
     public void internalSetWorkItem(WorkItem workItem) {
         this.workItem = workItem;
+        this.workItem.setProcessInstance(getProcessInstance());
+        this.workItem.setNodeInsstance(this);
     }
 
     public boolean isInversionOfControl() {
@@ -146,6 +148,8 @@ public class WorkItemNodeInstance extends StateBasedNodeInstance implements Even
         ((WorkItem) workItem).setDeploymentId(deploymentId);
         ((WorkItem) workItem).setNodeInstanceId(this.getId());
         ((WorkItem) workItem).setNodeId(getNodeId());
+        ((WorkItem) workItem).setNodeInsstance(this);
+        ((WorkItem) workItem).setProcessInstance(getProcessInstance());
         if (isInversionOfControl()) {
             ((ProcessInstance) getProcessInstance()).getKnowledgeRuntime()
                                                     .update(((ProcessInstance) getProcessInstance()).getKnowledgeRuntime().getFactHandle(this), this);

--- a/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcess.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcess.java
@@ -53,9 +53,9 @@ public abstract class AbstractProcess<T extends Model> implements Process<T> {
 
     protected CompletionEventListener completionEventListener = new CompletionEventListener();
     
-    protected boolean started;
-    private List<String> startTimerInstances = new ArrayList<>();
-    private ProcessRuntime processRuntime;
+    protected boolean activated;
+    protected List<String> startTimerInstances = new ArrayList<>();
+    protected ProcessRuntime processRuntime;
 
     protected AbstractProcess() {
         this(new LightProcessRuntimeServiceProvider());
@@ -117,72 +117,72 @@ public abstract class AbstractProcess<T extends Model> implements Process<T> {
     protected void registerListeners() {
         
     }
-    
+
     @Override
     public void activate() {
-    	
-    	configure();
-    	WorkflowProcessImpl p = (WorkflowProcessImpl) legacyProcess();
+
+        configure();
+        WorkflowProcessImpl p = (WorkflowProcessImpl) legacyProcess();
         List<StartNode> startNodes = p.getTimerStart();
         if (startNodes != null && !startNodes.isEmpty()) {
-        	this.processRuntime = createLegacyProcessRuntime();    
+            this.processRuntime = createLegacyProcessRuntime();
             for (StartNode startNode : startNodes) {
                 if (startNode != null && startNode.getTimer() != null) {
-                                           
-                	String timerId = processRuntime.getJobsService().scheduleProcessJob(ProcessJobDescription.of(configureTimerInstance(startNode.getTimer()), this));
-                	
-                	startTimerInstances.add(timerId);
+
+                    String timerId = processRuntime.getJobsService().scheduleProcessJob(ProcessJobDescription.of(configureTimerInstance(startNode.getTimer()), this));
+
+                    startTimerInstances.add(timerId);
                 }
             }
         }
-        this.started = true;
+        this.activated = true;
     }
-    
+
     @Override
     public void deactivate() {
 
-    	for (String startTimerId : startTimerInstances) {
-    		this.processRuntime.getJobsService().cancelJob(startTimerId);
-    	}
-    	this.started = false;
+        for (String startTimerId : startTimerInstances) {
+            this.processRuntime.getJobsService().cancelJob(startTimerId);
+        }
+        this.activated = false;
     }
-    
-    private ExpirationTime configureTimerInstance(Timer timer) {
+
+    protected ExpirationTime configureTimerInstance(Timer timer) {
         long duration = -1;
         switch (timer.getTimeType()) {
-        case Timer.TIME_CYCLE:
-            // when using ISO date/time period is not set
-            long[] repeatValues = DateTimeUtils.parseRepeatableDateTime(timer.getDelay());
-            if (repeatValues.length == 3) {
-                int parsedReapedCount = (int)repeatValues[0];
-                if (parsedReapedCount > -1) {
-                    parsedReapedCount = Integer.MAX_VALUE;
-                }
-                return DurationExpirationTime.repeat(repeatValues[1], repeatValues[2]);
-            } else {
-                long delay = repeatValues[0];
-                long period = -1;
-                try {
-                    period = TimeUtils.parseTimeString(timer.getPeriod());
-                    
-                } catch (RuntimeException e) {
-                    period = repeatValues[0];
-                }
-                
-                return DurationExpirationTime.repeat(delay, period);
-            }
-            
-        case Timer.TIME_DURATION:
+            case Timer.TIME_CYCLE:
+                // when using ISO date/time period is not set
+                long[] repeatValues = DateTimeUtils.parseRepeatableDateTime(timer.getDelay());
+                if (repeatValues.length == 3) {
+                    int parsedReapedCount = (int) repeatValues[0];
+                    if (parsedReapedCount > -1) {
+                        parsedReapedCount = Integer.MAX_VALUE;
+                    }
+                    return DurationExpirationTime.repeat(repeatValues[1], repeatValues[2]);
+                } else {
+                    long delay = repeatValues[0];
+                    long period = -1;
+                    try {
+                        period = TimeUtils.parseTimeString(timer.getPeriod());
 
-            duration = DateTimeUtils.parseDuration(timer.getDelay());
-            return DurationExpirationTime.repeat(duration);
+                    } catch (RuntimeException e) {
+                        period = repeatValues[0];
+                    }
 
-        case Timer.TIME_DATE:
-            
-            return ExactExpirationTime.of(timer.getDate());
-        
-        default: 
-            throw new UnsupportedOperationException("Not supported timer definition");
+                    return DurationExpirationTime.repeat(delay, period);
+                }
+
+            case Timer.TIME_DURATION:
+
+                duration = DateTimeUtils.parseDuration(timer.getDelay());
+                return DurationExpirationTime.repeat(duration);
+
+            case Timer.TIME_DATE:
+
+                return ExactExpirationTime.of(timer.getDate());
+
+            default:
+                throw new UnsupportedOperationException("Not supported timer definition");
         }
 
     }

--- a/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcess.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcess.java
@@ -15,15 +15,26 @@
 
 package org.kie.kogito.process.impl;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
+import org.drools.core.time.TimeUtils;
+import org.jbpm.process.core.timer.DateTimeUtils;
+import org.jbpm.process.core.timer.Timer;
 import org.jbpm.process.instance.LightProcessRuntime;
 import org.jbpm.process.instance.LightProcessRuntimeContext;
 import org.jbpm.process.instance.LightProcessRuntimeServiceProvider;
 import org.jbpm.process.instance.ProcessRuntimeServiceProvider;
+import org.jbpm.workflow.core.impl.WorkflowProcessImpl;
+import org.jbpm.workflow.core.node.StartNode;
 import org.kie.api.runtime.process.EventListener;
 import org.kie.api.runtime.process.ProcessRuntime;
 import org.kie.kogito.Model;
+import org.kie.kogito.jobs.DurationExpirationTime;
+import org.kie.kogito.jobs.ExactExpirationTime;
+import org.kie.kogito.jobs.ExpirationTime;
+import org.kie.kogito.jobs.ProcessJobDescription;
 import org.kie.kogito.process.MutableProcessInstances;
 import org.kie.kogito.process.Process;
 import org.kie.kogito.process.ProcessConfig;
@@ -41,6 +52,10 @@ public abstract class AbstractProcess<T extends Model> implements Process<T> {
     protected final ProcessRuntimeServiceProvider services;
 
     protected CompletionEventListener completionEventListener = new CompletionEventListener();
+    
+    protected boolean started;
+    private List<String> startTimerInstances = new ArrayList<>();
+    private ProcessRuntime processRuntime;
 
     protected AbstractProcess() {
         this(new LightProcessRuntimeServiceProvider());
@@ -86,7 +101,6 @@ public abstract class AbstractProcess<T extends Model> implements Process<T> {
         instances().values().forEach(pi -> pi.send(signal));
     }
     
-    @SuppressWarnings("unchecked")
     public Process<T> configure() {
 
         registerListeners();
@@ -102,6 +116,75 @@ public abstract class AbstractProcess<T extends Model> implements Process<T> {
 
     protected void registerListeners() {
         
+    }
+    
+    @Override
+    public void activate() {
+    	
+    	configure();
+    	WorkflowProcessImpl p = (WorkflowProcessImpl) legacyProcess();
+        List<StartNode> startNodes = p.getTimerStart();
+        if (startNodes != null && !startNodes.isEmpty()) {
+        	this.processRuntime = createLegacyProcessRuntime();    
+            for (StartNode startNode : startNodes) {
+                if (startNode != null && startNode.getTimer() != null) {
+                                           
+                	String timerId = processRuntime.getJobsService().scheduleProcessJob(ProcessJobDescription.of(configureTimerInstance(startNode.getTimer()), this));
+                	
+                	startTimerInstances.add(timerId);
+                }
+            }
+        }
+        this.started = true;
+    }
+    
+    @Override
+    public void deactivate() {
+
+    	for (String startTimerId : startTimerInstances) {
+    		this.processRuntime.getJobsService().cancelJob(startTimerId);
+    	}
+    	this.started = false;
+    }
+    
+    private ExpirationTime configureTimerInstance(Timer timer) {
+        long duration = -1;
+        switch (timer.getTimeType()) {
+        case Timer.TIME_CYCLE:
+            // when using ISO date/time period is not set
+            long[] repeatValues = DateTimeUtils.parseRepeatableDateTime(timer.getDelay());
+            if (repeatValues.length == 3) {
+                int parsedReapedCount = (int)repeatValues[0];
+                if (parsedReapedCount > -1) {
+                    parsedReapedCount = Integer.MAX_VALUE;
+                }
+                return DurationExpirationTime.repeat(repeatValues[1], repeatValues[2]);
+            } else {
+                long delay = repeatValues[0];
+                long period = -1;
+                try {
+                    period = TimeUtils.parseTimeString(timer.getPeriod());
+                    
+                } catch (RuntimeException e) {
+                    period = repeatValues[0];
+                }
+                
+                return DurationExpirationTime.repeat(delay, period);
+            }
+            
+        case Timer.TIME_DURATION:
+
+            duration = DateTimeUtils.parseDuration(timer.getDelay());
+            return DurationExpirationTime.repeat(duration);
+
+        case Timer.TIME_DATE:
+            
+            return ExactExpirationTime.of(timer.getDate());
+        
+        default: 
+            throw new UnsupportedOperationException("Not supported timer definition");
+        }
+
     }
 
     public abstract org.kie.api.definition.process.Process legacyProcess();

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ProcessGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ProcessGenerator.java
@@ -440,7 +440,7 @@ public class ProcessGenerator {
         
         if (useInjection()) {
                         
-            MethodDeclaration initMethod = annotator.withInitMethod(new MethodCallExpr(new ThisExpr(), "configure"));
+            MethodDeclaration initMethod = annotator.withInitMethod(new MethodCallExpr(new ThisExpr(), "activate"));
             
             cls.addMember(initMethod);
         }

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/tests/TimerEventTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/tests/TimerEventTest.java
@@ -18,6 +18,7 @@ package org.kie.kogito.codegen.tests;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.OffsetDateTime;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -207,5 +208,79 @@ public class TimerEventTest extends AbstractCodegenTest {
         assertThat(completed).isTrue();
      
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
+    }
+    
+    @Test
+    public void testStartTimerEvent() throws Exception {
+        
+        Application app = generateCodeProcessesOnly("timer/StartTimerDuration.bpmn2");        
+        assertThat(app).isNotNull();
+        
+        NodeLeftCountDownProcessEventListener listener = new NodeLeftCountDownProcessEventListener("timer fired", 1);
+        ((DefaultProcessEventListenerConfig)app.config().process().processEventListeners()).register(listener);
+                
+        Process<? extends Model> p = app.processes().processById("defaultPackage.TimerProcess");
+        // activate to schedule timers
+        p.activate();
+        
+        boolean completed = listener.waitTillCompleted(5000);
+        assertThat(completed).isTrue();
+        
+        Collection<?> instances = p.instances().values();
+        assertThat(instances).hasSize(1);
+        
+        ProcessInstance<?> processInstance = (ProcessInstance<?>) instances.iterator().next();
+        assertThat(processInstance).isNotNull();
+        
+        assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_ACTIVE);
+        
+        processInstance.abort();
+        assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_ABORTED);
+        
+        instances = p.instances().values();
+        assertThat(instances).hasSize(0);
+        
+        p.deactivate();
+        
+    }
+    
+    @Test
+    public void testStartTimerEventTimeCycle() throws Exception {
+        
+        Application app = generateCodeProcessesOnly("timer/StartTimerCycle.bpmn2");        
+        assertThat(app).isNotNull();
+        
+        NodeLeftCountDownProcessEventListener listener = new NodeLeftCountDownProcessEventListener("timer fired", 2);
+        ((DefaultProcessEventListenerConfig)app.config().process().processEventListeners()).register(listener);
+                
+        Process<? extends Model> p = app.processes().processById("defaultPackage.TimerProcess");
+        // activate to schedule timers
+        p.activate();
+        
+        boolean completed = listener.waitTillCompleted(5000);
+        assertThat(completed).isTrue();
+        
+        Collection<?> instances = p.instances().values();
+        assertThat(instances).hasSize(2);
+        
+        ProcessInstance<?> processInstance = (ProcessInstance<?>) instances.iterator().next();
+        assertThat(processInstance).isNotNull();
+        
+        assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_ACTIVE);
+        // deactivate to cancel timer, so there should be no more timers fired
+        p.deactivate();
+        
+        // reset the listener to make sure nothing more is triggered
+        listener.reset(1);        
+        completed = listener.waitTillCompleted(3000);
+        assertThat(completed).isFalse();
+        // same amount of instances should be active as before deactivation
+        instances = p.instances().values();
+        assertThat(instances).hasSize(2);
+        // clean up by aborting all instances
+        instances.forEach(i -> ((ProcessInstance<?>) i).abort());
+        instances = p.instances().values();
+        assertThat(instances).hasSize(0);
+        
     }
 }

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/tests/TimerEventTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/tests/TimerEventTest.java
@@ -209,69 +209,67 @@ public class TimerEventTest extends AbstractCodegenTest {
      
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
     }
-    
+
     @Test
     public void testStartTimerEvent() throws Exception {
-        
-        Application app = generateCodeProcessesOnly("timer/StartTimerDuration.bpmn2");        
+
+        Application app = generateCodeProcessesOnly("timer/StartTimerDuration.bpmn2");
         assertThat(app).isNotNull();
-        
+
         NodeLeftCountDownProcessEventListener listener = new NodeLeftCountDownProcessEventListener("timer fired", 1);
-        ((DefaultProcessEventListenerConfig)app.config().process().processEventListeners()).register(listener);
-                
+        ((DefaultProcessEventListenerConfig) app.config().process().processEventListeners()).register(listener);
+
         Process<? extends Model> p = app.processes().processById("defaultPackage.TimerProcess");
         // activate to schedule timers
         p.activate();
-        
+
         boolean completed = listener.waitTillCompleted(5000);
         assertThat(completed).isTrue();
-        
+
         Collection<?> instances = p.instances().values();
         assertThat(instances).hasSize(1);
-        
+
         ProcessInstance<?> processInstance = (ProcessInstance<?>) instances.iterator().next();
         assertThat(processInstance).isNotNull();
-        
+
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_ACTIVE);
-        
+
         processInstance.abort();
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_ABORTED);
-        
+
         instances = p.instances().values();
         assertThat(instances).hasSize(0);
-        
-        p.deactivate();
-        
+
     }
-    
+
     @Test
     public void testStartTimerEventTimeCycle() throws Exception {
-        
-        Application app = generateCodeProcessesOnly("timer/StartTimerCycle.bpmn2");        
+
+        Application app = generateCodeProcessesOnly("timer/StartTimerCycle.bpmn2");
         assertThat(app).isNotNull();
-        
+
         NodeLeftCountDownProcessEventListener listener = new NodeLeftCountDownProcessEventListener("timer fired", 2);
-        ((DefaultProcessEventListenerConfig)app.config().process().processEventListeners()).register(listener);
-                
+        ((DefaultProcessEventListenerConfig) app.config().process().processEventListeners()).register(listener);
+
         Process<? extends Model> p = app.processes().processById("defaultPackage.TimerProcess");
         // activate to schedule timers
         p.activate();
-        
+
         boolean completed = listener.waitTillCompleted(5000);
         assertThat(completed).isTrue();
-        
+
         Collection<?> instances = p.instances().values();
         assertThat(instances).hasSize(2);
-        
+
         ProcessInstance<?> processInstance = (ProcessInstance<?>) instances.iterator().next();
         assertThat(processInstance).isNotNull();
-        
+
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_ACTIVE);
         // deactivate to cancel timer, so there should be no more timers fired
         p.deactivate();
-        
+
         // reset the listener to make sure nothing more is triggered
-        listener.reset(1);        
+        listener.reset(1);
         completed = listener.waitTillCompleted(3000);
         assertThat(completed).isFalse();
         // same amount of instances should be active as before deactivation
@@ -281,6 +279,6 @@ public class TimerEventTest extends AbstractCodegenTest {
         instances.forEach(i -> ((ProcessInstance<?>) i).abort());
         instances = p.instances().values();
         assertThat(instances).hasSize(0);
-        
+
     }
 }

--- a/kogito-codegen/src/test/resources/timer/StartTimerCycle.bpmn2
+++ b/kogito-codegen/src/test/resources/timer/StartTimerCycle.bpmn2
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- origin at X=0.0 Y=0.0 -->
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmn20="http://www.omg.org/bpmn20" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" xmlns="http://www.jboss.org/drools" xmlns:ns="http://www.w3.org/2001/XMLSchema" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" id="_FNr5sGhrEeGMT7sG7hEI2w" exporter="org.eclipse.bpmn2.modeler.core" exporterVersion="1.5.1.Final-v20190425-2005-B1" targetNamespace="http://www.omg.org/bpmn20">
+  <bpmn2:itemDefinition id="ItemDefinition_1" isCollection="false" structureRef="java.lang.String"/>
+  <bpmn2:itemDefinition id="ItemDefinition_2" isCollection="false" structureRef="java.lang.Integer"/>
+  <bpmn2:itemDefinition id="ItemDefinition_3" isCollection="false" structureRef="java.lang.Boolean"/>
+  <bpmn2:process id="defaultPackage.TimerProcess" drools:packageName="defaultPackage" name="TimerProcess" isExecutable="true">
+    <bpmn2:scriptTask id="_E76AD186-6FA6-4378-B45B-C8F73E2C497C" name="timer fired" scriptFormat="http://www.java.com/java">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[timer fired]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>SequenceFlow_2</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_1</bpmn2:outgoing>
+      <bpmn2:script>System.out.println(&quot;timer process end&quot;);</bpmn2:script>
+    </bpmn2:scriptTask>
+    <bpmn2:endEvent id="_7232FBCC-81DD-4DEF-91DD-5D1D415117F8" drools:bgcolor="#ffffff" name="">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_85A5CC49-2B8B-440F-9F1D-145C7D807F6B</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="_85A5CC49-2B8B-440F-9F1D-145C7D807F6B" sourceRef="UserTask_1" targetRef="_7232FBCC-81DD-4DEF-91DD-5D1D415117F8"/>
+    <bpmn2:startEvent id="_F9AC8B12-8E75-49B5-B799-292F66270627" drools:bgcolor="#ffffff" name="start">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[start]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:outgoing>SequenceFlow_2</bpmn2:outgoing>
+      <bpmn2:timerEventDefinition id="_FNr5s2hrEeGMT7sG7hEI2w">
+        <bpmn2:timeCycle xsi:type="bpmn2:tFormalExpression" id="_FNr5tGhrEeGMT7sG7hEI2w">R/PT2S</bpmn2:timeCycle>
+      </bpmn2:timerEventDefinition>
+    </bpmn2:startEvent>
+    <bpmn2:sequenceFlow id="SequenceFlow_2" drools:priority="1" sourceRef="_F9AC8B12-8E75-49B5-B799-292F66270627" targetRef="_E76AD186-6FA6-4378-B45B-C8F73E2C497C"/>
+    <bpmn2:userTask id="UserTask_1" name="User Task 1">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[User Task 1]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>SequenceFlow_1</bpmn2:incoming>
+      <bpmn2:outgoing>_85A5CC49-2B8B-440F-9F1D-145C7D807F6B</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="InputOutputSpecification_1">
+        <bpmn2:dataInput id="DataInput_1" itemSubjectRef="ItemDefinition_1" name="TaskName"/>
+        <bpmn2:dataInput id="DataInput_2" itemSubjectRef="ItemDefinition_2" name="Priority"/>
+        <bpmn2:dataInput id="DataInput_3" itemSubjectRef="ItemDefinition_1" name="Comment"/>
+        <bpmn2:dataInput id="DataInput_4" itemSubjectRef="ItemDefinition_1" name="Description"/>
+        <bpmn2:dataInput id="DataInput_5" itemSubjectRef="ItemDefinition_1" name="GroupId"/>
+        <bpmn2:dataInput id="DataInput_6" itemSubjectRef="ItemDefinition_3" name="Skippable"/>
+        <bpmn2:dataInput id="DataInput_7" itemSubjectRef="ItemDefinition_1" name="Content"/>
+        <bpmn2:dataInput id="DataInput_8" itemSubjectRef="ItemDefinition_1" name="Locale"/>
+        <bpmn2:dataInput id="DataInput_9" itemSubjectRef="ItemDefinition_1" name="CreatedBy"/>
+        <bpmn2:inputSet id="_InputSet_2">
+          <bpmn2:dataInputRefs>DataInput_1</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>DataInput_2</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>DataInput_3</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>DataInput_4</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>DataInput_5</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>DataInput_6</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>DataInput_7</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>DataInput_8</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>DataInput_9</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet id="OutputSet_1" name="Output Set"/>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="DataInputAssociation_1">
+        <bpmn2:targetRef>DataInput_1</bpmn2:targetRef>
+        <bpmn2:assignment id="Assignment_1">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="FormalExpression_1">Task Name</bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="FormalExpression_2">DataInput_1</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="DataInputAssociation_2">
+        <bpmn2:targetRef>DataInput_2</bpmn2:targetRef>
+        <bpmn2:assignment id="Assignment_2">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="FormalExpression_3">1</bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="FormalExpression_4">DataInput_2</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="DataInputAssociation_3">
+        <bpmn2:targetRef>DataInput_3</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="DataInputAssociation_4">
+        <bpmn2:targetRef>DataInput_4</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="DataInputAssociation_5">
+        <bpmn2:targetRef>DataInput_5</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="DataInputAssociation_6">
+        <bpmn2:targetRef>DataInput_6</bpmn2:targetRef>
+        <bpmn2:assignment id="Assignment_6">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="FormalExpression_11">true</bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="FormalExpression_12">DataInput_6</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="DataInputAssociation_7">
+        <bpmn2:targetRef>DataInput_7</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="DataInputAssociation_8">
+        <bpmn2:targetRef>DataInput_8</bpmn2:targetRef>
+        <bpmn2:assignment id="Assignment_8">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="FormalExpression_15">en-UK</bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="FormalExpression_16">DataInput_8</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="DataInputAssociation_9">
+        <bpmn2:targetRef>DataInput_9</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+    </bpmn2:userTask>
+    <bpmn2:sequenceFlow id="SequenceFlow_1" drools:priority="1" sourceRef="_E76AD186-6FA6-4378-B45B-C8F73E2C497C" targetRef="UserTask_1"/>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="_FNr5tWhrEeGMT7sG7hEI2w">
+    <bpmndi:BPMNPlane id="_FNr5tmhrEeGMT7sG7hEI2w" bpmnElement="defaultPackage.TimerProcess">
+      <bpmndi:BPMNShape id="_FNr5umhrEeGMT7sG7hEI2w" bpmnElement="_E76AD186-6FA6-4378-B45B-C8F73E2C497C">
+        <dc:Bounds height="55.0" width="91.0" x="180.0" y="118.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_1" labelStyle="BPMNLabelStyle_1">
+          <dc:Bounds height="11.0" width="41.0" x="205.0" y="140.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_FNsgwWhrEeGMT7sG7hEI2w" bpmnElement="_7232FBCC-81DD-4DEF-91DD-5D1D415117F8">
+        <dc:Bounds height="28.0" width="28.0" x="460.0" y="130.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_2" labelStyle="BPMNLabelStyle_1"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_FNsgw2hrEeGMT7sG7hEI2w" bpmnElement="_F9AC8B12-8E75-49B5-B799-292F66270627">
+        <dc:Bounds height="30.0" width="30.0" x="75.0" y="129.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_3" labelStyle="BPMNLabelStyle_1">
+          <dc:Bounds height="11.0" width="18.0" x="81.0" y="159.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_UserTask_1" bpmnElement="UserTask_1" isExpanded="true">
+        <dc:Bounds height="50.0" width="110.0" x="311.0" y="121.0"/>
+        <bpmndi:BPMNLabel labelStyle="BPMNLabelStyle_1">
+          <dc:Bounds height="11.0" width="48.0" x="342.0" y="140.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_FNsgwmhrEeGMT7sG7hEI2w" bpmnElement="_85A5CC49-2B8B-440F-9F1D-145C7D807F6B" sourceElement="BPMNShape_UserTask_1" targetElement="_FNsgwWhrEeGMT7sG7hEI2w">
+        <di:waypoint xsi:type="dc:Point" x="421.0" y="146.0"/>
+        <di:waypoint xsi:type="dc:Point" x="440.0" y="146.0"/>
+        <di:waypoint xsi:type="dc:Point" x="440.0" y="144.0"/>
+        <di:waypoint xsi:type="dc:Point" x="460.0" y="144.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_4"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_2" bpmnElement="SequenceFlow_2" sourceElement="_FNsgw2hrEeGMT7sG7hEI2w" targetElement="_FNr5umhrEeGMT7sG7hEI2w">
+        <di:waypoint xsi:type="dc:Point" x="105.0" y="144.0"/>
+        <di:waypoint xsi:type="dc:Point" x="142.0" y="144.0"/>
+        <di:waypoint xsi:type="dc:Point" x="180.0" y="145.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_5"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_1" bpmnElement="SequenceFlow_1" sourceElement="_FNr5umhrEeGMT7sG7hEI2w" targetElement="BPMNShape_UserTask_1">
+        <di:waypoint xsi:type="dc:Point" x="271.0" y="145.0"/>
+        <di:waypoint xsi:type="dc:Point" x="291.0" y="145.0"/>
+        <di:waypoint xsi:type="dc:Point" x="311.0" y="146.0"/>
+        <bpmndi:BPMNLabel/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+    <bpmndi:BPMNLabelStyle id="BPMNLabelStyle_1">
+      <dc:Font name="arial" size="9.0"/>
+    </bpmndi:BPMNLabelStyle>
+  </bpmndi:BPMNDiagram>
+</bpmn2:definitions>

--- a/kogito-codegen/src/test/resources/timer/StartTimerDuration.bpmn2
+++ b/kogito-codegen/src/test/resources/timer/StartTimerDuration.bpmn2
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- origin at X=0.0 Y=0.0 -->
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmn20="http://www.omg.org/bpmn20" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" xmlns="http://www.jboss.org/drools" xmlns:ns="http://www.w3.org/2001/XMLSchema" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" id="_FNr5sGhrEeGMT7sG7hEI2w" exporter="org.eclipse.bpmn2.modeler.core" exporterVersion="1.5.1.Final-v20190425-2005-B1" targetNamespace="http://www.omg.org/bpmn20">
+  <bpmn2:itemDefinition id="ItemDefinition_1" isCollection="false" structureRef="java.lang.String"/>
+  <bpmn2:itemDefinition id="ItemDefinition_2" isCollection="false" structureRef="java.lang.Integer"/>
+  <bpmn2:itemDefinition id="ItemDefinition_3" isCollection="false" structureRef="java.lang.Boolean"/>
+  <bpmn2:process id="defaultPackage.TimerProcess" drools:packageName="defaultPackage" name="TimerProcess" isExecutable="true">
+    <bpmn2:scriptTask id="_E76AD186-6FA6-4378-B45B-C8F73E2C497C" name="timer fired" scriptFormat="http://www.java.com/java">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[timer fired]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>SequenceFlow_2</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_1</bpmn2:outgoing>
+      <bpmn2:script>System.out.println(&quot;timer process end&quot;);</bpmn2:script>
+    </bpmn2:scriptTask>
+    <bpmn2:endEvent id="_7232FBCC-81DD-4DEF-91DD-5D1D415117F8" drools:bgcolor="#ffffff" name="">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_85A5CC49-2B8B-440F-9F1D-145C7D807F6B</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="_85A5CC49-2B8B-440F-9F1D-145C7D807F6B" sourceRef="UserTask_1" targetRef="_7232FBCC-81DD-4DEF-91DD-5D1D415117F8"/>
+    <bpmn2:startEvent id="_F9AC8B12-8E75-49B5-B799-292F66270627" drools:bgcolor="#ffffff" name="start">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[start]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:outgoing>SequenceFlow_2</bpmn2:outgoing>
+      <bpmn2:timerEventDefinition id="_FNr5s2hrEeGMT7sG7hEI2w">
+        <bpmn2:timeDuration xsi:type="bpmn2:tFormalExpression" id="_FNr5tGhrEeGMT7sG7hEI2w">PT2S</bpmn2:timeDuration>
+      </bpmn2:timerEventDefinition>
+    </bpmn2:startEvent>
+    <bpmn2:sequenceFlow id="SequenceFlow_2" drools:priority="1" sourceRef="_F9AC8B12-8E75-49B5-B799-292F66270627" targetRef="_E76AD186-6FA6-4378-B45B-C8F73E2C497C"/>
+    <bpmn2:userTask id="UserTask_1" name="User Task 1">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[User Task 1]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>SequenceFlow_1</bpmn2:incoming>
+      <bpmn2:outgoing>_85A5CC49-2B8B-440F-9F1D-145C7D807F6B</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="InputOutputSpecification_1">
+        <bpmn2:dataInput id="DataInput_1" itemSubjectRef="ItemDefinition_1" name="TaskName"/>
+        <bpmn2:dataInput id="DataInput_2" itemSubjectRef="ItemDefinition_2" name="Priority"/>
+        <bpmn2:dataInput id="DataInput_3" itemSubjectRef="ItemDefinition_1" name="Comment"/>
+        <bpmn2:dataInput id="DataInput_4" itemSubjectRef="ItemDefinition_1" name="Description"/>
+        <bpmn2:dataInput id="DataInput_5" itemSubjectRef="ItemDefinition_1" name="GroupId"/>
+        <bpmn2:dataInput id="DataInput_6" itemSubjectRef="ItemDefinition_3" name="Skippable"/>
+        <bpmn2:dataInput id="DataInput_7" itemSubjectRef="ItemDefinition_1" name="Content"/>
+        <bpmn2:dataInput id="DataInput_8" itemSubjectRef="ItemDefinition_1" name="Locale"/>
+        <bpmn2:dataInput id="DataInput_9" itemSubjectRef="ItemDefinition_1" name="CreatedBy"/>
+        <bpmn2:inputSet id="_InputSet_2">
+          <bpmn2:dataInputRefs>DataInput_1</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>DataInput_2</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>DataInput_3</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>DataInput_4</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>DataInput_5</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>DataInput_6</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>DataInput_7</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>DataInput_8</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>DataInput_9</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet id="OutputSet_1" name="Output Set"/>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="DataInputAssociation_1">
+        <bpmn2:targetRef>DataInput_1</bpmn2:targetRef>
+        <bpmn2:assignment id="Assignment_1">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="FormalExpression_1">Task Name</bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="FormalExpression_2">DataInput_1</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="DataInputAssociation_2">
+        <bpmn2:targetRef>DataInput_2</bpmn2:targetRef>
+        <bpmn2:assignment id="Assignment_2">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="FormalExpression_3">1</bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="FormalExpression_4">DataInput_2</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="DataInputAssociation_3">
+        <bpmn2:targetRef>DataInput_3</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="DataInputAssociation_4">
+        <bpmn2:targetRef>DataInput_4</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="DataInputAssociation_5">
+        <bpmn2:targetRef>DataInput_5</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="DataInputAssociation_6">
+        <bpmn2:targetRef>DataInput_6</bpmn2:targetRef>
+        <bpmn2:assignment id="Assignment_6">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="FormalExpression_11">true</bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="FormalExpression_12">DataInput_6</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="DataInputAssociation_7">
+        <bpmn2:targetRef>DataInput_7</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="DataInputAssociation_8">
+        <bpmn2:targetRef>DataInput_8</bpmn2:targetRef>
+        <bpmn2:assignment id="Assignment_8">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="FormalExpression_15">en-UK</bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="FormalExpression_16">DataInput_8</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="DataInputAssociation_9">
+        <bpmn2:targetRef>DataInput_9</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+    </bpmn2:userTask>
+    <bpmn2:sequenceFlow id="SequenceFlow_1" drools:priority="1" sourceRef="_E76AD186-6FA6-4378-B45B-C8F73E2C497C" targetRef="UserTask_1"/>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="_FNr5tWhrEeGMT7sG7hEI2w">
+    <bpmndi:BPMNPlane id="_FNr5tmhrEeGMT7sG7hEI2w" bpmnElement="defaultPackage.TimerProcess">
+      <bpmndi:BPMNShape id="_FNr5umhrEeGMT7sG7hEI2w" bpmnElement="_E76AD186-6FA6-4378-B45B-C8F73E2C497C">
+        <dc:Bounds height="55.0" width="91.0" x="180.0" y="118.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_1" labelStyle="BPMNLabelStyle_1">
+          <dc:Bounds height="11.0" width="41.0" x="205.0" y="140.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_FNsgwWhrEeGMT7sG7hEI2w" bpmnElement="_7232FBCC-81DD-4DEF-91DD-5D1D415117F8">
+        <dc:Bounds height="28.0" width="28.0" x="460.0" y="130.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_2" labelStyle="BPMNLabelStyle_1"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_FNsgw2hrEeGMT7sG7hEI2w" bpmnElement="_F9AC8B12-8E75-49B5-B799-292F66270627">
+        <dc:Bounds height="30.0" width="30.0" x="75.0" y="129.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_3" labelStyle="BPMNLabelStyle_1">
+          <dc:Bounds height="11.0" width="18.0" x="81.0" y="159.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_UserTask_1" bpmnElement="UserTask_1" isExpanded="true">
+        <dc:Bounds height="50.0" width="110.0" x="311.0" y="121.0"/>
+        <bpmndi:BPMNLabel labelStyle="BPMNLabelStyle_1">
+          <dc:Bounds height="11.0" width="48.0" x="342.0" y="140.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_FNsgwmhrEeGMT7sG7hEI2w" bpmnElement="_85A5CC49-2B8B-440F-9F1D-145C7D807F6B" sourceElement="BPMNShape_UserTask_1" targetElement="_FNsgwWhrEeGMT7sG7hEI2w">
+        <di:waypoint xsi:type="dc:Point" x="421.0" y="146.0"/>
+        <di:waypoint xsi:type="dc:Point" x="440.0" y="146.0"/>
+        <di:waypoint xsi:type="dc:Point" x="440.0" y="144.0"/>
+        <di:waypoint xsi:type="dc:Point" x="460.0" y="144.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_4"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_2" bpmnElement="SequenceFlow_2" sourceElement="_FNsgw2hrEeGMT7sG7hEI2w" targetElement="_FNr5umhrEeGMT7sG7hEI2w">
+        <di:waypoint xsi:type="dc:Point" x="105.0" y="144.0"/>
+        <di:waypoint xsi:type="dc:Point" x="142.0" y="144.0"/>
+        <di:waypoint xsi:type="dc:Point" x="180.0" y="145.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_5"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_1" bpmnElement="SequenceFlow_1" sourceElement="_FNr5umhrEeGMT7sG7hEI2w" targetElement="BPMNShape_UserTask_1">
+        <di:waypoint xsi:type="dc:Point" x="271.0" y="145.0"/>
+        <di:waypoint xsi:type="dc:Point" x="291.0" y="145.0"/>
+        <di:waypoint xsi:type="dc:Point" x="311.0" y="146.0"/>
+        <bpmndi:BPMNLabel/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+    <bpmndi:BPMNLabelStyle id="BPMNLabelStyle_1">
+      <dc:Font name="arial" size="9.0"/>
+    </bpmndi:BPMNLabelStyle>
+  </bpmndi:BPMNDiagram>
+</bpmn2:definitions>


### PR DESCRIPTION
* added support for start timer event including code generation, added also life cycle methods (activate/deactivate) for process to allow control on availability of the process for execution
* allow to use custom dialects for assignments instead of hardcoded XPath
* externalise BpmnProcess compilation to separate class and allow to override to extend it, allow DMN namespace as script format
* allow to rely on errorCode of the error to handle work item exceptions
* expose node instance and process instance via work item so it can be accessed by work item handler
* allow to defined data intput and output associations on script task to control variables used