### PR TITLE
KOGITO-1555: Make sure Quarkus snapshot works with examples and runtimes

### DIFF
--- a/kogito-quarkus-extension/runtime/pom.xml
+++ b/kogito-quarkus-extension/runtime/pom.xml
@@ -36,6 +36,11 @@
             <artifactId>quarkus-arc</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>io.quarkus.arc</groupId>
+            <artifactId>arc-processor</artifactId>
+        </dependency>
+
         <!-- kogito -->
         <dependency>
             <groupId>org.kie.kogito</groupId>


### PR DESCRIPTION
add io.quarkus.arc:arc-processor to extension
so that dep ver is correctly overridden
verified via custom build https://rhba-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/blue/organizations/jenkins/custom%2Fevacchi%2Fcustom-quarkus-snapshot/detail/custom-quarkus-snapshot/3/pipeline

related https://github.com/kiegroup/kogito-examples/pull/164