### PR TITLE
KOGITO-1632: allow to fetch event descriptions that given process instance is listening to

### DIFF
--- a/addons/jobs/jobs-management-common/src/test/java/org/kie/kogito/jobs/management/RestJobsServiceTest.java
+++ b/addons/jobs/jobs-management-common/src/test/java/org/kie/kogito/jobs/management/RestJobsServiceTest.java
@@ -17,6 +17,7 @@
 package org.kie.kogito.jobs.management;
 
 import java.net.URI;
+import java.time.ZonedDateTime;
 
 import org.junit.jupiter.api.Test;
 import org.kie.kogito.jobs.ExactExpirationTime;
@@ -46,6 +47,11 @@ public class RestJobsServiceTest {
             @Override
             public boolean cancelJob(String id) {
                 return false;
+            }
+
+            @Override
+            public ZonedDateTime getScheduledTime(String id) {
+                return null;
             }
         };
     }

--- a/addons/jobs/jobs-management-quarkus-addon/src/main/java/org/kie/kogito/jobs/management/quarkus/VertxJobsService.java
+++ b/addons/jobs/jobs-management-quarkus-addon/src/main/java/org/kie/kogito/jobs/management/quarkus/VertxJobsService.java
@@ -17,26 +17,31 @@
 package org.kie.kogito.jobs.management.quarkus;
 
 import java.net.URI;
+import java.time.ZonedDateTime;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import io.vertx.core.Vertx;
-import io.vertx.core.json.jackson.DatabindCodec;
-import io.vertx.ext.web.client.WebClient;
-import io.vertx.ext.web.client.WebClientOptions;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.kie.kogito.jobs.ProcessInstanceJobDescription;
 import org.kie.kogito.jobs.ProcessJobDescription;
 import org.kie.kogito.jobs.api.Job;
 import org.kie.kogito.jobs.api.JobBuilder;
+import org.kie.kogito.jobs.api.JobNotFoundException;
 import org.kie.kogito.jobs.management.RestJobsService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.jackson.DatabindCodec;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
 
 @ApplicationScoped
 public class VertxJobsService extends RestJobsService {
@@ -66,13 +71,15 @@ public class VertxJobsService extends RestJobsService {
 
     @PostConstruct
     void initialize() {
-        DatabindCodec.mapper().disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE);        
+        DatabindCodec.mapper().disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE);
+        DatabindCodec.mapper().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);             
         DatabindCodec.mapper().registerModule(new JavaTimeModule());
         DatabindCodec.mapper().findAndRegisterModules();
         
         DatabindCodec.prettyMapper().registerModule(new JavaTimeModule());
         DatabindCodec.prettyMapper().findAndRegisterModules();
         DatabindCodec.prettyMapper().disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE);
+        DatabindCodec.prettyMapper().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
         if (providedWebClient.isResolvable()) {
             this.client = providedWebClient.get();
@@ -133,5 +140,25 @@ public class VertxJobsService extends RestJobsService {
         });
         
         return true;
+    }
+
+    @Override
+    public ZonedDateTime getScheduledTime(String id) {
+        Promise<Job> promise = Promise.promise();
+        
+        client.get(JOBS_PATH + "/" + id).send(res -> {
+            if (res.succeeded() && res.result().statusCode() == 200) {
+                promise.complete(res.result().bodyAsJson(Job.class));
+            } else if (res.succeeded() && res.result().statusCode() == 404) {
+                promise.fail(new JobNotFoundException(id));
+            } else {
+                promise.fail(new RuntimeException("Unable to find job with id " + id));
+            }
+        });
+        if (promise.future().result() != null) {
+            return promise.future().result().getExpirationTime();
+        } else {
+            throw new RuntimeException(promise.future().cause());
+        }
     }
 }

--- a/addons/jobs/jobs-management-springboot-addon/src/main/java/org/kie/kogito/jobs/management/springboot/SpringRestJobsService.java
+++ b/addons/jobs/jobs-management-springboot-addon/src/main/java/org/kie/kogito/jobs/management/springboot/SpringRestJobsService.java
@@ -16,12 +16,15 @@
 
 package org.kie.kogito.jobs.management.springboot;
 
+import java.time.ZonedDateTime;
+
 import javax.annotation.PostConstruct;
 
 import org.kie.kogito.jobs.ProcessInstanceJobDescription;
 import org.kie.kogito.jobs.ProcessJobDescription;
 import org.kie.kogito.jobs.api.Job;
 import org.kie.kogito.jobs.api.JobBuilder;
+import org.kie.kogito.jobs.api.JobNotFoundException;
 import org.kie.kogito.jobs.management.RestJobsService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,6 +32,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException.NotFound;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
@@ -100,8 +104,21 @@ public class SpringRestJobsService extends RestJobsService {
             
             return true;
         } catch (RestClientException e) {
-            LOGGER.debug("Exceltion thrown during canceling of job {}", id, e);
+            LOGGER.debug("Exception thrown during canceling of job {}", id, e);
             return false;
+        }
+    }
+
+    @Override
+    public ZonedDateTime getScheduledTime(String id) {
+        try {
+            Job foundJob = restTemplate.getForObject(getJobsServiceUri() + "/{id}", Job.class, id);
+            
+            return foundJob.getExpirationTime();
+        } catch (NotFound e) {
+            throw new JobNotFoundException(id);
+        } catch (RestClientException e) {
+            throw new RuntimeException(e);
         }
     }
 }

--- a/addons/jobs/jobs-management-springboot-addon/src/test/java/org/kie/kogito/jobs/management/springboot/SpringRestJobsServiceTest.java
+++ b/addons/jobs/jobs-management-springboot-addon/src/test/java/org/kie/kogito/jobs/management/springboot/SpringRestJobsServiceTest.java
@@ -17,6 +17,7 @@
 package org.kie.kogito.jobs.management.springboot;
 
 import java.net.URI;
+import java.time.ZonedDateTime;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,16 +26,19 @@ import org.kie.kogito.jobs.ExactExpirationTime;
 import org.kie.kogito.jobs.ProcessInstanceJobDescription;
 import org.kie.kogito.jobs.ProcessJobDescription;
 import org.kie.kogito.jobs.api.Job;
+import org.kie.kogito.jobs.api.JobNotFoundException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException.NotFound;
 import org.springframework.web.client.RestTemplate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -85,5 +89,29 @@ public class SpringRestJobsServiceTest {
     void testCancelJob() {
         tested.cancelJob("123");
         verify(restTemplate).delete(tested.getJobsServiceUri() + "/{id}", "123");
+    }
+    
+    @Test
+    void testGetScheduleTime() {
+        
+        Job job = new Job();
+        job.setId("123");
+        job.setExpirationTime(ZonedDateTime.now());
+        
+        when(restTemplate.getForObject(any(), any(), anyString())).thenReturn(job);
+        
+        ZonedDateTime scheduledTime = tested.getScheduledTime("123");
+        assertThat(scheduledTime).isNotNull();
+        verify(restTemplate).getForObject(tested.getJobsServiceUri() + "/{id}", Job.class, "123");
+    }
+    
+    @Test
+    void testGetScheduleTimeJobNotFound() {
+
+        when(restTemplate.getForObject(any(), any(), anyString())).thenThrow(NotFound.class);
+        
+        assertThatThrownBy(() -> tested.getScheduledTime("123"))
+        .isInstanceOf(JobNotFoundException.class);
+        verify(restTemplate).getForObject(tested.getJobsServiceUri() + "/{id}", Job.class, "123");
     }
 }

--- a/api/kogito-api/src/main/java/org/kie/api/runtime/process/EventListener.java
+++ b/api/kogito-api/src/main/java/org/kie/api/runtime/process/EventListener.java
@@ -16,6 +16,11 @@
 
 package org.kie.api.runtime.process;
 
+import java.util.Collections;
+import java.util.Set;
+
+import org.kie.kogito.process.EventDescription;
+
 /**
  * An interface that represents an element that is listening
  * for specific types of events.
@@ -38,5 +43,14 @@ public interface EventListener {
      * May return <code>null</code> if the event types are unknown.
      */
     String[] getEventTypes();
+    
+    
+    /**
+     * Returns unique set of event descriptions that this event listener is interested in.
+     * @return returns set of event definitions awaiting or empty set
+     */
+    default Set<EventDescription> getEventDescriptions() {
+        return Collections.emptySet();
+    }
 
 }

--- a/api/kogito-api/src/main/java/org/kie/api/runtime/process/WorkItem.java
+++ b/api/kogito-api/src/main/java/org/kie/api/runtime/process/WorkItem.java
@@ -147,7 +147,7 @@ public interface WorkItem {
      * @return the related node instance
      */
     NodeInstance getNodeInstance();
-    
+
     /**
      * The process instance that requested the execution of this
      * work item

--- a/api/kogito-api/src/main/java/org/kie/kogito/jobs/JobsService.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/jobs/JobsService.java
@@ -16,6 +16,8 @@
 
 package org.kie.kogito.jobs;
 
+import java.time.ZonedDateTime;
+
 /**
  * JobsService provides an entry point for working with different types of jobs
  * that are meant by default to run in background. 
@@ -42,7 +44,14 @@ public interface JobsService {
     /**
      * Cancels given job
      * @param id unique id of the job
-     * @return return true if the cancellation was successful, otherwise false 
+     * @return returns true if the cancellation was successful, otherwise false 
      */
     boolean cancelJob(String id);
+    
+    /**
+     * Returns actual schedule time for the next expiration of given job
+     * @param id unique id of the job
+     * @return returns actual expiration time for the job
+     */
+    ZonedDateTime getScheduledTime(String id);
 }

--- a/api/kogito-api/src/main/java/org/kie/kogito/process/EventDescription.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/process/EventDescription.java
@@ -1,0 +1,136 @@
+package org.kie.kogito.process;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class EventDescription {
+
+    private String event;
+    private String nodeId;
+    private String nodeName;
+    private String eventType;
+
+    private String nodeInstanceId;
+
+    private String processInstanceId;
+
+    private Object dataType;
+    
+    private Map<String, String> properties = new HashMap<>();
+       
+    public EventDescription(String event, String nodeId, String nodeName, String eventType, String nodeInstanceId, String processInstanceId, Object dataType) {
+        this.event = event;
+        this.nodeId = nodeId;
+        this.nodeName = nodeName;
+        this.eventType = eventType;
+        this.nodeInstanceId = nodeInstanceId;
+        this.processInstanceId = processInstanceId;
+        this.dataType = dataType;
+    }
+    
+    public EventDescription(String event, String nodeId, String nodeName, String eventType, String nodeInstanceId, String processInstanceId, Object dataType, Map<String, String> properties) {
+        this.event = event;
+        this.nodeId = nodeId;
+        this.nodeName = nodeName;
+        this.eventType = eventType;
+        this.nodeInstanceId = nodeInstanceId;
+        this.processInstanceId = processInstanceId;
+        this.dataType = dataType;
+        this.properties = properties;
+    }
+
+    public String getEvent() {
+        return event;
+    }
+
+    public String getNodeId() {
+        return nodeId;
+    }
+
+    public String getNodeName() {
+        return nodeName;
+    }
+    
+    public String getEventType() {
+        return eventType;
+    }
+
+    public String getNodeInstanceId() {
+        return nodeInstanceId;
+    }
+
+    public String getProcessInstanceId() {
+        return processInstanceId;
+    }
+
+    public Object getDataType() {
+        return dataType;
+    }
+    
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    @Override
+    public String toString() {
+        return "EventDesciption [event=" + event + ", nodeId=" + nodeId + ", nodeName=" + nodeName + ", eventType=" + eventType + ", nodeInstanceId=" + nodeInstanceId + ", processInstanceId=" + processInstanceId +
+               ", dataType=" + dataType + ", properties=" + properties + "]";
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((dataType == null) ? 0 : dataType.hashCode());
+        result = prime * result + ((event == null) ? 0 : event.hashCode());
+        result = prime * result + ((nodeId == null) ? 0 : nodeId.hashCode());
+        result = prime * result + ((nodeName == null) ? 0 : nodeName.hashCode());
+        result = prime * result + ((eventType == null) ? 0 : eventType.hashCode());
+        result = prime * result + ((processInstanceId == null) ? 0 : processInstanceId.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        EventDescription other = (EventDescription) obj;
+        if (dataType == null) {
+            if (other.dataType != null)
+                return false;
+        } else if (!dataType.equals(other.dataType))
+            return false;
+        if (event == null) {
+            if (other.event != null)
+                return false;
+        } else if (!event.equals(other.event))
+            return false;
+        if (nodeId == null) {
+            if (other.nodeId != null)
+                return false;
+        } else if (!nodeId.equals(other.nodeId))
+            return false;
+        if (nodeName == null) {
+            if (other.nodeName != null)
+                return false;
+        } else if (!nodeName.equals(other.nodeName))
+            return false;
+        if (eventType == null) {
+            if (other.eventType != null)
+                return false;
+        } else if (!eventType.equals(other.eventType))
+            return false;
+        if (processInstanceId == null) {
+            if (other.processInstanceId != null)
+                return false;
+        } else if (!processInstanceId.equals(other.processInstanceId))
+            return false;
+        return true;
+    }
+    
+    
+}

--- a/api/kogito-api/src/main/java/org/kie/kogito/process/Process.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/process/Process.java
@@ -38,4 +38,5 @@ public interface Process<T> {
     void activate();
 
     void deactivate();
+
 }

--- a/api/kogito-api/src/main/java/org/kie/kogito/process/ProcessInstance.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/process/ProcessInstance.java
@@ -18,6 +18,7 @@ package org.kie.kogito.process;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import org.kie.api.runtime.process.WorkItemNotFoundException;
 import org.kie.kogito.process.workitem.Policy;
@@ -158,5 +159,7 @@ public interface ProcessInstance<T> {
     void cancelNodeInstance(String nodeInstanceId);
     
     void retriggerNodeInstance(String nodeInstanceId);
+        
+    Set<EventDescription> events();
 
 }

--- a/api/kogito-services/src/main/java/org/kie/services/jobs/impl/InMemoryJobService.java
+++ b/api/kogito-services/src/main/java/org/kie/services/jobs/impl/InMemoryJobService.java
@@ -17,6 +17,7 @@
 package org.kie.services.jobs.impl;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
@@ -88,6 +89,20 @@ public class InMemoryJobService implements JobsService {
         }
         
         return false;
+    }
+    
+    @Override
+    public ZonedDateTime getScheduledTime(String id) {
+        if (scheduledJobs.containsKey(id)) {
+             ScheduledFuture<?> scheduled = scheduledJobs.get(id);
+             
+             long remainingTime = scheduled.getDelay(TimeUnit.MILLISECONDS);
+             if (remainingTime > 0) {
+                 return ZonedDateTime.from(Instant.ofEpochMilli(System.currentTimeMillis() + remainingTime));
+             }
+        }
+        
+        return null;
     }
     
     protected long calculateDelay(JobDescription description) {

--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/IntermediateEventTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/IntermediateEventTest.java
@@ -180,9 +180,11 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         Set<EventDescription> eventDescriptions = processInstance.getEventDescriptions();
         assertThat(eventDescriptions)
             .hasSize(2)
-            .extracting("event").contains("MySignal");
+            .extracting("event").contains("MySignal", "workItemCompleted");
         assertThat(eventDescriptions)
-            .extracting("eventType").contains("signal");
+            .extracting("eventType").contains("signal", "workItem");
+        assertThat(eventDescriptions)
+            .extracting("nodeId").contains("BoundaryEvent_2", "UserTask_1");
         assertThat(eventDescriptions)            
             .extracting("processInstanceId").contains(processInstance.getId());
         assertThat(eventDescriptions)
@@ -190,6 +192,22 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
             .hasSize(1)
             .extracting("properties", Map.class)
             .anyMatch(m -> m.containsKey("AttachedToID") && m.containsKey("AttachedToName"));
+        assertThat(eventDescriptions)
+            .filteredOn("eventType", "signal")
+            .hasSize(1)
+            .extracting("nodeInstanceId").containsOnlyNulls();        
+        
+        assertThat(eventDescriptions)
+            .filteredOn("eventType", "workItem")
+            .hasSize(1)
+            .extracting("nodeInstanceId").doesNotContainNull();
+        
+        assertThat(eventDescriptions)
+        .filteredOn("eventType", "workItem")
+        .hasSize(1)
+        .extracting("dataType", Map.class)
+        .anyMatch(m -> m.containsKey("Output"))
+        .anyMatch(m -> m.get("Output") instanceof StringDataType);
                
         ksession.signalEvent("MySignal", "value");
         assertProcessInstanceFinished(processInstance, ksession);
@@ -242,9 +260,9 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         Set<EventDescription> eventDescriptions = processInstance.getEventDescriptions();
         assertThat(eventDescriptions)
             .hasSize(2)
-            .extracting("event").contains("MyMessage");
+            .extracting("event").contains("MyMessage", "workItemCompleted");
         assertThat(eventDescriptions)
-            .extracting("eventType").contains("signal");
+            .extracting("eventType").contains("signal", "workItem");
         assertThat(eventDescriptions)            
             .extracting("processInstanceId").contains(processInstance.getId());
         assertThat(eventDescriptions)
@@ -321,6 +339,8 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
             .extracting("dataType").hasOnlyElementsOfType(StringDataType.class);
         assertThat(eventDescriptions)            
             .extracting("processInstanceId").contains(processInstance.getId());
+        assertThat(eventDescriptions)            
+            .extracting("nodeInstanceId").containsOnlyNulls();
         
         ksession.signalEvent("Yes", "YesValue", processInstance.getId());
         assertProcessInstanceFinished(processInstance, ksession);

--- a/jbpm/jbpm-bpmn2/src/test/resources/BPMN2-BoundarySignalEventOnTaskbpmn2.bpmn
+++ b/jbpm/jbpm-bpmn2/src/test/resources/BPMN2-BoundarySignalEventOnTaskbpmn2.bpmn
@@ -25,6 +25,7 @@
         <dataInput id="_DataInput_5" name="GroupId"/>
         <dataInput id="_DataInput_6" name="Skippable"/>
         <dataInput id="_DataInput_7" name="Content"/>
+        <dataOutput id="_DataOutput_1" name="Output"/>
         <inputSet id="_InputSet_2" name="  Input Set 2">
           <dataInputRefs>_DataInput_2</dataInputRefs>
           <dataInputRefs>_DataInput_3</dataInputRefs>
@@ -33,7 +34,9 @@
           <dataInputRefs>_DataInput_6</dataInputRefs>
           <dataInputRefs>_DataInput_7</dataInputRefs>
         </inputSet>
-        <outputSet/>
+        <outputSet>
+          <dataOutputRefs>_DataOutput_1</dataOutputRefs>
+        </outputSet>
       </ioSpecification>
       <dataInputAssociation id="_DataInputAssociation_2">
         <targetRef>_DataInput_2</targetRef>
@@ -53,6 +56,10 @@
       <dataInputAssociation id="_DataInputAssociation_7">
         <targetRef>_DataInput_7</targetRef>
       </dataInputAssociation>
+      <dataOutputAssociation id="_DataOutputAssociation_7">
+        <sourceRef>_DataOutput_1</sourceRef>
+        <targetRef>x</targetRef>
+      </dataOutputAssociation>
       <potentialOwner id="PotentialOwner_1" name="john">
         <resourceAssignmentExpression id="ResourceAssignmentExpression_1">
           <formalExpression id="FormalExpression_1">john</formalExpression>

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/CompositeNode.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/CompositeNode.java
@@ -491,4 +491,9 @@ public class CompositeNode extends StateBasedNode implements NodeContainer, Even
         
     }
 
+    @Override
+    public String getVariableName() {
+        return null;
+    }
+
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/EventNodeInterface.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/EventNodeInterface.java
@@ -25,5 +25,7 @@ public interface EventNodeInterface {
 	default	boolean acceptsEvent(String type, Object event, Function<String, String> resolver) {
 	    return acceptsEvent(type, event);
 	}
+	
+	String getVariableName();
 
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/EventSubProcessNode.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/EventSubProcessNode.java
@@ -92,5 +92,15 @@ public class EventSubProcessNode extends CompositeContextNode {
         return super.acceptsEvent(type, event);
     }
     
+    @Override
+    public String getVariableName() {
+        StartNode startNode = findStartNode();
+        if (startNode != null) {
+            return (String) startNode.getMetaData("TriggerMapping");
+        }
+        
+        return super.getVariableName();
+    }
+    
 }
 

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/WorkflowProcessInstanceImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/WorkflowProcessInstanceImpl.java
@@ -16,14 +16,18 @@
 
 package org.jbpm.workflow.instance.impl;
 
+import static org.jbpm.workflow.instance.impl.DummyEventListener.EMPTY_EVENT_LISTENER;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Function;
@@ -33,7 +37,9 @@ import java.util.stream.Collectors;
 import org.drools.core.common.InternalKnowledgeRuntime;
 import org.drools.core.util.MVELSafeHelper;
 import org.jbpm.process.core.ContextContainer;
+import org.jbpm.process.core.context.variable.Variable;
 import org.jbpm.process.core.context.variable.VariableScope;
+import org.jbpm.process.core.datatype.DataType;
 import org.jbpm.process.core.timer.BusinessCalendar;
 import org.jbpm.process.core.timer.DateTimeUtils;
 import org.jbpm.process.core.timer.Timer;
@@ -45,12 +51,14 @@ import org.jbpm.util.PatternConstants;
 import org.jbpm.workflow.core.DroolsAction;
 import org.jbpm.workflow.core.impl.NodeImpl;
 import org.jbpm.workflow.core.node.ActionNode;
+import org.jbpm.workflow.core.node.BoundaryEventNode;
 import org.jbpm.workflow.core.node.DynamicNode;
 import org.jbpm.workflow.core.node.EndNode;
 import org.jbpm.workflow.core.node.EventNode;
 import org.jbpm.workflow.core.node.EventNodeInterface;
 import org.jbpm.workflow.core.node.EventSubProcessNode;
 import org.jbpm.workflow.core.node.StateBasedNode;
+import org.jbpm.workflow.core.node.StateNode;
 import org.jbpm.workflow.instance.NodeInstance;
 import org.jbpm.workflow.instance.WorkflowProcessInstance;
 import org.jbpm.workflow.instance.node.CompositeNodeInstance;
@@ -61,6 +69,7 @@ import org.jbpm.workflow.instance.node.EventNodeInstance;
 import org.jbpm.workflow.instance.node.EventNodeInstanceInterface;
 import org.jbpm.workflow.instance.node.EventSubProcessNodeInstance;
 import org.jbpm.workflow.instance.node.FaultNodeInstance;
+import org.jbpm.workflow.instance.node.StateBasedNodeInstance;
 import org.kie.api.definition.process.Node;
 import org.kie.api.definition.process.NodeContainer;
 import org.kie.api.definition.process.WorkflowProcess;
@@ -70,12 +79,11 @@ import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.internal.process.CorrelationKey;
 import org.kie.kogito.jobs.DurationExpirationTime;
 import org.kie.kogito.jobs.ProcessInstanceJobDescription;
+import org.kie.kogito.process.EventDescription;
 import org.kie.services.time.TimerInstance;
 import org.mvel2.integration.VariableResolverFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.jbpm.workflow.instance.impl.DummyEventListener.EMPTY_EVENT_LISTENER;
 
 /**
  * Default implementation of a RuleFlow process instance.
@@ -764,6 +772,91 @@ public abstract class WorkflowProcessInstanceImpl extends ProcessInstanceImpl
     @Override
     public String[] getEventTypes() {
         return externalEventListeners.keySet().stream().map(this::resolveVariable).collect(Collectors.toList()).toArray(new String[externalEventListeners.size()]);
+    }
+    
+    @Override
+    public Set<EventDescription> getEventDescriptions() {
+        VariableScope variableScope = (VariableScope) ((ContextContainer) getProcess()).getDefaultContext(VariableScope.VARIABLE_SCOPE);
+        Set<EventDescription> eventDesciptions = new LinkedHashSet<>();
+        
+        List<EventListener> activeListeners = eventListeners.values().stream()
+                .flatMap(List::stream)
+                .collect(Collectors.toList());
+        
+        activeListeners.addAll(externalEventListeners.values().stream()
+                    .flatMap(List::stream)
+                    .collect(Collectors.toList()));
+        
+        activeListeners.forEach(el -> eventDesciptions.addAll(el.getEventDescriptions()));
+        
+ 
+        ((org.jbpm.workflow.core.WorkflowProcess)getProcess()).getNodesRecursively().stream().filter(n -> n instanceof EventNodeInterface).forEach(n -> {
+            
+            DataType dataType = null;
+            if (((EventNodeInterface)n).getVariableName() != null) {
+                Variable evantVar = variableScope.findVariable(((EventNodeInterface)n).getVariableName());
+                if (evantVar != null) {
+                    dataType = evantVar.getType();
+                }
+            }
+            if (n instanceof BoundaryEventNode) {
+                BoundaryEventNode boundaryEventNode = (BoundaryEventNode) n;
+                StateBasedNodeInstance attachedToNodeInstance = (StateBasedNodeInstance) getNodeInstances(true).stream().filter( ni -> ni.getNode().getMetaData().get("UniqueId").equals(boundaryEventNode.getAttachedToNodeId())).findFirst().get();
+                if (attachedToNodeInstance != null) {
+                    Map<String, String> properties = new HashMap<>();
+                    properties.put("AttachedToID", attachedToNodeInstance.getNodeDefinitionId());
+                    properties.put("AttachedToName", attachedToNodeInstance.getNodeName());
+                    String eventType = "signal";
+                    String eventName = boundaryEventNode.getType();
+                    Map<String, String> timerProperties = attachedToNodeInstance.extractTimerEventInformation();
+                    if (timerProperties != null) {
+                        properties.putAll(timerProperties);
+                        eventType = "timer";
+                        eventName = "timerTriggered";
+                    } 
+                
+                    eventDesciptions.add(new EventDescription(eventName, (String)n.getMetaData().get("UniqueId"), n.getName(), eventType, null, getId(), dataType, properties));
+                    
+                }
+                
+            } else if (n instanceof EventSubProcessNode) {
+                EventSubProcessNode eventSubProcessNode = (EventSubProcessNode) n;
+                Node startNode = eventSubProcessNode.findStartNode();
+                Map<Timer, DroolsAction> timers = eventSubProcessNode.getTimers();
+                if (timers != null && !timers.isEmpty()) {
+                    getNodeInstances(eventSubProcessNode.getId()).forEach(ni -> {
+                        
+                        Map<String, String> timerProperties = ((StateBasedNodeInstance) ni).extractTimerEventInformation();
+                        if (timerProperties != null) {
+                         
+                            eventDesciptions.add(new EventDescription("timerTriggered", (String)startNode.getMetaData().get("UniqueId"), startNode.getName(), "timer", ni.getId(), getId(), null, timerProperties));
+                          
+                        }
+                    });
+                } else {
+                
+                    for (String eventName : eventSubProcessNode.getEvents()) {
+                        
+                        eventDesciptions.add(new EventDescription(eventName, (String)startNode.getMetaData().get("UniqueId"), startNode.getName(), "signal", null, getId(), dataType));
+                    }
+                
+                }
+            } else if (n instanceof EventNode) {
+                DataType finalDataType = dataType;
+                getNodeInstances(n.getId()).forEach(ni -> {
+                    eventDesciptions.add(new EventDescription(((EventNode) n).getType(), (String)n.getMetaData().get("UniqueId"), n.getName(), (String)n.getMetaData().getOrDefault("EventType", "signal"), null, getId(), finalDataType));
+                });
+            } else if (n instanceof StateNode) {
+                
+                getNodeInstances(n.getId()).forEach(ni -> {
+                    eventDesciptions.add(new EventDescription((String)n.getMetaData().get("Condition"), (String)n.getMetaData().get("UniqueId"), n.getName(), (String)n.getMetaData().getOrDefault("EventType", "signal"), null, getId(), null));
+                });
+            }
+            
+        });
+        
+        
+        return eventDesciptions;
     }
 
     @Override

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/EventNodeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/EventNodeInstance.java
@@ -19,12 +19,15 @@ package org.jbpm.workflow.instance.node;
 import static org.jbpm.workflow.instance.impl.DummyEventListener.EMPTY_EVENT_LISTENER;
 
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 
 import org.jbpm.process.core.context.variable.VariableScope;
+import org.jbpm.process.core.datatype.DataType;
 import org.jbpm.process.core.event.EventTransformer;
 import org.jbpm.process.instance.InternalProcessRuntime;
 import org.jbpm.process.instance.ProcessInstance;
@@ -37,13 +40,14 @@ import org.jbpm.workflow.instance.impl.WorkflowProcessInstanceImpl;
 import org.kie.api.runtime.process.EventListener;
 import org.kie.api.runtime.process.NodeInstance;
 import org.kie.kogito.jobs.JobsService;
+import org.kie.kogito.process.EventDescription;
 import org.kie.services.time.TimerInstance;
 
 /**
  * Runtime counterpart of an event node.
  * 
  */
-public class EventNodeInstance extends ExtendedNodeInstanceImpl implements EventNodeInstanceInterface, EventBasedNodeInstanceInterface {
+public class EventNodeInstance extends ExtendedNodeInstanceImpl implements EventListener, EventNodeInstanceInterface, EventBasedNodeInstanceInterface {
 
     private static final long serialVersionUID = 510l;
 
@@ -285,4 +289,19 @@ public class EventNodeInstance extends ExtendedNodeInstanceImpl implements Event
 	private void callSignal(String type, Object event) {
 	    signalEvent(type, event);
 	}
+
+    @Override
+    public String[] getEventTypes() {
+        return new String[] {getEventType()};
+    }
+
+    @Override
+    public Set<EventDescription> getEventDescriptions() {
+        DataType dataType = null;
+        if (getEventNode().getVariableName() != null) {
+            VariableScope variableScope = (VariableScope) getEventNode().getContext(VariableScope.VARIABLE_SCOPE);
+            dataType = variableScope.findVariable(getEventNode().getVariableName()).getType();
+        }
+        return Collections.singleton(new EventDescription(getEventType(), getNodeDefinitionId(), getNodeName(), "signal", getId(), getProcessInstance().getId(), dataType));
+    }
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/StateBasedNodeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/StateBasedNodeInstance.java
@@ -57,7 +57,6 @@ import org.kie.kogito.jobs.ExactExpirationTime;
 import org.kie.kogito.jobs.ExpirationTime;
 import org.kie.kogito.jobs.JobsService;
 import org.kie.kogito.jobs.ProcessInstanceJobDescription;
-import org.kie.kogito.process.EventDescription;
 import org.kie.services.time.TimerInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/StateBasedNodeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/StateBasedNodeInstance.java
@@ -57,6 +57,7 @@ import org.kie.kogito.jobs.ExactExpirationTime;
 import org.kie.kogito.jobs.ExpirationTime;
 import org.kie.kogito.jobs.JobsService;
 import org.kie.kogito.jobs.ProcessInstanceJobDescription;
+import org.kie.kogito.process.EventDescription;
 import org.kie.services.time.TimerInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -483,4 +484,28 @@ public abstract class StateBasedNodeInstance extends ExtendedNodeInstanceImpl im
             }
         }
     }
+    
+    public Map<String, String> extractTimerEventInformation() {
+        if (getTimerInstances() != null) {
+            for (String id : getTimerInstances()) {
+                String[] ids = id.split("_");
+                
+                for (Map.Entry<Timer, DroolsAction> entry : getEventBasedNode().getTimers().entrySet()) {
+                    if (entry.getKey().getId() == Long.valueOf(ids[1])) {
+                        Map<String, String> properties = new HashMap<>();
+                        properties.put("TimerID", id);
+                        properties.put("Delay", entry.getKey().getDelay());
+                        properties.put("Period", entry.getKey().getPeriod());
+                        properties.put("Date", entry.getKey().getDate()); 
+                        
+                        return properties;
+                    }
+                
+                }
+            }
+        }
+        
+        return null;
+    }
+     
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/TimerNodeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/TimerNodeInstance.java
@@ -16,9 +16,14 @@
 
 package org.jbpm.workflow.instance.node;
 
+import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 
 import org.jbpm.process.instance.InternalProcessRuntime;
+import org.jbpm.process.instance.impl.ProcessInstanceImpl;
 import org.jbpm.workflow.core.node.TimerNode;
 import org.jbpm.workflow.instance.WorkflowProcessInstance;
 import org.kie.api.runtime.process.EventListener;
@@ -26,6 +31,7 @@ import org.kie.api.runtime.process.NodeInstance;
 import org.kie.kogito.jobs.ExpirationTime;
 import org.kie.kogito.jobs.JobsService;
 import org.kie.kogito.jobs.ProcessInstanceJobDescription;
+import org.kie.kogito.process.EventDescription;
 import org.kie.services.time.TimerInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,6 +40,7 @@ public class TimerNodeInstance extends StateBasedNodeInstance implements EventLi
 
     private static final long serialVersionUID = 510l;
     private static final Logger logger = LoggerFactory.getLogger(TimerNodeInstance.class);
+    private static final String TIMER_TRIGGERED_EVENT = "timerTriggered";
     
     private String timerId;
     
@@ -67,7 +74,7 @@ public class TimerNodeInstance extends StateBasedNodeInstance implements EventLi
 
     
     public void signalEvent(String type, Object event) {
-    	if ("timerTriggered".equals(type)) {
+    	if (TIMER_TRIGGERED_EVENT.equals(type)) {
     		TimerInstance timer = (TimerInstance) event;
             if (timer.getId().equals(timerId)) {
                 triggerCompleted(timer.getRepeatLimit() <= 0);
@@ -76,7 +83,7 @@ public class TimerNodeInstance extends StateBasedNodeInstance implements EventLi
     }
     
     public String[] getEventTypes() {
-    	return new String[] { "timerTriggered" };
+    	return new String[] { TIMER_TRIGGERED_EVENT };
     }
     
     public void triggerCompleted(boolean remove) {
@@ -99,7 +106,17 @@ public class TimerNodeInstance extends StateBasedNodeInstance implements EventLi
     
     public void removeEventListeners() {
         super.removeEventListeners();
-        ((WorkflowProcessInstance) getProcessInstance()).removeEventListener("timerTriggered", this, false);
+        ((WorkflowProcessInstance) getProcessInstance()).removeEventListener(TIMER_TRIGGERED_EVENT, this, false);
+    }
+
+    @Override
+    public Set<EventDescription> getEventDescriptions() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("TimerID", timerId);
+        properties.put("Delay", getTimerNode().getTimer().getDelay());
+        properties.put("Period", getTimerNode().getTimer().getPeriod());
+        properties.put("Date", getTimerNode().getTimer().getDate());        
+        return Collections.singleton(new EventDescription(TIMER_TRIGGERED_EVENT, getNodeDefinitionId(), getNodeName(), "timer", getId(), getProcessInstance().getId(), null, properties));
     }
 
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/TimerNodeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/TimerNodeInstance.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.jbpm.process.instance.InternalProcessRuntime;
-import org.jbpm.process.instance.impl.ProcessInstanceImpl;
 import org.jbpm.workflow.core.node.TimerNode;
 import org.jbpm.workflow.instance.WorkflowProcessInstance;
 import org.kie.api.runtime.process.EventListener;

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/WorkItemNodeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/WorkItemNodeInstance.java
@@ -690,8 +690,9 @@ public class WorkItemNodeInstance extends StateBasedNodeInstance implements Even
     @Override
     public Set<EventDescription> getEventDescriptions() {
         Map<String, DataType> outputs = new HashMap<>();
-        VariableScope variableScope = (VariableScope) getWorkItemNode().getContext(VariableScope.VARIABLE_SCOPE);
-        getWorkItemNode().getOutAssociations().forEach(da -> outputs.put(da.getTarget(), variableScope.findVariable(da.getTarget()).getType()));
+        VariableScope variableScope = (VariableScope) getProcessInstance().getContextContainer().getDefaultContext(VariableScope.VARIABLE_SCOPE);
+        getWorkItemNode().getOutAssociations().forEach(da -> da.getSources().forEach(s -> outputs.put(s, variableScope.findVariable(da.getTarget()).getType())));
+        
         // return just the main completion type of an event
         return Collections.singleton(new EventDescription("workItemCompleted", getNodeDefinitionId(), getNodeName(), "workItem", getId(), getProcessInstance().getId(), outputs));
     }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/WorkItemNodeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/WorkItemNodeInstance.java
@@ -19,11 +19,13 @@ package org.jbpm.workflow.instance.node;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 
 import org.drools.core.WorkItemHandlerNotFoundException;
@@ -66,6 +68,7 @@ import org.kie.api.runtime.process.DataTransformer;
 import org.kie.api.runtime.process.EventListener;
 import org.kie.api.runtime.process.NodeInstance;
 import org.kie.api.runtime.process.ProcessWorkItemHandlerException;
+import org.kie.kogito.process.EventDescription;
 import org.kie.kogito.process.workitem.WorkItemExecutionError;
 import org.mvel2.MVEL;
 import org.slf4j.Logger;
@@ -682,6 +685,15 @@ public class WorkItemNodeInstance extends StateBasedNodeInstance implements Even
         KieRuntime kruntime = ((ProcessInstance) getProcessInstance()).getKnowledgeRuntime();        
         
         return kruntime;
+    }
+
+    @Override
+    public Set<EventDescription> getEventDescriptions() {
+        Map<String, DataType> outputs = new HashMap<>();
+        VariableScope variableScope = (VariableScope) getWorkItemNode().getContext(VariableScope.VARIABLE_SCOPE);
+        getWorkItemNode().getOutAssociations().forEach(da -> outputs.put(da.getTarget(), variableScope.findVariable(da.getTarget()).getType()));
+        // return just the main completion type of an event
+        return Collections.singleton(new EventDescription("workItemCompleted", getNodeDefinitionId(), getNodeName(), "workItem", getId(), getProcessInstance().getId(), outputs));
     }
     
     /*

--- a/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcess.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcess.java
@@ -100,7 +100,7 @@ public abstract class AbstractProcess<T extends Model> implements Process<T> {
     public <S> void send(Signal<S> signal) {
         instances().values().forEach(pi -> pi.send(signal));
     }
-    
+
     public Process<T> configure() {
 
         registerListeners();

--- a/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcessInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcessInstance.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -42,6 +43,7 @@ import org.kie.internal.process.CorrelationAwareProcessRuntime;
 import org.kie.internal.process.CorrelationKey;
 import org.kie.internal.process.CorrelationProperty;
 import org.kie.kogito.Model;
+import org.kie.kogito.process.EventDescription;
 import org.kie.kogito.process.MutableProcessInstances;
 import org.kie.kogito.process.NodeInstanceNotFoundException;
 import org.kie.kogito.process.NodeNotFoundException;
@@ -351,6 +353,14 @@ public abstract class AbstractProcessInstance<T extends Model> implements Proces
         this.rt.getWorkItemManager().transitionWorkItem(id, transition);
         removeOnFinish();
     }
+    
+    
+    @Override
+    public Set<EventDescription> events() {
+        
+        return legacyProcessInstance().getEventDescriptions();
+    }
+
 
     protected void removeOnFinish() {
 

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/tests/SignalEventTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/tests/SignalEventTest.java
@@ -19,11 +19,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
+import org.jbpm.process.core.datatype.impl.type.ObjectDataType;
 import org.junit.jupiter.api.Test;
 import org.kie.kogito.Application;
 import org.kie.kogito.Model;
 import org.kie.kogito.codegen.AbstractCodegenTest;
+import org.kie.kogito.process.EventDescription;
 import org.kie.kogito.process.Process;
 import org.kie.kogito.process.ProcessInstance;
 import org.kie.kogito.process.WorkItem;
@@ -47,11 +50,29 @@ public class SignalEventTest extends AbstractCodegenTest {
         
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_ACTIVE);
         
+        Set<EventDescription> eventDescriptions = processInstance.events();
+        assertThat(eventDescriptions)
+            .hasSize(1)
+            .extracting("event").contains("workItemCompleted");
+        assertThat(eventDescriptions)
+            .extracting("eventType").contains("workItem");
+        assertThat(eventDescriptions)            
+            .extracting("processInstanceId").contains(processInstance.id());
+        
         List<WorkItem> workItems = processInstance.workItems();
         assertThat(workItems).hasSize(1);
         
         processInstance.completeWorkItem(workItems.get(0).getId(), null);
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_ACTIVE);
+        
+        eventDescriptions = processInstance.events();
+        assertThat(eventDescriptions)
+            .hasSize(1)
+            .extracting("event").contains("MyMessage");
+        assertThat(eventDescriptions)
+            .extracting("eventType").contains("signal");
+        assertThat(eventDescriptions)            
+            .extracting("processInstanceId").contains(processInstance.id());
         
         processInstance.send(Sig.of("MyMessage", "test"));
         
@@ -78,6 +99,17 @@ public class SignalEventTest extends AbstractCodegenTest {
         processInstance.start();
    
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_ACTIVE);
+        
+        Set<EventDescription> eventDescriptions = processInstance.events();
+        assertThat(eventDescriptions)
+            .hasSize(2)
+            .extracting("event").contains("MySignal", "workItemCompleted");
+        assertThat(eventDescriptions)
+            .extracting("eventType").contains("signal", "workItem");
+        assertThat(eventDescriptions)
+            .extracting("dataType").hasAtLeastOneElementOfType(ObjectDataType.class);
+        assertThat(eventDescriptions)            
+            .extracting("processInstanceId").contains(processInstance.id());
         
         processInstance.send(Sig.of("MySignal", "test"));
         


### PR DESCRIPTION
the main purpose of this change is to allow easily to get access to all possible listening components of the process instance. With this consumers can easily know what sort of "signals" or "events" given process instance can expect to move forward.

In addition to that an extra commit was added to enhance JobService used by the engine to allow to get current schedule time of a timer by its id. Something that the JobsService (vert.x based) already exposed as it returns complete ScheduledJob info.


````
Set<EventDescription> eventDescriptions = processInstance.getEventDescriptions();
        assertThat(eventDescriptions)
            .hasSize(2)
            .extracting("event").contains("Yes", "timerTriggered");
        assertThat(eventDescriptions)
            .extracting("eventType").contains("signal", "timer");
        assertThat(eventDescriptions)
            .extracting("dataType").hasAtLeastOneElementOfType(StringDataType.class);
        assertThat(eventDescriptions)            
            .extracting("processInstanceId").contains(processInstance.getId());
        assertThat(eventDescriptions)
        .filteredOn("eventType", "timer")
        .hasSize(1)
        .extracting("properties", Map.class)
        .anyMatch(m -> m.containsKey("TimerID") && m.containsKey("Delay"));
````