### PR TITLE
KOGITO-1781: set modelName and modelNamespace in DMNResult

### DIFF
--- a/drools/kogito-dmn/src/main/java/org/kie/kogito/dmn/DMNKogito.java
+++ b/drools/kogito-dmn/src/main/java/org/kie/kogito/dmn/DMNKogito.java
@@ -113,7 +113,7 @@ public class DMNKogito {
                                                                            null,
                                                                            null,
                                                                            null);
-        return new DMNResult(evaluationResult.result);
+        return new DMNResult(modelNamespace, modelName, evaluationResult.result);
     }
 
 }

--- a/drools/kogito-dmn/src/main/java/org/kie/kogito/dmn/rest/DMNResult.java
+++ b/drools/kogito-dmn/src/main/java/org/kie/kogito/dmn/rest/DMNResult.java
@@ -49,16 +49,12 @@ public class DMNResult implements Serializable, org.kie.dmn.api.core.DMNResult {
         // Intentionally blank.
     }
 
-    public DMNResult(org.kie.dmn.api.core.DMNResult dmnResult) {
+    public DMNResult(String namespace, String modelName, org.kie.dmn.api.core.DMNResult dmnResult) {
+        this.namespace = namespace;
+        this.modelName = modelName;
         this.setDmnContext(dmnResult.getContext().getAll());
         this.setMessages(dmnResult.getMessages());
         this.setDecisionResults(dmnResult.getDecisionResults());
-    }
-
-    public DMNResult(String namespace, String modelName, org.kie.dmn.api.core.DMNResult dmnResult) {
-        this(dmnResult);
-        this.namespace = namespace;
-        this.modelName = modelName;
     }
 
     public String getNamespace() {

--- a/drools/kogito-dmn/src/main/java/org/kie/kogito/dmn/rest/DMNResult.java
+++ b/drools/kogito-dmn/src/main/java/org/kie/kogito/dmn/rest/DMNResult.java
@@ -55,7 +55,7 @@ public class DMNResult implements Serializable, org.kie.dmn.api.core.DMNResult {
         this.setDecisionResults(dmnResult.getDecisionResults());
     }
 
-    public DMNResult(String namespace, String modelName, DMNResult dmnResult) {
+    public DMNResult(String namespace, String modelName, org.kie.dmn.api.core.DMNResult dmnResult) {
         this(dmnResult);
         this.namespace = namespace;
         this.modelName = modelName;

--- a/kogito-codegen/src/main/resources/class-templates/DMNRestResourceTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/DMNRestResourceTemplate.java
@@ -19,7 +19,7 @@ public class DMNRestResourceTemplate {
     @Produces(MediaType.APPLICATION_JSON)
     public Object dmn(java.util.Map<String, Object> variables) {
         org.kie.kogito.decision.DecisionModel decision = application.decisionModels().getDecisionModel("$modelNamespace$", "$modelName$");
-        org.kie.kogito.dmn.rest.DMNResult result = new org.kie.kogito.dmn.rest.DMNResult(decision.evaluateAll(decision.newContext(variables)));
+        org.kie.kogito.dmn.rest.DMNResult result = new org.kie.kogito.dmn.rest.DMNResult("$modelNamespace$", "$modelName$", decision.evaluateAll(decision.newContext(variables)));
         if (!result.hasErrors()) {
             return result.getDmnContext();
         } else {


### PR DESCRIPTION
Hi, 

For accountability purposes we need the modelName and modelNamespace properly set in the DMNResult, this is a small PR to do that. 

Best