### PR TITLE
KOGITO-1635 Update Kogito to Quarkus 1.3.1.Final 

### DIFF
--- a/kogito-quarkus-extension/integration-test/src/test/java/io/quarkus/it/kogito/drools/HotReloadTest.java
+++ b/kogito-quarkus-extension/integration-test/src/test/java/io/quarkus/it/kogito/drools/HotReloadTest.java
@@ -17,7 +17,6 @@
 package io.quarkus.it.kogito.drools;
 
 import java.util.List;
-import java.util.function.Supplier;
 
 import io.quarkus.test.QuarkusDevModeTest;
 import io.restassured.http.ContentType;
@@ -34,31 +33,43 @@ public class HotReloadTest {
 
     private static final String PACKAGE = "io.quarkus.it.kogito.drools";
     private static final String RESOURCE_FILE = PACKAGE.replace( '.', '/' ) + "/adult.drl";
+    private static final String HTTP_TEST_PORT = "65535";
 
     @RegisterExtension
-    final static QuarkusDevModeTest test = new QuarkusDevModeTest()
-            .setArchiveProducer(new Supplier<JavaArchive>() {
-                @Override
-                public JavaArchive get() {
-                    return ShrinkWrap.create(JavaArchive.class)
-                            .addAsResource( "adult.txt", RESOURCE_FILE );
-                }
-            });
+    final static QuarkusDevModeTest test = new QuarkusDevModeTest().setArchiveProducer(
+            () -> ShrinkWrap.create(JavaArchive.class).addAsResource("adult.txt", RESOURCE_FILE));
 
     @Test
     public void testServletChange() throws InterruptedException {
         String personsPayload = "{\"persons\":[{\"name\":\"Mario\",\"age\":45,\"adult\":false},{\"name\":\"Sofia\",\"age\":17,\"adult\":false}]}";
 
-        List<String> names = given().contentType( ContentType.JSON).accept(ContentType.JSON).body(personsPayload).when()
-                .post("/find-adult-names").then().statusCode(200).extract().as( List.class );
+        List<String> names = given()
+                .baseUri("http://localhost:" + HTTP_TEST_PORT)
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .body(personsPayload)
+                .when()
+                .post("/find-adult-names")
+                .then()
+                .statusCode(200)
+                .extract()
+                .as(List.class);
 
         assertEquals(1, names.size());
         assertEquals("Mario", names.get(0));
 
         test.modifyResourceFile( RESOURCE_FILE, s -> s.replaceAll("18", "16") );
 
-        names = given().contentType( ContentType.JSON).accept(ContentType.JSON).body(personsPayload).when()
-                .post("/find-adult-names").then().statusCode(200).extract().as( List.class );
+        names = given()
+                .baseUri("http://localhost:" + HTTP_TEST_PORT)
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .body(personsPayload).when()
+                .post("/find-adult-names")
+                .then()
+                .statusCode(200)
+                .extract().
+                        as(List.class);
 
         assertEquals(2, names.size());
         assertTrue(names.contains( "Mario" ));

--- a/kogito-quarkus-extension/integration-test/src/test/resources/application.properties
+++ b/kogito-quarkus-extension/integration-test/src/test/resources/application.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2020 Red Hat, Inc. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+quarkus.http.port=65535

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
 
     <version.io.fabric8.kubernetes-client>4.8.0</version.io.fabric8.kubernetes-client>
     <version.io.prometheus>0.5.0</version.io.prometheus>
-    <version.io.quarkus>1.3.0.Final</version.io.quarkus>
+    <version.io.quarkus>1.3.1.Final</version.io.quarkus>
     <version.io.restassured>4.2.0</version.io.restassured>
     <version.io.smallrye.reactive>1.1.0</version.io.smallrye.reactive>
 
@@ -117,9 +117,9 @@
     <version.org.assertj>3.13.2</version.org.assertj>
     <version.org.eclipse.jdt>3.19.0</version.org.eclipse.jdt>
     <version.org.hamcrest>1.3</version.org.hamcrest> <!-- else old version coming from Mockito wins and breaks tests -->
-    <version.org.infinispan>10.1.2.Final</version.org.infinispan>
-    <version.org.infinispan.image>10.1.2.Final</version.org.infinispan.image>
-    <version.org.infinispan.protostream>4.3.1.Final</version.org.infinispan.protostream>
+    <version.org.infinispan>10.1.5.Final</version.org.infinispan>
+    <version.org.infinispan.image>10.1.5.Final</version.org.infinispan.image>
+    <version.org.infinispan.protostream>4.3.2.Final</version.org.infinispan.protostream>
     <version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>1.0.1.Final</version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>
     <version.org.junit.minor>6.0</version.org.junit.minor> <!-- so that org.junit.platform and org.junit can share the same minor version -->
     <version.org.junit>5.${version.org.junit.minor}</version.org.junit>


### PR DESCRIPTION
Update Kogito to Quarkus 1.3.1.Final +  align versions on POM
Integration tests: http port change to avoid conflicts (instead of 8080)

I tested the Kogito Apps and Travel Agency, it seems all are working fine with Quarkus 1.3.1