### PR TITLE
KOGITO-1786: Cannot run Kogito Tests using Eclipse

### DIFF
--- a/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/util/MojoUtil.java
+++ b/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/util/MojoUtil.java
@@ -53,7 +53,7 @@ public final class MojoUtil {
         mavenProject.setArtifactFilter(new CumulativeScopeArtifactFilter(Arrays.asList("compile", "runtime")));
         for (final Artifact artifact : mavenProject.getArtifacts()) {
             final File file = artifact.getFile();
-            if (file != null) {
+            if (file != null && file.isFile()) {
                 urls.add(file.toURI().toURL());
                 final KieModuleModel depModel = getDependencyKieModel(file);
                 if (kmoduleDeps != null && depModel != null) {

--- a/kogito-maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/kogito-maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>generateDeclaredTypes</goal>
+          <goal>generateModel</goal>
+          <goal>process-model-classes</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <execute>
+          <runOnIncremental>true</runOnIncremental>
+          <runOnConfiguration>true</runOnConfiguration>
+        </execute>
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>


### PR DESCRIPTION
JIRA Ticket: https://issues.redhat.com/browse/KOGITO-1786
Description:
These changes are about to configure the kogito maven plugin to be used within Eclipse using M2E. 

In order to check that these changes are working fine now with Eclipse, I did:

- Removed [the lifecycle-mapping plugin](https://github.com/kiegroup/kogito-examples/blob/bc72d5e7934c8e3581eec4f630cfdc8336ee9e4a/pom.xml#L224) to ignore errors in Eclipse from the kogito-examples parent module. (I provided this [PR](https://github.com/kiegroup/kogito-examples/pull/228) to remove this plugin once these changes are merged)
- Compile and install the new version of the maven plugin. 
- Configure the [process-springboot-example](https://github.com/kiegroup/kogito-examples/tree/master/process-springboot-example) to use the version I've just created
- Then, if not done automatically, in Eclipse, select the process-springboot-example project, Maven -> Update Project. Now Eclipse should see the autogenerated sources.
- Finally, we can now run any test suite or test case without issues.

I did check that this is continuing working fine with Quarkus and via command line. 