### PR TITLE
[KOGITO-1844] IllegalStateException: illegal escape character with DM…

### DIFF
--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionContainerGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionContainerGenerator.java
@@ -15,6 +15,7 @@
 
 package org.kie.kogito.codegen.decision;
 
+import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
@@ -82,7 +83,7 @@ public class DecisionContainerGenerator extends AbstractApplicationSection {
         for (DMNModel model : models) {
             Path sourcePath = Paths.get(model.getResource().getSourcePath());
             Path relativizedPath = basePath.relativize(sourcePath);
-            String resourcePath = "/" + relativizedPath;
+            String resourcePath = "/" + relativizedPath.toString().replace(File.separatorChar, '/');
             MethodCallExpr getResAsStream = new MethodCallExpr(new FieldAccessExpr(applicationClass.getNameAsExpression(), "class"), "getResourceAsStream").addArgument(new StringLiteralExpr(resourcePath));
             ObjectCreationExpr isr = new ObjectCreationExpr().setType(inputStreamReaderClass).addArgument(getResAsStream);
             Optional<FieldDeclaration> dmnRuntimeField = typeDeclaration.getFieldByName("dmnRuntime");


### PR DESCRIPTION
…N when starting Quarkus in Windows

Manually verified that it fixes the issue in Windows with

- dmn-quarkus-example
- onboarding-example/payroll

Note that if I run "mvn test" for kogito-codegen in Windows, I get several errors (not likely related to this fix).
