### PR TITLE
KOGITO-1892: Spring Boot Archetype: use version property (0.9.x)

### DIFF
--- a/archetypes/kogito-springboot-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/kogito-springboot-archetype/src/main/resources/archetype-resources/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.1.3.RELEASE</version>
+    <version>${version.springboot}</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 


### PR DESCRIPTION
fix archetype -- it is pointing an outdated version of spring boot; use property so it is always up-to-date