### PR TITLE
[KOGITO-1644] Move docker-based test cases to maven-failsafe

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,7 +73,7 @@ pipeline {
     post {
         always {
             sh '$WORKSPACE/trace.sh'
-            junit '**/target/surefire-reports/**/*.xml'
+            junit '**/target/surefire-reports/**/*.xml, **/target/failsafe-reports/**/*.xml'
         }
         failure {
             script {

--- a/Jenkinsfile-sonarcloud-daily
+++ b/Jenkinsfile-sonarcloud-daily
@@ -47,7 +47,7 @@ pipeline {
             }
         }
         always {
-            junit '**/target/surefire-reports/**/*.xml'
+            junit '**/target/surefire-reports/**/*.xml, **/target/failsafe-reports/**/*.xml'
             cleanWs()
         }
     }

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -66,7 +66,7 @@ pipeline {
                      to: env.KOGITO_CI_EMAIL_TO
         }
         always {
-            junit '**/target/surefire-reports/**/*.xml'
+            junit '**/target/surefire-reports/**/*.xml, **/target/failsafe-reports/**/*.xml'
             cleanWs()
         }
     }

--- a/Jenkinsfile.quarkus
+++ b/Jenkinsfile.quarkus
@@ -76,7 +76,7 @@ pipeline {
                      to: env.KOGITO_CI_EMAIL_TO
         }
         always {
-            junit '**/target/surefire-reports/**/*.xml'
+            junit '**/target/surefire-reports/**/*.xml, **/target/failsafe-reports/**/*.xml'
             cleanWs()
         }
     }

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Requirements
 
 - [Maven](https://maven.apache.org/) 3.6.2 or later
 - [Java](https://openjdk.java.net/install/) 11 or later (devel package)
+- optional: Docker installation for running integration tests
 
 Getting Started
 ---------------
@@ -49,11 +50,13 @@ Building from source
 --------------------
 
 1. Check out the source:
+
 ```
 git clone git@github.com:kiegroup/kogito-runtimes.git
 ```
 
 If you don't have a GitHub account use this command instead:
+
 ```
 git clone https://github.com/kiegroup/kogito-runtimes.git
 ```
@@ -61,8 +64,18 @@ git clone https://github.com/kiegroup/kogito-runtimes.git
 2. Build with Maven:
 ```
 cd kogito-runtimes
-mvn clean install -DskipTests
+mvn clean install -DskipITs
 ```
+
+3. Run integration tests
+The integrations tests are skipped in the command above. To run the tests you need to have docker installed on your machine. To run the tests during the build, just remove the `-DskipITs` argument.
+Possible issues - the tests are running docker containers using [testcontainers](https://github.com/testcontainers/testcontainers-java). That by default requires access to the docker.sock file which might result in a security alert on your system and be blocked. In such case you'll see log message similar to 'Can not connect to Ryuk'. In this case do run the tests with following ENV variable set:
+
+```
+TESTCONTAINERS_RYUK_DISABLED=true mvn clean verify
+```
+When the test run is interrupted though, you might end up with docker containers still running, check those using `docker ps` and stop when neccessary.
+
 
 Contributing to Kogito
 --------------------

--- a/addons/persistence/infinispan-persistence-addon/pom.xml
+++ b/addons/persistence/infinispan-persistence-addon/pom.xml
@@ -124,6 +124,7 @@
           <execution>
             <goals>
               <goal>integration-test</goal>
+              <goal>verify</goal>
             </goals>
           </execution>
         </executions>

--- a/addons/persistence/infinispan-persistence-addon/pom.xml
+++ b/addons/persistence/infinispan-persistence-addon/pom.xml
@@ -124,7 +124,6 @@
           <execution>
             <goals>
               <goal>integration-test</goal>
-              <goal>verify</goal>
             </goals>
           </execution>
         </executions>

--- a/addons/persistence/infinispan-persistence-addon/pom.xml
+++ b/addons/persistence/infinispan-persistence-addon/pom.xml
@@ -90,6 +90,16 @@
       <artifactId>infinispan-query</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 
@@ -103,6 +113,18 @@
             <id>make-index</id>
             <goals>
               <goal>jandex</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
             </goals>
           </execution>
         </executions>

--- a/addons/persistence/infinispan-persistence-addon/pom.xml
+++ b/addons/persistence/infinispan-persistence-addon/pom.xml
@@ -126,6 +126,11 @@
               <goal>integration-test</goal>
               <goal>verify</goal>
             </goals>
+            <configuration>
+              <systemPropertyVariables>
+                <container.image.infinispan>${container.image.infinispan}</container.image.infinispan>
+              </systemPropertyVariables>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/addons/persistence/infinispan-persistence-addon/src/test/java/org/kie/kogito/infinispan/InfinispanServerContainer.java
+++ b/addons/persistence/infinispan-persistence-addon/src/test/java/org/kie/kogito/infinispan/InfinispanServerContainer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.infinispan;
+
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.FixedHostPortGenericContainer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+import org.testcontainers.lifecycle.Startable;
+
+public class InfinispanServerContainer implements Startable {
+
+    private static final String INFINISPAN_VERSION = Optional.ofNullable(System.getProperty("infinispan.version")).orElse("latest");
+    private static final Logger LOGGER = LoggerFactory.getLogger(InfinispanServerContainer.class);
+    private GenericContainer infinispan;
+
+    @Override
+    public void start() {
+        if (INFINISPAN_VERSION == null) {
+            throw new RuntimeException("Please define a valid Infinispan image version in system property infinispan.version");
+        }
+        LOGGER.info("Using Infinispan image version: {}", INFINISPAN_VERSION);
+        infinispan = new FixedHostPortGenericContainer("quay.io/infinispan/server:" + INFINISPAN_VERSION)
+                .withFixedExposedPort(11222, 11222)
+                //wait for the server to be  fully started
+                .waitingFor(Wait.forLogMessage(".*\\bstarted\\b.*", 1))
+                .withEnv("USER", "admin")
+                .withEnv("PASS", "admin")
+                .withLogConsumer(new Slf4jLogConsumer(LOGGER));
+        infinispan.start();
+    }
+
+    @Override
+    public void stop() {
+        infinispan.stop();
+    }
+}

--- a/addons/persistence/infinispan-persistence-addon/src/test/java/org/kie/kogito/infinispan/InfinispanServerContainer.java
+++ b/addons/persistence/infinispan-persistence-addon/src/test/java/org/kie/kogito/infinispan/InfinispanServerContainer.java
@@ -29,17 +29,17 @@ import org.testcontainers.lifecycle.Startable;
 
 public class InfinispanServerContainer implements Startable {
 
-    private static final String INFINISPAN_VERSION = Optional.ofNullable(System.getProperty("infinispan.version")).orElse("latest");
+    private static final String INFINISPAN_IMAGE = System.getProperty("container.image.infinispan");
     private static final Logger LOGGER = LoggerFactory.getLogger(InfinispanServerContainer.class);
     private GenericContainer infinispan;
 
     @Override
     public void start() {
-        if (INFINISPAN_VERSION == null) {
-            throw new RuntimeException("Please define a valid Infinispan image version in system property infinispan.version");
+        if (INFINISPAN_IMAGE == null) {
+            throw new RuntimeException("Please define a valid Infinispan image in system property container.image.infinispan");
         }
-        LOGGER.info("Using Infinispan image version: {}", INFINISPAN_VERSION);
-        infinispan = new FixedHostPortGenericContainer("quay.io/infinispan/server:" + INFINISPAN_VERSION)
+        LOGGER.info("Using Infinispan image: {}", INFINISPAN_IMAGE);
+        infinispan = new FixedHostPortGenericContainer(INFINISPAN_IMAGE)
                 .withFixedExposedPort(11222, 11222)
                 //wait for the server to be  fully started
                 .waitingFor(Wait.forLogMessage(".*\\bstarted\\b.*", 1))

--- a/addons/persistence/infinispan-quarkus-health-addon/pom.xml
+++ b/addons/persistence/infinispan-quarkus-health-addon/pom.xml
@@ -70,6 +70,18 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/addons/persistence/infinispan-quarkus-health-addon/pom.xml
+++ b/addons/persistence/infinispan-quarkus-health-addon/pom.xml
@@ -79,6 +79,11 @@
               <goal>integration-test</goal>
               <goal>verify</goal>
             </goals>
+            <configuration>
+              <systemPropertyVariables>
+                <container.image.infinispan>${container.image.infinispan}</container.image.infinispan>
+              </systemPropertyVariables>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/addons/persistence/infinispan-quarkus-health-addon/pom.xml
+++ b/addons/persistence/infinispan-quarkus-health-addon/pom.xml
@@ -77,7 +77,6 @@
           <execution>
             <goals>
               <goal>integration-test</goal>
-              <goal>verify</goal>
             </goals>
           </execution>
         </executions>

--- a/addons/persistence/infinispan-quarkus-health-addon/pom.xml
+++ b/addons/persistence/infinispan-quarkus-health-addon/pom.xml
@@ -77,6 +77,7 @@
           <execution>
             <goals>
               <goal>integration-test</goal>
+              <goal>verify</goal>
             </goals>
           </execution>
         </executions>

--- a/addons/persistence/infinispan-quarkus-health-addon/src/test/java/org/kie/kogito/infinispan/InfinispanServerTestResource.java
+++ b/addons/persistence/infinispan-quarkus-health-addon/src/test/java/org/kie/kogito/infinispan/InfinispanServerTestResource.java
@@ -18,7 +18,6 @@ package org.kie.kogito.infinispan;
 
 import java.util.Collections;
 import java.util.Map;
-import java.util.Optional;
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 import org.slf4j.Logger;
@@ -30,17 +29,17 @@ import org.testcontainers.containers.wait.strategy.Wait;
 
 public class InfinispanServerTestResource implements QuarkusTestResourceLifecycleManager {
 
-    private static final String INFINISPAN_VERSION = Optional.ofNullable(System.getProperty("infinispan.version")).orElse("latest");
+    private static final String INFINISPAN_IMAGE = System.getProperty("container.image.infinispan");
     private static final Logger LOGGER = LoggerFactory.getLogger(InfinispanServerTestResource.class);
     private GenericContainer infinispan;
 
     @Override
     public Map<String, String> start() {
-        if (INFINISPAN_VERSION == null) {
-            throw new RuntimeException("Please define a valid Infinispan image version in system property infinispan.version");
+        if (INFINISPAN_IMAGE == null) {
+            throw new RuntimeException("Please define a valid Infinispan image in system property container.image.infinispan");
         }
-        LOGGER.info("Using Infinispan image version: {}", INFINISPAN_VERSION);
-        infinispan = new FixedHostPortGenericContainer("quay.io/infinispan/server:" + INFINISPAN_VERSION)
+        LOGGER.info("Using Infinispan image: {}", INFINISPAN_IMAGE);
+        infinispan = new FixedHostPortGenericContainer(INFINISPAN_IMAGE)
                 .withFixedExposedPort(11232, 11222)
                 //wait for the server to be  fully started
                 .waitingFor(Wait.forLogMessage(".*\\bstarted\\b.*", 1))

--- a/addons/persistence/infinispan-quarkus-health-addon/src/test/java/org/kie/kogito/infinispan/health/InfinispanHealthCheckIT.java
+++ b/addons/persistence/infinispan-quarkus-health-addon/src/test/java/org/kie/kogito/infinispan/health/InfinispanHealthCheckIT.java
@@ -23,12 +23,11 @@ import io.quarkus.test.junit.QuarkusTest;
 import org.assertj.core.api.Assertions;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.infinispan.client.hotrod.RemoteCacheManager;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.kie.kogito.infinispan.InfinispanServerTestResource;
 
 @QuarkusTest
-public class InfinispanHealthCheckTest {
+public class InfinispanHealthCheckIT {
 
     private InfinispanHealthCheck healthCheck;
 
@@ -36,7 +35,7 @@ public class InfinispanHealthCheckTest {
     Instance<RemoteCacheManager> instance;
 
     @Test
-    void testCall() throws Exception{
+    void testCall() throws Exception {
         InfinispanServerTestResource resource = new InfinispanServerTestResource();
         resource.start();
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,8 @@
     <jacoco.exec.file>${project.root.dir}/target/jacoco.exec</jacoco.exec.file>
     <!--suppress UnresolvedMavenProperty -->
     <project.root.dir>${maven.multiModuleProjectDirectory}</project.root.dir>
+    <tests.surefire.include>**/*Test.java</tests.surefire.include>
+    <tests.failsafe.include>**/*IT.java</tests.failsafe.include>
 
     <!-- plugin versions -->
     <version.antapacheregexp>1.8.2</version.antapacheregexp>
@@ -1023,6 +1025,14 @@
         <plugin>
           <artifactId>maven-failsafe-plugin</artifactId>
           <version>${version.surefire.plugin}</version>
+          <configuration>
+            <includes>
+              <include>${tests.failsafe.include}</include>
+            </includes>
+            <excludes>
+              <exclude>${tests.surefire.include}</exclude>
+            </excludes>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -1030,10 +1040,10 @@
           <version>${version.surefire.plugin}</version>
           <configuration>
             <includes>
-              <include>**/*Test.java</include>
+              <include>${tests.surefire.include}</include>
             </includes>
             <excludes>
-              <exclude>**/*IntegrationTest.java</exclude>
+              <exclude>${tests.failsafe.include}</exclude>
             </excludes>
             <argLine>-Xmx1024m -Dfile.encoding=UTF-8</argLine>
             <systemPropertyVariables>

--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,9 @@
     <version.spring.framework>5.2.4.RELEASE</version.spring.framework>
     <version.xmlunit>2.2.1</version.xmlunit>
     <version.jsonschema2pojo-maven-plugin>1.0.1</version.jsonschema2pojo-maven-plugin>
+
+    <!-- container images for testing -->
+    <container.image.infinispan>quay.io/infinispan/server:${version.org.infinispan.image}</container.image.infinispan>
   </properties>
 
   <!-- distributionManagement section -->


### PR DESCRIPTION
Moving tests depending on docker images to integration phase using maven failsafe plugin (in case of 'infinispan-persistence-addon' also enabling previously disabled test).