### PR TITLE
KOGITO-2042 - Pass variable definitions via BpmnProcess and BpmnVaria…

### DIFF
--- a/jbpm/jbpm-bpmn2/src/main/java/org/kie/kogito/process/bpmn2/BpmnVariables.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/kie/kogito/process/bpmn2/BpmnVariables.java
@@ -84,6 +84,6 @@ public class BpmnVariables implements Model {
         return definitions.stream()
             .filter(filter)
             .filter(v -> variables.containsKey(v.getName()))
-            .collect(Collectors.toMap(v -> v.getName(), v -> v.getName()));               
+            .collect(Collectors.toMap(v -> v.getName(), v -> variables.get(v.getName())));              
     }
 }

--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/VariableTagsTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/VariableTagsTest.java
@@ -158,7 +158,7 @@ public class VariableTagsTest extends JbpmBpmn2TestCase {
         assertThat(instance.variables().toMap(BpmnVariables.OUTPUTS_ONLY)).hasSize(0);
         assertThat(instance.variables().toMap(BpmnVariables.INPUTS_ONLY)).hasSize(0);
         assertThat(instance.variables().toMap(BpmnVariables.INTERNAL_ONLY)).hasSize(0);
-        assertThat(instance.variables().toMap(v -> v.hasTag("onlyAdmin"))).hasSize(1);
+        assertThat(instance.variables().toMap(v -> v.hasTag("onlyAdmin"))).hasSize(1).containsEntry("approver", "john");
         
         instance.abort();
         


### PR DESCRIPTION
…bles, allow to filter variables on BpmnVariables - fixed retrieving of filtered variables

a small follow up fix for filtering to make sure actual data are returned. I blame @cristianonicolai who asked me to refactor to use `Collectors.toMap` ;)

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket