### PR TITLE
[KOGITO-1768] allow code scaffolding in kogito-maven-plugin

### DIFF
--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/GeneratedFile.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/GeneratedFile.java
@@ -20,19 +20,31 @@ import java.nio.charset.StandardCharsets;
 public class GeneratedFile {
 
     public enum Type {
-        APPLICATION,
-        APPLICATION_SECTION,
-        APPLICATION_CONFIG,
-        PROCESS,
-        PROCESS_INSTANCE,
-        REST,
-        RULE,
-        QUERY,
-        MODEL,
-        CLASS,
-        MESSAGE_CONSUMER,
-        MESSAGE_PRODUCER,
-        RESOURCE;
+        APPLICATION( false ),
+        APPLICATION_SECTION( false ),
+        APPLICATION_CONFIG( false ),
+        PROCESS( false ),
+        PROCESS_INSTANCE( false ),
+        REST( false ),
+        RULE( false ),
+        DECLARED_TYPE( true ),
+        DTO( true ),
+        QUERY( true ),
+        MODEL( false ),
+        CLASS( false ),
+        MESSAGE_CONSUMER( false ),
+        MESSAGE_PRODUCER( false ),
+        RESOURCE( false );
+
+        private final boolean customizable;
+
+        Type( boolean customizable ) {
+            this.customizable = customizable;
+        }
+
+        public boolean isCustomizable() {
+            return customizable;
+        }
     }
 
     private final String relativePath;

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/DeclaredTypeCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/DeclaredTypeCodegen.java
@@ -161,7 +161,7 @@ public class DeclaredTypeCodegen extends AbstractGenerator {
         return modelFiles.stream()
                 .filter(Objects::nonNull)
                 .map(f -> new org.kie.kogito.codegen.GeneratedFile(
-                        org.kie.kogito.codegen.GeneratedFile.Type.RULE,
+                        org.kie.kogito.codegen.GeneratedFile.Type.DECLARED_TYPE,
                         f.getPath(), f.getData())).collect(toList());
     }
 

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
@@ -178,6 +178,7 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
     private KieModuleModel kieModuleModel;
     private boolean hotReloadMode = false;
     private boolean useMonitoring = false;
+    private boolean useWebServices = true;
     private String packageName;
     private final boolean decisionTableSupported;
     private final Map<String, RuleUnitConfig> configs;
@@ -349,26 +350,33 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
 
             ruleUnit.pojo().ifPresent(p -> generatedFiles.add(p.generateFile( org.kie.kogito.codegen.GeneratedFile.Type.RULE)));
 
-            List<QueryEndpointGenerator> queries = ruleUnit.queries();
-            if (!queries.isEmpty()) {
-                RuleUnitDescription ruleUnitDesc = ruleUnit.getRuleUnitDescription();
-                AssignableChecker checker;
-                if (ruleUnitDesc instanceof ReflectiveRuleUnitDescription ) {
-                    checker = (( ReflectiveRuleUnitDescription ) ruleUnitDesc).getAssignableChecker();
-                } else {
-                    if (contextChecker == null) {
-                        contextChecker = AssignableChecker.create(contextClassLoader, hotReloadMode);
-                    }
-                    checker = contextChecker;
-                }
-
-                generatedFiles.add( new RuleUnitDTOSourceClass( ruleUnitDesc, checker ).generateFile( org.kie.kogito.codegen.GeneratedFile.Type.RULE) );
-
-                for (QueryEndpointGenerator query : queries) {
-                    generateQueryEndpoint( errors, generatedFiles, query );
-                }
+            if (useWebServices) {
+                contextChecker = generateQueriesEndpoint( errors, generatedFiles, contextChecker, ruleUnit );
             }
         }
+    }
+
+    private AssignableChecker generateQueriesEndpoint( List<DroolsError> errors, List<org.kie.kogito.codegen.GeneratedFile> generatedFiles, AssignableChecker contextChecker, RuleUnitGenerator ruleUnit ) {
+        List<QueryEndpointGenerator> queries = ruleUnit.queries();
+        if (!queries.isEmpty()) {
+            RuleUnitDescription ruleUnitDesc = ruleUnit.getRuleUnitDescription();
+            AssignableChecker checker;
+            if (ruleUnitDesc instanceof ReflectiveRuleUnitDescription ) {
+                checker = (( ReflectiveRuleUnitDescription ) ruleUnitDesc).getAssignableChecker();
+            } else {
+                if (contextChecker == null) {
+                    contextChecker = AssignableChecker.create(contextClassLoader, hotReloadMode);
+                }
+                checker = contextChecker;
+            }
+
+            generatedFiles.add( new RuleUnitDTOSourceClass( ruleUnitDesc, checker ).generateFile( org.kie.kogito.codegen.GeneratedFile.Type.RULE) );
+
+            for (QueryEndpointGenerator query : queries) {
+                generateQueryEndpoint( errors, generatedFiles, query );
+            }
+        }
+        return contextChecker;
     }
 
     private void generateQueryEndpoint( List<DroolsError> errors, List<org.kie.kogito.codegen.GeneratedFile> generatedFiles, QueryEndpointGenerator query ) {
@@ -468,6 +476,11 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
 
     public IncrementalRuleCodegen withMonitoring(boolean useMonitoring) {
         this.useMonitoring = useMonitoring;
+        return this;
+    }
+
+    public IncrementalRuleCodegen withWebServices(boolean useWebServices) {
+        this.useWebServices = useWebServices;
         return this;
     }
 }

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
@@ -370,7 +370,7 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
                 checker = contextChecker;
             }
 
-            generatedFiles.add( new RuleUnitDTOSourceClass( ruleUnitDesc, checker ).generateFile( org.kie.kogito.codegen.GeneratedFile.Type.RULE) );
+            generatedFiles.add( new RuleUnitDTOSourceClass( ruleUnitDesc, checker ).generateFile( org.kie.kogito.codegen.GeneratedFile.Type.DTO) );
 
             for (QueryEndpointGenerator query : queries) {
                 generateQueryEndpoint( errors, generatedFiles, query );

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
@@ -178,7 +178,7 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
     private KieModuleModel kieModuleModel;
     private boolean hotReloadMode = false;
     private boolean useMonitoring = false;
-    private boolean useWebServices = true;
+    private boolean useRestServices = true;
     private String packageName;
     private final boolean decisionTableSupported;
     private final Map<String, RuleUnitConfig> configs;
@@ -350,7 +350,7 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
 
             ruleUnit.pojo().ifPresent(p -> generatedFiles.add(p.generateFile( org.kie.kogito.codegen.GeneratedFile.Type.RULE)));
 
-            if (useWebServices) {
+            if ( useRestServices ) {
                 contextChecker = generateQueriesEndpoint( errors, generatedFiles, contextChecker, ruleUnit );
             }
         }
@@ -479,8 +479,8 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
         return this;
     }
 
-    public IncrementalRuleCodegen withWebServices(boolean useWebServices) {
-        this.useWebServices = useWebServices;
+    public IncrementalRuleCodegen withRestServices(boolean useRestServices) {
+        this.useRestServices = useRestServices;
         return this;
     }
 }

--- a/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/AbstractKieMojo.java
+++ b/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/AbstractKieMojo.java
@@ -72,7 +72,8 @@ public abstract class AbstractKieMojo extends AbstractMojo {
         if (hasQuarkus) {
             return new QuarkusKogitoBuildContext(fqcn -> hasClassOnClasspath(project, fqcn));
         }
-        throw new IllegalStateException("Unable to determine Kogito runtime.");
+
+        return null;
     }
     
     protected boolean hasClassOnClasspath(MavenProject project, String className) {

--- a/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/AbstractKieMojo.java
+++ b/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/AbstractKieMojo.java
@@ -46,12 +46,12 @@ public abstract class AbstractKieMojo extends AbstractMojo {
 
     protected DependencyInjectionAnnotator discoverDependencyInjectionAnnotator(boolean dependencyInjection, MavenProject project) {
         if (dependencyInjection) {
-            if ( hasSpring( project ) ) {
-                return new SpringDependencyInjectionAnnotator();
-            }
-
             if ( hasQuarkus( project ) ) {
                 return new CDIDependencyInjectionAnnotator();
+            }
+
+            if ( hasSpring( project ) ) {
+                return new SpringDependencyInjectionAnnotator();
             }
         }
 
@@ -59,12 +59,12 @@ public abstract class AbstractKieMojo extends AbstractMojo {
     }
 
     protected KogitoBuildContext discoverKogitoRuntimeContext(MavenProject project)  {
-        if ( hasSpring( project ) ) {
-            return new SpringBootKogitoBuildContext(fqcn -> hasClassOnClasspath(project, fqcn));
-        }
-
         if ( hasQuarkus( project ) ) {
             return new QuarkusKogitoBuildContext(fqcn -> hasClassOnClasspath(project, fqcn));
+        }
+
+        if ( hasSpring( project ) ) {
+            return new SpringBootKogitoBuildContext(fqcn -> hasClassOnClasspath(project, fqcn));
         }
 
         return null;

--- a/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateDeclaredTypes.java
+++ b/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateDeclaredTypes.java
@@ -74,9 +74,6 @@ public class GenerateDeclaredTypes extends AbstractKieMojo {
     @Parameter(property = "kogito.sources.keep", defaultValue = "false")
     private boolean keepSources;
 
-    @Parameter(property = "kogito.di.enabled", defaultValue = "true")
-    private boolean dependencyInjection;
-    
     @Parameter(property = "kogito.persistence.enabled", defaultValue = "false")
     private boolean persistence;
 
@@ -141,7 +138,7 @@ public class GenerateDeclaredTypes extends AbstractKieMojo {
 
         ApplicationGenerator appGen =
                 new ApplicationGenerator(appPackageName, targetDirectory)
-                        .withDependencyInjection(discoverDependencyInjectionAnnotator(dependencyInjection, project))
+                        .withDependencyInjection(discoverDependencyInjectionAnnotator(project))
                         .withClassLoader(projectClassLoader)
                         .withGeneratorContext(context);
 

--- a/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
+++ b/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
@@ -62,7 +62,7 @@ public class GenerateModelMojo extends AbstractKieMojo {
     @Parameter(required = true, defaultValue = "${project.build.outputDirectory}")
     private File outputDirectory;
 
-    @Parameter(defaultValue = "${project.build.directory}/generated-sources/kogito")
+    @Parameter(property = "kogito.codegen.sources.directory", defaultValue = "${project.build.directory}/generated-sources/kogito")
     private File generatedSources;
 
     // due to a limitation of the injector, the following 2 params have to be Strings

--- a/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
+++ b/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
@@ -62,6 +62,9 @@ public class GenerateModelMojo extends AbstractKieMojo {
     @Parameter(required = true, defaultValue = "${project.build.outputDirectory}")
     private File outputDirectory;
 
+    @Parameter(property = "kogito.codegen.rest.directory", defaultValue = "${project.build.directory}/generated-sources/kogito")
+    private File generatedRestSources;
+
     @Parameter(property = "kogito.codegen.sources.directory", defaultValue = "${project.build.directory}/generated-sources/kogito")
     private File generatedSources;
 

--- a/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
+++ b/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
@@ -209,12 +209,12 @@ public class GenerateModelMojo extends AbstractKieMojo {
         }
 
         if (generateRules()) {
-            boolean useWebServices = hasClassOnClasspath(project, "javax.ws.rs.Path");
+            boolean useRestServices = hasClassOnClasspath(project, "javax.ws.rs.Path");
             appGen.withGenerator(IncrementalRuleCodegen.ofPath(kieSourcesDirectory.toPath()))
                     .withKModule(getKModuleModel())
                     .withClassLoader(projectClassLoader)
                     .withMonitoring(useMonitoring)
-                    .withWebServices(useWebServices);
+                    .withRestServices(useRestServices);
         }
 
         if (generateDecisions()) {

--- a/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
+++ b/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
@@ -94,9 +94,6 @@ public class GenerateModelMojo extends AbstractKieMojo {
     @Parameter(property = "kogito.sources.keep", defaultValue = "false")
     private boolean keepSources;
 
-    @Parameter(property = "kogito.di.enabled", defaultValue = "true")
-    private boolean dependencyInjection;
-
     @Parameter(property = "kogito.persistence.enabled", defaultValue = "false")
     private boolean persistence;
 
@@ -193,7 +190,7 @@ public class GenerateModelMojo extends AbstractKieMojo {
 
         ApplicationGenerator appGen =
                 new ApplicationGenerator(appPackageName, targetDirectory)
-                        .withDependencyInjection(discoverDependencyInjectionAnnotator(dependencyInjection, project))
+                        .withDependencyInjection(discoverDependencyInjectionAnnotator(project))
                         .withPersistence(usePersistence)
                         .withMonitoring(useMonitoring)
                         .withClassLoader(projectClassLoader)

--- a/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/ProcessClassesMojo.java
+++ b/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/ProcessClassesMojo.java
@@ -71,9 +71,6 @@ public class ProcessClassesMojo extends AbstractKieMojo {
     @Parameter(required = true, defaultValue = "${project.basedir}/src/main/resources")
     private File kieSourcesDirectory;
     
-    @Parameter(property = "kogito.di.enabled", defaultValue = "true")
-    private boolean dependencyInjection;
-
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {        
         try {
@@ -117,7 +114,7 @@ public class ProcessClassesMojo extends AbstractKieMojo {
 
                 PersistenceGenerator persistenceGenerator = new PersistenceGenerator(targetDirectory, modelClasses, !classes.isEmpty(), new ReflectionProtoGenerator(), cl, parameters);
                 persistenceGenerator.setPackageName(appPackageName);
-                persistenceGenerator.setDependencyInjection(discoverDependencyInjectionAnnotator(dependencyInjection, project));
+                persistenceGenerator.setDependencyInjection(discoverDependencyInjectionAnnotator(project));
                 persistenceGenerator.setContext(context);
                 Collection<GeneratedFile> generatedFiles = persistenceGenerator.generate();
 

--- a/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/KogitoAssetsProcessor.java
+++ b/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/KogitoAssetsProcessor.java
@@ -242,7 +242,7 @@ public class KogitoAssetsProcessor {
             try {
                 if (f.getType() == GeneratedFile.Type.RESOURCE) {
                     writeGeneratedFile(f, resourcePath);
-                } else if (f.relativePath().endsWith("Resource.java")) {
+                } else if (isCustomizable(f)) {
                     writeGeneratedFile(f, restResourcePath);
                 } else {
                     writeGeneratedFile(f, sourcePath);
@@ -252,6 +252,13 @@ public class KogitoAssetsProcessor {
             }
         }
     }
+
+    private boolean isCustomizable(GeneratedFile f) {
+        return f.relativePath().endsWith("Resource.java")
+                || (f.relativePath().contains("Query") && f.relativePath().endsWith(".java"))
+                || (f.relativePath().contains("DTO") && f.relativePath().endsWith(".java"));
+    }
+
 
     private Path getProjectPath(Path archiveLocation) {
         //TODO: revisit this, we should not be depending on a project, it breaks the upgrade use case

--- a/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/KogitoAssetsProcessor.java
+++ b/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/KogitoAssetsProcessor.java
@@ -68,7 +68,9 @@ import org.slf4j.LoggerFactory;
 
 public class KogitoAssetsProcessor {
 
-    private static final String generatedDashboardsDir = "/target/resources/";
+    private static final String generatedResourcesDir = System.getProperty("kogito.codegen.sources.directory", "target/generated-resources/kogito");
+    private static final String generatedSourcesDir = System.getProperty("kogito.codegen.resources.directory", "target/generated-sources/kogito/");
+    private static final String generatedRestSourcesDir = System.getProperty("kogito.codegen.rest.directory", "target/generated-sources/kogito/");
     private static final Logger logger = LoggerFactory.getLogger(KogitoAssetsProcessor.class);
     private final transient String generatedClassesDir = System.getProperty("quarkus.debug.generated-classes-dir");
     private final transient String appPackageName = "org.kie.kogito.app";
@@ -125,9 +127,7 @@ public class KogitoAssetsProcessor {
 
         if (!generatedFiles.isEmpty()) {
             MemoryFileSystem trgMfs = new MemoryFileSystem();
-            CompilationResult result = compile(root, trgMfs, curateOutcomeBuildItem.getEffectiveModel(), generatedFiles,
-                    launchMode.getLaunchMode(),
-                    root.getArchiveLocation());
+            CompilationResult result = compile(root, trgMfs, curateOutcomeBuildItem.getEffectiveModel(), generatedFiles);
             register(trgMfs, generatedBeans, (className, data) -> new GeneratedBeanBuildItem(className, data),
                     launchMode.getLaunchMode(), result, root.getArchiveLocation());
         }
@@ -179,10 +179,7 @@ public class KogitoAssetsProcessor {
         Collection<GeneratedFile> generatedFiles = appGen.generate();
 
         Collection<GeneratedFile> javaFiles = generatedFiles.stream().filter( f -> f.relativePath().endsWith( ".java" ) ).collect( Collectors.toCollection( ArrayList::new ));
-        Collection<GeneratedFile> resourceFiles = generatedFiles.stream().filter( f -> f.getType() == GeneratedFile.Type.RESOURCE ).collect( Collectors.toCollection( ArrayList::new ));
-
-        String resourcePath = Paths.get(projectPath.toString()).toString() + generatedDashboardsDir;
-        writeResourceFiles(resourcePath, resourceFiles);
+        writeGeneratedFiles(projectPath, generatedFiles);
 
         if (!javaFiles.isEmpty()) {
 
@@ -190,9 +187,7 @@ public class KogitoAssetsProcessor {
             Set<DotName> kogitoIndex = new HashSet<>();
 
             MemoryFileSystem trgMfs = new MemoryFileSystem();
-            CompilationResult result = compile(root, trgMfs, curateOutcomeBuildItem.getEffectiveModel(), javaFiles,
-                    launchMode.getLaunchMode(),
-                    targetClassesPath);
+            CompilationResult result = compile(root, trgMfs, curateOutcomeBuildItem.getEffectiveModel(), javaFiles);
             register(trgMfs, generatedBeans, (className, data) -> {
 
                 IndexingUtil.indexClass(className, kogitoIndexer, combinedIndexBuildItem.getIndex(), kogitoIndex,
@@ -238,22 +233,31 @@ public class KogitoAssetsProcessor {
 
     }
 
-    private void writeResourceFiles(String projectPath, Collection<GeneratedFile> resourceFiles){
-        resourceFiles.forEach(f -> {
+    private void writeGeneratedFiles(Path projectPath, Collection<GeneratedFile> resourceFiles) {
+        String restResourcePath = projectPath.resolve(generatedRestSourcesDir).toString();
+        String resourcePath = projectPath.resolve(generatedResourcesDir).toString();
+        String sourcePath = projectPath.resolve(generatedSourcesDir).toString();
+
+        for (GeneratedFile f : resourceFiles) {
             try {
-                writeGeneratedFile(f, projectPath);
+                if (f.getType() == GeneratedFile.Type.RESOURCE) {
+                    writeGeneratedFile(f, resourcePath);
+                } else if (f.relativePath().endsWith("Resource.java")) {
+                    writeGeneratedFile(f, restResourcePath);
+                } else {
+                    writeGeneratedFile(f, sourcePath);
+                }
             } catch (IOException e) {
-                logger.warn(String.format("Could not write resource file %s", f.toString()), e);
+                logger.warn(String.format("Could not write file '%s'", f.toString()), e);
             }
-        });
+        }
     }
 
     private Path getProjectPath(Path archiveLocation) {
         //TODO: revisit this, we should not be depending on a project, it breaks the upgrade use case
-        String path = archiveLocation.toString();
-        if (path.endsWith("target" + File.separator + "classes")) {
+        if (archiveLocation.endsWith(Paths.get("target", "classes"))) {
             return archiveLocation.getParent().getParent();
-        } else if (path.endsWith(".jar") && archiveLocation.getParent().getFileName().toString().equals("target")) {
+        } else if (Files.isRegularFile(archiveLocation) && archiveLocation.getParent().endsWith("target")) {
             return archiveLocation.getParent().getParent();
         }
         return archiveLocation;
@@ -261,9 +265,7 @@ public class KogitoAssetsProcessor {
 
     private CompilationResult compile(ArchiveRootBuildItem root, MemoryFileSystem trgMfs,
             AppModel appModel,
-            Collection<GeneratedFile> generatedFiles,
-            LaunchMode launchMode, Path projectPath)
-            throws IOException, BootstrapDependencyProcessingException {
+            Collection<GeneratedFile> generatedFiles) {
 
         JavaCompiler javaCompiler = JavaParserCompiler.getCompiler();
         JavaCompilerSettings compilerSettings = javaCompiler.createDefaultSettings();
@@ -285,14 +287,6 @@ public class KogitoAssetsProcessor {
             sources[index++] = fileName;
 
             srcMfs.write(fileName, entry.contents());
-
-            String location = generatedClassesDir;
-            if (launchMode == LaunchMode.DEVELOPMENT) {
-                location = Paths.get(projectPath.toString()).toString();
-            }
-
-            writeGeneratedFile(entry, location);
-
         }
 
         return javaCompiler.compile(sources, srcMfs, trgMfs,

--- a/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/KogitoAssetsProcessor.java
+++ b/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/KogitoAssetsProcessor.java
@@ -242,7 +242,7 @@ public class KogitoAssetsProcessor {
             try {
                 if (f.getType() == GeneratedFile.Type.RESOURCE) {
                     writeGeneratedFile(f, resourcePath);
-                } else if (isCustomizable(f)) {
+                } else if (f.getType().isCustomizable()) {
                     writeGeneratedFile(f, restResourcePath);
                 } else {
                     writeGeneratedFile(f, sourcePath);
@@ -252,13 +252,6 @@ public class KogitoAssetsProcessor {
             }
         }
     }
-
-    private boolean isCustomizable(GeneratedFile f) {
-        return f.relativePath().endsWith("Resource.java")
-                || (f.relativePath().contains("Query") && f.relativePath().endsWith(".java"))
-                || (f.relativePath().contains("DTO") && f.relativePath().endsWith(".java"));
-    }
-
 
     private Path getProjectPath(Path archiveLocation) {
         //TODO: revisit this, we should not be depending on a project, it breaks the upgrade use case


### PR DESCRIPTION
@evacchi I had to rebase the old PR so instead I closed the old one, made the changes you suggested and open this one.

It is true that (except a minor thing to exclude generation of the rest service in the unlikely case that also the ws annotation are not available on the classpath) I didn't change much on the plugin itself. In particular I did the change to generate the sources in different folders depending on the type of the source file as we discussed but then I found it inconvenient and I undid it. In fact by doing so the user, in order to use the programmatic API and compile his project has to add as source folders in his project all the different folders where we put our code instead of just one. I'm open to discuss this but I didn't find this reasonable (and now I wonder if other libraries like jOOQ has the same problem and how they solved it). I still want to change the generated code and the programmatic API but this is out of the scope of this task and I opened another jira ( https://issues.redhat.com/browse/KOGITO-2074 ) to work on this.