### PR TITLE
KOGITO-2232 - Externalize method of BpmnProcessCompiler to allow extensions, KOGITO-2231 - Can't use business key with BpmnProcess

### DIFF
--- a/jbpm/jbpm-bpmn2/src/main/java/org/kie/kogito/process/bpmn2/BpmnProcess.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/kie/kogito/process/bpmn2/BpmnProcess.java
@@ -53,6 +53,13 @@ public class BpmnProcess extends AbstractProcess<BpmnVariables> {
     public ProcessInstance<BpmnVariables> createInstance() {
         return new BpmnProcessInstance(this, createModel(), this.createLegacyProcessRuntime());
     }
+    
+    @Override
+    public ProcessInstance<BpmnVariables> createInstance(String businessKey, BpmnVariables variables) {
+        BpmnVariables variablesModel = createModel();
+        variablesModel.fromMap(variables.toMap());
+        return new BpmnProcessInstance(this, variablesModel, businessKey, this.createLegacyProcessRuntime());
+    }
 
     @Override
     public ProcessInstance<BpmnVariables> createInstance(BpmnVariables variables) {

--- a/jbpm/jbpm-bpmn2/src/main/java/org/kie/kogito/process/bpmn2/BpmnProcessCompiler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/kie/kogito/process/bpmn2/BpmnProcessCompiler.java
@@ -60,12 +60,13 @@ public class BpmnProcessCompiler {
             XmlProcessReader xmlReader = new XmlProcessReader(
                                                               getSemanticModules(),
                                                               Thread.currentThread().getContextClassLoader());
+            configureProcessReader(xmlReader, config);
 
             for (Resource resource : resources) {
                 processes.addAll(xmlReader.read(resource.getReader()));
             }
             List<BpmnProcess> bpmnProcesses = processes.stream()
-                                                       .map(p -> (config == null ? new BpmnProcess(p) : new BpmnProcess(p, config)))
+                                                       .map(p -> create(p, config))
                                                        .collect(Collectors.toList());
 
             bpmnProcesses.forEach(p -> {
@@ -80,6 +81,14 @@ public class BpmnProcessCompiler {
         } catch (Exception e) {
             throw new BpmnProcessReaderException(e);
         }
+    }
+    
+    protected void configureProcessReader(XmlProcessReader xmlReader, ProcessConfig config) {
+        
+    }
+    
+    protected BpmnProcess create(Process process, ProcessConfig config) {
+        return config == null ? new BpmnProcess(process) : new BpmnProcess(process, config);
     }
 
     protected void processNode(Node node, List<BpmnProcess> bpmnProcesses) {

--- a/jbpm/jbpm-bpmn2/src/main/java/org/kie/kogito/process/bpmn2/BpmnProcessInstance.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/kie/kogito/process/bpmn2/BpmnProcessInstance.java
@@ -26,6 +26,10 @@ public class BpmnProcessInstance extends AbstractProcessInstance<BpmnVariables> 
     public BpmnProcessInstance(AbstractProcess<BpmnVariables> process, BpmnVariables variables, ProcessRuntime rt) {
         super(process, variables, rt);
     }
+    
+    public BpmnProcessInstance(AbstractProcess<BpmnVariables> process, BpmnVariables variables, String businessKey, ProcessRuntime rt) {
+        super(process, variables, businessKey, rt);
+    }
 
     @Override
     protected Map<String, Object> bind(BpmnVariables variables) {


### PR DESCRIPTION
A small enhancements to the `BpmnProcessCompiler` to allow extensions and a bug fix for `BpmnProcess` when used with business key


Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket