### PR TITLE
KOGITO-1645 Update contribution guidelines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@ Many thanks for submitting your Pull Request :heart:!
 
 Please make sure that your PR meets the following requirements:
 
-- [ ] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
+- [ ] You have read the [contributors guide](CONTRIBUTING.md)
 - [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
 - [ ] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
 - [ ] Pull Request contains link to the JIRA issue

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ But first, read this page (including the small print at the end).
 
 ## Legal
 
-All original contributions to Quarkus are licensed under the
+All original contributions to Kogito are licensed under the
 [ASL - Apache License](https://www.apache.org/licenses/LICENSE-2.0),
 version 2.0 or later, or, if another license is specified as governing the file or directory being
 modified, such other license.
@@ -72,7 +72,8 @@ If you have not done so on this machine, you need to:
 * Install Java SDK (OpenJDK recommended)
 * For Native Image, follow Quarkus instructions at [GraalVM](https://quarkus.io/guides/building-native-image)
 
-Docker is not strictly necessary, but it is a required to run some of the integration tests. We recommend to install it to run these tests locally.
+Docker is not strictly necessary, but it is a required to run some of the integration tests. 
+These tests can be skipped (see the [Build](#build) section), but we recommend to install it to run these tests locally.
 
 * Check [the installation guide](https://docs.docker.com/install/), and [the MacOS installation guide](https://docs.docker.com/docker-for-mac/install/)
 * If you just install docker, be sure that your current user can run a container (no root required). 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ If you are contributing a new feature, we strongly advise submitting an [Example
 
 ### Code Reviews and Continuous Integration
 
-All submissions, including submissions by project members, need to be reviewed before being merged. Our CI, Jenkins, should be green.
+All submissions, including submissions by project members, need to be reviewed by others before being merged. Our CI, Jenkins, should successfully execute your PR, marking the GitHub check as green
 
 ## Feature Proposals
 
@@ -72,7 +72,7 @@ If you have not done so on this machine, you need to:
 * Install Java SDK (OpenJDK recommended)
 * For Native Image, follow Quarkus instructions at [GraalVM](https://quarkus.io/guides/building-native-image)
 
-Docker is not strictly necessary: it is used to run the test the persistence backend: it is a recommended install if you plan to work on this component.
+Docker is not strictly necessary, but it is a required to run some of the integration tests. We recommend to install it to run these tests locally.
 
 * Check [the installation guide](https://docs.docker.com/install/), and [the MacOS installation guide](https://docs.docker.com/docker-for-mac/install/)
 * If you just install docker, be sure that your current user can run a container (no root required). 
@@ -85,8 +85,7 @@ On Linux, check [the post-installation guide](https://docs.docker.com/install/li
 
 ```bash
 git clone https://github.com/kiegroup/kogito-runtimes.git
-cd quarkus
-export MAVEN_OPTS="-Xmx1563m"
+cd kogito-runtimes
 ./mvnw clean install -DskipTests -DskipITs 
 # Wait... success!
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,23 +27,23 @@ Sometimes a bug has been fixed in the `master` branch of Kogito and you want to 
 
 If you are interested in having more details, refer to the [Build section](#build) and the [Usage section](#usage).
 
-## Creating a Pull Request
+## Creating a Pull Request (PR)
 
 To contribute, use GitHub Pull Requests, from your **own** fork. 
 
 - PRs should be always related to an open JIRA issue. If there is none, you should create one.
-- Try to fix only one issue per PRs
+- Try to fix only one issue per PR.
 - Make sure to create a new branch. Usually branches are named after the JIRA ticket they are addressing. E.g. for ticket "KOGITO-XYZ An example issue" your branch should be at least prefixed with `KOGITO-XYZ`. E.g.:
 
         git checkout -b KOGITO-XYZ
         # or
         git checkout -b KOGITO-XYZ-my-fix
 
-- When you submit your PR, make sure to include the ticket ID, and its title; e.g., "KOGITO-XYZ An example issue"
+- When you submit your PR, make sure to include the ticket ID, and its title; e.g., "KOGITO-XYZ An example issue".
 - The description of your PR should describe the code you wrote. The issue that is solved should be at least described properly in the corresponding JIRA ticket. 
 - If your contribution spans across multiple repositories, 
   use the same branch name (e.g. `KOGITO-XYZ`) in each PR so that our CI (Jenkins) can build them all at once.
-- If your contribution spans across multiple repositories, make sure to list all the related PRs 
+- If your contribution spans across multiple repositories, make sure to list all the related PRs.
 
 ### Coding Guidelines
 
@@ -56,13 +56,13 @@ If you are contributing a new feature, we strongly advise submitting an [Example
 
 ### Code Reviews and Continuous Integration
 
-All submissions, including those by project members, need to be reviewed by others before being merged. Our CI, Jenkins, should successfully execute your PR, marking the GitHub check as green
+All submissions, including those by project members, need to be reviewed by others before being merged. Our CI, Jenkins, should successfully execute your PR, marking the GitHub check as green.
 
 ## Feature Proposals
 
 If you would like to see some feature in Kogito, start with an email to [our mailing list](https://groups.google.com/forum/#!forum/kogito-development) or just [pop into our Zulip chat](https://kie.zulipchat.com/) and tell us what you would like to see. 
 
-Great feature proposals should include a short **Description** of the feature, the **Motivation** tha makes that feature necessary and the **Goals** that are achieved by realizing it. If the feature is deemed worthy, then an [**Epic**](https://issues.redhat.com/issues/?filter=12347334) will be created.
+Great feature proposals should include a short **Description** of the feature, the **Motivation** that makes that feature necessary and the **Goals** that are achieved by realizing it. If the feature is deemed worthy, then an [**Epic**](https://issues.redhat.com/issues/?filter=12347334) will be created.
 
 ## Setup
 
@@ -82,7 +82,7 @@ On Linux, check [the post-installation guide](https://docs.docker.com/install/li
 
 ## Build
 
-* Clone the repository,  Navigate to the directory, invoke `./mvnw clean install -DskipTests -DskipITs` from the root directory.
+* Clone the repository, navigate to the directory, invoke `./mvnw clean install -DskipTests -DskipITs` from the root directory.
 
 ```bash
 git clone https://github.com/kiegroup/kogito-runtimes.git
@@ -91,16 +91,16 @@ cd kogito-runtimes
 # Wait... success!
 ```
 
-This build skipped all the tests. 
+This build skipped all the tests:
+- `-DskipTests` skips unit tests
+- `-DskipITs` skips integration tests
 
-Removing the `-DskipTests -DskipITs` flags enables the tests. 
+By removing the flags, you will run the corresponding tests. 
 It will take much longer to build but will give you more guarantees on your code. 
 
 ## Usage
 
-After the build was successful, the artifacts are available in your local Maven repository.
-
-To include them into your project a few things have to be changed.
+After the build is successful, the artifacts are available in your local Maven repository.
 
 ### Test Coverage
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,124 @@
+# Contributing guide
+
+**Want to contribute? Great!** 
+We try to make it easy, and all contributions, even the smaller ones, are more than welcome.
+This includes bug reports, fixes, documentation, examples... 
+But first, read this page (including the small print at the end).
+
+## Legal
+
+All original contributions to Quarkus are licensed under the
+[ASL - Apache License](https://www.apache.org/licenses/LICENSE-2.0),
+version 2.0 or later, or, if another license is specified as governing the file or directory being
+modified, such other license.
+
+All contributions are subject to the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
+The DCO text is also included verbatim in the [dco.txt](dco.txt) file in the root directory of the repository.
+
+## Issues
+
+Kogito uses [JIRA to manage and report issues](https://issues.redhat.com/projects/KOGITO/).
+
+If you believe you found a bug, please indicate a way to reproduce it, what you are seeing and what you would expect to see.
+Don't forget to indicate your Quarkus, Java, Maven/Gradle and GraalVM version. 
+
+### Checking an issue is fixed in master
+
+Sometimes a bug has been fixed in the `master` branch of Quarkus and you want to confirm it is fixed for your own application.
+Testing the `master` branch is easy and you have two options:
+
+* either use the snapshots we publish daily on https://oss.sonatype.org/content/repositories/snapshots/
+* or build Kogito all by yourself
+
+This is a quick summary to get you to quickly test master.
+If you are interested in having more details, refer to the [Build section](#build) and the [Usage section](#usage).
+
+## Creating a Pull Request
+
+To contribute, use GitHub Pull Requests, from your **own** fork. 
+
+- PRs should be always related to an open JIRA issue. If there is none, you should create one.
+- Make sure to create a new branch. Usually branches are named after the JIRA ticket they are addressing. E.g. for ticket *KOGITO-XYZ An example issue* your branch should be at least prefixed with `KOGITO-XYZ`. 
+
+    ```
+    git checkout -b KOGITO-XYZ
+    ```
+
+    or 
+
+    ```
+    git checkout -b KOGITO-XYZ-my-fix
+    ```
+
+- When you submit your PR, make sure to include the ticket ID, and its title; e.g., "KOGITO-XYZ An example issue" 
+
+
+### Code reviews
+
+All submissions, including submissions by project members, need to be reviewed before being merged.
+
+### Coding Guidelines
+
+We decided to disallow `@author` tags in the Javadoc: they are hard to maintain, especially in a very active project, and we use the Git history to track authorship. GitHub also has [this nice page with your contributions](https://github.com/kiegroup/kogito-runtimes/graphs/contributors). 
+
+### Tests and documentation are not optional
+
+Don't forget to include tests in your pull requests. 
+Also don't forget the documentation (reference documentation, javadoc...).
+If you are contributing a new feature, you should also submit an [Example](https://github.com/kiegroup/kogito-examples). 
+
+
+## Feature Proposals
+
+If you would like to see some feature in Kogito, start with an email to [our mailing list](https://groups.google.com/forum/#!forum/kogito-development) or just [pop into our Zulip chat](https://kie.zulipchat.com/) and tell us what you would like to see. 
+
+Great feature proposals should include a short **Description** of the feature, the **Motivation** tha makes that feature necessary and the **Goals** that are achieved by realizing it. If the feature is deemed worthy, then an [**Epic**](https://issues.redhat.com/issues/?filter=12347334) will be created.
+
+## Setup
+
+If you have not done so on this machine, you need to:
+ 
+* Install Git and configure your GitHub access
+* Install Java SDK (OpenJDK recommended)
+* For Native Image, follow Quarkus instructions at [GraalVM](https://quarkus.io/guides/building-native-image)
+
+Docker is not strictly necessary: it is used to run the test the persistence backend: it is a recommended install if you plan to work on this component.
+
+* Check [the installation guide](https://docs.docker.com/install/), and [the MacOS installation guide](https://docs.docker.com/docker-for-mac/install/)
+* If you just install docker, be sure that your current user can run a container (no root required). 
+On Linux, check [the post-installation guide](https://docs.docker.com/install/linux/linux-postinstall/)
+
+
+## Build
+
+* Clone the repository,  Navigate to the directory, invoke `./mvnw clean install -DskipTests -DskipITs` from the root directory.
+
+```bash
+git clone https://github.com/kiegroup/kogito-runtimes.git
+cd quarkus
+export MAVEN_OPTS="-Xmx1563m"
+./mvnw clean install -DskipTests -DskipITs 
+# Wait... success!
+```
+
+This build skipped all the tests. 
+
+Removing the `-DskipTests -DskipITs` flags enables the tests. 
+It will take much longer to build but will give you more guarantees on your code. 
+
+## Usage
+
+After the build was successful, the artifacts are available in your local Maven repository.
+
+To include them into your project a few things have to be changed.
+
+
+### Test Coverage
+
+Kogito uses Jacoco to generate test coverage. If you would like to generate the report run `mvn clean verify -Ptest-coverage`. 
+The code coverage report will be generated in `target/site/jacoco/`.
+
+## The small print
+
+This project is an open source project, please act responsibly, be nice, polite and enjoy!
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,14 +33,14 @@ To contribute, use GitHub Pull Requests, from your **own** fork.
 
 - PRs should be always related to an open JIRA issue. If there is none, you should create one.
 - Try to fix only one issue per PRs
-- Make sure to create a new branch. Usually branches are named after the JIRA ticket they are addressing. E.g. for ticket *KOGITO-XYZ An example issue* your branch should be at least prefixed with `KOGITO-XYZ`. E.g.:
+- Make sure to create a new branch. Usually branches are named after the JIRA ticket they are addressing. E.g. for ticket "KOGITO-XYZ An example issue" your branch should be at least prefixed with `KOGITO-XYZ`. E.g.:
 
         git checkout -b KOGITO-XYZ
         # or
         git checkout -b KOGITO-XYZ-my-fix
 
 - When you submit your PR, make sure to include the ticket ID, and its title; e.g., "KOGITO-XYZ An example issue"
-- The description of your PR should describe the code you wrote. The issues that is solved should be at least properly described in the corresponding JIRA ticket. 
+- The description of your PR should describe the code you wrote. The issue that is solved should be at least described properly in the corresponding JIRA ticket. 
 - If your contribution spans across multiple repositories, 
   use the same branch name (e.g. `KOGITO-XYZ`) in each PR so that our CI (Jenkins) can build them all at once.
 - If your contribution spans across multiple repositories, make sure to list all the related PRs 
@@ -51,12 +51,12 @@ We decided to disallow `@author` tags in the Javadoc: they are hard to maintain,
 
 ### Tests and Documentation 
 
-Don't forget to include tests in your pull requests, and documentation (reference documentation, javadoc...). Guides and reference documentation should be submitted to the [Kogito Docs repository](https://github.com/kiegroup/kie-docs/tree/master-kogito).
+Don't forget to include tests in your pull requests, and documentation (reference documentation, javadoc...). Guides and reference documentation should be submitted to the [Kogito Docs Repository](https://github.com/kiegroup/kie-docs/tree/master-kogito).
 If you are contributing a new feature, we strongly advise submitting an [Example](https://github.com/kiegroup/kogito-examples). 
 
 ### Code Reviews and Continuous Integration
 
-All submissions, including submissions by project members, need to be reviewed by others before being merged. Our CI, Jenkins, should successfully execute your PR, marking the GitHub check as green
+All submissions, including those by project members, need to be reviewed by others before being merged. Our CI, Jenkins, should successfully execute your PR, marking the GitHub check as green
 
 ## Feature Proposals
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing guide
+# Contribution guide
 
 **Want to contribute? Great!** 
 We try to make it easy, and all contributions, even the smaller ones, are more than welcome.
@@ -12,25 +12,19 @@ All original contributions to Quarkus are licensed under the
 version 2.0 or later, or, if another license is specified as governing the file or directory being
 modified, such other license.
 
-All contributions are subject to the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
-The DCO text is also included verbatim in the [dco.txt](dco.txt) file in the root directory of the repository.
-
 ## Issues
 
 Kogito uses [JIRA to manage and report issues](https://issues.redhat.com/projects/KOGITO/).
 
-If you believe you found a bug, please indicate a way to reproduce it, what you are seeing and what you would expect to see.
-Don't forget to indicate your Quarkus, Java, Maven/Gradle and GraalVM version. 
+If you believe you found a bug, please indicate a way to reproduce it, what you are seeing and what you would expect to see. Don't forget to indicate your Kogito, Java, Maven, Quarkus/Spring, GraalVM version. 
 
 ### Checking an issue is fixed in master
 
-Sometimes a bug has been fixed in the `master` branch of Quarkus and you want to confirm it is fixed for your own application.
-Testing the `master` branch is easy and you have two options:
+Sometimes a bug has been fixed in the `master` branch of Kogito and you want to confirm it is fixed for your own application. Testing the `master` branch is easy and you have two options:
 
-* either use the snapshots we publish daily on https://oss.sonatype.org/content/repositories/snapshots/
+* either use the snapshots we publish daily on https://repository.jboss.org/nexus/content/repositories/snapshots/
 * or build Kogito all by yourself
 
-This is a quick summary to get you to quickly test master.
 If you are interested in having more details, refer to the [Build section](#build) and the [Usage section](#usage).
 
 ## Creating a Pull Request
@@ -38,35 +32,31 @@ If you are interested in having more details, refer to the [Build section](#buil
 To contribute, use GitHub Pull Requests, from your **own** fork. 
 
 - PRs should be always related to an open JIRA issue. If there is none, you should create one.
-- Make sure to create a new branch. Usually branches are named after the JIRA ticket they are addressing. E.g. for ticket *KOGITO-XYZ An example issue* your branch should be at least prefixed with `KOGITO-XYZ`. 
+- Try to fix only one issue per PRs
+- Make sure to create a new branch. Usually branches are named after the JIRA ticket they are addressing. E.g. for ticket *KOGITO-XYZ An example issue* your branch should be at least prefixed with `KOGITO-XYZ`. E.g.:
 
-    ```
-    git checkout -b KOGITO-XYZ
-    ```
+        git checkout -b KOGITO-XYZ
+        # or
+        git checkout -b KOGITO-XYZ-my-fix
 
-    or 
-
-    ```
-    git checkout -b KOGITO-XYZ-my-fix
-    ```
-
-- When you submit your PR, make sure to include the ticket ID, and its title; e.g., "KOGITO-XYZ An example issue" 
-
-
-### Code reviews
-
-All submissions, including submissions by project members, need to be reviewed before being merged.
+- When you submit your PR, make sure to include the ticket ID, and its title; e.g., "KOGITO-XYZ An example issue"
+- The description of your PR should describe the code you wrote. The issues that is solved should be at least properly described in the corresponding JIRA ticket. 
+- If your contribution spans across multiple repositories, 
+  use the same branch name (e.g. `KOGITO-XYZ`) in each PR so that our CI (Jenkins) can build them all at once.
+- If your contribution spans across multiple repositories, make sure to list all the related PRs 
 
 ### Coding Guidelines
 
 We decided to disallow `@author` tags in the Javadoc: they are hard to maintain, especially in a very active project, and we use the Git history to track authorship. GitHub also has [this nice page with your contributions](https://github.com/kiegroup/kogito-runtimes/graphs/contributors). 
 
-### Tests and documentation are not optional
+### Tests and Documentation 
 
-Don't forget to include tests in your pull requests. 
-Also don't forget the documentation (reference documentation, javadoc...).
-If you are contributing a new feature, you should also submit an [Example](https://github.com/kiegroup/kogito-examples). 
+Don't forget to include tests in your pull requests, and documentation (reference documentation, javadoc...). Guides and reference documentation should be submitted to the [Kogito Docs repository](https://github.com/kiegroup/kie-docs/tree/master-kogito).
+If you are contributing a new feature, we strongly advise submitting an [Example](https://github.com/kiegroup/kogito-examples). 
 
+### Code Reviews and Continuous Integration
+
+All submissions, including submissions by project members, need to be reviewed before being merged. Our CI, Jenkins, should be green.
 
 ## Feature Proposals
 
@@ -111,7 +101,6 @@ It will take much longer to build but will give you more guarantees on your code
 After the build was successful, the artifacts are available in your local Maven repository.
 
 To include them into your project a few things have to be changed.
-
 
 ### Test Coverage
 

--- a/README.md
+++ b/README.md
@@ -19,13 +19,9 @@ Quick Links
 
 **Homepage:** http://kogito.kie.org
 
-**Wiki:** https://github.com/kiegroup/kogito-runtimes/wiki
+**Documentation:** https://github.com/kiegroup/kie-docs/tree/master-kogito
 
 **JIRA:** https://issues.jboss.org/projects/KOGITO
-
-**jBPM:** https://www.jbpm.org/
-
-**Drools:** https://www.drools.org/
 
 Requirements
 ------------
@@ -37,51 +33,7 @@ Requirements
 Getting Started
 ---------------
 
-The [Kogito Examples repository](https://github.com/kiegroup/kogito-examples) module contains a number of examples that you can take a look at and try out yourself.
- Please take a look at the readme of each individual example for more details on how the example works and how to run it yourself (either locally or on Kubernetes):
-- Process + Quarkus: [README.md](https://github.com/kiegroup/kogito-examples/tree/master/process-quarkus-example/README.md)
-- Process + Spring Boot: [README.md](https://github.com/kiegroup/kogito-examples/tree/master/process-springboot-example/README.md)
-- Process + Decision + Rules + Quarkus: [README.md](https://github.com/kiegroup/kogito-examples/tree/master/onboarding-example/README.md) - Onboarding example combining one process and two decision services
-- Rules + Quarkus: [README.md](https://github.com/kiegroup/kogito-examples/tree/master/rules-quarkus-helloworld/README.md)
-- DMN + Quarkus: [README.md](https://github.com/kiegroup/kogito-examples/tree/master/dmn-quarkus-example/README.md)
-- Rule Unit + Quarkus: [README.md](https://github.com/kiegroup/kogito-examples/tree/master/ruleunit-quarkus-example/README.md)
-
-Building from source
---------------------
-
-1. Check out the source:
-
-```
-git clone git@github.com:kiegroup/kogito-runtimes.git
-```
-
-If you don't have a GitHub account use this command instead:
-
-```
-git clone https://github.com/kiegroup/kogito-runtimes.git
-```
-
-2. Build with Maven:
-```
-cd kogito-runtimes
-mvn clean install -DskipITs
-```
-
-3. Run integration tests
-The integrations tests are skipped in the command above. To run the tests you need to have docker installed on your machine. To run the tests during the build, just remove the `-DskipITs` argument.
-Possible issues - the tests are running docker containers using [testcontainers](https://github.com/testcontainers/testcontainers-java). That by default requires access to the docker.sock file which might result in a security alert on your system and be blocked. In such case you'll see log message similar to 'Can not connect to Ryuk'. In this case do run the tests with following ENV variable set:
-
-```
-TESTCONTAINERS_RYUK_DISABLED=true mvn clean verify
-```
-When the test run is interrupted though, you might end up with docker containers still running, check those using `docker ps` and stop when neccessary.
-
-
-Contributing to Kogito
---------------------
-
-All contributions are welcome! Before you start please read the [Developing Drools and jBPM](https://github.com/kiegroup/droolsjbpm-build-bootstrap/blob/master/README.md) guide.
-
+The [Kogito Examples repository](https://github.com/kiegroup/kogito-examples) module contains a number of examples that you can take a look at and try out yourself. Please take a look at the readme of each individual example for more details on how the example works and how to run it yourself (either locally or on Kubernetes).
 
 Guides
 --------------------
@@ -90,3 +42,11 @@ Here are some of the most notable ones for quick reference:
 
 - [Quarkus - Using Kogito to add business automation capabilities to an application](https://quarkus.io/guides/kogito-guide) - This guide demonstrates how your Quarkus application can use Kogito to add business automation to power it up with business processes and rules.
 - [Quarkus - Getting Started](https://quarkus.io/get-started/) - Quarkus Getting Started guide
+
+
+
+Building and Contributing to Kogito
+-----------------------------------
+
+All contributions are welcome! Before you start please read the [contribution guide](CONTRIBUTING.md).
+

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Quick Links
 
 **Homepage:** http://kogito.kie.org
 
-**Documentation:** https://github.com/kiegroup/kie-docs/tree/master-kogito
+**Guides and Documentation:** https://kogito.kie.org/guides/
 
-**JIRA:** https://issues.jboss.org/projects/KOGITO
+**JIRA Issues:** https://issues.jboss.org/projects/KOGITO
 
 Requirements
 ------------
@@ -38,10 +38,14 @@ The [Kogito Examples repository](https://github.com/kiegroup/kogito-examples) mo
 Guides
 --------------------
 
-Here are some of the most notable ones for quick reference:
+The official guides for Kogito can be found at our main website, these include guides for Quarkus and Spring Boot.
 
-- [Quarkus - Using Kogito to add business automation capabilities to an application](https://quarkus.io/guides/kogito-guide) - This guide demonstrates how your Quarkus application can use Kogito to add business automation to power it up with business processes and rules.
+- [Kogito Guides](https://kogito.kie.org/guides/).
+
+If you want to read more about Quarkus:
+
 - [Quarkus - Getting Started](https://quarkus.io/get-started/) - Quarkus Getting Started guide
+- [Quarkus - Using Kogito to add business automation capabilities to an application](https://quarkus.io/guides/kogito) - A simple quick start hosted on the Quarkus web site.
 
 
 


### PR DESCRIPTION
I have reworked our "traditional" contribution guidelines, [shamelessly copying from those for Quarkus.](https://github.com/quarkusio/quarkus/blob/master/CONTRIBUTING.md)

I started with a copy, but I customized it with stuff from our old contribution guide, wherever it made sense; e.g. I left out all references to first-time setup of Maven and Git (I think we can give them for granted); I left out considerations on style guide (let's avoid (some) bike-shedding for now) but I have included a few of our best practices. 

Quarkus also include a reference to [a contribution agreement (the DCO)](https://developercertificate.org/) that we may re-introduce here if it makes sense.

Let the bike-shedding begin! :fire: 

