### PR TITLE
KOGITO-2389  Simplify tryGenerateStronglyTypedInput with better implementation

### DIFF
--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionCodegen.java
@@ -203,13 +203,9 @@ public class DecisionCodegen extends AbstractGenerator {
                     model,
                     index, factory )
                     .generateSourceCodeOfAllTypes();
-
-            allTypesSourceCode.entrySet().stream()
-                    .map(kv -> {
-                        String key = kv.getKey().replace(".", "/") + ".java";
-                        return new GeneratedFile(GeneratedFile.Type.CLASS, key, kv.getValue());
-                    })
-                    .forEach(generatedFiles::add);
+            
+            allTypesSourceCode.forEach((k,v) -> storeFile(GeneratedFile.Type.CLASS, k.replace(".", "/") + ".java", v));
+            
         } catch(Exception e) {
             logger.error("Unable to generate Strongly Typed Input for: {} {}", model.getNamespace(), model.getName());
             throw e;


### PR DESCRIPTION
Hi,

tryGenerateStronglyTypedInput method could be simpler if it uses storeFile method helper.
we can reuse storeFile into forEach call from allTypesSourceCode variable.

JIRA link : https://issues.redhat.com/browse/KOGITO-2389

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [X] You have read the [contributors guide](CONTRIBUTING.md)
- [X] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [X] Pull Request contains link to the JIRA issue
- [X] Pull Request contains link to any dependent or related Pull Request
- [X] Pull Request contains description of the issue
- [X] Pull Request does not include fixes for issues other than the main ticket