### PR TITLE
KOGITO-2482 Add `kogito:scaffold` Mojo

### DIFF
--- a/integration-tests/integration-tests-kogito-plugin/src/it/integration-tests-kogito-plugin-it/invoker.properties
+++ b/integration-tests/integration-tests-kogito-plugin/src/it/integration-tests-kogito-plugin-it/invoker.properties
@@ -1,1 +1,1 @@
-invoker.goals = clean compile org.kie.kogito:kogito-maven-plugin:generateModel package  -Dkogito.codegen.sources.directory=src/main/java 
+invoker.goals = clean compile kogito:scaffold compile verify

--- a/integration-tests/integration-tests-kogito-plugin/src/it/integration-tests-kogito-plugin-it/pom.xml
+++ b/integration-tests/integration-tests-kogito-plugin/src/it/integration-tests-kogito-plugin-it/pom.xml
@@ -63,11 +63,9 @@
                 <groupId>org.kie.kogito</groupId>
                 <artifactId>kogito-maven-plugin</artifactId>
                 <version>${project.version}</version>
-                <executions>
-                    <execution>
-                        <phase>none</phase>
-                    </execution>
-                </executions>
+                <configuration>
+                    <onDemand>true</onDemand>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>io.quarkus</groupId>

--- a/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/ScaffoldMojo.java
+++ b/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/ScaffoldMojo.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.kie.kogito.maven.plugin;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+
+@Mojo(name = "scaffold",
+        requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME,
+        requiresProject = true)
+public class ScaffoldMojo extends GenerateModelMojo {
+
+    @Parameter(property = "kogito.codegen.ondemand", defaultValue = "true")
+    private boolean onDemand;
+
+    @Parameter(property = "kogito.codegen.sources.directory", defaultValue = "${project.build.sourceDirectory}")
+    private File customizableSources;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        try {
+            addCompileSourceRoots();
+            generateModel();
+        } catch (IOException e) {
+            throw new MojoExecutionException("An I/O error occurred", e);
+        }
+    }
+
+    public boolean isOnDemand() {
+        return onDemand;
+    }
+
+    @Override
+    protected File getCustomizableSources() {
+        return customizableSources;
+    }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-2482

Add `kogito:scaffold` to use with scaffolding, with updated default values for source directories.
This is a very minimal (and a bit ugly) refactoring to reuse the logic in `kogito:generateModel` an improved refactoring will follow.

Usage:

```
mvn compile kogito:scaffold
```

default output directory is `src/main/java`. You can override with:

```
mvn compile kogito:scaffold -Dkogito.codegen.sources.directory=your/output/dir
```

there is also a new boolean configuration parameter `onDemand` (also usable with property `kogito.codegen.ondemand`). When this is true, the "usual" `kogito:generateModel` won't execute, even if it's bound to a phase (normally, it defaults to being bound to `compile`), so that it does not conflict when users run `kogito:scaffold`.

Users, may therefore configure the maven plugin as follows:

```
      <plugin>
        <groupId>org.kie.kogito</groupId>
        <artifactId>kogito-maven-plugin</artifactId>
        <configuration>
          <onDemand>true</onDemand>
        </configuration>
      </plugin>
```
