### PR TITLE
KOGITO-2483: Classify generated Process Model classes as "customizable"

### DIFF
--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/GeneratedFile.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/GeneratedFile.java
@@ -31,7 +31,7 @@ public class GeneratedFile {
         DECLARED_TYPE( true ),
         DTO( true ),
         QUERY( true ),
-        MODEL( false ),
+        MODEL( true ),
         CLASS( false ),
         MESSAGE_CONSUMER( false ),
         MESSAGE_PRODUCER( false ),


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-2483

Currently process *Model classes (e.g. MyProcessModel.java) are generated under target/ because they are not classified as "customizable". We should allow "scaffolding" to generate these classes in a custom location. This is also required to have a correct build order.

The fix is a oneliner, and it is used in #567 