### PR TITLE
KOGITO-2026 Enforce JDK 11 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
   </licenses>
 
   <properties>
+    <version.jdk>11</version.jdk>
     <maven.compiler.release>8</maven.compiler.release>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -960,7 +961,7 @@
                     <version>${version.maven}</version>
                   </requireMavenVersion>
                   <requireJavaVersion>
-                    <version>${maven.compiler.release}</version>
+                    <version>${version.jdk}</version>
                   </requireJavaVersion>
                 </rules>
               </configuration>


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-2026

add the java version enforcer rule for build to be jdk 11 (build will still target bytecode version java8)

