### PR TITLE
KOGITO-2472 Codegen does not create handler for ServiceTasks with overloaded methods

### DIFF
--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/canonical/ActivityGenerationModelTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/canonical/ActivityGenerationModelTest.java
@@ -407,7 +407,7 @@ public class ActivityGenerationModelTest extends JbpmBpmn2TestCase {
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         Map<String, Object> params = new HashMap<String, Object>();
         params.put("s", "john");
-        Map<String, BpmnProcess> processes = createProcesses(classData, Collections.singletonMap("org.jbpm.bpmn2.objects.HelloService.hello", workItemHandler));
+        Map<String, BpmnProcess> processes = createProcesses(classData, Collections.singletonMap("org.jbpm.bpmn2.objects.HelloService_hello_java$lang$String_Handler", workItemHandler));
         ProcessInstance<BpmnVariables> processInstance = processes.get("ServiceProcess").createInstance(BpmnVariables.create(params));
 
         processInstance.start();

--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/canonical/ActivityGenerationModelTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/canonical/ActivityGenerationModelTest.java
@@ -407,7 +407,7 @@ public class ActivityGenerationModelTest extends JbpmBpmn2TestCase {
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         Map<String, Object> params = new HashMap<String, Object>();
         params.put("s", "john");
-        Map<String, BpmnProcess> processes = createProcesses(classData, Collections.singletonMap("org.jbpm.bpmn2.objects.HelloService_hello_java$lang$String_Handler", workItemHandler));
+        Map<String, BpmnProcess> processes = createProcesses(classData, Collections.singletonMap("org.jbpm.bpmn2.objects.HelloService_hello_2_Handler", workItemHandler));
         ProcessInstance<BpmnVariables> processInstance = processes.get("ServiceProcess").createInstance(BpmnVariables.create(params));
 
         processInstance.start();
@@ -444,7 +444,7 @@ public class ActivityGenerationModelTest extends JbpmBpmn2TestCase {
 
         assertThat(metaData.getWorkItems())
         .hasSize(1)
-        .contains("org.jbpm.bpmn2.objects.HelloService_hello_java$lang$String_Handler");
+        .contains("org.jbpm.bpmn2.objects.HelloService_hello_2_Handler");
     }
     
     @SuppressWarnings("unchecked")

--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/canonical/ActivityGenerationModelTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/canonical/ActivityGenerationModelTest.java
@@ -444,7 +444,7 @@ public class ActivityGenerationModelTest extends JbpmBpmn2TestCase {
 
         assertThat(metaData.getWorkItems())
         .hasSize(1)
-        .contains("org.jbpm.bpmn2.objects.HelloService.hello");
+        .contains("org.jbpm.bpmn2.objects.HelloService_hello_java$lang$String_Handler");
     }
     
     @SuppressWarnings("unchecked")

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ServiceTaskDescriptor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ServiceTaskDescriptor.java
@@ -140,8 +140,6 @@ public class ServiceTaskDescriptor {
     }
 
     private String mangledHandlerName(String interfaceName, String operationName, Map<String, String> parameters) {
-        String simpleName = interfaceName.substring(interfaceName.lastIndexOf(".") + 1);
-
         // mangle dotted identifiers foo.bar.Baz into foo$bar$Baz
         // then concatenate the collection with $$
         // e.g. List.of("foo.bar.Baz", "qux.Quux") -> "foo$bar$Baz$$qux$Quux"
@@ -149,7 +147,7 @@ public class ServiceTaskDescriptor {
                 parameters.values().stream().map(s -> s.replace('.', '$'))
                         .collect(joining("$$"));
 
-        return String.format("%s_%s_%s_Handler", simpleName, operationName, mangledParameterTypes);
+        return String.format("%s_%s_%s_Handler", interfaceName, operationName, mangledParameterTypes);
     }
 
     public CompilationUnit generateHandlerClassForService() {

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ServiceTaskDescriptor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ServiceTaskDescriptor.java
@@ -1,0 +1,214 @@
+/*
+ *  Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.jbpm.compiler.canonical;
+
+import java.lang.reflect.Method;
+import java.text.MessageFormat;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.VariableDeclarator;
+import com.github.javaparser.ast.expr.CastExpr;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.expr.NullLiteralExpr;
+import com.github.javaparser.ast.expr.StringLiteralExpr;
+import com.github.javaparser.ast.expr.VariableDeclarationExpr;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.ReturnStmt;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import org.jbpm.process.core.ParameterDefinition;
+import org.jbpm.workflow.core.node.DataAssociation;
+import org.jbpm.workflow.core.node.WorkItemNode;
+import org.kie.api.runtime.process.WorkItem;
+import org.kie.api.runtime.process.WorkItemHandler;
+import org.kie.api.runtime.process.WorkItemManager;
+
+import static java.util.stream.Collectors.joining;
+
+public class ServiceTaskDescriptor {
+    private final ClassLoader contextClassLoader;
+    private final String interfaceName;
+    private final String operationName;
+    private final Map<String, String> parameters;
+    private final WorkItemNode workItemNode;
+    private final String mangledName;
+    Class<?> cls;
+
+    ServiceTaskDescriptor(WorkItemNode workItemNode, ClassLoader contextClassLoader) {
+        this.workItemNode = workItemNode;
+        interfaceName = (String) workItemNode.getWork().getParameter("Interface");
+        operationName = (String) workItemNode.getWork().getParameter("Operation");
+        this.contextClassLoader = contextClassLoader;
+
+        NodeValidator.of("workItemNode", workItemNode.getName())
+                .notEmpty("interfaceName", interfaceName)
+                .notEmpty("operationName", operationName)
+                .validate();
+
+        parameters = serviceTaskParameters();
+
+        mangledName = mangledHandlerName(interfaceName, operationName, parameters);
+    }
+
+    public String mangledName() {
+        return mangledName;
+    }
+
+    private Map<String, String> serviceTaskParameters() {
+        String type = (String) workItemNode.getWork().getParameter("ParameterType");
+        Map<String, String> parameters = null;
+        if (type != null) {
+            if (isDefaultParameterType(type)) {
+                type = inferParameterType(workItemNode.getName(), interfaceName, operationName, type);
+            }
+
+            parameters = Collections.singletonMap("Parameter", type);
+        } else {
+            parameters = new LinkedHashMap<>();
+
+            for (ParameterDefinition def : workItemNode.getWork().getParameterDefinitions()) {
+                parameters.put(def.getName(), def.getType().getStringType());
+            }
+        }
+        return parameters;
+    }
+
+
+    // assume 1 single arg as above
+    private String inferParameterType(String nodeName, String interfaceName, String operationName, String defaultType) {
+        try {
+            Class<?> i = contextClassLoader.loadClass(interfaceName);
+            for (Method m : i.getMethods()) {
+                if (m.getName().equals(operationName) && m.getParameterCount() == 1) {
+                    return m.getParameterTypes()[0].getCanonicalName();
+                }
+            }
+        } catch (ClassNotFoundException e) {
+            throw new IllegalArgumentException(MessageFormat.format("Invalid work item \"{0}\": class not found for interfaceName \"{1}\"", nodeName, interfaceName));
+        }
+        throw new IllegalArgumentException(MessageFormat.format("Invalid work item \"{0}\": could not find a method called \"{1}\" in class \"{2}\"", nodeName, operationName, interfaceName));
+    }
+
+    private boolean isDefaultParameterType(String type) {
+        return type.equals("java.lang.Object") || type.equals("Object");
+    }
+
+    private String mangledHandlerName(String interfaceName, String operationName, Map<String, String> parameters) {
+        String simpleName = interfaceName.substring(interfaceName.lastIndexOf(".") + 1);
+
+        // mangle dotted identifiers foo.bar.Baz into foo$bar$Baz
+        // then concatenate the collection with $$
+        // e.g. List.of("foo.bar.Baz", "qux.Quux") -> "foo$bar$Baz$$qux$Quux"
+        String mangledParameterTypes =
+                parameters.values().stream().map(s -> s.replace('.', '$'))
+                        .collect(joining("$$"));
+
+        return String.format("%s_%s_%s_Handler", simpleName, operationName, mangledParameterTypes);
+    }
+
+
+    public CompilationUnit generateHandlerClassForService() {
+        CompilationUnit compilationUnit = new CompilationUnit("org.kie.kogito.handlers");
+
+        compilationUnit.getTypes().add(classDeclaration());
+
+        return compilationUnit;
+    }
+
+
+    public ClassOrInterfaceDeclaration classDeclaration() {
+        ClassOrInterfaceDeclaration cls = new ClassOrInterfaceDeclaration()
+                .setName(mangledName)
+                .setModifiers(Modifier.Keyword.PUBLIC)
+                .addImplementedType(WorkItemHandler.class.getCanonicalName());
+        ClassOrInterfaceType serviceType = new ClassOrInterfaceType(null, interfaceName);
+        FieldDeclaration serviceField = new FieldDeclaration()
+                .addVariable(new VariableDeclarator(serviceType, "service"));
+        cls.addMember(serviceField);
+
+        // executeWorkItem method
+        BlockStmt executeWorkItemBody = new BlockStmt();
+        MethodDeclaration executeWorkItem = new MethodDeclaration()
+                .setModifiers(Modifier.Keyword.PUBLIC)
+                .setType(void.class)
+                .setName("executeWorkItem")
+                .setBody(executeWorkItemBody)
+                .addParameter(WorkItem.class.getCanonicalName(), "workItem")
+                .addParameter(WorkItemManager.class.getCanonicalName(), "workItemManager");
+
+        MethodCallExpr callService = new MethodCallExpr(new NameExpr("service"), operationName);
+
+        for (Map.Entry<String, String> paramEntry : parameters.entrySet()) {
+            MethodCallExpr getParamMethod = new MethodCallExpr(new NameExpr("workItem"), "getParameter").addArgument(new StringLiteralExpr(paramEntry.getKey()));
+            callService.addArgument(new CastExpr(new ClassOrInterfaceType(null, paramEntry.getValue()), getParamMethod));
+        }
+        Expression results = null;
+        List<DataAssociation> outAssociations = workItemNode.getOutAssociations();
+        if (outAssociations.isEmpty()) {
+
+            executeWorkItemBody.addStatement(callService);
+            results = new NullLiteralExpr();
+        } else {
+            VariableDeclarationExpr resultField = new VariableDeclarationExpr()
+                    .addVariable(new VariableDeclarator(new ClassOrInterfaceType(null, Object.class.getCanonicalName()), "result", callService));
+
+            executeWorkItemBody.addStatement(resultField);
+
+            results = new MethodCallExpr(new NameExpr("java.util.Collections"), "singletonMap")
+                    .addArgument(new StringLiteralExpr(outAssociations.get(0).getSources().get(0)))
+                    .addArgument(new NameExpr("result"));
+        }
+
+        MethodCallExpr completeWorkItem = new MethodCallExpr(new NameExpr("workItemManager"), "completeWorkItem")
+                .addArgument(new MethodCallExpr(new NameExpr("workItem"), "getId"))
+                .addArgument(results);
+
+        executeWorkItemBody.addStatement(completeWorkItem);
+
+        // abortWorkItem method
+        BlockStmt abortWorkItemBody = new BlockStmt();
+        MethodDeclaration abortWorkItem = new MethodDeclaration()
+                .setModifiers(Modifier.Keyword.PUBLIC)
+                .setType(void.class)
+                .setName("abortWorkItem")
+                .setBody(abortWorkItemBody)
+                .addParameter(WorkItem.class.getCanonicalName(), "workItem")
+                .addParameter(WorkItemManager.class.getCanonicalName(), "workItemManager");
+
+        // getName method
+        MethodDeclaration getName = new MethodDeclaration()
+                .setModifiers(Modifier.Keyword.PUBLIC)
+                .setType(String.class)
+                .setName("getName")
+                .setBody(new BlockStmt().addStatement(new ReturnStmt(new StringLiteralExpr(interfaceName + "." + operationName))));
+        cls.addMember(executeWorkItem)
+                .addMember(abortWorkItem)
+                .addMember(getName);
+
+        return cls;
+    }
+
+}

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ServiceTaskDescriptor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ServiceTaskDescriptor.java
@@ -162,8 +162,9 @@ public class ServiceTaskDescriptor {
     }
 
     public ClassOrInterfaceDeclaration classDeclaration() {
+        String unqualifiedName = StaticJavaParser.parseName(mangledName).removeQualifier().asString();
         ClassOrInterfaceDeclaration cls = new ClassOrInterfaceDeclaration()
-                .setName(StaticJavaParser.parseName(mangledName).removeQualifier().asString())
+                .setName(unqualifiedName)
                 .setModifiers(Modifier.Keyword.PUBLIC)
                 .addImplementedType(WorkItemHandler.class.getCanonicalName());
         ClassOrInterfaceType serviceType = new ClassOrInterfaceType(null, interfaceName);

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ServiceTaskDescriptor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ServiceTaskDescriptor.java
@@ -141,8 +141,6 @@ public class ServiceTaskDescriptor {
     }
 
     private String mangledHandlerName(String interfaceName, String operationName, Map<String, String> parameters) {
-        String simpleName = interfaceName.substring(interfaceName.lastIndexOf(".") + 1);
-
         // mangle dotted identifiers foo.bar.Baz into foo$bar$Baz
         // then concatenate the collection with $$
         // e.g. List.of("foo.bar.Baz", "qux.Quux") -> "foo$bar$Baz$$qux$Quux"
@@ -150,7 +148,7 @@ public class ServiceTaskDescriptor {
                 parameters.values().stream().map(s -> s.replace('.', '$'))
                         .collect(joining("$$"));
 
-        return String.format("%s_%s_%s_Handler", simpleName, operationName, mangledParameterTypes);
+        return String.format("%s_%s_%s_Handler", interfaceName, operationName, mangledParameterTypes);
     }
 
     public CompilationUnit generateHandlerClassForService() {

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ServiceTaskDescriptor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ServiceTaskDescriptor.java
@@ -190,7 +190,7 @@ public class ServiceTaskDescriptor {
                 .setModifiers(Modifier.Keyword.PUBLIC)
                 .setType(String.class)
                 .setName("getName")
-                .setBody(new BlockStmt().addStatement(new ReturnStmt(new StringLiteralExpr(interfaceName + "." + operationName))));
+                .setBody(new BlockStmt().addStatement(new ReturnStmt(new StringLiteralExpr(mangledName))));
         cls.addMember(executeWorkItem)
                 .addMember(abortWorkItem)
                 .addMember(getName);

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/WorkItemNodeVisitor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/WorkItemNodeVisitor.java
@@ -99,7 +99,16 @@ public class WorkItemNodeVisitor<T extends WorkItemNode> extends AbstractNodeVis
     @Override
     public void visitNode(String factoryField, T node, BlockStmt body, VariableScope variableScope, ProcessMetaData metadata) {
         Work work = node.getWork();
-        String workName = workItemName(node, metadata);
+        String workName = node.getWork().getName();
+
+        if (workName.equals("Service Task")) {
+            ServiceTaskDescriptor d = new ServiceTaskDescriptor(node, contextClassLoader);
+            String mangledName = d.mangledName();
+            CompilationUnit generatedHandler = d.generateHandlerClassForService();
+            metadata.getGeneratedHandlers().put(mangledName, generatedHandler);
+            workName = mangledName;
+        }
+
         body.addStatement(getAssignedFactoryMethod(factoryField, WorkItemNodeFactory.class, getNodeId(node), getNodeKey(), new LongLiteralExpr(node.getId())))
                 .addStatement(getNameMethod(node, work.getName()))
                 .addStatement(getFactoryMethod(getNodeId(node), METHOD_WORK_NAME, new StringLiteralExpr(workName)));
@@ -147,155 +156,6 @@ public class WorkItemNodeVisitor<T extends WorkItemNode> extends AbstractNodeVis
         }
     }
 
-    protected String workItemName(WorkItemNode workItemNode, ProcessMetaData metadata) {
-        String workName = workItemNode.getWork().getName();
 
-        if (workName.equals("Service Task")) {
-            String interfaceName = (String) workItemNode.getWork().getParameter("Interface");
-            String operationName = (String) workItemNode.getWork().getParameter("Operation");
-            String type = (String) workItemNode.getWork().getParameter("ParameterType");
 
-            NodeValidator.of(getNodeKey(), workItemNode.getName())
-                    .notEmpty("interfaceName", interfaceName)
-                    .notEmpty("operationName", operationName)
-                    .validate();
-
-            Map<String, String> parameters = null;
-            if (type != null) {
-                if (isDefaultParameterType(type)) {
-                    type = inferParameterType(workItemNode.getName(), interfaceName, operationName, type);
-                }
-
-                parameters = Collections.singletonMap("Parameter", type);
-            } else {
-                parameters = new LinkedHashMap<>();
-
-                for (ParameterDefinition def : workItemNode.getWork().getParameterDefinitions()) {
-                    parameters.put(def.getName(), def.getType().getStringType());
-                }
-            }
-
-            String uniqueHandlerName = mangledHandlerName(interfaceName, operationName, parameters);
-
-            CompilationUnit handlerClass = generateHandlerClassForService(
-                    uniqueHandlerName, interfaceName, operationName, parameters, workItemNode.getOutAssociations());
-
-            metadata.getGeneratedHandlers().put(uniqueHandlerName, handlerClass);
-
-            return uniqueHandlerName;
-        }
-
-        return workName;
-    }
-
-    private String mangledHandlerName(String interfaceName, String operationName, Map<String, String> parameters) {
-        String simpleName = interfaceName.substring(interfaceName.lastIndexOf(".") + 1);
-
-        // mangle dotted identifiers foo.bar.Baz into foo$bar$Baz
-        // then concatenate the collection with $$
-        // e.g. List.of("foo.bar.Baz", "qux.Quux") -> "foo$bar$Baz$$qux$Quux"
-        String mangledParameterTypes =
-                parameters.values().stream().map(s -> s.replace('.', '$'))
-                        .collect(joining("$$"));
-
-        return String.format("%s_%s_%s_Handler", simpleName, operationName, mangledParameterTypes);
-    }
-
-    // assume 1 single arg as above
-    private String inferParameterType(String nodeName, String interfaceName, String operationName, String defaultType) {
-        try {
-            Class<?> i = contextClassLoader.loadClass(interfaceName);
-            for (Method m : i.getMethods()) {
-                if (m.getName().equals(operationName) && m.getParameterCount() == 1) {
-                    return m.getParameterTypes()[0].getCanonicalName();
-                }
-            }
-        } catch (ClassNotFoundException e) {
-            throw new IllegalArgumentException(MessageFormat.format("Invalid work item \"{0}\": class not found for interfaceName \"{1}\"", nodeName, interfaceName));
-        }
-        throw new IllegalArgumentException(MessageFormat.format("Invalid work item \"{0}\": could not find a method called \"{1}\" in class \"{2}\"", nodeName, operationName, interfaceName));
-    }
-
-    private boolean isDefaultParameterType(String type) {
-        return type.equals("java.lang.Object") || type.equals("Object");
-    }
-
-    protected CompilationUnit generateHandlerClassForService(String mangledHandlerName, String interfaceName, String operation, Map<String, String> parameters, List<DataAssociation> outAssociations) {
-        CompilationUnit compilationUnit = new CompilationUnit("org.kie.kogito.handlers");
-
-        compilationUnit.getTypes().add(classDeclaration(mangledHandlerName, interfaceName, operation, parameters, outAssociations));
-
-        return compilationUnit;
-    }
-
-    public ClassOrInterfaceDeclaration classDeclaration(String mangledHandlerName, String interfaceName, String operation, Map<String, String> parameters, List<DataAssociation> outAssociations) {
-        ClassOrInterfaceDeclaration cls = new ClassOrInterfaceDeclaration()
-                .setName(mangledHandlerName)
-                .setModifiers(Modifier.Keyword.PUBLIC)
-                .addImplementedType(WorkItemHandler.class.getCanonicalName());
-        ClassOrInterfaceType serviceType = new ClassOrInterfaceType(null, interfaceName);
-        FieldDeclaration serviceField = new FieldDeclaration()
-                .addVariable(new VariableDeclarator(serviceType, "service"));
-        cls.addMember(serviceField);
-
-        // executeWorkItem method
-        BlockStmt executeWorkItemBody = new BlockStmt();
-        MethodDeclaration executeWorkItem = new MethodDeclaration()
-                .setModifiers(Modifier.Keyword.PUBLIC)
-                .setType(void.class)
-                .setName("executeWorkItem")
-                .setBody(executeWorkItemBody)
-                .addParameter(WorkItem.class.getCanonicalName(), "workItem")
-                .addParameter(WorkItemManager.class.getCanonicalName(), "workItemManager");
-
-        MethodCallExpr callService = new MethodCallExpr(new NameExpr("service"), operation);
-
-        for (Entry<String, String> paramEntry : parameters.entrySet()) {
-            MethodCallExpr getParamMethod = new MethodCallExpr(new NameExpr("workItem"), "getParameter").addArgument(new StringLiteralExpr(paramEntry.getKey()));
-            callService.addArgument(new CastExpr(new ClassOrInterfaceType(null, paramEntry.getValue()), getParamMethod));
-        }
-        Expression results = null;
-        if (outAssociations.isEmpty()) {
-
-            executeWorkItemBody.addStatement(callService);
-            results = new NullLiteralExpr();
-        } else {
-            VariableDeclarationExpr resultField = new VariableDeclarationExpr()
-                    .addVariable(new VariableDeclarator(new ClassOrInterfaceType(null, Object.class.getCanonicalName()), "result", callService));
-
-            executeWorkItemBody.addStatement(resultField);
-
-            results = new MethodCallExpr(new NameExpr("java.util.Collections"), "singletonMap")
-                    .addArgument(new StringLiteralExpr(outAssociations.get(0).getSources().get(0)))
-                    .addArgument(new NameExpr("result"));
-        }
-
-        MethodCallExpr completeWorkItem = new MethodCallExpr(new NameExpr("workItemManager"), "completeWorkItem")
-                .addArgument(new MethodCallExpr(new NameExpr("workItem"), "getId"))
-                .addArgument(results);
-
-        executeWorkItemBody.addStatement(completeWorkItem);
-
-        // abortWorkItem method
-        BlockStmt abortWorkItemBody = new BlockStmt();
-        MethodDeclaration abortWorkItem = new MethodDeclaration()
-                .setModifiers(Modifier.Keyword.PUBLIC)
-                .setType(void.class)
-                .setName("abortWorkItem")
-                .setBody(abortWorkItemBody)
-                .addParameter(WorkItem.class.getCanonicalName(), "workItem")
-                .addParameter(WorkItemManager.class.getCanonicalName(), "workItemManager");
-
-        // getName method
-        MethodDeclaration getName = new MethodDeclaration()
-                .setModifiers(Modifier.Keyword.PUBLIC)
-                .setType(String.class)
-                .setName("getName")
-                .setBody(new BlockStmt().addStatement(new ReturnStmt(new StringLiteralExpr(interfaceName + "." + operation))));
-        cls.addMember(executeWorkItem)
-                .addMember(abortWorkItem)
-                .addMember(getName);
-
-        return cls;
-    }
 }

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/data/HelloService.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/data/HelloService.java
@@ -56,4 +56,18 @@ public class HelloService {
         System.out.println("Service invoked with " + name + " " + age + " on service " + this.toString());
         return "Hello " + name.toString() + " " + age + "!";
     }
+
+    int count = 0;
+
+    public void doSomething(String str1) {
+        if (count > 0) {
+            throw new RuntimeException("You should not be here");
+        }
+        count++;
+    }
+
+    public void doSomething(String str1, String str2) {
+
+    }
+
 }

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/tests/ServiceTaskTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/tests/ServiceTaskTest.java
@@ -258,4 +258,17 @@ public class ServiceTaskTest extends AbstractCodegenTest {
         assertThat(result.toMap().get("result")).isNotNull().isEqualTo("Hello john 35!");
         
     }
+
+    @Test
+    public void testOverloadedService() throws Exception {
+
+        Application app = generateCodeProcessesOnly("servicetask/ServiceProcessOverloaded.bpmn2");
+        assertThat(app).isNotNull();
+
+        Process<? extends Model> p = app.processes().processById("ServiceProcessOverloaded");
+        ProcessInstance<?> processInstance = p.createInstance(p.createModel());
+        processInstance.start();
+
+        assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
+    }
 }

--- a/kogito-codegen/src/test/resources/servicetask/ServiceProcessOverloaded.bpmn2
+++ b/kogito-codegen/src/test/resources/servicetask/ServiceProcessOverloaded.bpmn2
@@ -1,0 +1,176 @@
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_UG_38JLDEDirTshjDs_RRQ" exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
+  <bpmn2:itemDefinition id="__33DACA6B-A02B-4C4D-82D3-AC478CAE6AE4_str1InputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__0F0B7B16-F3AB-48E4-ACBD-9188D4CBD07E_str1InputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__0F0B7B16-F3AB-48E4-ACBD-9188D4CBD07E_str2InputXItem" structureRef="String"/>
+  <bpmn2:interface id="_33DACA6B-A02B-4C4D-82D3-AC478CAE6AE4_ServiceInterface" name="org.kie.kogito.codegen.data.HelloService" implementationRef="org.kie.kogito.codegen.data.HelloService">
+    <bpmn2:operation id="_33DACA6B-A02B-4C4D-82D3-AC478CAE6AE4_ServiceOperation" name="doSomething" implementationRef="doSomething"/>
+  </bpmn2:interface>
+  <bpmn2:interface id="_0F0B7B16-F3AB-48E4-ACBD-9188D4CBD07E_ServiceInterface" name="org.kie.kogito.codegen.data.HelloService" implementationRef="org.kie.kogito.codegen.data.HelloService">
+    <bpmn2:operation id="_0F0B7B16-F3AB-48E4-ACBD-9188D4CBD07E_ServiceOperation" name="doSomething" implementationRef="doSomething"/>
+  </bpmn2:interface>
+  <bpmn2:process id="ServiceProcessOverloaded" drools:packageName="ruletask" drools:version="1.0" drools:adHoc="false" name="ServiceProcessOverloaded" isExecutable="true" processType="Public">
+    <bpmn2:sequenceFlow id="_425B3F03-CE0D-4A0C-BFEE-73EECC7B7633" sourceRef="_33DACA6B-A02B-4C4D-82D3-AC478CAE6AE4" targetRef="_0F0B7B16-F3AB-48E4-ACBD-9188D4CBD07E">
+      <bpmn2:extensionElements>
+        <drools:metaData name="isAutoConnection.target">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+    </bpmn2:sequenceFlow>
+    <bpmn2:sequenceFlow id="_549BF900-4DDB-4FD8-A66F-4DD18BAEF0A2" sourceRef="_0F0B7B16-F3AB-48E4-ACBD-9188D4CBD07E" targetRef="_016357A1-C56A-4BC1-9614-3E246E5115AD"/>
+    <bpmn2:sequenceFlow id="_2AD2F754-EAA7-4BDC-9BC9-39B9C37BB3F1" sourceRef="_75AC8C0C-CFBD-4ADF-A3B4-83AB90581A73" targetRef="_33DACA6B-A02B-4C4D-82D3-AC478CAE6AE4">
+      <bpmn2:extensionElements>
+        <drools:metaData name="isAutoConnection.source">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+        <drools:metaData name="isAutoConnection.target">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+    </bpmn2:sequenceFlow>
+    <bpmn2:serviceTask id="_0F0B7B16-F3AB-48E4-ACBD-9188D4CBD07E" drools:serviceimplementation="Java" drools:serviceinterface="org.kie.kogito.codegen.data.HelloService" drools:serviceoperation="doSomething" name="ServiceTask2" implementation="Java" operationRef="_0F0B7B16-F3AB-48E4-ACBD-9188D4CBD07E_ServiceOperation">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[ServiceTask2]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_425B3F03-CE0D-4A0C-BFEE-73EECC7B7633</bpmn2:incoming>
+      <bpmn2:outgoing>_549BF900-4DDB-4FD8-A66F-4DD18BAEF0A2</bpmn2:outgoing>
+      <bpmn2:ioSpecification>
+        <bpmn2:dataInput id="_0F0B7B16-F3AB-48E4-ACBD-9188D4CBD07E_str1InputX" drools:dtype="String" itemSubjectRef="__0F0B7B16-F3AB-48E4-ACBD-9188D4CBD07E_str1InputXItem" name="str1"/>
+        <bpmn2:dataInput id="_0F0B7B16-F3AB-48E4-ACBD-9188D4CBD07E_str2InputX" drools:dtype="String" itemSubjectRef="__0F0B7B16-F3AB-48E4-ACBD-9188D4CBD07E_str2InputXItem" name="str2"/>
+        <bpmn2:inputSet>
+          <bpmn2:dataInputRefs>_0F0B7B16-F3AB-48E4-ACBD-9188D4CBD07E_str1InputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_0F0B7B16-F3AB-48E4-ACBD-9188D4CBD07E_str2InputX</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation>
+        <bpmn2:targetRef>_0F0B7B16-F3AB-48E4-ACBD-9188D4CBD07E_str1InputX</bpmn2:targetRef>
+        <bpmn2:assignment>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA[value1]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_0F0B7B16-F3AB-48E4-ACBD-9188D4CBD07E_str1InputX]]></bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation>
+        <bpmn2:targetRef>_0F0B7B16-F3AB-48E4-ACBD-9188D4CBD07E_str2InputX</bpmn2:targetRef>
+        <bpmn2:assignment>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA[value2]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_0F0B7B16-F3AB-48E4-ACBD-9188D4CBD07E_str2InputX]]></bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+    </bpmn2:serviceTask>
+    <bpmn2:serviceTask id="_33DACA6B-A02B-4C4D-82D3-AC478CAE6AE4" drools:serviceimplementation="Java" drools:serviceinterface="org.kie.kogito.codegen.data.HelloService" drools:serviceoperation="doSomething" name="ServiceTask1" implementation="Java" operationRef="_33DACA6B-A02B-4C4D-82D3-AC478CAE6AE4_ServiceOperation">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[ServiceTask1]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_2AD2F754-EAA7-4BDC-9BC9-39B9C37BB3F1</bpmn2:incoming>
+      <bpmn2:outgoing>_425B3F03-CE0D-4A0C-BFEE-73EECC7B7633</bpmn2:outgoing>
+      <bpmn2:ioSpecification>
+        <bpmn2:dataInput id="_33DACA6B-A02B-4C4D-82D3-AC478CAE6AE4_str1InputX" drools:dtype="String" itemSubjectRef="__33DACA6B-A02B-4C4D-82D3-AC478CAE6AE4_str1InputXItem" name="str1"/>
+        <bpmn2:inputSet>
+          <bpmn2:dataInputRefs>_33DACA6B-A02B-4C4D-82D3-AC478CAE6AE4_str1InputX</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation>
+        <bpmn2:targetRef>_33DACA6B-A02B-4C4D-82D3-AC478CAE6AE4_str1InputX</bpmn2:targetRef>
+        <bpmn2:assignment>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA[value1]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_33DACA6B-A02B-4C4D-82D3-AC478CAE6AE4_str1InputX]]></bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+    </bpmn2:serviceTask>
+    <bpmn2:endEvent id="_016357A1-C56A-4BC1-9614-3E246E5115AD">
+      <bpmn2:incoming>_549BF900-4DDB-4FD8-A66F-4DD18BAEF0A2</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:startEvent id="_75AC8C0C-CFBD-4ADF-A3B4-83AB90581A73">
+      <bpmn2:outgoing>_2AD2F754-EAA7-4BDC-9BC9-39B9C37BB3F1</bpmn2:outgoing>
+    </bpmn2:startEvent>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram>
+    <bpmndi:BPMNPlane bpmnElement="ServiceTaskTest">
+      <bpmndi:BPMNShape id="shape__75AC8C0C-CFBD-4ADF-A3B4-83AB90581A73" bpmnElement="_75AC8C0C-CFBD-4ADF-A3B4-83AB90581A73">
+        <dc:Bounds height="56" width="56" x="344" y="222"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__016357A1-C56A-4BC1-9614-3E246E5115AD" bpmnElement="_016357A1-C56A-4BC1-9614-3E246E5115AD">
+        <dc:Bounds height="56" width="56" x="1023" y="222"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__33DACA6B-A02B-4C4D-82D3-AC478CAE6AE4" bpmnElement="_33DACA6B-A02B-4C4D-82D3-AC478CAE6AE4">
+        <dc:Bounds height="102" width="154" x="522" y="199"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__0F0B7B16-F3AB-48E4-ACBD-9188D4CBD07E" bpmnElement="_0F0B7B16-F3AB-48E4-ACBD-9188D4CBD07E">
+        <dc:Bounds height="102" width="154" x="815" y="199"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="edge_shape__75AC8C0C-CFBD-4ADF-A3B4-83AB90581A73_to_shape__33DACA6B-A02B-4C4D-82D3-AC478CAE6AE4" bpmnElement="_2AD2F754-EAA7-4BDC-9BC9-39B9C37BB3F1">
+        <di:waypoint x="400" y="250"/>
+        <di:waypoint x="522" y="250"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_shape__0F0B7B16-F3AB-48E4-ACBD-9188D4CBD07E_to_shape__016357A1-C56A-4BC1-9614-3E246E5115AD" bpmnElement="_549BF900-4DDB-4FD8-A66F-4DD18BAEF0A2">
+        <di:waypoint x="892" y="250"/>
+        <di:waypoint x="1051" y="250"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_shape__33DACA6B-A02B-4C4D-82D3-AC478CAE6AE4_to_shape__0F0B7B16-F3AB-48E4-ACBD-9188D4CBD07E" bpmnElement="_425B3F03-CE0D-4A0C-BFEE-73EECC7B7633">
+        <di:waypoint x="599" y="250"/>
+        <di:waypoint x="892" y="199"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters/>
+          <bpsim:ElementParameters elementRef="_75AC8C0C-CFBD-4ADF-A3B4-83AB90581A73">
+            <bpsim:TimeParameters>
+              <bpsim:ProcessingTime>
+                <bpsim:NormalDistribution mean="0" standardDeviation="0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters elementRef="_33DACA6B-A02B-4C4D-82D3-AC478CAE6AE4">
+            <bpsim:TimeParameters>
+              <bpsim:ProcessingTime>
+                <bpsim:NormalDistribution mean="0" standardDeviation="0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters>
+              <bpsim:Availability>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:Availability>
+              <bpsim:Quantity>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters>
+              <bpsim:UnitCost>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters elementRef="_0F0B7B16-F3AB-48E4-ACBD-9188D4CBD07E">
+            <bpsim:TimeParameters>
+              <bpsim:ProcessingTime>
+                <bpsim:NormalDistribution mean="0" standardDeviation="0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters>
+              <bpsim:Availability>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:Availability>
+              <bpsim:Quantity>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters>
+              <bpsim:UnitCost>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_UG_38JLDEDirTshjDs_RRQ</bpmn2:source>
+    <bpmn2:target>_UG_38JLDEDirTshjDs_RRQ</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-2472

the problem is actually _subtler_. The handlers that are internally generated are named using the `interfaceName_methodName` template, which causes them to overwrite each other in the case of overloading. The solution is to use a _mangled_ name instead, including type parameters. Now the template is ``SomeClass_doSomethingHandler_my$Type1$$my$Type2`` which should be more reliable