### PR TITLE
[KOGITO-2643] upgrade testcontainers version and add dependency management for the mongodb module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
     <version.org.kie7>7.39.0.Final</version.org.kie7>
     <version.org.reflections>0.9.11</version.org.reflections>
     <version.org.slf4j>1.7.25</version.org.slf4j>
-    <version.testcontainers>1.14.1</version.testcontainers>
+    <version.testcontainers>1.14.3</version.testcontainers>
     <version.resteasy.springboot>4.5.0.Final</version.resteasy.springboot>
     <version.springboot>2.2.5.RELEASE</version.springboot>
     <version.spring.framework>5.2.4.RELEASE</version.spring.framework>
@@ -563,6 +563,12 @@
       <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>junit-jupiter</artifactId>
+        <version>${version.testcontainers}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>mongodb</artifactId>
         <version>${version.testcontainers}</version>
         <scope>test</scope>
       </dependency>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/KOGITO-2643

The mongodb module was introduced to testcontainers since version 1.14.2.
So upgrade the testcontainers version and add new dependency management for the mongodb module.

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket