### PR TITLE
KOGITO-2735: Make kogito-maven-plugin threadsafe

### DIFF
--- a/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateDeclaredTypes.java
+++ b/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateDeclaredTypes.java
@@ -26,9 +26,10 @@ import org.kie.kogito.codegen.rules.DeclaredTypeCodegen;
 import org.kie.kogito.maven.plugin.util.MojoUtil;
 
 @Mojo(name = "generateDeclaredTypes",
-        requiresDependencyResolution = ResolutionScope.NONE,
-        requiresProject = true,
-        defaultPhase = LifecyclePhase.GENERATE_SOURCES)
+      requiresDependencyResolution = ResolutionScope.NONE,
+      requiresProject = true,
+      defaultPhase = LifecyclePhase.GENERATE_SOURCES,
+      threadSafe = true)
 public class GenerateDeclaredTypes extends AbstractKieMojo {
 
 

--- a/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
+++ b/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
@@ -50,9 +50,10 @@ import org.kie.kogito.codegen.rules.IncrementalRuleCodegen;
 import org.kie.kogito.maven.plugin.util.MojoUtil;
 
 @Mojo(name = "generateModel",
-        requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME,
-        requiresProject = true,
-        defaultPhase = LifecyclePhase.COMPILE)
+      requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME,
+      requiresProject = true,
+      defaultPhase = LifecyclePhase.COMPILE,
+      threadSafe = true)
 public class GenerateModelMojo extends AbstractKieMojo {
 
     public static final List<String> DROOLS_EXTENSIONS = Arrays.asList(".drl", ".xls", ".xlsx", ".csv");

--- a/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/ProcessClassesMojo.java
+++ b/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/ProcessClassesMojo.java
@@ -59,7 +59,8 @@ import org.reflections.util.ConfigurationBuilder;
 @Mojo(name = "process-model-classes",
       requiresDependencyResolution = ResolutionScope.RUNTIME,
       requiresProject = true,
-      defaultPhase = LifecyclePhase.PROCESS_CLASSES)
+      defaultPhase = LifecyclePhase.PROCESS_CLASSES,
+      threadSafe = true)
 public class ProcessClassesMojo extends AbstractKieMojo {
         
     private static final JavaCompiler JAVA_COMPILER = JavaCompilerFactory.getInstance().loadCompiler(JavaDialectConfiguration.CompilerType.NATIVE, "1.8");

--- a/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/ScaffoldMojo.java
+++ b/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/ScaffoldMojo.java
@@ -26,8 +26,9 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
 @Mojo(name = "scaffold",
-        requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME,
-        requiresProject = true)
+      requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME,
+      requiresProject = true,
+      threadSafe = true)
 public class ScaffoldMojo extends GenerateModelMojo {
 
     @Parameter(property = "kogito.codegen.ondemand", defaultValue = "true")
@@ -46,6 +47,7 @@ public class ScaffoldMojo extends GenerateModelMojo {
         }
     }
 
+    @Override
     public boolean isOnDemand() {
         return onDemand;
     }


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/KOGITO-2735
Description: 

Make kogito-maven-plugin threadsafe in parallel.
I reviewed all the MOJOs and I think they are already thread safe, so I marked them as so and checked that maven is not warning about it when building the project in parallel.

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket