### PR TITLE
KOGITO-2737 - refactoring injection of addons configuration

### DIFF
--- a/kogito-codegen/README.md
+++ b/kogito-codegen/README.md
@@ -11,7 +11,7 @@ configure its global behavior.
     ApplicationGenerator appGen =
             new ApplicationGenerator(appPackageName, targetDirectory)
                     .withDependencyInjection(...)
-                    .withPersistence(...);
+                    .withAddons(...);
     ```
 
 - Each supported component (process, rules, etc.) implements the `Generator` 
@@ -27,7 +27,7 @@ configure its global behavior.
             .withClassLoader(...);
     
     appGen.withGenerator(ProcessCodegen.ofPath(processSourceDirectory))                    
-            .withPersistence(...);
+            .withAddons(...);
     ```
 
 - Each `Generator` should delegate to a subcomponent, to process a single

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/AddonsConfig.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/AddonsConfig.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.codegen;
+
+public class AddonsConfig {
+    private boolean usePersistence = false;
+    private boolean useTracing = false;
+    private boolean useMonitoring = false;
+
+    public AddonsConfig withPersistence(boolean usePersistence){
+        this.usePersistence = usePersistence;
+        return this;
+    }
+
+    public AddonsConfig withTracing(boolean useTracing){
+        this.useTracing = useTracing;
+        return this;
+    }
+
+    public AddonsConfig withMonitoring(boolean useMonitoring){
+        this.useMonitoring = useMonitoring;
+        return this;
+    }
+
+    public boolean usePersistence(){
+        return usePersistence;
+    }
+
+    public boolean useTracing(){
+        return useTracing;
+    }
+
+    public boolean useMonitoring(){
+        return useMonitoring;
+    }
+}

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/AddonsConfig.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/AddonsConfig.java
@@ -16,34 +16,40 @@
 package org.kie.kogito.codegen;
 
 public class AddonsConfig {
-    private boolean usePersistence = false;
-    private boolean useTracing = false;
-    private boolean useMonitoring = false;
 
-    public AddonsConfig withPersistence(boolean usePersistence){
+    public static final AddonsConfig DEFAULT = new AddonsConfig()
+            .withPersistence(false)
+            .withTracing(false)
+            .withMonitoring(false);
+
+    private boolean usePersistence;
+    private boolean useTracing;
+    private boolean useMonitoring;
+
+    public AddonsConfig withPersistence(boolean usePersistence) {
         this.usePersistence = usePersistence;
         return this;
     }
 
-    public AddonsConfig withTracing(boolean useTracing){
+    public AddonsConfig withTracing(boolean useTracing) {
         this.useTracing = useTracing;
         return this;
     }
 
-    public AddonsConfig withMonitoring(boolean useMonitoring){
+    public AddonsConfig withMonitoring(boolean useMonitoring) {
         this.useMonitoring = useMonitoring;
         return this;
     }
 
-    public boolean usePersistence(){
+    public boolean usePersistence() {
         return usePersistence;
     }
 
-    public boolean useTracing(){
+    public boolean useTracing() {
         return useTracing;
     }
 
-    public boolean useMonitoring(){
+    public boolean useMonitoring() {
         return useMonitoring;
     }
 }

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/ApplicationGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/ApplicationGenerator.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
 import javax.lang.model.SourceVersion;
 
 import com.github.javaparser.ast.CompilationUnit;
@@ -72,7 +73,6 @@ public class ApplicationGenerator {
     private List<Labeler> labelers = new ArrayList<>();
 
     private GeneratorContext context;
-    private boolean persistence;       
 
     public ApplicationGenerator(String packageName, File targetDirectory) {
         if (packageName == null) {
@@ -192,17 +192,12 @@ public class ApplicationGenerator {
         return this;
     }
 
-   public ApplicationGenerator withPersistence(boolean persistence) {
-       this.persistence = persistence;
-       return this;
-   }
-
-   public ApplicationGenerator withMonitoring(boolean monitoring) {
-       if (monitoring) {
-           this.labelers.add(new PrometheusLabeler());
-       }
-       return this;
-   }
+    public ApplicationGenerator withAddons(AddonsConfig addonsConfig) {
+        if (addonsConfig.useMonitoring()) {
+            this.labelers.add(new PrometheusLabeler());
+        }
+        return this;
+    }
 
     public Collection<GeneratedFile> generate() {
         List<GeneratedFile> generatedFiles = generateComponents();

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/ApplicationGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/ApplicationGenerator.java
@@ -20,7 +20,9 @@ import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -70,7 +72,7 @@ public class ApplicationGenerator {
     private final List<BodyDeclaration<?>> factoryMethods;
     private ConfigGenerator configGenerator;
     private List<Generator> generators = new ArrayList<>();
-    private List<Labeler> labelers = new ArrayList<>();
+    private Map<Class, Labeler> labelers = new HashMap<>();
 
     private GeneratorContext context;
 
@@ -194,7 +196,7 @@ public class ApplicationGenerator {
 
     public ApplicationGenerator withAddons(AddonsConfig addonsConfig) {
         if (addonsConfig.useMonitoring()) {
-            this.labelers.add(new PrometheusLabeler());
+            this.labelers.put(PrometheusLabeler.class, new PrometheusLabeler());
         }
         return this;
     }
@@ -212,7 +214,7 @@ public class ApplicationGenerator {
             generators.stream().filter(gen -> gen.section() != null)
                     .forEach(gen -> generateSectionClass(gen.section(), generatedFiles));
         }
-        this.labelers.forEach(l -> MetaDataWriter.writeLabelsImageMetadata(targetDirectory, l.generateLabels()));
+        this.labelers.values().forEach(l -> MetaDataWriter.writeLabelsImageMetadata(targetDirectory, l.generateLabels()));
         return generatedFiles;
     }
 

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DMNRestResourceGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DMNRestResourceGenerator.java
@@ -38,6 +38,7 @@ import org.drools.core.util.StringUtils;
 import org.kie.dmn.api.core.DMNModel;
 import org.kie.dmn.feel.codegen.feel11.CodegenStringUtil;
 import org.kie.dmn.model.api.DecisionService;
+import org.kie.kogito.codegen.AddonsConfig;
 import org.kie.kogito.codegen.BodyDeclarationComparator;
 import org.kie.kogito.codegen.CodegenUtils;
 import org.kie.kogito.codegen.di.DependencyInjectionAnnotator;
@@ -56,7 +57,7 @@ public class DMNRestResourceGenerator {
     private final String resourceClazzName;
     private final String appCanonicalName;
     private DependencyInjectionAnnotator annotator;
-    private boolean useMonitoring;
+    private AddonsConfig addonsConfig = new AddonsConfig();
     private boolean isStronglyTyped = false;
 
     public DMNRestResourceGenerator(DMNModel model, String appCanonicalName) {
@@ -115,14 +116,14 @@ public class DMNRestResourceGenerator {
                 rewrittenReturnExpr.setName("extractSingletonDSIfSucceded");
             }
 
-            if (useMonitoring) {
+            if (addonsConfig.useMonitoring()) {
                 addMonitoringToMethod(clonedMethod, ds.getName());
             }
 
             template.addMember(clonedMethod);
         }
 
-        if (useMonitoring) {
+        if (addonsConfig.useMonitoring()) {
             addMonitoringImports(clazz);
             ClassOrInterfaceDeclaration exceptionClazz = clazz.findFirst(ClassOrInterfaceDeclaration.class, x -> "DMNEvaluationErrorExceptionMapper".equals(x.getNameAsString()))
                     .orElseThrow(() -> new NoSuchElementException("Could not find DMNEvaluationErrorExceptionMapper, template has changed."));
@@ -153,8 +154,8 @@ public class DMNRestResourceGenerator {
         return this;
     }
 
-    public DMNRestResourceGenerator withMonitoring(boolean useMonitoring) {
-        this.useMonitoring = useMonitoring;
+    public DMNRestResourceGenerator withAddons(AddonsConfig addonsConfig) {
+        this.addonsConfig = addonsConfig;
         return this;
     }
 

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DMNRestResourceGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DMNRestResourceGenerator.java
@@ -57,7 +57,7 @@ public class DMNRestResourceGenerator {
     private final String resourceClazzName;
     private final String appCanonicalName;
     private DependencyInjectionAnnotator annotator;
-    private AddonsConfig addonsConfig = new AddonsConfig();
+    private AddonsConfig addonsConfig = AddonsConfig.DEFAULT;
     private boolean isStronglyTyped = false;
 
     public DMNRestResourceGenerator(DMNModel model, String appCanonicalName) {

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionCodegen.java
@@ -136,7 +136,7 @@ public class DecisionCodegen extends AbstractGenerator {
 
     private final List<DMNResource> resources;
     private final List<GeneratedFile> generatedFiles = new ArrayList<>();
-    private AddonsConfig addonsConfig = new AddonsConfig();
+    private AddonsConfig addonsConfig = AddonsConfig.DEFAULT;
 
     public DecisionCodegen(List<DMNResource> resources) {
         this.resources = resources;

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionCodegen.java
@@ -46,6 +46,7 @@ import org.kie.dmn.typesafe.DMNAllTypesIndex;
 import org.kie.dmn.typesafe.DMNTypeSafePackageName;
 import org.kie.dmn.typesafe.DMNTypeSafeTypeGenerator;
 import org.kie.kogito.codegen.AbstractGenerator;
+import org.kie.kogito.codegen.AddonsConfig;
 import org.kie.kogito.codegen.ApplicationGenerator;
 import org.kie.kogito.codegen.ApplicationSection;
 import org.kie.kogito.codegen.ConfigGenerator;
@@ -55,7 +56,6 @@ import org.kie.kogito.codegen.di.DependencyInjectionAnnotator;
 import org.kie.kogito.grafana.GrafanaConfigurationWriter;
 
 import static java.util.stream.Collectors.toList;
-
 import static org.drools.core.util.IoUtils.readBytesFromInputStream;
 import static org.kie.api.io.ResourceType.determineResourceType;
 import static org.kie.kogito.codegen.ApplicationGenerator.log;
@@ -136,7 +136,7 @@ public class DecisionCodegen extends AbstractGenerator {
 
     private final List<DMNResource> resources;
     private final List<GeneratedFile> generatedFiles = new ArrayList<>();
-    private boolean useMonitoring = false;
+    private AddonsConfig addonsConfig = new AddonsConfig();
 
     public DecisionCodegen(List<DMNResource> resources) {
         this.resources = resources;
@@ -182,13 +182,13 @@ public class DecisionCodegen extends AbstractGenerator {
             }
             DMNRestResourceGenerator resourceGenerator = new DMNRestResourceGenerator(model, applicationCanonicalName)
                     .withDependencyInjection(annotator)
-                    .withMonitoring(useMonitoring)
+                    .withAddons(addonsConfig)
                     .withStronglyTyped(stronglyTypedEnabled);
             rgs.add(resourceGenerator);
         }
 
         for (DMNRestResourceGenerator resourceGenerator : rgs) {
-            if (useMonitoring) {
+            if (addonsConfig.useMonitoring()) {
                 generateAndStoreGrafanaDashboards(resourceGenerator);
             }
 
@@ -253,13 +253,9 @@ public class DecisionCodegen extends AbstractGenerator {
         return moduleGenerator;
     }
 
-    public DecisionCodegen withMonitoring(boolean useMonitoring) {
-        this.useMonitoring = useMonitoring;
-        return this;
-    }
-
-    public DecisionCodegen withTracing(boolean useTracing) {
-        this.moduleGenerator.withTracing(useTracing);
+    public DecisionCodegen withAddons(AddonsConfig addonsConfig) {
+        this.moduleGenerator.withAddons(addonsConfig);
+        this.addonsConfig = addonsConfig;
         return this;
     }
 }

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionContainerGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionContainerGenerator.java
@@ -44,6 +44,7 @@ import com.github.javaparser.ast.stmt.Statement;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import org.drools.core.util.IoUtils;
 import org.kie.kogito.codegen.AbstractApplicationSection;
+import org.kie.kogito.codegen.AddonsConfig;
 import org.kie.kogito.decision.DecisionModels;
 import org.kie.kogito.dmn.DmnExecutionIdSupplier;
 
@@ -55,7 +56,7 @@ public class DecisionContainerGenerator extends AbstractApplicationSection {
 
     private String applicationCanonicalName;
     private final List<DMNResource> resources;
-    private boolean useTracing = false;
+    private AddonsConfig addonsConfig = new AddonsConfig();
 
     public DecisionContainerGenerator(String applicationCanonicalName, List<DMNResource> resources) {
         super("DecisionModels", "decisionModels", DecisionModels.class);
@@ -63,8 +64,8 @@ public class DecisionContainerGenerator extends AbstractApplicationSection {
         this.resources = resources;
     }
 
-    public DecisionContainerGenerator withTracing(boolean useTracing) {
-        this.useTracing = useTracing;
+    public DecisionContainerGenerator withAddons(AddonsConfig addonsConfig) {
+        this.addonsConfig = addonsConfig;
         return this;
     }
 
@@ -99,7 +100,7 @@ public class DecisionContainerGenerator extends AbstractApplicationSection {
                 throw new RuntimeException("The template " + TEMPLATE_JAVA + " has been modified.");
             }
         }
-        if (useTracing) {
+        if (addonsConfig.useTracing()) {
             VariableDeclarator execIdSupplierVariable = typeDeclaration.getFieldByName("execIdSupplier")
                     .map(x -> x.getVariable(0))
                     .orElseThrow(() -> new RuntimeException("Can't find \"execIdSupplier\" field in " + TEMPLATE_JAVA));

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionContainerGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionContainerGenerator.java
@@ -56,7 +56,7 @@ public class DecisionContainerGenerator extends AbstractApplicationSection {
 
     private String applicationCanonicalName;
     private final List<DMNResource> resources;
-    private AddonsConfig addonsConfig = new AddonsConfig();
+    private AddonsConfig addonsConfig = AddonsConfig.DEFAULT;
 
     public DecisionContainerGenerator(String applicationCanonicalName, List<DMNResource> resources) {
         super("DecisionModels", "decisionModels", DecisionModels.class);

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ProcessCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ProcessCodegen.java
@@ -205,7 +205,7 @@ public class ProcessCodegen extends AbstractGenerator {
     private final Map<String, WorkflowProcess> processes;
     private final List<GeneratedFile> generatedFiles = new ArrayList<>();
 
-    private AddonsConfig addonsConfig = new AddonsConfig();
+    private AddonsConfig addonsConfig = AddonsConfig.DEFAULT;
 
     public ProcessCodegen(Collection<? extends Process> processes) {
         this.processes = new HashMap<>();

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ProcessCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ProcessCodegen.java
@@ -58,6 +58,7 @@ import org.kie.api.definition.process.WorkflowProcess;
 import org.kie.api.io.Resource;
 import org.kie.api.io.ResourceType;
 import org.kie.kogito.codegen.AbstractGenerator;
+import org.kie.kogito.codegen.AddonsConfig;
 import org.kie.kogito.codegen.ApplicationGenerator;
 import org.kie.kogito.codegen.ApplicationSection;
 import org.kie.kogito.codegen.ConfigGenerator;
@@ -204,7 +205,7 @@ public class ProcessCodegen extends AbstractGenerator {
     private final Map<String, WorkflowProcess> processes;
     private final List<GeneratedFile> generatedFiles = new ArrayList<>();
 
-    private boolean persistence;
+    private AddonsConfig addonsConfig = new AddonsConfig();
 
     public ProcessCodegen(Collection<? extends Process> processes) {
         this.processes = new HashMap<>();
@@ -243,8 +244,8 @@ public class ProcessCodegen extends AbstractGenerator {
         return moduleGenerator;
     }
 
-    public ProcessCodegen withPersistence(boolean persistence) {
-        this.persistence = persistence;
+    public ProcessCodegen withAddons(AddonsConfig addonsConfig) {
+        this.addonsConfig = addonsConfig;
         return this;
     }
 
@@ -335,7 +336,7 @@ public class ProcessCodegen extends AbstractGenerator {
                     applicationCanonicalName
             )
                     .withDependencyInjection(annotator)
-                    .withPersistence(persistence);
+                    .withAddons(addonsConfig);
 
             ProcessInstanceGenerator pi = new ProcessInstanceGenerator(
                     workFlowProcess.getPackageName(),

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ProcessGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ProcessGenerator.java
@@ -84,7 +84,7 @@ public class ProcessGenerator {
     private final String appCanonicalName;
     private String targetTypeName;
     private DependencyInjectionAnnotator annotator;
-    private AddonsConfig addonsConfig = new AddonsConfig();
+    private AddonsConfig addonsConfig = AddonsConfig.DEFAULT;
 
     private List<CompilationUnit> additionalClasses = new ArrayList<>();
 

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ProcessGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ProcessGenerator.java
@@ -51,13 +51,14 @@ import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.UnknownType;
 import org.drools.compiler.compiler.io.memory.MemoryFileSystem;
 import org.drools.core.util.StringUtils;
-import org.kie.kogito.codegen.BodyDeclarationComparator;
 import org.jbpm.compiler.canonical.ProcessMetaData;
 import org.jbpm.compiler.canonical.TriggerMetaData;
 import org.kie.api.definition.process.Process;
 import org.kie.api.definition.process.WorkflowProcess;
 import org.kie.api.runtime.process.WorkItemHandler;
 import org.kie.kogito.Model;
+import org.kie.kogito.codegen.AddonsConfig;
+import org.kie.kogito.codegen.BodyDeclarationComparator;
 import org.kie.kogito.codegen.di.DependencyInjectionAnnotator;
 import org.kie.kogito.process.ProcessInstancesFactory;
 import org.kie.kogito.process.impl.AbstractProcess;
@@ -83,7 +84,7 @@ public class ProcessGenerator {
     private final String appCanonicalName;
     private String targetTypeName;
     private DependencyInjectionAnnotator annotator;
-    private boolean persistence;
+    private AddonsConfig addonsConfig = new AddonsConfig();
 
     private List<CompilationUnit> additionalClasses = new ArrayList<>();
 
@@ -411,7 +412,7 @@ public class ProcessGenerator {
                 .addMember(internalRegisterListeners(processMetaData))
                 .addMember(process(processMetaData));
         
-        if (persistence) {
+        if (addonsConfig.usePersistence()) {
         
             if (useInjection()) {
                 
@@ -528,8 +529,8 @@ public class ProcessGenerator {
         return this;
     }
     
-    public ProcessGenerator withPersistence(boolean persistence) {
-        this.persistence = persistence;
+    public ProcessGenerator withAddons(AddonsConfig addonsConfig) {
+        this.addonsConfig = addonsConfig;
         return this;
     }
     

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
@@ -184,7 +184,7 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
 
     private KieModuleModel kieModuleModel;
     private boolean hotReloadMode = false;
-    private AddonsConfig addonsConfig = new AddonsConfig();
+    private AddonsConfig addonsConfig = AddonsConfig.DEFAULT;
     private boolean useRestServices = true;
     private String packageName;
     private final boolean decisionTableSupported;

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
@@ -62,6 +62,7 @@ import org.kie.api.runtime.conf.ClockTypeOption;
 import org.kie.internal.builder.CompositeKnowledgeBuilder;
 import org.kie.internal.ruleunit.RuleUnitDescription;
 import org.kie.kogito.codegen.AbstractGenerator;
+import org.kie.kogito.codegen.AddonsConfig;
 import org.kie.kogito.codegen.ApplicationSection;
 import org.kie.kogito.codegen.ConfigGenerator;
 import org.kie.kogito.codegen.GeneratorContext;
@@ -76,9 +77,8 @@ import org.kie.kogito.rules.RuleUnitConfig;
 import org.kie.kogito.rules.units.AssignableChecker;
 import org.kie.kogito.rules.units.ReflectiveRuleUnitDescription;
 
-import static java.util.stream.Collectors.toList;
-
 import static com.github.javaparser.StaticJavaParser.parse;
+import static java.util.stream.Collectors.toList;
 import static org.drools.compiler.kie.builder.impl.KieBuilderImpl.setDefaultsforEmptyKieModule;
 import static org.drools.core.util.IoUtils.readBytesFromInputStream;
 import static org.kie.api.io.ResourceType.determineResourceType;
@@ -184,7 +184,7 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
 
     private KieModuleModel kieModuleModel;
     private boolean hotReloadMode = false;
-    private boolean useMonitoring = false;
+    private AddonsConfig addonsConfig = new AddonsConfig();
     private boolean useRestServices = true;
     private String packageName;
     private final boolean decisionTableSupported;
@@ -310,7 +310,7 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
                     RuleUnitGenerator ruSource = new RuleUnitGenerator(ruleUnit, pkgSources.getRulesFileName())
                             .withDependencyInjection(annotator)
                             .withQueries( pkgSources.getQueriesInRuleUnit( ruleUnit.getCanonicalName() ) )
-                            .withMonitoring(useMonitoring);
+                            .withAddons(addonsConfig);
 
                     moduleGenerator.addRuleUnit(ruSource);
                     unitsMap.put(ruleUnit.getCanonicalName(), ruSource.targetCanonicalName());
@@ -393,7 +393,7 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
     }
 
     private Optional<String> generateQueryEndpoint( List<DroolsError> errors, List<org.kie.kogito.codegen.GeneratedFile> generatedFiles, QueryEndpointGenerator query ) {
-        if (useMonitoring){
+        if (addonsConfig.useMonitoring()){
             String dashboard = GrafanaConfigurationWriter.generateOperationalDashboard(operationalDashboardDmnTemplate, query.getEndpointName());
 
             generatedFiles.add(new org.kie.kogito.codegen.GeneratedFile( org.kie.kogito.codegen.GeneratedFile.Type.RESOURCE,
@@ -488,8 +488,8 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
         return this;
     }
 
-    public IncrementalRuleCodegen withMonitoring(boolean useMonitoring) {
-        this.useMonitoring = useMonitoring;
+    public IncrementalRuleCodegen withAddons(AddonsConfig addonsConfig) {
+        this.addonsConfig = addonsConfig;
         return this;
     }
 

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/QueryEndpointGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/QueryEndpointGenerator.java
@@ -45,6 +45,7 @@ import com.github.javaparser.ast.type.Type;
 import org.drools.compiler.compiler.DroolsError;
 import org.drools.modelcompiler.builder.QueryModel;
 import org.kie.internal.ruleunit.RuleUnitDescription;
+import org.kie.kogito.codegen.AddonsConfig;
 import org.kie.kogito.codegen.BodyDeclarationComparator;
 import org.kie.kogito.codegen.FileGenerator;
 import org.kie.kogito.codegen.di.DependencyInjectionAnnotator;
@@ -65,9 +66,9 @@ public class QueryEndpointGenerator implements FileGenerator {
     private final String queryClassName;
     private final String targetCanonicalName;
     private final String generatedFilePath;
-    private final boolean useMonitoring;
+    private final AddonsConfig addonsConfig;
 
-    public QueryEndpointGenerator(RuleUnitDescription ruleUnit, QueryModel query, DependencyInjectionAnnotator annotator, boolean useMonitoring) {
+    public QueryEndpointGenerator(RuleUnitDescription ruleUnit, QueryModel query, DependencyInjectionAnnotator annotator, AddonsConfig addonsConfig) {
         this.ruleUnit = ruleUnit;
         this.query = query;
         this.name = toCamelCase(query.getName());
@@ -77,7 +78,7 @@ public class QueryEndpointGenerator implements FileGenerator {
         this.queryClassName = ruleUnit.getSimpleName() + "Query" + name;
         this.targetCanonicalName = queryClassName + "Endpoint";
         this.generatedFilePath = (query.getNamespace() + "." + targetCanonicalName).replace('.', '/') + ".java";
-        this.useMonitoring = useMonitoring;
+        this.addonsConfig = addonsConfig;
     }
 
     public QueryGenerator getQueryGenerator() {
@@ -198,7 +199,7 @@ public class QueryEndpointGenerator implements FileGenerator {
                 .getStatement(1);
         returnMethodSingle.findAll(VariableDeclarator.class).forEach(decl -> decl.setType(toNonPrimitiveType(returnType)));
 
-        if (useMonitoring) {
+        if (addonsConfig.useMonitoring()) {
             addMonitoringToResource(cu, new MethodDeclaration[]{queryMethod, queryMethodSingle}, endpointName);
         }
     }

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/RuleUnitGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/RuleUnitGenerator.java
@@ -56,7 +56,7 @@ public class RuleUnitGenerator implements FileGenerator {
     private DependencyInjectionAnnotator annotator;
     private Collection<QueryModel> queries;
     private String applicationPackageName;
-    private AddonsConfig addonsConfig = new AddonsConfig();
+    private AddonsConfig addonsConfig = AddonsConfig.DEFAULT;
 
     public RuleUnitGenerator(RuleUnitDescription ruleUnit, String generatedSourceFile) {
         this.ruleUnit = ruleUnit;

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/RuleUnitGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/RuleUnitGenerator.java
@@ -31,6 +31,7 @@ import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.TypeParameter;
 import org.drools.modelcompiler.builder.QueryModel;
 import org.kie.internal.ruleunit.RuleUnitDescription;
+import org.kie.kogito.codegen.AddonsConfig;
 import org.kie.kogito.codegen.ApplicationGenerator;
 import org.kie.kogito.codegen.FileGenerator;
 import org.kie.kogito.codegen.di.DependencyInjectionAnnotator;
@@ -38,10 +39,9 @@ import org.kie.kogito.rules.RuleUnit;
 import org.kie.kogito.rules.units.GeneratedRuleUnitDescription;
 import org.kie.kogito.rules.units.impl.AbstractRuleUnit;
 
-import static java.util.stream.Collectors.toList;
-
 import static com.github.javaparser.StaticJavaParser.parse;
 import static com.github.javaparser.ast.NodeList.nodeList;
+import static java.util.stream.Collectors.toList;
 import static org.kie.kogito.codegen.metadata.ImageMetaData.LABEL_PREFIX;
 
 public class RuleUnitGenerator implements FileGenerator {
@@ -56,7 +56,7 @@ public class RuleUnitGenerator implements FileGenerator {
     private DependencyInjectionAnnotator annotator;
     private Collection<QueryModel> queries;
     private String applicationPackageName;
-    private boolean useMonitoring;
+    private AddonsConfig addonsConfig = new AddonsConfig();
 
     public RuleUnitGenerator(RuleUnitDescription ruleUnit, String generatedSourceFile) {
         this.ruleUnit = ruleUnit;
@@ -76,7 +76,7 @@ public class RuleUnitGenerator implements FileGenerator {
     public List<QueryEndpointGenerator> queries() {
         return queries.stream()
                 .filter(query -> !query.hasParameters())
-                .map(query -> new QueryEndpointGenerator(ruleUnit, query, annotator, useMonitoring))
+                .map(query -> new QueryEndpointGenerator(ruleUnit, query, annotator, addonsConfig))
                 .collect(toList());
     }
 
@@ -181,8 +181,8 @@ public class RuleUnitGenerator implements FileGenerator {
         return this;
     }
 
-    public RuleUnitGenerator withMonitoring(boolean useMonitoring) {
-        this.useMonitoring = useMonitoring;
+    public RuleUnitGenerator withAddons(AddonsConfig addonsConfig) {
+        this.addonsConfig = addonsConfig;
         return this;
     }
 

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/AddonsConfigTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/AddonsConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/AddonsConfigTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/AddonsConfigTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.codegen;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AddonsConfigTest {
+
+    @Test
+    public void allAddonsAreDisabledInDefaultConfiguration() {
+        AddonsConfig addonsConfig = AddonsConfig.DEFAULT;
+        assertThat(addonsConfig.useMonitoring()).isFalse();
+        assertThat(addonsConfig.useTracing()).isFalse();
+        assertThat(addonsConfig.usePersistence()).isFalse();
+    }
+
+    @Test
+    public void addonsAreProperlyActivated() {
+        AddonsConfig addonsConfig = new AddonsConfig();
+
+        assertThat(addonsConfig.useMonitoring()).isFalse();
+        assertThat(addonsConfig.withMonitoring(true).useMonitoring()).isTrue();
+
+        assertThat(addonsConfig.useTracing()).isFalse();
+        assertThat(addonsConfig.withTracing(true).useTracing()).isTrue();
+
+        assertThat(addonsConfig.usePersistence()).isFalse();
+        assertThat(addonsConfig.withPersistence(true).usePersistence()).isTrue();
+    }
+}

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/ApplicationGeneratorTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/ApplicationGeneratorTest.java
@@ -123,7 +123,7 @@ public class ApplicationGeneratorTest {
     @Test
     public void generateWithMonitoring() throws IOException {
         final Path targetDirectory = Paths.get("target");
-        final ApplicationGenerator appGenerator = new ApplicationGenerator(PACKAGE_NAME, targetDirectory.toFile()).withMonitoring(true);
+        final ApplicationGenerator appGenerator = new ApplicationGenerator(PACKAGE_NAME, targetDirectory.toFile()).withAddons(new AddonsConfig().withMonitoring(true));
         appGenerator.generate();
         assertImageMetadata(targetDirectory, new PrometheusLabeler().generateLabels());
     }

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/decision/DecisionCodegenTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/decision/DecisionCodegenTest.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.kie.kogito.codegen.AddonsConfig;
 import org.kie.kogito.codegen.GeneratedFile;
 import org.kie.kogito.codegen.GeneratorContext;
 import org.kie.kogito.grafana.JGrafana;
@@ -90,7 +91,7 @@ public class DecisionCodegenTest {
 
     @Test
     public void GivenADMNModel_WhenMonitoringIsActive_ThenGrafanaDashboardsAreGenerated() throws Exception {
-        DecisionCodegen codeGenerator = DecisionCodegen.ofPath(Paths.get("src/test/resources/decision/models/vacationDays").toAbsolutePath()).withMonitoring(true);
+        DecisionCodegen codeGenerator = DecisionCodegen.ofPath(Paths.get("src/test/resources/decision/models/vacationDays").toAbsolutePath()).withAddons(new AddonsConfig().withMonitoring(true));
 
         List<GeneratedFile> generatedFiles = codeGenerator.generate();
 

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegenTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegenTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.kie.api.internal.utils.ServiceRegistry;
 import org.kie.api.io.ResourceType;
+import org.kie.kogito.codegen.AddonsConfig;
 import org.kie.kogito.codegen.GeneratedFile;
 
 import static java.util.Arrays.asList;
@@ -165,7 +166,7 @@ public class IncrementalRuleCodegenTest {
                 IncrementalRuleCodegen.ofFiles(
                         Collections.singleton(
                                 new File("src/test/resources/org/kie/kogito/codegen/unit/RuleUnitQuery.drl")))
-                        .withMonitoring(true);
+                        .withAddons(new AddonsConfig().withMonitoring(true));
         incrementalRuleCodegen.setPackageName("com.acme");
         List<GeneratedFile> generatedFiles = incrementalRuleCodegen.withHotReloadMode().generate();
 

--- a/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/KogitoAssetsProcessor.java
+++ b/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/KogitoAssetsProcessor.java
@@ -58,6 +58,7 @@ import org.kie.internal.kogito.codegen.Generated;
 import org.kie.internal.kogito.codegen.VariableInfo;
 import org.kie.kogito.Model;
 import org.kie.kogito.UserTask;
+import org.kie.kogito.codegen.AddonsConfig;
 import org.kie.kogito.codegen.ApplicationGenerator;
 import org.kie.kogito.codegen.GeneratedFile;
 import org.kie.kogito.codegen.GeneratorContext;
@@ -382,29 +383,33 @@ public class KogitoAssetsProcessor {
         boolean useTracing = !combinedIndexBuildItem.getIndex()
                 .getAllKnownSubclasses(createDotName(tracingClass)).isEmpty();
 
+        AddonsConfig addonsConfig = new AddonsConfig()
+                .withPersistence(usePersistence)
+                .withMonitoring(useMonitoring)
+                .withTracing(useTracing);
+
         GeneratorContext context = buildContext(appPaths, combinedIndexBuildItem.getIndex());
 
         ApplicationGenerator appGen = new ApplicationGenerator(appPackageName, new File(appPaths.getFirstProjectPath().toFile(), "target"))
                 .withDependencyInjection(new CDIDependencyInjectionAnnotator())
-                .withPersistence(usePersistence)
-                .withMonitoring(useMonitoring)
+                .withAddons(addonsConfig)
                 .withGeneratorContext(context);
 
-        addProcessGenerator(appPaths, usePersistence, appGen);
-        addRuleGenerator(appPaths, appGen, useMonitoring);
-        addDecisionGenerator(appPaths, appGen, useMonitoring, useTracing);
+        addProcessGenerator(appPaths, addonsConfig, appGen);
+        addRuleGenerator(appPaths, appGen, addonsConfig);
+        addDecisionGenerator(appPaths, appGen, addonsConfig);
 
         return appGen;
     }
 
-    private void addRuleGenerator( AppPaths appPaths, ApplicationGenerator appGen, boolean useMonitoring ) throws IOException {
+    private void addRuleGenerator( AppPaths appPaths, ApplicationGenerator appGen, AddonsConfig addonsConfig ) throws IOException {
         IncrementalRuleCodegen generator = appPaths.isJar ?
                 IncrementalRuleCodegen.ofJar(appPaths.getJarPath()) :
                 IncrementalRuleCodegen.ofPath(appPaths.getSourcePaths());
 
         appGen.withGenerator(generator)
                 .withKModule( findKieModuleModel( appPaths ) )
-                .withMonitoring(useMonitoring)
+                .withAddons(addonsConfig)
                 .withClassLoader(Thread.currentThread().getContextClassLoader());
     }
 
@@ -422,23 +427,22 @@ public class KogitoAssetsProcessor {
                 "<kmodule xmlns=\"http://www.drools.org/xsd/kmodule\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"/>");
     }
 
-    private void addProcessGenerator( AppPaths appPaths, boolean usePersistence, ApplicationGenerator appGen ) throws IOException {
+    private void addProcessGenerator( AppPaths appPaths, AddonsConfig addonsConfig, ApplicationGenerator appGen ) throws IOException {
         ProcessCodegen generator = appPaths.isJar ?
                 ProcessCodegen.ofJar(appPaths.getJarPath()) :
                 ProcessCodegen.ofPath(appPaths.getProjectPaths());
 
         appGen.withGenerator( generator )
-                .withPersistence(usePersistence)
+                .withAddons(addonsConfig)
                 .withClassLoader(Thread.currentThread().getContextClassLoader());
     }
 
-    private void addDecisionGenerator( AppPaths appPaths, ApplicationGenerator appGen, boolean useMonitoring, boolean useTracing ) throws IOException {
+    private void addDecisionGenerator( AppPaths appPaths, ApplicationGenerator appGen, AddonsConfig addonsConfig ) throws IOException {
         DecisionCodegen generator = appPaths.isJar ?
                 DecisionCodegen.ofJar(appPaths.getJarPath()) :
                 DecisionCodegen.ofPath(appPaths.getResourcePaths());
 
-        appGen.withGenerator(generator.withTracing(useTracing))
-                .withMonitoring(useMonitoring);
+        appGen.withGenerator(generator.withAddons(addonsConfig));
     }
 
     private String toRuntimeSource(String className) {


### PR DESCRIPTION
Hi,

I'd like to propose the following refactoring of the injection of the addons configurations. Since atm the addons are injected one by one with a simple boolean, I thought that using an object would make it much more easier to extend and maintain. 

Just as a side note: I'm working on a component that needs to know if the `tracing` and the `monitoring` addons are activated, and I would have had to inject both of them with some redundant code for the reason above. 

Let me know what do you think :) 


Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket