### PR TITLE
KOGITO-2729 Better error message if DRL is compiled at runtime and drools-core-static is in the classpath

### DIFF
--- a/drools/drools-core-static/pom.xml
+++ b/drools/drools-core-static/pom.xml
@@ -30,5 +30,20 @@
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-internal</artifactId>
       </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-engine</artifactId>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-api</artifactId>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
 </project>

--- a/drools/drools-core-static/src/main/java/org/drools/statics/StaticComponentsSupplier.java
+++ b/drools/drools-core-static/src/main/java/org/drools/statics/StaticComponentsSupplier.java
@@ -46,7 +46,8 @@ public class StaticComponentsSupplier implements ComponentsSupplier {
         public Class< ? > defineClass(final String name,
                                       final byte[] bytes,
                                       final ProtectionDomain domain) {
-            throw new UnsupportedOperationException();
+            throw new UnsupportedOperationException(
+                    "The artifact drools-core-static does not support this operation, try using drools-core-dynamic instead.");
         }
     }
 

--- a/drools/drools-core-static/src/test/java/org/drools/statics/DummyByteArrayClassLoaderTest.java
+++ b/drools/drools-core-static/src/test/java/org/drools/statics/DummyByteArrayClassLoaderTest.java
@@ -1,0 +1,17 @@
+package org.drools.statics;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class DummyByteArrayClassLoaderTest {
+
+    @Test
+    public void defineClassShouldThrow() {
+        StaticComponentsSupplier.DummyByteArrayClassLoader cl =
+                new StaticComponentsSupplier.DummyByteArrayClassLoader();
+        assertThatThrownBy(() -> cl.defineClass("test", null, null))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("drools-core-static");
+    }
+}


### PR DESCRIPTION
Add a descriptive error message to the UnsupportedOperationException that gets thrown by the Dummy classloader implementation.