### PR TITLE
KOGITO-2597  Some tests fail when testing with GraalVM because of JS support

### DIFF
--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/ActivityTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/ActivityTest.java
@@ -229,8 +229,8 @@ public class ActivityTest extends JbpmBpmn2TestCase {
         Assumptions.assumeThat(
                 new ScriptEngineManager().getEngineByName("JavaScript")
                         .getClass().getSimpleName())
-                .isNotEqualTo("GraalJSScriptEngine")
-                .describedAs("GraalJS is not supported.");
+                .describedAs("GraalJS is not supported.")
+                .isNotEqualTo("GraalJSScriptEngine");
 
         KieBase kbase = createKnowledgeBase("BPMN2-ScriptTaskJS.bpmn2");
         ksession = createKnowledgeSession(kbase);

--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/ActivityTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/ActivityTest.java
@@ -31,6 +31,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
+
+import org.assertj.core.api.Assumptions;
 import org.drools.compiler.rule.builder.PackageBuildContext;
 import org.jbpm.bpmn2.handler.ReceiveTaskHandler;
 import org.jbpm.bpmn2.handler.SendTaskHandler;
@@ -222,6 +226,12 @@ public class ActivityTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testScriptTaskJS() throws Exception {
+        Assumptions.assumeThat(
+                new ScriptEngineManager().getEngineByName("JavaScript")
+                        .getClass().getSimpleName())
+                .isNotEqualTo("GraalJSScriptEngine")
+                .describedAs("GraalJS is not supported.");
+
         KieBase kbase = createKnowledgeBase("BPMN2-ScriptTaskJS.bpmn2");
         ksession = createKnowledgeSession(kbase);
         TestWorkItemHandler handler = new TestWorkItemHandler();


### PR DESCRIPTION
Add assumption so that the test is skipped when GraalJS is detected -- currently exact match on Class name. May break in the future.