### PR TITLE
Removed deprecated loadsApplicationClasses param

### DIFF
--- a/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/DecisionTablesCompilationProvider.java
+++ b/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/DecisionTablesCompilationProvider.java
@@ -14,11 +14,11 @@ import org.kie.kogito.codegen.rules.IncrementalRuleCodegen;
 
 public class DecisionTablesCompilationProvider extends KogitoCompilationProvider {
 
-    private static final Set<String> MANAGED_EXTESIONS = Collections.unmodifiableSet( new HashSet<>( Arrays.asList( ".xls", ".xlsx", ".csv" ) ) );
+    private static final Set<String> MANAGED_EXTENSIONS = Collections.unmodifiableSet( new HashSet<>( Arrays.asList( ".xls", ".xlsx", ".csv" ) ) );
 
     @Override
     public Set<String> handledExtensions() {
-        return MANAGED_EXTESIONS;
+        return MANAGED_EXTENSIONS;
     }
 
     @Override

--- a/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/KogitoAssetsProcessor.java
+++ b/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/KogitoAssetsProcessor.java
@@ -184,7 +184,7 @@ public class KogitoAssetsProcessor {
         return new RuntimeInitializedClassBuildItem(ClassFieldAccessorFactory.class.getName());
     }
 
-    @BuildStep(loadsApplicationClasses = true)
+    @BuildStep
     public void generateModel(ArchiveRootBuildItem root,
                               BuildProducer<GeneratedBeanBuildItem> generatedBeans,
                               CombinedIndexBuildItem combinedIndexBuildItem,


### PR DESCRIPTION
See `BuildStep`'s javadoc
```java
/**
 * This no longer has any effect, and will be removed in future.
 */
@Deprecated
boolean loadsApplicationClasses() default false;
```

@mariofusco @evacchi @radtriste 