### PR TITLE
[KOGITO-2756] Hide Implementation details of WorkItemHandler

### DIFF
--- a/jbpm/jbpm-flow-builder/src/main/resources/class-templates/TaskInputTemplate.java
+++ b/jbpm/jbpm-flow-builder/src/main/resources/class-templates/TaskInputTemplate.java
@@ -2,6 +2,7 @@ package org.jbpm.process.codegen;
 
 import java.util.Map;
 
+
 public class XXXTaskInput {
 
     private String _id;
@@ -23,7 +24,7 @@ public class XXXTaskInput {
         return this._name;
     }
 
-    public static XXXTaskInput fromMap(String id, String name,  Map<String, Object> params) {
+    public static XXXTaskInput fromMap(org.kie.kogito.process.WorkItem workItem) {
         
     }
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/humantask/HumanTaskTransition.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/humantask/HumanTaskTransition.java
@@ -16,6 +16,7 @@
 package org.jbpm.process.instance.impl.humantask;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -35,24 +36,23 @@ public class HumanTaskTransition implements Transition<Map<String, Object>> {
     private Map<String, Object> data;
     private List<Policy<?>> policies = new ArrayList<>();
     
-    public HumanTaskTransition(String phase) {
-        this(phase, null);
+    public static HumanTaskTransition withModel(String phase, Map<String, Object> data, Policy<?>... policies) {
+        return new HumanTaskTransition(phase, data, policies);
     }
-    
-    public HumanTaskTransition(String phase, Map<String, Object> data) {
-        this.phase = phase;
-        this.data = data;
+
+    public static HumanTaskTransition withoutModel(String phase, Policy<?>... policies) {
+        return new HumanTaskTransition(phase, Collections.emptyMap(), policies);
+    }
+
+    public HumanTaskTransition(String phase) {
+        this(phase, Collections.emptyMap());
     }
     
     public HumanTaskTransition(String phase, Map<String, Object> data, IdentityProvider identity) {
-        this.phase = phase;
-        this.data = data;
-        if (identity != null) {
-            this.policies.add(SecurityPolicy.of(identity));
-        }
+        this(phase, data, SecurityPolicy.of(identity));
     }
     
-    public HumanTaskTransition(String phase, Map<String, Object> data, Policy<?>...policies) {
+    public HumanTaskTransition(String phase, Map<String, Object> data, Policy<?>... policies) {
         this.phase = phase;
         this.data = data;
         for (Policy<?> policy : policies) {
@@ -74,5 +74,4 @@ public class HumanTaskTransition implements Transition<Map<String, Object>> {
     public List<Policy<?>> policies() {
         return policies;
     }
-
 }

--- a/kogito-codegen/src/main/resources/class-templates/RestResourceSignalTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/RestResourceSignalTemplate.java
@@ -33,13 +33,10 @@ public class $Type$Resource {
     @Produces(MediaType.APPLICATION_JSON)
     public $Type$Output signal(@PathParam("id") final String id, final $signalType$ data) {
         return org.kie.kogito.services.uow.UnitOfWorkExecutor.executeInUnitOfWork(application.unitOfWorkManager(), () -> {
-            ProcessInstance<$Type$> pi = process.instances().findById(id).orElse(null);
-            if (pi == null) {
-                return null;
-            }
-            pi.send(Sig.of("$signalName$", data));
-            return getModel(pi);
+            return process.instances().findById(id).map(pi -> {
+                pi.send(Sig.of("$signalName$", data));
+                return getModel(pi);
+            }).orElse(null);
         });
     }
-
 }

--- a/kogito-codegen/src/main/resources/class-templates/RestResourceTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/RestResourceTemplate.java
@@ -18,7 +18,6 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 
-
 import org.kie.api.runtime.process.WorkItemNotFoundException;
 import org.jbpm.util.JsonSchemaUtil;
 import org.kie.kogito.Application;
@@ -26,6 +25,7 @@ import org.kie.kogito.auth.SecurityPolicy;
 import org.kie.kogito.process.Process;
 import org.kie.kogito.process.ProcessInstance;
 import org.kie.kogito.process.ProcessInstanceExecutionException;
+import org.kie.kogito.process.ProcessInstanceNotFoundException;
 import org.kie.kogito.process.WorkItem;
 import org.kie.kogito.process.workitem.Policy;
 import org.kie.kogito.process.impl.Sig;
@@ -37,12 +37,12 @@ import org.slf4j.LoggerFactory;
 public class $Type$Resource {
 
     Process<$Type$> process;
-    
+
     Application application;
 
     @POST()
     @Produces(MediaType.APPLICATION_JSON)
-    @Consumes(MediaType.APPLICATION_JSON)    
+    @Consumes(MediaType.APPLICATION_JSON)
     public $Type$Output createResource_$name$(@Context HttpHeaders httpHeaders, @QueryParam("businessKey") String businessKey, $Type$Input resource) {
         if (resource == null) {
             resource = new $Type$Input();
@@ -52,11 +52,10 @@ public class $Type$Resource {
         return org.kie.kogito.services.uow.UnitOfWorkExecutor.executeInUnitOfWork(application.unitOfWorkManager(), () -> {
             ProcessInstance<$Type$> pi = process.createInstance(businessKey, mapInput(value, new $Type$()));
             String startFromNode = httpHeaders.getHeaderString("X-KOGITO-StartFromNode");
-            
+
             if (startFromNode != null) {
                 pi.startFrom(startFromNode);
             } else {
-            
                 pi.start();
             }
             return getModel(pi);
@@ -67,8 +66,8 @@ public class $Type$Resource {
     @Produces(MediaType.APPLICATION_JSON)
     public List<$Type$Output> getResources_$name$() {
         return process.instances().values().stream()
-                .map(pi -> mapOutput(new $Type$Output(), pi.variables()))
-                .collect(Collectors.toList());
+                      .map(pi -> mapOutput(new $Type$Output(), pi.variables()))
+                      .collect(Collectors.toList());
     }
 
     @GET()
@@ -76,86 +75,69 @@ public class $Type$Resource {
     @Produces(MediaType.APPLICATION_JSON)
     public $Type$Output getResource_$name$(@PathParam("id") String id) {
         return process.instances()
-                .findById(id)
-                .map(pi -> mapOutput(new $Type$Output(), pi.variables()))
-                .orElse(null);
+                      .findById(id)
+                      .map(pi -> mapOutput(new $Type$Output(), pi.variables()))
+                      .orElse(null);
     }
 
     @DELETE()
     @Path("/{id}")
     @Produces(MediaType.APPLICATION_JSON)
     public $Type$Output deleteResource_$name$(@PathParam("id") final String id) {
-        return org.kie.kogito.services.uow.UnitOfWorkExecutor.executeInUnitOfWork(application.unitOfWorkManager(), () -> {
-            ProcessInstance<$Type$> pi = process.instances()
-                    .findById(id)
-                    .orElse(null);
-            if (pi == null) {
-                return null;
-            } else {
-                pi.abort();
-                return getModel(pi);
-            }
-        });
+        return org.kie.kogito.services.uow.UnitOfWorkExecutor.executeInUnitOfWork(application.unitOfWorkManager(), () -> process.instances().findById(id).map(pi -> {
+            pi.abort();
+            return getModel(pi);
+        }).orElse(null));
     }
-    
+
     @POST()
     @Path("/{id}")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public $Type$Output updateModel_$name$(@PathParam("id") String id, $Type$ resource) {
-        return org.kie.kogito.services.uow.UnitOfWorkExecutor.executeInUnitOfWork(application.unitOfWorkManager(), () -> {
-            ProcessInstance<$Type$> pi = process.instances()
-                    .findById(id)
-                    .orElse(null);
-            if (pi == null) {
-                return null;
-            } else {
-                pi.updateVariables(resource);
-                return mapOutput(new $Type$Output(), pi.variables());
-            }
-        });
+        return org.kie.kogito.services.uow.UnitOfWorkExecutor.executeInUnitOfWork(application.unitOfWorkManager(), () -> process.instances().findById(id).map(pi -> {
+            pi.updateVariables(resource);
+            return mapOutput(new $Type$Output(), pi.variables());
+        }).orElse(null));
     }
-    
+
     @GET()
     @Path("/{id}/tasks")
     @Produces(MediaType.APPLICATION_JSON)
     public Map<String, String> getTasks_$name$(@PathParam("id") String id, @QueryParam("user") final String user, @QueryParam("group") final List<String> groups) {
-        
         return process.instances()
-                .findById(id)
-                .map(pi -> pi.workItems(policies(user, groups)))
-                .map(l -> l.stream().collect(Collectors.toMap(WorkItem::getId, WorkItem::getName)))
-                .orElse(null);
+                      .findById(id)
+                      .map(pi -> pi.workItems(policies(user, groups)))
+                      .map(l -> l.stream().collect(Collectors.toMap(WorkItem::getId, WorkItem::getName)))
+                      .orElse(null);
     }
-    
+
     protected $Type$Output getModel(ProcessInstance<$Type$> pi) {
         if (pi.status() == ProcessInstance.STATE_ERROR && pi.error().isPresent()) {
             throw new ProcessInstanceExecutionException(pi.id(), pi.error().get().failedNodeId(), pi.error().get().errorMessage());
         }
-        
+
         return mapOutput(new $Type$Output(), pi.variables());
     }
-    
+
     protected Policy[] policies(String user, List<String> groups) {
         if (user == null) {
             return new Policy[0];
-        } 
+        }
         org.kie.kogito.auth.IdentityProvider identity = null;
         if (user != null) {
             identity = new org.kie.kogito.services.identity.StaticIdentityProvider(user, groups);
         }
-        return new Policy[] {SecurityPolicy.of(identity)};
+        return new Policy[]{SecurityPolicy.of(identity)};
     }
-    
+
     protected $Type$ mapInput($Type$Input input, $Type$ resource) {
         resource.fromMap(input.toMap());
-        
         return resource;
     }
-    
+
     protected $Type$Output mapOutput($Type$Output output, $Type$ resource) {
         output.fromMap(resource.getId(), resource.toMap());
-        
         return output;
     }
 }

--- a/kogito-codegen/src/main/resources/class-templates/RestResourceUserTaskTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/RestResourceUserTaskTemplate.java
@@ -3,11 +3,9 @@ package com.myspace.demo;
 import java.util.List;
 
 import org.drools.core.WorkItemNotFoundException;
-import org.jbpm.util.JsonSchemaUtil;
 import org.kie.kogito.process.ProcessInstance;
 import org.kie.kogito.process.WorkItem;
 import org.kie.kogito.process.impl.Sig;
-
 
 public class $Type$Resource {
 
@@ -17,18 +15,16 @@ public class $Type$Resource {
     @Produces(MediaType.APPLICATION_JSON)
     public javax.ws.rs.core.Response signal(@PathParam("id") final String id) {
         return org.kie.kogito.services.uow.UnitOfWorkExecutor.executeInUnitOfWork(application.unitOfWorkManager(), () -> {
-            ProcessInstance<$Type$> pi = process.instances().findById(id).orElse(null);
-            if (pi == null) {
-                return null;
-            }
-            pi.send(Sig.of("$taskNodeName$", java.util.Collections.emptyMap()));
-            java.util.Optional<WorkItem> task = pi.workItems().stream().filter(wi -> wi.getName().equals("$taskName$")).findFirst();
-            if(task.isPresent()) {
-                return javax.ws.rs.core.Response.ok(getModel(pi))
-                        .header("Link", "</" + id + "/$taskName$/" + task.get().getId() + ">; rel='instance'")
-                        .build();
-            }
-            return javax.ws.rs.core.Response.status(javax.ws.rs.core.Response.Status.NOT_FOUND).build();
+            return process.instances().findById(id).map(pi -> {
+                pi.send(Sig.of("$taskNodeName$", java.util.Collections.emptyMap()));
+                java.util.Optional<WorkItem> task = pi.workItems().stream().filter(wi -> wi.getName().equals("$taskName$")).findFirst();
+                if (task.isPresent()) {
+                    return javax.ws.rs.core.Response.ok(getModel(pi))
+                                                    .header("Link", "</" + id + "/$taskName$/" + task.get().getId() + ">; rel='instance'")
+                                                    .build();
+                }
+                return javax.ws.rs.core.Response.status(javax.ws.rs.core.Response.Status.NOT_FOUND).build();
+            }).orElse(null);
         });
     }
 
@@ -36,45 +32,23 @@ public class $Type$Resource {
     @Path("/{id}/$taskName$/{workItemId}")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public $Type$Output completeTask(@PathParam("id") final String id, @PathParam("workItemId") final String workItemId, @QueryParam("phase") @DefaultValue("complete") final String phase, @QueryParam("user") final String user, @QueryParam("group") final List<String> groups, final $TaskOutput$ model) {
-        try {
-            return org.kie.kogito.services.uow.UnitOfWorkExecutor.executeInUnitOfWork(application.unitOfWorkManager(), () -> {
-                ProcessInstance<$Type$> pi = process.instances().findById(id).orElse(null);
-                if (pi == null) {
-                    return null;
-                }
-                org.kie.kogito.auth.IdentityProvider identity = null;
-                if (user != null) {
-                    identity = new org.kie.kogito.services.identity.StaticIdentityProvider(user, groups);
-                }
-                org.jbpm.process.instance.impl.humantask.HumanTaskTransition transition = new org.jbpm.process.instance.impl.humantask.HumanTaskTransition(phase, model.toMap(), identity);
-                pi.transitionWorkItem(workItemId, transition);
-
-                return getModel(pi);
-            });
-        } catch (WorkItemNotFoundException e) {
-            return null;
-        }
+    public $Type$Output completeTask(@PathParam("id") final String id,
+                                     @PathParam("workItemId") final String workItemId,
+                                     @QueryParam("phase") @DefaultValue("complete") final String phase,
+                                     @QueryParam("user") final String user,
+                                     @QueryParam("group") final List<String> groups,
+                                     final $TaskOutput$ model) {
+        return org.kie.kogito.services.uow.UnitOfWorkExecutor.executeInUnitOfWork(application.unitOfWorkManager(), () -> process.instances().findById(id).map(pi -> {
+            pi.transitionWorkItem(workItemId, org.jbpm.process.instance.impl.humantask.HumanTaskTransition.withModel(phase, model.toMap(), policies(user, groups)));
+            return getModel(pi);
+        }).orElse(null));
     }
-    
-    
+
     @GET()
     @Path("/{id}/$taskName$/{workItemId}")
     @Produces(MediaType.APPLICATION_JSON)
     public $TaskInput$ getTask(@PathParam("id") String id, @PathParam("workItemId") String workItemId, @QueryParam("user") final String user, @QueryParam("group") final List<String> groups) {
-        try {
-            ProcessInstance<$Type$> pi = process.instances().findById(id).orElse(null);
-            if (pi == null) {
-                return null;
-            }
-            WorkItem workItem = pi.workItem(workItemId, policies(user, groups));
-            if (workItem == null) {
-                return null;
-            }
-            return $TaskInput$.fromMap(workItem.getId(), workItem.getName(), workItem.getParameters());
-        } catch (WorkItemNotFoundException e) {
-            return null;
-        }
+        return process.instances().findById(id).map(pi ->  $TaskInput$.fromMap(pi.workItem(workItemId, policies(user, groups)))).orElse(null);
     }
 
     @GET()
@@ -97,26 +71,14 @@ public class $Type$Resource {
     @DELETE()
     @Path("/{id}/$taskName$/{workItemId}")
     @Produces(MediaType.APPLICATION_JSON)
-    public $Type$Output abortTask(@PathParam("id") final String id, @PathParam("workItemId") final String workItemId, @QueryParam("phase") @DefaultValue("abort") final String phase, @QueryParam("user") final String user, @QueryParam("group") final List<String> groups) {
-        
-        try {
-            
-            return org.kie.kogito.services.uow.UnitOfWorkExecutor.executeInUnitOfWork(application.unitOfWorkManager(), () -> {
-                ProcessInstance<$Type$> pi = process.instances().findById(id).orElse(null);
-                if (pi == null) {
-                    return null;
-                }
-                org.kie.kogito.auth.IdentityProvider identity = null;
-                if (user != null) {
-                    identity = new org.kie.kogito.services.identity.StaticIdentityProvider(user, groups);
-                }
-                org.jbpm.process.instance.impl.humantask.HumanTaskTransition transition = new org.jbpm.process.instance.impl.humantask.HumanTaskTransition(phase, null, identity);
-                pi.transitionWorkItem(workItemId, transition);
-
-                return getModel(pi);
-            });
-        } catch (WorkItemNotFoundException e) {
-            return null;
-        }
+    public $Type$Output abortTask(@PathParam("id") final String id,
+                                  @PathParam("workItemId") final String workItemId,
+                                  @QueryParam("phase") @DefaultValue("abort") final String phase,
+                                  @QueryParam("user") final String user,
+                                  @QueryParam("group") final List<String> groups) {
+        return org.kie.kogito.services.uow.UnitOfWorkExecutor.executeInUnitOfWork(application.unitOfWorkManager(), () -> process.instances().findById(id).map(pi -> {
+            pi.transitionWorkItem(workItemId, org.jbpm.process.instance.impl.humantask.HumanTaskTransition.withoutModel(phase, policies(user, groups)));
+            return getModel(pi);
+        }).orElse(null));
     }
 }

--- a/kogito-codegen/src/main/resources/class-templates/spring/SpringRestResourceSignalTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/spring/SpringRestResourceSignalTemplate.java
@@ -33,12 +33,10 @@ public class $Type$Resource {
     @PostMapping(value = "/{id}/$signalPath$", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
     public $Type$Output signal(@PathVariable("id") final String id, final @RequestBody $signalType$ data) {
         return org.kie.kogito.services.uow.UnitOfWorkExecutor.executeInUnitOfWork(application.unitOfWorkManager(), () -> {
-            ProcessInstance<$Type$> pi = process.instances().findById(id).orElse(null);
-            if (pi == null) {
-                return null;
-            }
-            pi.send(Sig.of("$signalName$", data));
-            return getModel(pi);
+            return process.instances().findById(id).map(pi -> {
+                pi.send(Sig.of("$signalName$", data));
+                return getModel(pi);
+            }).orElse(null);
         });
     }
 }

--- a/kogito-codegen/src/main/resources/class-templates/spring/SpringRestResourceTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/spring/SpringRestResourceTemplate.java
@@ -63,12 +63,11 @@ public class $Type$Resource {
 
         return org.kie.kogito.services.uow.UnitOfWorkExecutor.executeInUnitOfWork(application.unitOfWorkManager(), () -> {
             ProcessInstance<$Type$> pi = process.createInstance(businessKey, mapInput(value, new $Type$()));
-            String startFromNode = httpHeaders.getFirst("X-KOGITO-StartFromNode");
+            String startFromNode = httpHeaders.getHeaderString("X-KOGITO-StartFromNode");
 
             if (startFromNode != null) {
                 pi.startFrom(startFromNode);
             } else {
-
                 pi.start();
             }
             return getModel(pi);
@@ -92,33 +91,19 @@ public class $Type$Resource {
 
     @DeleteMapping(value = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
     public $Type$Output deleteResource_$name$(@PathVariable("id") final String id) {
-        return org.kie.kogito.services.uow.UnitOfWorkExecutor.executeInUnitOfWork(application.unitOfWorkManager(), () -> {
-            ProcessInstance<$Type$> pi = process.instances()
-                    .findById(id)
-                    .orElse(null);
-            if (pi == null) {
-                return null;
-            } else {
-                pi.abort();
-                return getModel(pi);
-            }
-        });
+        return org.kie.kogito.services.uow.UnitOfWorkExecutor.executeInUnitOfWork(application.unitOfWorkManager(), () -> process.instances().findById(id).map(pi -> {
+            pi.abort();
+            return getModel(pi);
+        }).orElse(null));
     }
 
     @PostMapping(value = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE,
             consumes = MediaType.APPLICATION_JSON_VALUE)
     public $Type$Output updateModel_$name$(@PathVariable("id") String id, @RequestBody $Type$ resource) {
-        return org.kie.kogito.services.uow.UnitOfWorkExecutor.executeInUnitOfWork(application.unitOfWorkManager(), () -> {
-            ProcessInstance<$Type$> pi = process.instances()
-                    .findById(id)
-                    .orElse(null);
-            if (pi == null) {
-                return null;
-            } else {
-                pi.updateVariables(resource);
-                return mapOutput(new $Type$Output(), pi.variables());
-            }
-        });
+        return org.kie.kogito.services.uow.UnitOfWorkExecutor.executeInUnitOfWork(application.unitOfWorkManager(), () -> process.instances().findById(id).map(pi -> {
+            pi.updateVariables(resource);
+            return mapOutput(new $Type$Output(), pi.variables());
+        }).orElse(null));
     }
 
     @GetMapping(value = "/{id}/tasks", produces = MediaType.APPLICATION_JSON_VALUE)


### PR DESCRIPTION
Reducing generated code size by using map and orElse ( I think orElse(null) should be orElseThrow (()-> new ProcessInstanceNotFound(id)), I have opened https://issues.redhat.com/browse/KOGITO-2875 to change that) 
ToMap() method call cannot be removed unless xxx_TaskOuput implements Model (method fromMap of Model interface does not exist for xxx_TaskOuput, the same than toMap does not exist for xxx_TaskInput)
A set of static initializers has been added for HumanTaskTransition (constructors has been left for backward compatibility)
xxx_TaskInput generated fromMap method now accepts a WorkItem rather than three parameters
The JIRA was asking for return pi.workItem(Travels_6_TaskInput.class, policies(user, groups)); rather than Travels_6_TaskInput.fromMap(pi.workItem(workItemId, policies(user, groups))), but doing that will imply to make ProcessInstance dependant on generated code, which is not a good idea. I mean, one thing is parametrized ProcessInstance with generated model class (as it is currently done) and another to deal will all generated xxx_TaskInput class