### PR TITLE
KOGITO-2750 - add explainability-core to kogito-bom

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -502,6 +502,13 @@
         <classifier>javadoc</classifier>
       </dependency>
 
+      <!-- Explainability Services -->
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>explainability-core</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
       <!-- Management Console -->
       <dependency>
         <groupId>org.kie.kogito</groupId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -508,6 +508,18 @@
         <artifactId>explainability-core</artifactId>
         <version>${project.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>explainability-core</artifactId>
+        <version>${project.version}</version>
+        <classifier>sources</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>explainability-core</artifactId>
+        <version>${project.version}</version>
+        <classifier>javadoc</classifier>
+      </dependency>
 
       <!-- Management Console -->
       <dependency>


### PR DESCRIPTION
Add `explainability-core` to `kogito-bom` so that it can be used as a dependency in other modules.
See [KOGITO-2750](https://issues.redhat.com/browse/KOGITO-2750) and https://github.com/kiegroup/kogito-apps/pull/324.


Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket