### PR TITLE
KOGITO-2911 Refactor Codegen for "RuleUnits" class in Application.java 

### DIFF
--- a/api/kogito-api/src/main/java/org/kie/kogito/rules/RuleUnit.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/rules/RuleUnit.java
@@ -19,6 +19,8 @@ import java.util.UUID;
 
 public interface RuleUnit<T extends RuleUnitData> {
 
+    String id();
+
     default RuleUnitInstance<T> createInstance(T data) {
         return createInstance( data, UUID.randomUUID().toString() );
     }

--- a/drools/kogito-ruleunits/src/main/java/org/kie/kogito/rules/units/InterpretedRuleUnit.java
+++ b/drools/kogito-ruleunits/src/main/java/org/kie/kogito/rules/units/InterpretedRuleUnit.java
@@ -24,11 +24,11 @@ import org.kie.kogito.uow.UnitOfWorkManager;
 public class InterpretedRuleUnit<T extends RuleUnitData> extends AbstractRuleUnit<T> {
 
     public static <T extends RuleUnitData> RuleUnit<T> of(Class<T> type) {
-        return new InterpretedRuleUnit<>();
+        return new InterpretedRuleUnit<>(type.getCanonicalName());
     }
 
-    private InterpretedRuleUnit() {
-        super(DummyApplication.INSTANCE);
+    private InterpretedRuleUnit(String id) {
+        super(id, DummyApplication.INSTANCE);
     }
 
     @Override

--- a/drools/kogito-ruleunits/src/main/java/org/kie/kogito/rules/units/impl/AbstractRuleUnit.java
+++ b/drools/kogito-ruleunits/src/main/java/org/kie/kogito/rules/units/impl/AbstractRuleUnit.java
@@ -22,13 +22,20 @@ import org.kie.kogito.rules.RuleUnitInstance;
 
 public abstract class AbstractRuleUnit<T extends RuleUnitData> implements RuleUnit<T> {
 
+    private final String id;
     protected final Application app;
 
-    public AbstractRuleUnit(Application app) {
+    public AbstractRuleUnit(String id, Application app) {
+        this.id = id;
         this.app = app;
     }
 
     protected abstract RuleUnitInstance<T> internalCreateInstance(T data);
+
+    @Override
+    public String id() {
+        return id;
+    }
 
     @Override
     public RuleUnitInstance<T> createInstance(T data, String name) {

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/TemplatedGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/TemplatedGenerator.java
@@ -109,8 +109,8 @@ public class TemplatedGenerator {
                             .setPackageDeclaration(packageName);
 
             return Optional.of(compilationUnit);
-        } catch (ParseProblemException ex) {
-            throw new TemplateInstantiationException(targetTypeName, selectedResource, ex);
+        } catch (ParseProblemException | AssertionError e) {
+            throw new TemplateInstantiationException(targetTypeName, selectedResource, e);
         }
     }
 

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
@@ -206,7 +206,7 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
     private boolean hotReloadMode = false;
     private AddonsConfig addonsConfig = AddonsConfig.DEFAULT;
     private boolean useRestServices = true;
-    private String packageName = "defaultpkg";
+    private String packageName = KnowledgeBuilderConfigurationImpl.DEFAULT_PACKAGE;
     private final boolean decisionTableSupported;
     private final Map<String, RuleUnitConfig> configs;
 

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
@@ -206,7 +206,7 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
     private boolean hotReloadMode = false;
     private AddonsConfig addonsConfig = AddonsConfig.DEFAULT;
     private boolean useRestServices = true;
-    private String packageName;
+    private String packageName = "defaultpkg";
     private final boolean decisionTableSupported;
     private final Map<String, RuleUnitConfig> configs;
 
@@ -255,7 +255,7 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
             throw new MissingDecisionTableDependencyError();
         }
 
-        moduleGenerator = new RuleUnitContainerGenerator();
+        moduleGenerator = new RuleUnitContainerGenerator(packageName);
         moduleGenerator.withDependencyInjection(annotator);
 
         KnowledgeBuilderConfigurationImpl configuration =
@@ -327,15 +327,17 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
             if (!ruleUnits.isEmpty()) {
                 hasRuleUnits = true;
                 for (RuleUnitDescription ruleUnit : ruleUnits) {
+                    String canonicalName = ruleUnit.getCanonicalName();
                     RuleUnitGenerator ruSource = new RuleUnitGenerator(ruleUnit, pkgSources.getRulesFileName())
                             .withDependencyInjection(annotator)
-                            .withQueries( pkgSources.getQueriesInRuleUnit( ruleUnit.getCanonicalName() ) )
-                            .withAddons(addonsConfig);
+                            .withQueries(pkgSources.getQueriesInRuleUnit(canonicalName))
+                            .withAddons(addonsConfig)
+                            .mergeConfig(configs.get(canonicalName));
 
                     moduleGenerator.addRuleUnit(ruSource);
-                    unitsMap.put(ruleUnit.getCanonicalName(), ruSource.targetCanonicalName());
+                    unitsMap.put(canonicalName, ruSource.targetCanonicalName());
                     // only Class<?> has config for now
-                    addUnitConfToKieModule( ruleUnit );
+                    addUnitConfToKieModule(ruleUnit);
                 }
             }
         }

--- a/kogito-codegen/src/main/resources/class-templates/CdiApplicationTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/CdiApplicationTemplate.java
@@ -10,14 +10,14 @@ public class Application extends StaticApplication {
     @javax.inject.Inject
     public Application(
             Config config,
-            javax.enterprise.inject.Instance<Processes> processes/*,
-            javax.enterprise.inject.Instance<RuleUnits> ruleUnits,
+            javax.enterprise.inject.Instance<Processes> processes,
+            javax.enterprise.inject.Instance<RuleUnits> ruleUnits/*,
             javax.enterprise.inject.Instance<DecisionModels> decisionModels,
             java.util.Collection<PredictionModels> predictionModels
             */) {
         this.config = config;
         this.processes = orNull(processes);
-        this.ruleUnits = null /* $RuleUnits$ */;
+        this.ruleUnits = orNull(ruleUnits);
         this.decisionModels = null /* $DecisionModels$ */;
         this.predictionModels = null /* $PredictionModels$ */;
 

--- a/kogito-codegen/src/main/resources/class-templates/CdiApplicationTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/CdiApplicationTemplate.java
@@ -3,6 +3,7 @@ package $Package$;
 import org.kie.kogito.Config;
 import org.kie.kogito.StaticApplication;
 import org.kie.kogito.process.Processes;
+import org.kie.kogito.rules.RuleUnits;
 
 @javax.inject.Singleton
 public class Application extends StaticApplication {

--- a/kogito-codegen/src/main/resources/class-templates/SessionRuleUnitTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/SessionRuleUnitTemplate.java
@@ -10,6 +10,11 @@ public class SessionRuleUnit extends SessionUnit {
     KieRuntimeBuilder runtimeBuilder;
 
     @Override
+    public String id() {
+        return "$SessionName$";
+    }
+
+    @Override
     public SessionRuleUnitInstance createInstance( SessionData memory, String name ) {
         return new SessionRuleUnitInstance(this, memory, runtimeBuilder.newKieSession("$SessionName$"));
     }

--- a/kogito-codegen/src/main/resources/class-templates/SpringApplicationTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/SpringApplicationTemplate.java
@@ -11,14 +11,14 @@ public class Application extends StaticApplication {
     @org.springframework.beans.factory.annotation.Autowired()
     public Application(
             Config config,
-            java.util.Collection<Processes> processes/*,
-            java.util.Collection<RuleUnits> ruleUnits,
+            java.util.Collection<Processes> processes,
+            java.util.Collection<RuleUnits> ruleUnits/*,
             java.util.Collection<DecisionModels> decisionModels,
             java.util.Collection<PredictionModels> predictionModels,
             */) {
         this.config = config;
         this.processes = orNull(processes);
-        this.ruleUnits = null /* $RuleUnits$ */;
+        this.ruleUnits = orNull(ruleUnits);
         this.decisionModels = null /* $DecisionModels$ */;
         this.predictionModels = null /* $PredictionModels$ */;
 

--- a/kogito-codegen/src/main/resources/class-templates/SpringApplicationTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/SpringApplicationTemplate.java
@@ -3,6 +3,7 @@ package $Package$;
 import org.kie.kogito.Config;
 import org.kie.kogito.StaticApplication;
 import org.kie.kogito.process.Processes;
+import org.kie.kogito.rules.RuleUnits;
 
 @org.springframework.stereotype.Component
 @org.springframework.web.context.annotation.ApplicationScope

--- a/kogito-codegen/src/main/resources/class-templates/rules/CdiRuleUnitContainerTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/rules/CdiRuleUnitContainerTemplate.java
@@ -1,0 +1,29 @@
+package $Package$;
+
+import org.kie.kogito.rules.RuleUnit;
+
+@javax.enterprise.context.ApplicationScoped
+public class RuleUnits extends org.kie.kogito.rules.units.impl.AbstractRuleUnits {
+
+    @javax.inject.Inject
+    javax.enterprise.inject.Instance<org.kie.kogito.rules.RuleUnit<? extends org.kie.kogito.rules.RuleUnitData>> ruleUnits;
+
+    private java.util.Map<String, org.kie.kogito.rules.RuleUnit<? extends org.kie.kogito.rules.RuleUnitData>> mappedRuleUnits = new java.util.HashMap<>();
+    private final org.kie.kogito.rules.KieRuntimeBuilder ruleRuntimeBuilder = new org.drools.project.model.ProjectRuntime();
+
+    public org.kie.kogito.rules.KieRuntimeBuilder ruleRuntimeBuilder() {
+        return this.ruleRuntimeBuilder;
+    }
+
+    @javax.annotation.PostConstruct
+    public void setup() {
+        for (org.kie.kogito.rules.RuleUnit<? extends org.kie.kogito.rules.RuleUnitData> ruleUnit : ruleUnits) {
+            mappedRuleUnits.put(ruleUnit.id(), ruleUnit);
+        }
+    }
+
+    protected org.kie.kogito.rules.RuleUnit<?> create(String fqcn) {
+        return mappedRuleUnits.get(fqcn);
+    }
+
+}

--- a/kogito-codegen/src/main/resources/class-templates/rules/RuleUnitContainerTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/rules/RuleUnitContainerTemplate.java
@@ -1,0 +1,25 @@
+package $Package$;
+
+public class RuleUnits extends org.kie.kogito.rules.units.impl.AbstractRuleUnits {
+
+    private final Application application;
+
+    private final org.kie.kogito.rules.KieRuntimeBuilder ruleRuntimeBuilder = new org.drools.project.model.ProjectRuntime();
+
+    public RuleUnits(Application application) {
+        this.application = application;
+    }
+
+    public org.kie.kogito.rules.KieRuntimeBuilder ruleRuntimeBuilder() {
+        return this.ruleRuntimeBuilder;
+    }
+
+    protected org.kie.kogito.rules.RuleUnit<?> create(String fqcn) {
+        switch(fqcn) {
+            case "$RuleUnit$":
+                return new $RuleUnit$RuleUnit(application);
+            default:
+                throw new java.lang.UnsupportedOperationException();
+        }
+    }
+}

--- a/kogito-codegen/src/main/resources/class-templates/rules/RuleUnitTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/rules/RuleUnitTemplate.java
@@ -1,13 +1,19 @@
 package $Package$;
 
+import org.drools.core.ClockType;
+import org.drools.core.RuleBaseConfiguration;
+import org.drools.core.SessionConfigurationImpl;
+import org.drools.core.impl.EnvironmentImpl;
+import org.kie.api.conf.EventProcessingOption;
 import org.kie.api.runtime.KieSession;
+import org.kie.api.runtime.KieSessionsPool;
 import org.kie.kogito.rules.RuleEventListenerConfig;
 import org.kie.kogito.rules.units.impl.AbstractRuleUnit;
 
 public class $Name$ extends AbstractRuleUnit<$ModelName$> {
 
     public $Name$(org.kie.kogito.Application app) {
-        super(app);
+        super($ModelName$.class.getCanonicalName(), app);
     }
 
     public $InstanceName$ internalCreateInstance($ModelName$ value) {
@@ -15,10 +21,23 @@ public class $Name$ extends AbstractRuleUnit<$ModelName$> {
     }
 
     private KieSession createLegacySession() {
-        KieSession ks = app.ruleUnits().ruleRuntimeBuilder().newKieSession( $ModelClass$ );
+        RuleBaseConfiguration ruleBaseConfig = new RuleBaseConfiguration();
+        ruleBaseConfig.setEventProcessingMode($EventProcessingMode$);
+        ruleBaseConfig.setSessionPoolSize($SessionPoolSize$);
+        org.drools.core.impl.InternalKnowledgeBase kb =
+                org.drools.modelcompiler.builder.KieBaseBuilder.createKieBaseFromModel(
+                        new $RuleModelName$(), ruleBaseConfig);
+
+        SessionConfigurationImpl sessionConfig = new SessionConfigurationImpl();
+        sessionConfig.setClockType($ClockType$);
+
+        KieSession ks = kb.newKieSession(sessionConfig, new EnvironmentImpl());
+        ((org.drools.core.impl.KogitoStatefulKnowledgeSessionImpl)ks).setStateless( /*$IsStateful$*/ true );
         ((org.drools.core.impl.KogitoStatefulKnowledgeSessionImpl)ks).setApplication( app );
-        if (app.config() != null && app.config().rule() != null) {
-            RuleEventListenerConfig ruleEventListenerConfig = app.config().rule().ruleEventListeners();
+
+        org.kie.kogito.Config cfg = app.config();
+        if (cfg != null) {
+            RuleEventListenerConfig ruleEventListenerConfig = cfg.rule().ruleEventListeners();
             ruleEventListenerConfig.agendaListeners().forEach(ks::addEventListener);
             ruleEventListenerConfig.ruleRuntimeListeners().forEach(ks::addEventListener);
         }

--- a/kogito-codegen/src/main/resources/class-templates/rules/SpringRuleUnitContainerTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/rules/SpringRuleUnitContainerTemplate.java
@@ -1,0 +1,30 @@
+package $Package$;
+
+import org.kie.kogito.rules.RuleUnit;
+
+@org.springframework.web.context.annotation.ApplicationScope
+@org.springframework.stereotype.Component
+public class RuleUnits extends org.kie.kogito.rules.units.impl.AbstractRuleUnits {
+
+    @org.springframework.beans.factory.annotation.Autowired
+    java.util.Collection<org.kie.kogito.rules.RuleUnit<? extends org.kie.kogito.rules.RuleUnitData>> ruleUnits;
+
+    private java.util.Map<String, org.kie.kogito.rules.RuleUnit<? extends org.kie.kogito.rules.RuleUnitData>> mappedRuleUnits = new java.util.HashMap<>();
+    private final org.kie.kogito.rules.KieRuntimeBuilder ruleRuntimeBuilder = new org.drools.project.model.ProjectRuntime();
+
+    public org.kie.kogito.rules.KieRuntimeBuilder ruleRuntimeBuilder() {
+        return this.ruleRuntimeBuilder;
+    }
+
+    @javax.annotation.PostConstruct
+    public void setup() {
+        for (org.kie.kogito.rules.RuleUnit<? extends org.kie.kogito.rules.RuleUnitData> ruleUnit : ruleUnits) {
+            mappedRuleUnits.put(ruleUnit.id(), ruleUnit);
+        }
+    }
+
+    protected org.kie.kogito.rules.RuleUnit<?> create(String fqcn) {
+        return mappedRuleUnits.get(fqcn);
+    }
+
+}


### PR DESCRIPTION
follow up to https://github.com/kiegroup/kogito-runtimes/pull/657 

must merge with: https://github.com/kiegroup/kogito-examples/pull/350

- this mimicks the work done for Application.java and Processes.java but for RuleUnits.java
- RuleUnits is now a factory in non-DI contexts (i.e. kogito-codegen) 
- otherwise it collects and provides all the RuleUnit beans and it can be injected with `@Inject/@Autowire RuleUnits` 

The change is that currently `RuleUnits` is _always_ a factory; i.e. it always returns _new beans_. While in DI contexts, it should delegate generation to the DI container.

This PR also makes less necessary `ProjectModel`/`ProjectRuntime`, which are currently _always_ being used to construct rule units. This PR makes every RuleUnit<T> class self-contained, it no longer requires an external generated factory, _unless_ it is a `SessionRuleUnit`, i.e. a RuleUnit that mimicks the old Session behavior. Follow up to clean up: https://issues.redhat.com/browse/KOGITO-2929

A minor API change is also introduced; RuleUnit has now an id() method that returns a String representing the fully qualified name of the rule unit; in case the rule unit is a `SessionRuleUnit`  then ID is the name of the KieSession. This is required so that the generated `RuleUnits` class can cache and return the bean instances (on CDI/Spring), as it is currently done for processes.
