### PR TITLE
KOGITO-2923  Remove unnecessary Infinispan dependencies from bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -691,50 +691,15 @@
       <!-- infinispan -->
       <dependency>
         <groupId>org.infinispan</groupId>
-        <artifactId>infinispan-client-hotrod</artifactId>
+        <artifactId>infinispan-remote-query-client</artifactId>
         <version>${version.org.infinispan}</version>
-      </dependency>
+      </dependency>      
       <dependency>
         <groupId>org.infinispan.protostream</groupId>
         <artifactId>protostream</artifactId>
         <version>${version.org.infinispan.protostream}</version>
       </dependency>
-      <dependency>
-        <groupId>org.infinispan</groupId>
-        <artifactId>infinispan-server-hotrod</artifactId>
-        <version>${version.org.infinispan}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.infinispan</groupId>
-        <artifactId>infinispan-remote-query-server</artifactId>
-        <version>${version.org.infinispan}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.infinispan</groupId>
-        <artifactId>infinispan-query</artifactId>
-        <version>${version.org.infinispan}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.infinispan</groupId>
-        <artifactId>infinispan-core</artifactId>
-        <version>${version.org.infinispan}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.infinispan</groupId>
-        <artifactId>infinispan-query-dsl</artifactId>
-        <version>${version.org.infinispan}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.infinispan</groupId>
-        <artifactId>infinispan-remote-query-client</artifactId>
-        <version>${version.org.infinispan}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.infinispan</groupId>
-        <artifactId>infinispan-commons</artifactId>
-        <version>${version.org.infinispan}</version>
-      </dependency>
-
+      
       <!-- spring related -->
       <dependency>
         <groupId>org.springframework.kafka</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -693,7 +693,12 @@
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-remote-query-client</artifactId>
         <version>${version.org.infinispan}</version>
-      </dependency>      
+      </dependency>
+      <dependency>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-query-dsl</artifactId>
+        <version>${version.org.infinispan}</version>
+      </dependency> 
       <dependency>
         <groupId>org.infinispan.protostream</groupId>
         <artifactId>protostream</artifactId>


### PR DESCRIPTION

We are using test containers so we can keep just


      <dependency>
        <groupId>org.infinispan</groupId>
        <artifactId>infinispan-remote-query-client</artifactId>
        <version>${version.org.infinispan}</version>
      </dependency>      
      <dependency>
        <groupId>org.infinispan</groupId>
        <artifactId>infinispan-query-dsl</artifactId>
        <version>${version.org.infinispan}</version>
      </dependency> 
      <dependency>
        <groupId>org.infinispan.protostream</groupId>
        <artifactId>protostream</artifactId>
        <version>${version.org.infinispan.protostream}</version>
      </dependency>

and the container image
