### PR TITLE
FAI-240: Model definition endpoint - trusty-service

### DIFF
--- a/addons/tracing/tracing-decision-api/src/main/java/org/kie/kogito/tracing/decision/event/model/ModelEvent.java
+++ b/addons/tracing/tracing-decision-api/src/main/java/org/kie/kogito/tracing/decision/event/model/ModelEvent.java
@@ -30,8 +30,6 @@ public class ModelEvent {
 
     private final String namespace;
 
-    private final String identifier;
-
     private final DecisionModelType type;
 
     private final String definition;
@@ -74,13 +72,11 @@ public class ModelEvent {
     public ModelEvent(final @JsonProperty("gav") GAV gav,
                       final @JsonProperty("name") String name,
                       final @JsonProperty("namespace") String namespace,
-                      final @JsonProperty("identifier") String identifier,
                       final @JsonProperty("type") DecisionModelType type,
                       final @JsonProperty("definition") String definition) {
         this.gav = gav;
         this.name = name;
         this.namespace = namespace;
-        this.identifier = identifier;
         this.type = type;
         this.definition = definition;
     }
@@ -97,11 +93,7 @@ public class ModelEvent {
         return namespace;
     }
 
-    public String getIdentifier() {
-        return identifier;
-    }
-
-    public DecisionModelType getModelType() {
+    public DecisionModelType getType() {
         return type;
     }
 

--- a/addons/tracing/tracing-decision-api/src/test/java/org/kie/kogito/tracing/decision/event/model/ModelEventTest.java
+++ b/addons/tracing/tracing-decision-api/src/test/java/org/kie/kogito/tracing/decision/event/model/ModelEventTest.java
@@ -27,15 +27,14 @@ public class ModelEventTest {
     @Test
     public void testGetters() {
         final GAV gav = new GAV("groupID", "artifactId", "version");
-        final ModelEvent e = new ModelEvent(ModelEvent.GAV.from(gav), "name", "namespace", "identifier", DecisionModelType.DMN, "definition");
+        final ModelEvent e = new ModelEvent(ModelEvent.GAV.from(gav), "name", "namespace", DecisionModelType.DMN, "definition");
 
         assertEquals(gav.getGroupId(), e.getGav().getGroupId());
         assertEquals(gav.getArtifactId(), e.getGav().getArtifactId());
         assertEquals(gav.getVersion(), e.getGav().getVersion());
         assertEquals("name", e.getName());
         assertEquals("namespace", e.getNamespace());
-        assertEquals("identifier", e.getIdentifier());
-        assertEquals(DecisionModelType.DMN, e.getModelType());
+        assertEquals(DecisionModelType.DMN, e.getType());
         assertEquals("definition", e.getDefinition());
     }
 }

--- a/addons/tracing/tracing-decision-common/src/main/java/org/kie/kogito/tracing/decision/BaseModelEventEmitter.java
+++ b/addons/tracing/tracing-decision-common/src/main/java/org/kie/kogito/tracing/decision/BaseModelEventEmitter.java
@@ -39,7 +39,6 @@ public abstract class BaseModelEventEmitter implements EventEmitter {
                                                               new ModelEvent(ModelEvent.GAV.from(resource.getGav()),
                                                                              resource.getModelName(),
                                                                              resource.getNamespace(),
-                                                                             resource.getIdentifier(),
                                                                              resource.getModelType(),
                                                                              resource.get()),
                                                               ModelEvent.class)));

--- a/addons/tracing/tracing-decision-quarkus-addon/src/test/java/org/kie/kogito/tracing/decision/QuarkusModelEventEmitterTest.java
+++ b/addons/tracing/tracing-decision-quarkus-addon/src/test/java/org/kie/kogito/tracing/decision/QuarkusModelEventEmitterTest.java
@@ -64,7 +64,6 @@ public class QuarkusModelEventEmitterTest {
         when(model.getGav()).thenReturn(new GAV("groupId", "artifactId", "version"));
         when(model.getModelName()).thenReturn("name");
         when(model.getNamespace()).thenReturn("namespace");
-        when(model.getIdentifier()).thenReturn("identifier");
         when(model.getModelType()).thenReturn(DecisionModelType.DMN);
         when(model.get()).thenReturn("model");
         return model;

--- a/addons/tracing/tracing-decision-springboot-addon/src/test/java/org/kie/kogito/tracing/decision/SpringBootModelEventEmitterTest.java
+++ b/addons/tracing/tracing-decision-springboot-addon/src/test/java/org/kie/kogito/tracing/decision/SpringBootModelEventEmitterTest.java
@@ -74,7 +74,6 @@ public class SpringBootModelEventEmitterTest {
         when(model.getGav()).thenReturn(new GAV("groupId", "artifactId", "version"));
         when(model.getModelName()).thenReturn("name");
         when(model.getNamespace()).thenReturn("namespace");
-        when(model.getIdentifier()).thenReturn("identifier");
         when(model.getModelType()).thenReturn(DecisionModelType.DMN);
         when(model.get()).thenReturn("model");
         return model;

--- a/api/kogito-api/src/main/java/org/kie/kogito/decision/DecisionModelType.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/decision/DecisionModelType.java
@@ -17,12 +17,6 @@ package org.kie.kogito.decision;
 
 public enum DecisionModelType {
 
-    DMN("dmn");
-
-    private String type;
-
-    DecisionModelType(final String type) {
-        this.type = type;
-    }
+    DMN
 
 }

--- a/api/kogito-internal/src/main/java/org/kie/internal/decision/DecisionModelResource.java
+++ b/api/kogito-internal/src/main/java/org/kie/internal/decision/DecisionModelResource.java
@@ -30,8 +30,6 @@ public interface DecisionModelResource extends Supplier<String> {
 
     String getModelName();
 
-    String getIdentifier();
-
     DecisionModelType getModelType();
 
     InputStream getInputStream();

--- a/drools/kogito-dmn/src/main/java/org/kie/kogito/dmn/BaseDecisionModelResource.java
+++ b/drools/kogito-dmn/src/main/java/org/kie/kogito/dmn/BaseDecisionModelResource.java
@@ -34,20 +34,17 @@ public abstract class BaseDecisionModelResource implements DecisionModelResource
     protected final String path;
     protected final String namespace;
     protected final String modelName;
-    protected final String identifier;
     protected final DecisionModelType type;
 
     protected BaseDecisionModelResource(GAV gav,
                                         String path,
                                         String namespace,
                                         String modelName,
-                                        String identifier,
                                         DecisionModelType type) {
         this.gav = gav;
         this.path = path;
         this.namespace = namespace;
         this.modelName = modelName;
-        this.identifier = identifier;
         this.type = type;
     }
 
@@ -69,11 +66,6 @@ public abstract class BaseDecisionModelResource implements DecisionModelResource
     @Override
     public String getModelName() {
         return modelName;
-    }
-
-    @Override
-    public String getIdentifier() {
-        return identifier;
     }
 
     @Override

--- a/drools/kogito-dmn/src/main/java/org/kie/kogito/dmn/DecisionModelJarResource.java
+++ b/drools/kogito-dmn/src/main/java/org/kie/kogito/dmn/DecisionModelJarResource.java
@@ -26,13 +26,11 @@ public class DecisionModelJarResource extends BaseDecisionModelResource {
                                     String path,
                                     String namespace,
                                     String modelName,
-                                    String identifier,
                                     DecisionModelType type) {
         super(gav,
               path,
               namespace,
               modelName,
-              identifier,
               type);
     }
 

--- a/drools/kogito-dmn/src/main/java/org/kie/kogito/dmn/DecisionModelRelativeResource.java
+++ b/drools/kogito-dmn/src/main/java/org/kie/kogito/dmn/DecisionModelRelativeResource.java
@@ -27,14 +27,12 @@ public class DecisionModelRelativeResource extends BaseDecisionModelResource {
                                          String path,
                                          String namespace,
                                          String modelName,
-                                         String identifier,
                                          DecisionModelType type,
                                          Class application) {
         super(gav,
               path,
               namespace,
               modelName,
-              identifier,
               type);
         this.application = application;
     }

--- a/drools/kogito-dmn/src/test/java/org/kie/kogito/dmn/DecisionModelJarResourceTest.java
+++ b/drools/kogito-dmn/src/test/java/org/kie/kogito/dmn/DecisionModelJarResourceTest.java
@@ -31,13 +31,11 @@ public class DecisionModelJarResourceTest {
                                                                                "/resources/org/kie/kogito/dmn/profile.dmn",
                                                                                "namespace",
                                                                                "name",
-                                                                               "identifier",
                                                                                DecisionModelType.DMN);
 
         assertEquals(GAV, resource.getGav());
         assertEquals("name", resource.getModelName());
         assertEquals("namespace", resource.getNamespace());
-        assertEquals("identifier", resource.getIdentifier());
         assertEquals(DecisionModelType.DMN, resource.getModelType());
         assertEquals("/resources/org/kie/kogito/dmn/profile.dmn", resource.getPath());
     }
@@ -48,7 +46,6 @@ public class DecisionModelJarResourceTest {
                                                                                "org/kie/kogito/dmn/profile.dmn",
                                                                                "namespace",
                                                                                "name",
-                                                                               "identifier",
                                                                                DecisionModelType.DMN);
         assertNotNull(resource.get());
     }

--- a/drools/kogito-dmn/src/test/java/org/kie/kogito/dmn/DecisionModelRelativeResourceTest.java
+++ b/drools/kogito-dmn/src/test/java/org/kie/kogito/dmn/DecisionModelRelativeResourceTest.java
@@ -31,14 +31,12 @@ public class DecisionModelRelativeResourceTest {
                                                                                          "profile.dmn",
                                                                                          "namespace",
                                                                                          "name",
-                                                                                         "identifier",
                                                                                          DecisionModelType.DMN,
                                                                                          this.getClass());
 
         assertEquals(GAV, resource.getGav());
         assertEquals("name", resource.getModelName());
         assertEquals("namespace", resource.getNamespace());
-        assertEquals("identifier", resource.getIdentifier());
         assertEquals(DecisionModelType.DMN, resource.getModelType());
         assertEquals("profile.dmn", resource.getPath());
     }
@@ -49,7 +47,6 @@ public class DecisionModelRelativeResourceTest {
                                                                                          "profile.dmn",
                                                                                          "namespace",
                                                                                          "name",
-                                                                                         "identifier",
                                                                                          DecisionModelType.DMN,
                                                                                          this.getClass());
         assertNotNull(resource.get());

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionModelResourcesProviderGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionModelResourcesProviderGenerator.java
@@ -112,7 +112,6 @@ public class DecisionModelResourcesProviderGenerator {
                                           new StringLiteralExpr(getDecisionModelJarResourcePath(resource)),
                                           new StringLiteralExpr(resource.getDmnModel().getNamespace()),
                                           new StringLiteralExpr(resource.getDmnModel().getName()),
-                                          makeDMNIdentifier(resource),
                                           makeDMNType()));
             } else {
                 final ClassOrInterfaceType applicationClass = StaticJavaParser.parseClassOrInterfaceType(applicationCanonicalName);
@@ -121,7 +120,6 @@ public class DecisionModelResourcesProviderGenerator {
                                           new StringLiteralExpr(getDecisionModelRelativeResourcePath(resource)),
                                           new StringLiteralExpr(resource.getDmnModel().getNamespace()),
                                           new StringLiteralExpr(resource.getDmnModel().getName()),
-                                          makeDMNIdentifier(resource),
                                           makeDMNType(),
                                           new FieldAccessExpr(applicationClass.getNameAsExpression(), "class")));
             }
@@ -135,10 +133,6 @@ public class DecisionModelResourcesProviderGenerator {
                          new StringLiteralExpr("dummy"),
                          new StringLiteralExpr("dummy"),
                          new StringLiteralExpr("0.0"));
-    }
-
-    private StringLiteralExpr makeDMNIdentifier(final DMNResource resource) {
-        return new StringLiteralExpr(resource.getDmnModel().getNamespace() + ":" + resource.getDmnModel().getName());
     }
 
     private FieldAccessExpr makeDMNType() {


### PR DESCRIPTION
See https://issues.redhat.com/browse/FAI-240

This PR relates to the _receiving_ end of the `ModelEvent`s published from the tracing addon.

Receipt is actually in `kogito-apps/trusty` however there were a few changes needed here too.

This is part of an ensemble:
- https://github.com/kiegroup/kogito-runtimes/pull/667
- https://github.com/kiegroup/kogito-apps/pull/357 

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket