### PR TITLE
KOGITO-2937  Remove redundant test dependencies in processes

### DIFF
--- a/jbpm/jbpm-bpmn2/pom.xml
+++ b/jbpm/jbpm-bpmn2/pom.xml
@@ -100,12 +100,6 @@
       <artifactId>xstream</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.kie.kogito</groupId>
-      <artifactId>drools-core</artifactId>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
 

--- a/jbpm/jbpm-flow-builder/pom.xml
+++ b/jbpm/jbpm-flow-builder/pom.xml
@@ -81,11 +81,5 @@
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.kie.kogito</groupId>
-      <artifactId>drools-compiler</artifactId>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/jbpm/jbpm-serverless-workflow/pom.xml
+++ b/jbpm/jbpm-serverless-workflow/pom.xml
@@ -113,12 +113,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.kie.kogito</groupId>
-      <artifactId>drools-core</artifactId>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path-assert</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
test-jar dependencies on `drools-*` in `jbpm/*` are not really required and they mess up the build of the unfork https://github.com/kiegroup/kogito-runtimes/pull/649