### PR TITLE
[KOGITO-2753] Processes: Remove model transformations from REST endpoint

### DIFF
--- a/api/kogito-api/src/main/java/org/kie/kogito/MapInput.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/MapInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,17 @@
 
 package org.kie.kogito;
 
+import java.util.Map;
+
 /**
- * Represents data model type of objects that are usually descriptor of data holders.
- *
+ * To be implemented by classes which can be populated from a Map
  */
-public interface Model extends MapInput, MapOutput {
+public interface MapInput {
+
+    /**
+     * Fills the class with information retrieved from the map
+     * @param params Map containing keys which matches names of fields
+     * in the class*/
+    void fromMap(Map<String, Object> params);
+
 }

--- a/api/kogito-api/src/main/java/org/kie/kogito/MapOutput.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/MapOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,16 @@
 
 package org.kie.kogito;
 
+import java.util.Map;
+
 /**
- * Represents data model type of objects that are usually descriptor of data holders.
- *
+ * To be implemented by classes which can express its internal information as a Map
  */
-public interface Model extends MapInput, MapOutput {
+public interface MapOutput {
+
+    /**
+     * Returns class representation as map  
+     * @return non null map of data extracted from the class
+     */
+    Map<String, Object> toMap();
 }

--- a/api/kogito-api/src/main/java/org/kie/kogito/process/ProcessInstance.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/process/ProcessInstance.java
@@ -94,7 +94,7 @@ public interface ProcessInstance<T> {
     /**
      * Updates process variables of this process instance
      */
-    void updateVariables(T updates);
+    T updateVariables(T updates);
 
     /**
      * Returns current status of this process instance
@@ -181,6 +181,14 @@ public interface ProcessInstance<T> {
      * @return returns process error
      */
     Optional<ProcessError> error();
+
+    default ProcessInstance<T> checkError() {
+        Optional<ProcessError> error = error();
+        if (error.isPresent()) {
+            throw new ProcessInstanceExecutionException(id(), error.get().failedNodeId(), error.get().errorMessage());
+        }
+        return this;
+    }
 
     void triggerNode(String nodeId);
 

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ModelMetaData.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ModelMetaData.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -69,6 +70,7 @@ public class ModelMetaData {
     private String visibility;
     private boolean hidden;
     private String templateName;
+    private Consumer<CompilationUnit> customGenerator;
 
     private boolean supportsValidation;
 
@@ -77,6 +79,12 @@ public class ModelMetaData {
     }
 
     public ModelMetaData(String processId, String packageName, String modelClassSimpleName, String visibility, VariableDeclarations variableScope, boolean hidden, String templateName) {
+        this(processId, packageName, modelClassSimpleName, visibility, variableScope, hidden, templateName, c -> {
+        });
+    }
+
+    public ModelMetaData(String processId, String packageName, String modelClassSimpleName, String visibility, VariableDeclarations variableScope, boolean hidden, String templateName,
+                         Consumer<CompilationUnit> customGenerator) {
         this.processId = processId;
         this.packageName = packageName;
         this.modelClassSimpleName = modelClassSimpleName;
@@ -85,10 +93,12 @@ public class ModelMetaData {
         this.visibility = visibility;
         this.hidden = hidden;
         this.templateName = templateName;
+        this.customGenerator = customGenerator;
     }
 
     public String generate() {
         CompilationUnit modelClass = compilationUnit();
+        customGenerator.accept(modelClass);
         return modelClass.toString();
     }
 

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ProcessToExecModelGenerator.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ProcessToExecModelGenerator.java
@@ -20,12 +20,25 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.AssignExpr;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.ast.expr.VariableDeclarationExpr;
 import com.github.javaparser.ast.nodeTypes.NodeWithName;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.ReturnStmt;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import org.drools.core.util.StringUtils;
 import org.jbpm.process.core.ContextContainer;
+import org.jbpm.process.core.context.variable.Variable;
 import org.jbpm.process.core.context.variable.VariableScope;
 import org.jbpm.workflow.core.impl.WorkflowProcessImpl;
 import org.jbpm.workflow.core.node.HumanTaskNode;
@@ -33,11 +46,13 @@ import org.kie.api.definition.process.Node;
 import org.kie.api.definition.process.WorkflowProcess;
 
 import static com.github.javaparser.StaticJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parseClassOrInterfaceType;
 import static org.drools.core.util.StringUtils.ucFirst;
 
 public class ProcessToExecModelGenerator {
 
-    public static final ProcessToExecModelGenerator INSTANCE = new ProcessToExecModelGenerator(ProcessToExecModelGenerator.class.getClassLoader());
+    public static final ProcessToExecModelGenerator INSTANCE = new ProcessToExecModelGenerator(
+                                                                                               ProcessToExecModelGenerator.class.getClassLoader());
 
     private static final String PROCESS_CLASS_SUFFIX = "Process";
     private static final String MODEL_CLASS_SUFFIX = "Model";
@@ -52,7 +67,9 @@ public class ProcessToExecModelGenerator {
     public ProcessMetaData generate(WorkflowProcess process) {
         CompilationUnit parsedClazzFile = parse(this.getClass().getResourceAsStream(PROCESS_TEMPLATE_FILE));
         parsedClazzFile.setPackageDeclaration(process.getPackageName());
-        Optional<ClassOrInterfaceDeclaration> processClazzOptional = parsedClazzFile.findFirst(ClassOrInterfaceDeclaration.class, sl -> true);
+        Optional<ClassOrInterfaceDeclaration> processClazzOptional = parsedClazzFile.findFirst(
+                                                                                               ClassOrInterfaceDeclaration.class,
+                                                                                               sl -> true);
 
         String extractedProcessId = extractProcessId(process.getId());
 
@@ -62,14 +79,14 @@ public class ProcessToExecModelGenerator {
         ClassOrInterfaceDeclaration processClazz = processClazzOptional.get();
         processClazz.setName(ucFirst(extractedProcessId + PROCESS_CLASS_SUFFIX));
         String packageName = parsedClazzFile.getPackageDeclaration().map(NodeWithName::getNameAsString).orElse(null);
-        ProcessMetaData metadata = new ProcessMetaData(process.getId(),
-                extractedProcessId,
-                process.getName(),
-                process.getVersion(),
-                packageName,
-                processClazz.getNameAsString());
+        ProcessMetaData metadata =
+                new ProcessMetaData(process.getId(), extractedProcessId, process.getName(), process.getVersion(),
+                                    packageName, processClazz.getNameAsString());
 
-        Optional<MethodDeclaration> processMethod = parsedClazzFile.findFirst(MethodDeclaration.class, sl -> sl.getName().asString().equals("process"));
+        Optional<MethodDeclaration> processMethod = parsedClazzFile.findFirst(MethodDeclaration.class, sl -> sl
+                                                                                                               .getName()
+                                                                                                               .asString()
+                                                                                                               .equals("process"));
 
         processVisitor.visitProcess(process, processMethod.get(), metadata);
 
@@ -85,13 +102,9 @@ public class ProcessToExecModelGenerator {
         String extractedProcessId = extractProcessId(process.getId());
 
         String packageName = clazz.getPackageDeclaration().map(NodeWithName::getNameAsString).orElse(null);
-        ProcessMetaData metadata = new ProcessMetaData(process.getId(),
-                extractedProcessId,
-                process.getName(),
-                process.getVersion(),
-                packageName,
-                "process");
-
+        ProcessMetaData metadata =
+                new ProcessMetaData(process.getId(), extractedProcessId, process.getName(), process.getVersion(),
+                                    packageName, "process");
         MethodDeclaration processMethod = new MethodDeclaration();
         processVisitor.visitProcess(process, processMethod, metadata);
 
@@ -101,28 +114,89 @@ public class ProcessToExecModelGenerator {
     public ModelMetaData generateModel(WorkflowProcess process) {
         String packageName = process.getPackageName();
         String name = extractModelClassName(process.getId());
-
-        return new ModelMetaData(process.getId(), packageName, name, process.getVisibility(),
-                VariableDeclarations.of((VariableScope) ((org.jbpm.process.core.Process) process).getDefaultContext(VariableScope.VARIABLE_SCOPE)),
-                false);
+        VariableScope variableScope = getVariableScope(process);
+        return new ModelMetaData(process.getId(),
+                                 packageName,
+                                 name,
+                                 process.getVisibility(),
+                                 VariableDeclarations.of(variableScope),
+                                 false,
+                                 "/class-templates/ModelTemplate.java",
+                                 new AddMethodConsumer("toOutput", extractModelClassName(process.getId()) + "Output",
+                                                       VariableDeclarations.ofOutput(variableScope), true));
     }
 
     public ModelMetaData generateInputModel(WorkflowProcess process) {
         String packageName = process.getPackageName();
-        String name = extractModelClassName(process.getId()) + "Input";
-
-        return new ModelMetaData(process.getId(), packageName, name, process.getVisibility(),
-                VariableDeclarations.ofInput((VariableScope) ((org.jbpm.process.core.Process) process).getDefaultContext(VariableScope.VARIABLE_SCOPE)),
-                true, "/class-templates/ModelNoIDTemplate.java");
+        String modelName = extractModelClassName(process.getId());
+        String name = modelName + "Input";
+        VariableDeclarations inputVars = VariableDeclarations.ofInput(getVariableScope(process));
+        return new ModelMetaData(process.getId(),
+                                 packageName, name,
+                                 process.getVisibility(),
+                                 inputVars,
+                                 true,
+                                 "/class-templates/ModelNoIDTemplate.java",
+                                 new AddMethodConsumer("toModel", modelName, inputVars, false));
     }
 
     public ModelMetaData generateOutputModel(WorkflowProcess process) {
         String packageName = process.getPackageName();
         String name = extractModelClassName(process.getId()) + "Output";
+        return new ModelMetaData(process.getId(),
+                                 packageName,
+                                 name,
+                                 process.getVisibility(),
+                                 VariableDeclarations.ofOutput(getVariableScope(process)), true);
+    }
 
-        return new ModelMetaData(process.getId(), packageName, name, process.getVisibility(),
-                VariableDeclarations.ofOutput((VariableScope) ((org.jbpm.process.core.Process) process).getDefaultContext(VariableScope.VARIABLE_SCOPE)),
-                true);
+    private static VariableScope getVariableScope(WorkflowProcess process) {
+        return (VariableScope) ((org.jbpm.process.core.Process) process).getDefaultContext(VariableScope.VARIABLE_SCOPE);
+    }
+
+    private static class AddMethodConsumer implements Consumer<CompilationUnit> {
+
+        private String methodName;
+        private String returnClassName;
+        private VariableDeclarations vars;
+        private boolean includeId;
+
+        public AddMethodConsumer(String methodName, String returnClassName, VariableDeclarations vars,
+                                 boolean includeId) {
+            this.methodName = methodName;
+            this.returnClassName = returnClassName;
+            this.vars = vars;
+            this.includeId = includeId;
+        }
+
+        @Override
+        public void accept(CompilationUnit cu) {
+            Optional<ClassOrInterfaceDeclaration> clazz = cu.findFirst(ClassOrInterfaceDeclaration.class);
+            if (!clazz.isPresent()) {
+                throw new NoSuchElementException("Cannot find class declaration in the template");
+            }
+            ClassOrInterfaceType type = parseClassOrInterfaceType(returnClassName);
+            final String resultVarName = "result";
+            MethodDeclaration method = clazz.get().addMethod(methodName, Modifier.Keyword.PUBLIC).setType(type);
+            BlockStmt body = new BlockStmt();
+            VariableDeclarationExpr returnVar = new VariableDeclarationExpr(type, resultVarName);
+            body.addStatement(new AssignExpr(returnVar, new ObjectCreationExpr(null, type, NodeList.nodeList()),
+                                             AssignExpr.Operator.ASSIGN));
+            NameExpr returnName = new NameExpr(resultVarName);
+            // fill id
+            if (includeId) {
+                body.addStatement(new MethodCallExpr(returnName, "setId").addArgument(new MethodCallExpr(null,
+                                                                                                         "getId")));
+            }
+            for (Variable var : vars.getTypes().values()) {
+                final String fieldName = StringUtils.ucFirst(var.getSanitizedName());
+                body.addStatement(new MethodCallExpr(returnName, "set" + fieldName).addArgument(new MethodCallExpr(null,
+                                                                                                                   "get" +
+                                                                                                                         fieldName)));
+            }
+            body.addStatement(new ReturnStmt(returnName));
+            method.setBody(body);
+        }
     }
 
     public static String extractModelClassName(String processId) {
@@ -133,16 +207,19 @@ public class ProcessToExecModelGenerator {
         String packageName = process.getPackageName();
         List<UserTaskModelMetaData> usertaskModels = new ArrayList<>();
 
-        VariableScope variableScope = (VariableScope) ((org.jbpm.process.core.Process) process).getDefaultContext(VariableScope.VARIABLE_SCOPE);
+        VariableScope variableScope = (VariableScope) ((org.jbpm.process.core.Process) process).getDefaultContext(
+                                                                                                                  VariableScope.VARIABLE_SCOPE);
 
         for (Node node : ((WorkflowProcessImpl) process).getNodesRecursively()) {
             if (node instanceof HumanTaskNode) {
                 HumanTaskNode humanTaskNode = (HumanTaskNode) node;
-                VariableScope nodeVariableScope = (VariableScope) ((ContextContainer) humanTaskNode.getParentContainer()).getDefaultContext(VariableScope.VARIABLE_SCOPE);
+                VariableScope nodeVariableScope = (VariableScope) ((ContextContainer) humanTaskNode
+                                                                                                   .getParentContainer()).getDefaultContext(VariableScope.VARIABLE_SCOPE);
                 if (nodeVariableScope == null) {
                     nodeVariableScope = variableScope;
                 }
-                usertaskModels.add(new UserTaskModelMetaData(packageName, variableScope, nodeVariableScope, humanTaskNode, process.getId()));
+                usertaskModels.add(new UserTaskModelMetaData(packageName, variableScope, nodeVariableScope,
+                                                             humanTaskNode, process.getId()));
             }
         }
 

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/UserTaskModelMetaData.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/UserTaskModelMetaData.java
@@ -186,7 +186,7 @@ public class UserTaskModelMetaData {
         
         modelClass.setName(inputModelClassSimpleName);
 
-        // setup of static fromMap method body
+        // setup of static from method body
         ClassOrInterfaceType modelType = new ClassOrInterfaceType(null, modelClass.getNameAsString());
         BlockStmt staticFromMap = new BlockStmt();
         VariableDeclarationExpr itemField = new VariableDeclarationExpr(modelType, "item");
@@ -229,7 +229,7 @@ public class UserTaskModelMetaData {
             fd.createGetter();
             fd.createSetter();
 
-            // fromMap static method body
+            // from static method body
             FieldAccessExpr field = new FieldAccessExpr(item, entry.getKey());
 
 
@@ -259,7 +259,7 @@ public class UserTaskModelMetaData {
             fd.createGetter();
             fd.createSetter();
 
-            // fromMap static method body
+            // from static method body
             FieldAccessExpr field = new FieldAccessExpr(item, entry.getKey());
 
             ClassOrInterfaceType type = parseClassOrInterfaceType(entry.getValue().getClass().getCanonicalName());
@@ -270,13 +270,13 @@ public class UserTaskModelMetaData {
                                                                                              "get")
                                                                                                    .addArgument(new StringLiteralExpr(entry.getKey()))), AssignExpr.Operator.ASSIGN));
         }
-        Optional<MethodDeclaration> staticFromMapMethod = modelClass.findFirst(
-                                                                               MethodDeclaration.class, sl -> sl.getName().asString().equals("fromMap") && sl.isStatic());
-        if (staticFromMapMethod.isPresent()) {
-            MethodDeclaration fromMap = staticFromMapMethod.get();
-            fromMap.setType(modelClass.getNameAsString());
+        Optional<MethodDeclaration> staticFromMethod = modelClass.findFirst(
+                                                                               MethodDeclaration.class, sl -> sl.getName().asString().equals("from") && sl.isStatic());
+        if (staticFromMethod.isPresent()) {
+            MethodDeclaration from = staticFromMethod.get();
+            from.setType(modelClass.getNameAsString());
             staticFromMap.addStatement(new ReturnStmt(new NameExpr("item")));
-            fromMap.setBody(staticFromMap);
+            from.setBody(staticFromMap);
         }
         return compilationUnit;
     }

--- a/jbpm/jbpm-flow-builder/src/main/resources/class-templates/TaskInputTemplate.java
+++ b/jbpm/jbpm-flow-builder/src/main/resources/class-templates/TaskInputTemplate.java
@@ -24,7 +24,7 @@ public class XXXTaskInput {
         return this._name;
     }
 
-    public static XXXTaskInput fromMap(org.kie.kogito.process.WorkItem workItem) {
+    public static XXXTaskInput from(org.kie.kogito.process.WorkItem workItem) {
         
     }
 }

--- a/jbpm/jbpm-flow-builder/src/main/resources/class-templates/TaskOutputTemplate.java
+++ b/jbpm/jbpm-flow-builder/src/main/resources/class-templates/TaskOutputTemplate.java
@@ -3,7 +3,7 @@ package org.jbpm.process.codegen;
 import java.util.Map;
 import java.util.HashMap;
 
-public class XXXTaskOutput {
+public class XXXTaskOutput implements org.kie.kogito.MapOutput {
 
     
     public Map<String, Object> toMap() {

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/humantask/HumanTaskTransition.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/humantask/HumanTaskTransition.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.kie.kogito.MapOutput;
 import org.kie.kogito.auth.IdentityProvider;
 import org.kie.kogito.auth.SecurityPolicy;
 import org.kie.kogito.process.workitem.Policy;
@@ -36,8 +37,8 @@ public class HumanTaskTransition implements Transition<Map<String, Object>> {
     private Map<String, Object> data;
     private List<Policy<?>> policies = new ArrayList<>();
     
-    public static HumanTaskTransition withModel(String phase, Map<String, Object> data, Policy<?>... policies) {
-        return new HumanTaskTransition(phase, data, policies);
+    public static HumanTaskTransition withModel(String phase, MapOutput data, Policy<?>... policies) {
+        return new HumanTaskTransition(phase, data.toMap(), policies);
     }
 
     public static HumanTaskTransition withoutModel(String phase, Policy<?>... policies) {

--- a/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcessInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcessInstance.java
@@ -283,13 +283,14 @@ public abstract class AbstractProcessInstance<T extends Model> implements Proces
     }
 
     @Override
-    public void updateVariables(T updates) {
+    public T updateVariables(T updates) {
         Map<String, Object> map = bind(updates);
 
         for (Entry<String, Object> entry : map.entrySet()) {
             processInstance().setVariable(entry.getKey(), entry.getValue());
         }
         addToUnitOfWork(pi -> ((MutableProcessInstances<T>) process.instances()).update(pi.id(), pi));
+        return variables;
     }
 
     @Override

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/InputModelClassGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/InputModelClassGenerator.java
@@ -18,8 +18,6 @@ package org.kie.kogito.codegen.process;
 import org.drools.core.util.StringUtils;
 import org.jbpm.compiler.canonical.ModelMetaData;
 import org.jbpm.compiler.canonical.ProcessToExecModelGenerator;
-import org.jbpm.compiler.canonical.VariableDeclarations;
-import org.jbpm.process.core.context.variable.VariableScope;
 import org.kie.api.definition.process.WorkflowProcess;
 import org.kie.kogito.codegen.GeneratorContext;
 
@@ -43,11 +41,7 @@ public class InputModelClassGenerator {
 
     public ModelMetaData generate() {
         // create model class for all variables
-        String packageName = workFlowProcess.getPackageName();        
-
-        modelMetaData = new ModelMetaData(workFlowProcess.getId(), packageName, className, workFlowProcess.getVisibility(),
-                                 VariableDeclarations.ofInput((VariableScope) ((org.jbpm.process.core.Process) workFlowProcess).getDefaultContext(VariableScope.VARIABLE_SCOPE)),
-                                 true, "/class-templates/ModelNoIDTemplate.java");
+        modelMetaData = ProcessToExecModelGenerator.INSTANCE.generateInputModel(workFlowProcess);
         modelMetaData.setSupportsValidation(context.getBuildContext().isValidationSupported());
                 
         modelFileName = modelMetaData.getModelClassName().replace('.', '/') + ".java";

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/OutputModelClassGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/OutputModelClassGenerator.java
@@ -18,8 +18,6 @@ package org.kie.kogito.codegen.process;
 import org.drools.core.util.StringUtils;
 import org.jbpm.compiler.canonical.ModelMetaData;
 import org.jbpm.compiler.canonical.ProcessToExecModelGenerator;
-import org.jbpm.compiler.canonical.VariableDeclarations;
-import org.jbpm.process.core.context.variable.VariableScope;
 import org.kie.api.definition.process.WorkflowProcess;
 import org.kie.kogito.codegen.GeneratorContext;
 
@@ -43,11 +41,7 @@ public class OutputModelClassGenerator {
 
     public ModelMetaData generate() {
         // create model class for all variables
-        String packageName = workFlowProcess.getPackageName();        
-
-        modelMetaData = new ModelMetaData(workFlowProcess.getId(), packageName, className, workFlowProcess.getVisibility(),
-                                 VariableDeclarations.ofOutput((VariableScope) ((org.jbpm.process.core.Process) workFlowProcess).getDefaultContext(VariableScope.VARIABLE_SCOPE)),
-                                 true);       
+        modelMetaData = ProcessToExecModelGenerator.INSTANCE.generateOutputModel(workFlowProcess);
         modelFileName = modelMetaData.getModelClassName().replace('.', '/') + ".java";
         modelMetaData.setSupportsValidation(context.getBuildContext().isValidationSupported());
         return modelMetaData;

--- a/kogito-codegen/src/main/resources/class-templates/RestResourceSignalTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/RestResourceSignalTemplate.java
@@ -32,10 +32,10 @@ public class $Type$Resource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public $Type$Output signal(@PathParam("id") final String id, final $signalType$ data) {
-        return org.kie.kogito.services.uow.UnitOfWorkExecutor.executeInUnitOfWork(application.unitOfWorkManager(), () -> {
+        return UnitOfWorkExecutor.executeInUnitOfWork(application.unitOfWorkManager(), () -> {
             return process.instances().findById(id).map(pi -> {
                 pi.send(Sig.of("$signalName$", data));
-                return getModel(pi);
+                return pi.checkError().variables().toOutput();
             }).orElse(null);
         });
     }

--- a/kogito-codegen/src/main/resources/class-templates/RestResourceUserTaskTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/RestResourceUserTaskTemplate.java
@@ -15,17 +15,24 @@ public class $Type$Resource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public javax.ws.rs.core.Response signal(@PathParam("id") final String id) {
-        return org.kie.kogito.services.uow.UnitOfWorkExecutor.executeInUnitOfWork(application.unitOfWorkManager(), () -> {
-            return process.instances().findById(id).map(pi -> {
-                pi.send(Sig.of("$taskNodeName$", java.util.Collections.emptyMap()));
-                java.util.Optional<WorkItem> task = pi.workItems().stream().filter(wi -> wi.getName().equals("$taskName$")).findFirst();
-                if (task.isPresent()) {
-                    return javax.ws.rs.core.Response.ok(getModel(pi))
-                                                    .header("Link", "</" + id + "/$taskName$/" + task.get().getId() + ">; rel='instance'")
-                                                    .build();
-                }
-                return javax.ws.rs.core.Response.status(javax.ws.rs.core.Response.Status.NOT_FOUND).build();
-            }).orElse(null);
+        return UnitOfWorkExecutor.executeInUnitOfWork(application.unitOfWorkManager(), () -> {
+            return process
+                          .instances()
+                          .findById(id)
+                          .map(pi -> {
+                              pi.send(Sig.of("$taskNodeName$", java.util.Collections.emptyMap()));
+                              java.util.Optional<WorkItem> task =
+                                      pi.workItems().stream().filter(wi -> wi.getName().equals("$taskName$"))
+                                        .findFirst();
+                              if (task.isPresent()) {
+                                  return Response.ok(pi.variables().toOutput())
+                                                 .header("Link", "</" + id + "/$taskName$/" + task.get().getId() +
+                                                                 ">; rel='instance'")
+                                                 .build();
+                              }
+                              return Response.status(Response.Status.NOT_FOUND).build();
+                          })
+                          .orElse(null);
         });
     }
 
@@ -39,17 +46,32 @@ public class $Type$Resource {
                                      @QueryParam("user") final String user,
                                      @QueryParam("group") final List<String> groups,
                                      final $TaskOutput$ model) {
-        return org.kie.kogito.services.uow.UnitOfWorkExecutor.executeInUnitOfWork(application.unitOfWorkManager(), () -> process.instances().findById(id).map(pi -> {
-            pi.transitionWorkItem(workItemId, org.jbpm.process.instance.impl.humantask.HumanTaskTransition.withModel(phase, model.toMap(), policies(user, groups)));
-            return getModel(pi);
-        }).orElse(null));
+        return UnitOfWorkExecutor.executeInUnitOfWork(application.unitOfWorkManager(),
+                                                      () -> process
+                                                                   .instances()
+                                                                   .findById(id)
+                                                                   .map(pi -> {
+                                                                       pi.transitionWorkItem(workItemId,
+                                                                                             HumanTaskTransition.withModel(phase,
+                                                                                                                           model,
+                                                                                                                           policies(user,
+                                                                                                                                    groups)));
+                                                                       return pi.variables().toOutput();
+                                                                   })
+                                                                   .orElse(null));
     }
 
     @GET()
     @Path("/{id}/$taskName$/{workItemId}")
     @Produces(MediaType.APPLICATION_JSON)
-    public $TaskInput$ getTask(@PathParam("id") String id, @PathParam("workItemId") String workItemId, @QueryParam("user") final String user, @QueryParam("group") final List<String> groups) {
-        return process.instances().findById(id, ProcessInstanceReadMode.READ_ONLY).map(pi ->  $TaskInput$.fromMap(pi.workItem(workItemId, policies(user, groups)))).orElse(null);
+    public $TaskInput$ getTask(@PathParam("id") String id,
+                               @PathParam("workItemId") String workItemId,
+                               @QueryParam("user") final String user,
+                               @QueryParam("group") final List<String> groups) {
+        return process.instances()
+                      .findById(id, ProcessInstanceReadMode.READ_ONLY)
+                      .map(pi -> $TaskInput$.from(pi.workItem(workItemId, policies(user, groups))))
+                      .orElse(null);
     }
 
     @GET()
@@ -58,7 +80,7 @@ public class $Type$Resource {
     public Map<String, Object> getSchema() {
         return JsonSchemaUtil.load(this.getClass().getClassLoader(), process.id(), "$taskName$");
     }
-    
+
     @GET()
     @Path("/{id}/$taskName$/{workItemId}/schema")
     @Produces(MediaType.APPLICATION_JSON)
@@ -66,7 +88,9 @@ public class $Type$Resource {
                                                   @PathParam("workItemId") final String workItemId,
                                                   @QueryParam("user") final String user,
                                                   @QueryParam("group") final List<String> groups) {
-        return JsonSchemaUtil.addPhases(process, application, id, workItemId, policies(user, groups), JsonSchemaUtil.load(this.getClass().getClassLoader(), process.id(), "$taskName$"));
+        return JsonSchemaUtil.addPhases(process, application, id, workItemId, policies(user, groups),
+                                        JsonSchemaUtil.load(this.getClass().getClassLoader(), process.id(),
+                                                            "$taskName$"));
     }
 
     @DELETE()
@@ -77,9 +101,17 @@ public class $Type$Resource {
                                   @QueryParam("phase") @DefaultValue("abort") final String phase,
                                   @QueryParam("user") final String user,
                                   @QueryParam("group") final List<String> groups) {
-        return org.kie.kogito.services.uow.UnitOfWorkExecutor.executeInUnitOfWork(application.unitOfWorkManager(), () -> process.instances().findById(id).map(pi -> {
-            pi.transitionWorkItem(workItemId, org.jbpm.process.instance.impl.humantask.HumanTaskTransition.withoutModel(phase, policies(user, groups)));
-            return getModel(pi);
-        }).orElse(null));
+        return UnitOfWorkExecutor.executeInUnitOfWork(application.unitOfWorkManager(),
+                                                      () -> process
+                                                                   .instances()
+                                                                   .findById(id)
+                                                                   .map(pi -> {
+                                                                       pi.transitionWorkItem(workItemId,
+                                                                                             HumanTaskTransition.withoutModel(phase,
+                                                                                                                              policies(user,
+                                                                                                                                       groups)));
+                                                                       return pi.variables().toOutput();
+                                                                   })
+                                                                   .orElse(null));
     }
 }

--- a/kogito-codegen/src/main/resources/class-templates/spring/SpringRestResourceSignalTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/spring/SpringRestResourceSignalTemplate.java
@@ -32,10 +32,10 @@ public class $Type$Resource {
 
     @PostMapping(value = "/{id}/$signalPath$", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
     public $Type$Output signal(@PathVariable("id") final String id, final @RequestBody $signalType$ data) {
-        return org.kie.kogito.services.uow.UnitOfWorkExecutor.executeInUnitOfWork(application.unitOfWorkManager(), () -> {
+        return UnitOfWorkExecutor.executeInUnitOfWork(application.unitOfWorkManager(), () -> {
             return process.instances().findById(id).map(pi -> {
                 pi.send(Sig.of("$signalName$", data));
-                return getModel(pi);
+                return pi.checkError().variables().toOutput();
             }).orElse(null);
         });
     }

--- a/kogito-codegen/src/main/resources/class-templates/spring/SpringRestResourceUserTaskTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/spring/SpringRestResourceUserTaskTemplate.java
@@ -18,41 +18,70 @@ import org.springframework.web.bind.annotation.RequestParam;
 public class $Type$Resource {
 
     @PostMapping(value = "/{id}/$taskName$", produces = MediaType.APPLICATION_JSON_VALUE,
-            consumes = MediaType.APPLICATION_JSON_VALUE)
-    public org.springframework.http.ResponseEntity<$Type$Output> signal(@PathVariable("id") final String id) {
-        return org.kie.kogito.services.uow.UnitOfWorkExecutor.executeInUnitOfWork(application.unitOfWorkManager(), () -> {
-            return process.instances().findById(id).map(pi -> {
-                pi.send(Sig.of("$taskNodeName$", java.util.Collections.emptyMap()));
-                java.util.Optional<WorkItem> task = pi.workItems().stream().filter(wi -> wi.getName().equals("$taskName$")).findFirst();
-                if (task.isPresent()) {
-                    return javax.ws.rs.core.Response.ok(getModel(pi))
-                                                    .header("Link", "</" + id + "/$taskName$/" + task.get().getId() + ">; rel='instance'")
-                                                    .build();
-                }
-                return javax.ws.rs.core.Response.status(javax.ws.rs.core.Response.Status.NOT_FOUND).build();
-            }).orElse(null);
-        });
+                 consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<$Type$Output> signal(@PathVariable("id") final String id) {
+        return UnitOfWorkExecutor.executeInUnitOfWork(application.unitOfWorkManager(),
+                                                      () -> process
+                                                                   .instances()
+                                                                   .findById(id)
+                                                                   .map(pi -> {
+                                                                       pi.send(Sig.of("$taskNodeName$",
+                                                                                      java.util.Collections.emptyMap()));
+                                                                       java.util.Optional<WorkItem> task =
+                                                                               pi.workItems()
+                                                                                 .stream()
+                                                                                 .filter(wi -> wi.getName()
+                                                                                                 .equals("$taskName$"))
+                                                                                 .findFirst();
+                                                                       if (task.isPresent()) {
+                                                                           return ResponseEntity.status(HttpStatus.OK)
+                                                                                                .header("Link",
+                                                                                                        "</" + id +
+                                                                                                                "/$taskName$/" +
+                                                                                                                task.get()
+                                                                                                                    .getId() +
+                                                                                                                ">; rel='instance'")
+                                                                                                .body(pi.variables()
+                                                                                                        .toOutput())
+                                                                                                .build();
+                                                                       }
+                                                                       return ResponseEntity.notFound().build();
+                                                                   })
+                                                                   .orElse(null));
     }
 
     @PostMapping(value = "/{id}/$taskName$/{workItemId}", produces = MediaType.APPLICATION_JSON_VALUE,
-            consumes = MediaType.APPLICATION_JSON_VALUE)
+                 consumes = MediaType.APPLICATION_JSON_VALUE)
     public $Type$Output completeTask(@PathVariable("id") final String id,
                                      @PathVariable("workItemId") final String workItemId,
                                      @RequestParam(value = "phase", defaultValue = "complete") final String phase,
                                      @RequestParam(value = "user", required = false) final String user,
                                      @RequestParam(value = "group", required = false) final List<String> groups,
                                      @RequestBody final $TaskOutput$ model) {
-        return org.kie.kogito.services.uow.UnitOfWorkExecutor.executeInUnitOfWork(application.unitOfWorkManager(), () -> process.instances().findById(id).map(pi -> {
-            pi.transitionWorkItem(workItemId, org.jbpm.process.instance.impl.humantask.HumanTaskTransition.withModel(phase, model.toMap(), policies(user, groups)));
-            return getModel(pi);
-        }).orElse(null));
+        return UnitOfWorkExecutor.executeInUnitOfWork(application.unitOfWorkManager(),
+                                                      () -> process
+                                                                   .instances()
+                                                                   .findById(id)
+                                                                   .map(pi -> {
+                                                                       pi.transitionWorkItem(workItemId,
+                                                                                             HumanTaskTransition.withoutModel(phase,
+                                                                                                                              policies(user,
+                                                                                                                                       groups)));
+                                                                       return pi.variables().toOutput();
+                                                                   })
+                                                                   .orElse(null));
     }
 
     @GetMapping(value = "/{id}/$taskName$/{workItemId}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public $TaskInput$ getTask(@PathVariable("id") String id, @PathVariable("workItemId") String workItemId,
+    public $TaskInput$ getTask(@PathVariable("id") String id,
+                               @PathVariable("workItemId") String workItemId,
                                @RequestParam(value = "user", required = false) final String user,
                                @RequestParam(value = "group", required = false) final List<String> groups) {
-        return process.instances().findById(id).map(pi ->  $TaskInput$.fromMap(pi.workItem(workItemId, policies(user, groups)))).orElse(null);
+        return process
+                      .instances()
+                      .findById(id)
+                      .map(pi -> $TaskInput$.from(pi.workItem(workItemId, policies(user, groups))))
+                      .orElse(null);
     }
 
     @GetMapping(value = "$taskName$/schema", produces = MediaType.APPLICATION_JSON)
@@ -61,8 +90,13 @@ public class $Type$Resource {
     }
 
     @GetMapping(value = "/{id}/$taskName$/{workItemId}/schema", produces = MediaType.APPLICATION_JSON)
-    public JsonSchema getSchemaAndPhases(@PathParam("id") final String id, @PathParam("workItemId") final String workItemId, @QueryParam("user") final String user, @QueryParam("group") final List<String> groups) {
-        return JsonSchemaUtil.addPhases(process, application, id, workItemId, policies(user, groups), JsonSchemaUtil.load(this.getClass().getClassLoader(), process.id(), "$taskName$"));
+    public JsonSchema getSchemaAndPhases(@PathParam("id") final String id,
+                                         @PathParam("workItemId") final String workItemId,
+                                         @QueryParam("user") final String user,
+                                         @QueryParam("group") final List<String> groups) {
+        return JsonSchemaUtil.addPhases(process, application, id, workItemId, policies(user, groups),
+                                        JsonSchemaUtil.load(this.getClass().getClassLoader(), process.id(),
+                                                            "$taskName$"));
     }
 
     @DeleteMapping(value = "/{id}/$taskName$/{workItemId}", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -71,9 +105,18 @@ public class $Type$Resource {
                                   @RequestParam(value = "phase", defaultValue = "abort") final String phase,
                                   @RequestParam(value = "user", required = false) final String user,
                                   @RequestParam(value = "group", required = false) final List<String> groups) {
-        return org.kie.kogito.services.uow.UnitOfWorkExecutor.executeInUnitOfWork(application.unitOfWorkManager(), () -> process.instances().findById(id).map(pi -> {
-            pi.transitionWorkItem(workItemId, org.jbpm.process.instance.impl.humantask.HumanTaskTransition.withoutModel(phase, policies(user, groups)));
-            return getModel(pi);
-        }).orElse(null));
+        return UnitOfWorkExecutor.executeInUnitOfWork(application.unitOfWorkManager(),
+                                                      () -> process
+                                                                   .instances()
+                                                                   .findById(id)
+                                                                   .map(
+                                                                        pi -> {
+                                                                            pi.transitionWorkItem(workItemId,
+                                                                                                  HumanTaskTransition.withoutModel(phase,
+                                                                                                                                   policies(user,
+                                                                                                                                            groups)));
+                                                                            return pi.variables().toOutput();
+                                                                        })
+                                                                   .orElse(null));
     }
 }


### PR DESCRIPTION
- Model interface extends MapOutput and MapInput interfaces
- xxxTaskOutput classes implements MapOutput (generated code does not
longer need to invoke toMap when building HumanTaskTransition)
- New methods toModel on InputModel and toOutput on Model
- Add chechError to ProcessInstance
- Modification on templates to use them (removing mapInput, mapOutput and
getModel)

