### PR TITLE
KOGITO-2973: Set default container images in TestResources

### DIFF
--- a/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/test/java/pom.xml
+++ b/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/test/java/pom.xml
@@ -122,9 +122,9 @@
                             <goal>verify</goal>
                         </goals>
                         <configuration>
-                            <systemProperties>
+                            <systemPropertyVariables>
                                 <container.image.infinispan>@container.image.infinispan@</container.image.infinispan>
-                            </systemProperties>
+                            </systemPropertyVariables>
                         </configuration>
                     </execution>
                 </executions>
@@ -178,9 +178,9 @@
                         <executions>
                             <execution>
                                 <configuration>
-                                    <systemProperties>
+                                    <systemPropertyVariables>
                                         <enable.resource.infinispan>true</enable.resource.infinispan>
-                                    </systemProperties>
+                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>

--- a/kogito-test-utils/src/main/java/org/kie/kogito/testcontainers/InfinispanContainer.java
+++ b/kogito-test-utils/src/main/java/org/kie/kogito/testcontainers/InfinispanContainer.java
@@ -33,6 +33,7 @@ public class InfinispanContainer extends GenericContainer<InfinispanContainer> i
     public static final String INFINISPAN_PROPERTY = "container.image." + NAME;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(InfinispanContainer.class);
+    private static final String DEFAULT_IMAGE = "quay.io/infinispan/server:11.0.1.Final";
 
     public InfinispanContainer() {
         addExposedPort(PORT);
@@ -40,7 +41,7 @@ public class InfinispanContainer extends GenericContainer<InfinispanContainer> i
         withEnv("PASS", "admin");
         withLogConsumer(new Slf4jLogConsumer(LOGGER));
         waitingFor(Wait.forLogMessage(".*ISPN080001.*", 1));
-        setDockerImageName(System.getProperty(INFINISPAN_PROPERTY));
+        setDockerImageName(System.getProperty(INFINISPAN_PROPERTY, DEFAULT_IMAGE));
     }
 
     @Override

--- a/kogito-test-utils/src/main/java/org/kie/kogito/testcontainers/KeycloakContainer.java
+++ b/kogito-test-utils/src/main/java/org/kie/kogito/testcontainers/KeycloakContainer.java
@@ -37,6 +37,7 @@ public class KeycloakContainer extends GenericContainer<KeycloakContainer> imple
 
     private static final String REALM_FILE = "/tmp/realm.json";
     private static final Logger LOGGER = LoggerFactory.getLogger(KeycloakContainer.class);
+    private static final String DEFAULT_IMAGE = "quay.io/keycloak/keycloak:11.0.0";
 
     public KeycloakContainer() {
         addExposedPort(PORT);
@@ -46,7 +47,7 @@ public class KeycloakContainer extends GenericContainer<KeycloakContainer> imple
         withClasspathResourceMapping("testcontainers/keycloak/kogito-realm.json", REALM_FILE, BindMode.READ_ONLY);
         withLogConsumer(new Slf4jLogConsumer(LOGGER));
         waitingFor(Wait.forHttp("/auth").withStartupTimeout(Duration.ofMinutes(5)));
-        setDockerImageName(System.getProperty(KEYCLOAK_PROPERTY));
+        setDockerImageName(System.getProperty(KEYCLOAK_PROPERTY, DEFAULT_IMAGE));
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,6 @@
     <version.org.eclipse.jdt>3.19.0</version.org.eclipse.jdt>
     <version.org.hamcrest>1.3</version.org.hamcrest> <!-- else old version coming from Mockito wins and breaks tests -->
     <version.org.infinispan>11.0.1.Final</version.org.infinispan>
-    <version.org.infinispan.image>11.0.1.Final</version.org.infinispan.image>
     <version.org.infinispan.protostream>4.3.3.Final</version.org.infinispan.protostream>
     <version.org.infinispan.starter>2.2.3.Final</version.org.infinispan.starter>
     <version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>1.0.1.Final</version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>
@@ -138,7 +137,7 @@
     <version.org.junit.jupiter>${version.org.junit}</version.org.junit.jupiter>
     <version.org.junit.vintage>${version.org.junit}</version.org.junit.vintage>
     <version.org.junit.platform>1.${version.org.junit.minor}</version.org.junit.platform> <!-- otherwise Quarkus brings its own, silently disabling some tests -->
-    <version.org.keycloak.image>11.0.0</version.org.keycloak.image>
+    <version.org.keycloak>11.0.0</version.org.keycloak>
     <version.org.mockito>3.3.3</version.org.mockito>
     <version.org.mvel>2.4.7.Final</version.org.mvel>
     <version.org.kie7>7.41.0.Final</version.org.kie7>
@@ -153,9 +152,9 @@
 
 
     <!-- container images for testing -->
-    <container.image.infinispan>quay.io/infinispan/server:${version.org.infinispan.image}</container.image.infinispan>
-    <container.image.keycloak.version>8.0.1</container.image.keycloak.version>
-    <container.image.keycloak>quay.io/keycloak/keycloak:${container.image.keycloak.version}</container.image.keycloak>
+    <!-- if the container image values change, please update the default images in the kogito-test-utils module as well -->
+    <container.image.infinispan>quay.io/infinispan/server:${version.org.infinispan}</container.image.infinispan>
+    <container.image.keycloak>quay.io/keycloak/keycloak:${version.org.keycloak}</container.image.keycloak>
   </properties>
   
   <!-- distributionManagement section -->


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/KOGITO-2973
Description: The images for containers are set at pom level. However, when running the tests via IDE, these images are not injected. This task is about to default the images.
When running the tests via maven, it won't make any change. But when running the tests via IDE, it will continue working as expected.

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket