### PR TITLE
KOGITO-1796: Triggering a node after cancelling a node instance is no…

### DIFF
--- a/integration-tests/integration-tests-quarkus/pom.xml
+++ b/integration-tests/integration-tests-quarkus/pom.xml
@@ -78,6 +78,11 @@
       <artifactId>kogito-test-utils</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <pluginManagement>

--- a/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcessInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcessInstance.java
@@ -170,7 +170,7 @@ public abstract class AbstractProcessInstance<T extends Model> implements Proces
             correlationKey = new StringCorrelationKey(businessKey);
         }
     }
-    
+
     public WorkflowProcessInstance internalGetProcessInstance() {
         return processInstance;
     }
@@ -188,10 +188,12 @@ public abstract class AbstractProcessInstance<T extends Model> implements Proces
         processInstance = null;
     }
 
+    @Override
     public void start() {
         start(null, null);
     }
 
+    @Override
     public void start(String trigger, String referenceId) {
         if (this.status != ProcessInstance.STATE_PENDING) {
             throw new IllegalStateException("Impossible to start process instance that already was started");
@@ -222,6 +224,7 @@ public abstract class AbstractProcessInstance<T extends Model> implements Proces
         ((InternalProcessRuntime) getProcessRuntime()).getUnitOfWorkManager().currentUnitOfWork().intercept(new ProcessInstanceWorkUnit(this, action));
     }
 
+    @Override
     public void abort() {
         String pid = processInstance().getId();
         unbind(variables, processInstance().getVariables());
@@ -318,7 +321,6 @@ public abstract class AbstractProcessInstance<T extends Model> implements Proces
             processInstance.setReferenceId(referenceId);
         }
         triggerNode(nodeId);
-        addToUnitOfWork(pi -> ((MutableProcessInstances<T>) process.instances()).update(pi.id(), pi));
         unbind(variables, processInstance.getVariables());
         if (processInstance != null) {
             this.status = processInstance.getState();
@@ -339,6 +341,8 @@ public abstract class AbstractProcessInstance<T extends Model> implements Proces
         NodeInstanceContainer nodeInstanceContainerNode = parentNode == null ? wfpi : ((NodeInstanceContainer) wfpi.getNodeInstance(parentNode));
 
         nodeInstanceContainerNode.getNodeInstance(node).trigger(null, org.jbpm.workflow.core.Node.CONNECTION_DEFAULT_TYPE);
+
+        addToUnitOfWork(pi -> ((MutableProcessInstances<T>) process.instances()).update(pi.id(), pi));
     }
 
     @Override
@@ -438,12 +442,12 @@ public abstract class AbstractProcessInstance<T extends Model> implements Proces
 
     @Override
     public Collection<Milestone> milestones() {
-        return ((WorkflowProcessInstance) processInstance).milestones();
+        return processInstance.milestones();
     }
 
     @Override
     public Collection<AdHocFragment> adHocFragments() {
-        return ((WorkflowProcessInstance) processInstance).adHocFragments();
+        return processInstance.adHocFragments();
     }
 
     protected void removeOnFinish() {


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/KOGITO-1796
Description: 
When starting a node, the status is not persisted. The solution here is to move the add the unit of work in the trigger method as this method is invoked from the startFrom and from the management console UI only.

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket