### PR TITLE
KOGITO-3055  Refactor Quarkus Extension

### DIFF
--- a/api/kogito-api/src/main/java/org/kie/api/io/ResourceType.java
+++ b/api/kogito-api/src/main/java/org/kie/api/io/ResourceType.java
@@ -83,9 +83,6 @@ public class ResourceType
 
         CACHE.put( resourceType, resource );
         resource.getAllExtensions().forEach( ext -> {
-            if (ext.contains( "." )) {
-                throw new IllegalArgumentException( "A resource extension cannot contain a dot. Found: " + ext );
-            }
             CACHE.put( "." + ext, resource );
         } );
         return resource;
@@ -264,6 +261,14 @@ public class ResourceType
                                                                      "src/main/resources",
                                                                      "feel");
 
+    /** Serverless Workflow language */
+    public static final ResourceType SW = addResourceTypeToRegistry("SW",
+                                                                      false,
+                                                                      "Serverless Workflow",
+                                                                      "src/main/resources",
+                                                                      "sw.yml", "sw.yaml", "sw.json");
+
+
     /** NO-Operation ResourceType - used for example to dynamically disable a given AssemblerService */
     public static final ResourceType NOOP = addResourceTypeToRegistry("NOOP",
                                                                       false,
@@ -281,8 +286,10 @@ public class ResourceType
     }
 
     public static ResourceType determineResourceType(final String resourceName) {
-        int dotPos = resourceName.lastIndexOf( '.' );
-        return dotPos < 0 ? null : CACHE.get( resourceName.substring( dotPos ) );
+        return CACHE.values().stream()
+                .filter(r -> r.matchesExtension(resourceName))
+                .findFirst()
+                .orElse(null);
     }
 
     public boolean matchesExtension(String resourceName) {

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionCodegen.java
@@ -22,6 +22,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
@@ -58,6 +59,7 @@ import org.kie.kogito.codegen.ConfigGenerator;
 import org.kie.kogito.codegen.GeneratedFile;
 import org.kie.kogito.codegen.decision.config.DecisionConfigGenerator;
 import org.kie.kogito.codegen.di.DependencyInjectionAnnotator;
+import org.kie.kogito.codegen.io.CollectedResource;
 import org.kie.kogito.grafana.GrafanaConfigurationWriter;
 
 import static java.util.stream.Collectors.toList;
@@ -70,6 +72,15 @@ public class DecisionCodegen extends AbstractGenerator {
 
     public static String STRONGLY_TYPED_CONFIGURATION_KEY = "kogito.decisions.stronglytyped";
 
+    public static DecisionCodegen ofCollectedResources(Collection<CollectedResource> resources) {
+        List<DMNResource> dmnResources = resources.stream()
+                .filter(r -> r.resource().getResourceType() == ResourceType.DMN)
+                .flatMap(r -> parseDecisions(r.basePath(), Collections.singletonList(r.resource())).stream())
+                .collect(toList());
+        return ofDecisions(dmnResources);
+    }
+
+    @Deprecated
     public static DecisionCodegen ofJar(Path... jarPaths) throws IOException {
         List<DMNResource> dmnResources = new ArrayList<>();
 

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/io/CollectedResource.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/io/CollectedResource.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.kogito.codegen.io;
 
 import java.io.IOException;

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/io/CollectedResource.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/io/CollectedResource.java
@@ -35,8 +35,15 @@ import org.kie.api.io.ResourceType;
 import static org.drools.core.util.IoUtils.readBytesFromInputStream;
 import static org.kie.api.io.ResourceType.determineResourceType;
 
+/**
+ * A (Path basePath, Resource resource) pair
+ */
 public class CollectedResource {
 
+    /**
+     * Returns a collection of CollectedResource from the given paths.
+     * If a path is a jar, then walks inside the jar.
+     */
     public static Collection<CollectedResource> fromPaths(Path... paths) {
         Collection<CollectedResource> resources = new ArrayList<>();
 
@@ -55,6 +62,9 @@ public class CollectedResource {
         return resources;
     }
 
+    /**
+     * Returns a collection of CollectedResource from the given jar file.
+     */
     public static Collection<CollectedResource> fromJarFile(Path jarPath) {
         Collection<CollectedResource> resources = new ArrayList<>();
         try (ZipFile zipFile = new ZipFile(jarPath.toFile())) {
@@ -76,6 +86,9 @@ public class CollectedResource {
         }
     }
 
+    /**
+     * Returns a collection of CollectedResource from the given directory.
+     */
     public static Collection<CollectedResource> fromDirectory(Path path) {
         Collection<CollectedResource> resources = new ArrayList<>();
         try {

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/io/CollectedResource.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/io/CollectedResource.java
@@ -1,0 +1,91 @@
+package org.kie.kogito.codegen.io;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import org.drools.core.io.impl.ByteArrayResource;
+import org.drools.core.io.impl.FileSystemResource;
+import org.drools.core.io.internal.InternalResource;
+import org.kie.api.io.Resource;
+import org.kie.api.io.ResourceType;
+
+import static org.drools.core.util.IoUtils.readBytesFromInputStream;
+import static org.kie.api.io.ResourceType.determineResourceType;
+
+public class CollectedResource {
+
+    public static Collection<CollectedResource> fromPaths(Path... paths) {
+        Collection<CollectedResource> resources = new ArrayList<>();
+
+        for (Path path : paths) {
+            if (path.toFile().isDirectory()) {
+                Collection<CollectedResource> res = fromDirectory(path);
+                resources.addAll(res);
+            } else if (path.getFileName().toString().endsWith(".jar")) {
+                Collection<CollectedResource> res = fromJarFile(path);
+                resources.addAll(res);
+            } else {
+                throw new IllegalArgumentException("Expected directory or archive, file given: " + path);
+            }
+        }
+
+        return resources;
+    }
+
+    public static Collection<CollectedResource> fromJarFile(Path jarPath) {
+        Collection<CollectedResource> resources = new ArrayList<>();
+        try (ZipFile zipFile = new ZipFile(jarPath.toFile())) {
+            Enumeration<? extends ZipEntry> entries = zipFile.entries();
+            while (entries.hasMoreElements()) {
+                ZipEntry entry = entries.nextElement();
+                ResourceType resourceType = determineResourceType(entry.getName());
+                if (resourceType != null) {
+                    InternalResource resource = new ByteArrayResource(readBytesFromInputStream(zipFile.getInputStream(entry)));
+                    resource.setResourceType(resourceType);
+                    resource.setSourcePath(entry.getName());
+                    CollectedResource collectedResource = new CollectedResource(jarPath, resource);
+                    resources.add(collectedResource);
+                }
+            }
+            return resources;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public static Collection<CollectedResource> fromDirectory(Path path) {
+        Collection<CollectedResource> resources = new ArrayList<>();
+        try {
+            Files.walk(path).map(Path::toFile)
+                    .map(f -> new FileSystemResource(f).setResourceType(determineResourceType(f.getName())))
+                    .map(f -> new CollectedResource(path, f))
+                    .forEach(resources::add);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return resources;
+    }
+
+    private final Path basePath;
+    private final Resource resource;
+
+    public CollectedResource(Path basePath, Resource resource) {
+        this.basePath = basePath;
+        this.resource = resource;
+    }
+
+    public Path basePath() {
+        return basePath;
+    }
+
+    public Resource resource() {
+        return resource;
+    }
+}

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/io/CollectedResource.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/io/CollectedResource.java
@@ -51,7 +51,7 @@ public class CollectedResource {
             if (path.toFile().isDirectory()) {
                 Collection<CollectedResource> res = fromDirectory(path);
                 resources.addAll(res);
-            } else if (path.getFileName().toString().endsWith(".jar")) {
+            } else if (path.getFileName().toString().endsWith(".jar") || path.getFileName().toString().endsWith(".jar.original")) {
                 Collection<CollectedResource> res = fromJarFile(path);
                 resources.addAll(res);
             } else {

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/prediction/PredictionCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/prediction/PredictionCodegen.java
@@ -22,6 +22,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
@@ -54,6 +55,7 @@ import org.kie.kogito.codegen.ConfigGenerator;
 import org.kie.kogito.codegen.GeneratedFile;
 import org.kie.kogito.codegen.KogitoPackageSources;
 import org.kie.kogito.codegen.di.DependencyInjectionAnnotator;
+import org.kie.kogito.codegen.io.CollectedResource;
 import org.kie.kogito.codegen.prediction.config.PredictionConfigGenerator;
 import org.kie.kogito.codegen.rules.RuleCodegenError;
 import org.kie.pmml.commons.model.HasSourcesMap;
@@ -84,6 +86,14 @@ public class PredictionCodegen extends AbstractGenerator {
         // set default package name
         setPackageName(ApplicationGenerator.DEFAULT_PACKAGE_NAME);
         this.moduleGenerator = new PredictionContainerGenerator(applicationCanonicalName, resources);
+    }
+
+    public static PredictionCodegen ofCollectedResources(Collection<CollectedResource> resources) {
+        List<PMMLResource> dmnResources = resources.stream()
+                .filter(r -> r.resource().getResourceType() == ResourceType.PMML)
+                .flatMap(r -> parsePredictions(r.basePath(), Collections.singletonList(r.resource())).stream())
+                .collect(toList());
+        return ofPredictions(dmnResources);
     }
 
     public static PredictionCodegen ofJar(Path... jarPaths) throws IOException {

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
@@ -69,6 +69,7 @@ import org.kie.kogito.codegen.ConfigGenerator;
 import org.kie.kogito.codegen.GeneratorContext;
 import org.kie.kogito.codegen.KogitoPackageSources;
 import org.kie.kogito.codegen.di.DependencyInjectionAnnotator;
+import org.kie.kogito.codegen.io.CollectedResource;
 import org.kie.kogito.codegen.rules.config.NamedRuleUnitConfig;
 import org.kie.kogito.codegen.rules.config.RuleConfigGenerator;
 import org.kie.kogito.conf.ClockType;
@@ -88,6 +89,14 @@ import static org.kie.kogito.codegen.ApplicationGenerator.log;
 import static org.kie.kogito.codegen.ApplicationGenerator.logger;
 
 public class IncrementalRuleCodegen extends AbstractGenerator {
+
+    public static IncrementalRuleCodegen ofCollectedResources(Collection<CollectedResource> resources) {
+        List<Resource> dmnResources = resources.stream()
+                .map(CollectedResource::resource)
+                .filter(IncrementalRuleCodegen::isSupportedResourceType)
+                .collect(toList());
+        return ofResources(dmnResources);
+    }
 
     public static IncrementalRuleCodegen ofJar(Path... jarPaths) {
         Collection<Resource> resources = new ArrayList<>();
@@ -158,6 +167,15 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
 
     private static Set<Resource> toResources(Stream<File> files) {
         return files.map(FileSystemResource::new).peek(r -> r.setResourceType(typeOf(r))).filter(r -> r.getResourceType() != null).collect(Collectors.toSet());
+    }
+
+    private static boolean isSupportedResourceType(Resource r) {
+        for (ResourceType rt : resourceTypes) {
+            if (r.getResourceType() == rt) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static ResourceType typeOf(FileSystemResource r) {

--- a/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/AppPaths.java
+++ b/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/AppPaths.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.kogito.quarkus.deployment;
 
 import java.io.File;

--- a/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/AppPaths.java
+++ b/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/AppPaths.java
@@ -45,7 +45,6 @@ class AppPaths {
 
     final Set<Path> projectPaths = new LinkedHashSet<>();
     final List<Path> classesPaths = new ArrayList<>();
-    Path[] decompressedPaths;
 
     boolean isJar = false;
 
@@ -76,21 +75,6 @@ class AppPaths {
             }
         }
 
-        if (isJar) {
-            logger.warn("Got JAR: decompressing to a temporary directory for codegen");
-            Path[] jarPaths = getJarPath();
-            this.decompressedPaths = new Path[jarPaths.length];
-            try {
-                for (int i = 0, jarPathsLength = jarPaths.length; i < jarPathsLength; i++) {
-                    Path jarPath = jarPaths[i];
-                    Path tmp = Files.createTempDirectory(jarPath.getFileName().toString());
-                    unzipJar(jarPath, tmp);
-                    decompressedPaths[i] = tmp;
-                }
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
-        }
     }
 
     public Path[] getPath() {
@@ -98,33 +82,6 @@ class AppPaths {
             return getJarPath();
         } else {
             return getResourcePaths();
-        }
-    }
-
-    public static void unzipJar(Path jarPath, Path destinationDir) throws IOException {
-        File file = jarPath.toFile();
-        JarFile jar = new JarFile(file);
-        for (Enumeration<JarEntry> enums = jar.entries(); enums.hasMoreElements(); ) {
-            JarEntry entry = enums.nextElement();
-            String fileName = destinationDir + File.separator + entry.getName();
-            File f = new File(fileName);
-            if (fileName.endsWith("/")) {
-                f.mkdirs();
-            }
-        }
-        for (Enumeration<JarEntry> enums = jar.entries(); enums.hasMoreElements(); ) {
-            JarEntry entry = enums.nextElement();
-            String fileName = destinationDir + File.separator + entry.getName();
-            File f = new File(fileName);
-            if (!fileName.endsWith("/")) {
-                InputStream is = jar.getInputStream(entry);
-                FileOutputStream fos = new FileOutputStream(f);
-                while (is.available() > 0) {
-                    fos.write(is.read());
-                }
-                fos.close();
-                is.close();
-            }
         }
     }
 

--- a/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/GeneratedFileWriter.java
+++ b/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/GeneratedFileWriter.java
@@ -1,0 +1,89 @@
+package org.kie.kogito.quarkus.deployment;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+
+import org.kie.kogito.codegen.GeneratedFile;
+
+public class GeneratedFileWriter {
+
+    public static class Builder {
+
+        private final String classesDir;
+        private final String sourcesDir;
+        private final String resourcePath;
+        private final String scaffoldedSourcesDir;
+
+        public Builder(String classesDir, String sourcesDir, String resourcesDir, String scaffoldedSourcesDir) {
+            this.classesDir = classesDir;
+            this.sourcesDir = sourcesDir;
+            this.resourcePath = resourcesDir;
+            this.scaffoldedSourcesDir = scaffoldedSourcesDir;
+        }
+
+        public GeneratedFileWriter build(Path basePath) {
+            return new GeneratedFileWriter(
+                    basePath.resolve(classesDir),
+                    basePath.resolve(sourcesDir),
+                    basePath.resolve(resourcePath),
+                    basePath.resolve(scaffoldedSourcesDir));
+        }
+    }
+
+    private final Path classesDir;
+    private final Path sourcesDir;
+    private final Path resourcePath;
+    private final Path scaffoldedSourcesDir;
+
+    public GeneratedFileWriter(Path classesDir, Path sourcesDir, Path resourcePath, Path scaffoldedSourcesDir) {
+        this.classesDir = classesDir;
+        this.sourcesDir = sourcesDir;
+        this.resourcePath = resourcePath;
+        this.scaffoldedSourcesDir = scaffoldedSourcesDir;
+    }
+
+    public void writeAll(Collection<GeneratedFile> generatedFiles) {
+        generatedFiles.forEach(this::write);
+    }
+
+    public void write(GeneratedFile f) throws UncheckedIOException {
+        try {
+            GeneratedFile.Type type = f.getType();
+            switch (type) {
+                case RESOURCE:
+                    writeGeneratedFile(f, resourcePath);
+                    break;
+                case GENERATED_CP_RESOURCE:
+                    writeGeneratedFile(f, classesDir);
+                    break;
+                default:
+                    if (type.isCustomizable()) {
+                        writeGeneratedFile(f, scaffoldedSourcesDir);
+                    } else {
+                        writeGeneratedFile(f, sourcesDir);
+                    }
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private void writeGeneratedFile(GeneratedFile f, Path location) throws IOException {
+        if (location == null) {
+            return;
+        }
+        String generatedClassFile = f.relativePath().replace("src/main/java", "");
+        Files.write(
+                pathOf(location, generatedClassFile),
+                f.contents());
+    }
+
+    private Path pathOf(Path location, String end) {
+        Path path = location.resolve(end);
+        path.getParent().toFile().mkdirs();
+        return path;
+    }
+}

--- a/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/GeneratedFileWriter.java
+++ b/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/GeneratedFileWriter.java
@@ -24,6 +24,10 @@ import java.util.Collection;
 
 import org.kie.kogito.codegen.GeneratedFile;
 
+/**
+ * Writes {@link GeneratedFile} to the right directory, depending on its
+ * {@link GeneratedFile.Type}
+ */
 public class GeneratedFileWriter {
 
     public static class Builder {
@@ -33,6 +37,13 @@ public class GeneratedFileWriter {
         private final String resourcePath;
         private final String scaffoldedSourcesDir;
 
+        /**
+         *
+         * @param classesDir usually target/classes/
+         * @param sourcesDir usually target/generated-sources/kogito/
+         * @param resourcesDir usually target/generated-resources/kogito/
+         * @param scaffoldedSourcesDir usually src/main/java/
+         */
         public Builder(String classesDir, String sourcesDir, String resourcesDir, String scaffoldedSourcesDir) {
             this.classesDir = classesDir;
             this.sourcesDir = sourcesDir;
@@ -40,6 +51,11 @@ public class GeneratedFileWriter {
             this.scaffoldedSourcesDir = scaffoldedSourcesDir;
         }
 
+        /**
+         * @param basePath the path to which the given subdirectories will be written
+         *                 e.g. ${basePath}/${classesDir}/myfile.ext
+         *
+         */
         public GeneratedFileWriter build(Path basePath) {
             return new GeneratedFileWriter(
                     basePath.resolve(classesDir),
@@ -54,6 +70,13 @@ public class GeneratedFileWriter {
     private final Path resourcePath;
     private final Path scaffoldedSourcesDir;
 
+    /**
+     *
+     * @param classesDir usually target/classes/
+     * @param sourcesDir usually target/generated-sources/kogito/
+     * @param resourcePath usually target/generated-resources/kogito/
+     * @param scaffoldedSourcesDir usually src/main/java/
+     */
     public GeneratedFileWriter(Path classesDir, Path sourcesDir, Path resourcePath, Path scaffoldedSourcesDir) {
         this.classesDir = classesDir;
         this.sourcesDir = sourcesDir;
@@ -91,6 +114,7 @@ public class GeneratedFileWriter {
         if (location == null) {
             return;
         }
+        // verify if this is still needed https://issues.redhat.com/browse/KOGITO-3085
         String generatedClassFile = f.relativePath().replace("src/main/java", "");
         Files.write(
                 pathOf(location, generatedClassFile),

--- a/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/GeneratedFileWriter.java
+++ b/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/GeneratedFileWriter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.kogito.quarkus.deployment;
 
 import java.io.IOException;

--- a/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/InMemoryCompiler.java
+++ b/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/InMemoryCompiler.java
@@ -32,6 +32,10 @@ import org.kie.kogito.codegen.GeneratedFile;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * A instance of a Java compiler with a given classpath,
+ * default flags, and its target directories.
+ */
 public class InMemoryCompiler {
 
     private static final Logger logger = LoggerFactory.getLogger(KogitoAssetsProcessor.class);
@@ -55,12 +59,17 @@ public class InMemoryCompiler {
         }
     }
 
+    /**
+     * Compiles the given {@link GeneratedFile}s and returns the compilation results.
+     * It throws an {@link IllegalStateException} if there are errors.
+     */
     CompilationResult compile(Collection<GeneratedFile> generatedFiles) {
         MemoryFileSystem srcMfs = new MemoryFileSystem();
 
         String[] sources = new String[generatedFiles.size()];
         int index = 0;
         for (GeneratedFile entry : generatedFiles) {
+            // verify if this is still needed https://issues.redhat.com/browse/KOGITO-3085
             String generatedClassFile = entry.relativePath().replace("src/main/java/", "");
             String fileName = toRuntimeSource(toClassName(generatedClassFile));
             sources[index++] = fileName;
@@ -89,6 +98,9 @@ public class InMemoryCompiler {
         return result;
     }
 
+    /**
+     * @return the MemoryFileSystem where class files have been generated
+     */
     public MemoryFileSystem getTargetFileSystem() {
         return trgMfs;
     }
@@ -106,6 +118,7 @@ public class InMemoryCompiler {
     }
 
     private String toRuntimeSource(String className) {
+        // verify if this is still needed https://issues.redhat.com/browse/KOGITO-3085
         return "src/main/java/" + className.replace('.', '/') + ".java";
     }
 }

--- a/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/InMemoryCompiler.java
+++ b/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/InMemoryCompiler.java
@@ -1,0 +1,95 @@
+package org.kie.kogito.quarkus.deployment;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import io.quarkus.bootstrap.model.AppDependency;
+import org.drools.compiler.commons.jci.compilers.CompilationResult;
+import org.drools.compiler.commons.jci.compilers.JavaCompiler;
+import org.drools.compiler.commons.jci.compilers.JavaCompilerSettings;
+import org.drools.compiler.compiler.io.memory.MemoryFileSystem;
+import org.drools.modelcompiler.builder.JavaParserCompiler;
+import org.kie.internal.jci.CompilationProblem;
+import org.kie.kogito.codegen.GeneratedFile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class InMemoryCompiler {
+
+    private static final Logger logger = LoggerFactory.getLogger(KogitoAssetsProcessor.class);
+
+
+    private final JavaCompiler javaCompiler;
+    private final JavaCompilerSettings compilerSettings;
+    private final MemoryFileSystem trgMfs = new MemoryFileSystem();
+
+    InMemoryCompiler(
+            List<Path> classesPaths,
+            List<AppDependency> userDependencies) {
+        javaCompiler = JavaParserCompiler.getCompiler();
+        compilerSettings = javaCompiler.createDefaultSettings();
+        compilerSettings.addOption("-proc:none"); // force disable annotation processing
+        for (Path classPath : classesPaths) {
+            compilerSettings.addClasspath(classPath.toString());
+        }
+        for (AppDependency i : userDependencies) {
+            compilerSettings.addClasspath(i.getArtifact().getPaths().getSinglePath().toAbsolutePath().toString());
+        }
+    }
+
+    CompilationResult compile(Collection<GeneratedFile> generatedFiles) {
+        MemoryFileSystem srcMfs = new MemoryFileSystem();
+
+        String[] sources = new String[generatedFiles.size()];
+        int index = 0;
+        for (GeneratedFile entry : generatedFiles) {
+            String generatedClassFile = entry.relativePath().replace("src/main/java/", "");
+            String fileName = toRuntimeSource(toClassName(generatedClassFile));
+            sources[index++] = fileName;
+
+            srcMfs.write(fileName, entry.contents());
+        }
+
+        CompilationResult result = javaCompiler.compile(
+                sources,
+                srcMfs,
+                trgMfs,
+                Thread.currentThread().getContextClassLoader(),
+                compilerSettings);
+
+        if (result.getErrors().length > 0) {
+            StringBuilder errorInfo = new StringBuilder();
+            for (CompilationProblem compilationProblem : result.getErrors()) {
+                errorInfo.append(compilationProblem.toString());
+                errorInfo.append("\n");
+                logger.error(compilationProblem.toString());
+            }
+            Arrays.stream(result.getErrors()).forEach(cp -> errorInfo.append(cp.toString()));
+            throw new IllegalStateException(errorInfo.toString());
+        }
+
+        return result;
+    }
+
+    public MemoryFileSystem getTargetFileSystem() {
+        return trgMfs;
+    }
+
+    private String toClassName(String sourceName) {
+        if (sourceName.startsWith("./")) {
+            sourceName = sourceName.substring(2);
+        }
+        if (sourceName.endsWith(".java")) {
+            sourceName = sourceName.substring(0, sourceName.length() - 5);
+        } else if (sourceName.endsWith(".class")) {
+            sourceName = sourceName.substring(0, sourceName.length() - 6);
+        }
+        return sourceName.replace('/', '.');
+    }
+
+    private String toRuntimeSource(String className) {
+        return "src/main/java/" + className.replace('.', '/') + ".java";
+    }
+}

--- a/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/InMemoryCompiler.java
+++ b/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/InMemoryCompiler.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.kogito.quarkus.deployment;
 
 import java.nio.file.Path;

--- a/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/KogitoAssetsProcessor.java
+++ b/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/KogitoAssetsProcessor.java
@@ -1,10 +1,23 @@
 package org.kie.kogito.quarkus.deployment;
 
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
 import io.quarkus.arc.deployment.GeneratedBeanBuildItem;
-import io.quarkus.bootstrap.BootstrapDependencyProcessingException;
-import io.quarkus.bootstrap.model.AppDependency;
-import io.quarkus.bootstrap.model.AppModel;
-import io.quarkus.bootstrap.model.PathsCollection;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.ArchiveRootBuildItem;
@@ -12,7 +25,6 @@ import io.quarkus.deployment.builditem.CapabilityBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
-import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.LiveReloadBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
@@ -20,16 +32,10 @@ import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyIgnoreWarn
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.deployment.index.IndexingUtil;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
-import io.quarkus.runtime.LaunchMode;
 import org.drools.compiler.builder.impl.KogitoKieModuleModelImpl;
-import org.drools.compiler.commons.jci.compilers.CompilationResult;
-import org.drools.compiler.commons.jci.compilers.JavaCompiler;
-import org.drools.compiler.commons.jci.compilers.JavaCompilerSettings;
 import org.drools.compiler.compiler.io.memory.MemoryFileSystem;
 import org.drools.core.base.ClassFieldAccessorFactory;
-import org.drools.modelcompiler.builder.JavaParserCompiler;
 import org.jboss.jandex.AnnotationInstance;
-import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.CompositeIndex;
 import org.jboss.jandex.DotName;
@@ -39,7 +45,6 @@ import org.jboss.jandex.Indexer;
 import org.jboss.jandex.MethodInfo;
 import org.jbpm.util.JsonSchemaUtil;
 import org.kie.api.builder.model.KieModuleModel;
-import org.kie.internal.jci.CompilationProblem;
 import org.kie.internal.kogito.codegen.Generated;
 import org.kie.internal.kogito.codegen.VariableInfo;
 import org.kie.kogito.Model;
@@ -52,6 +57,7 @@ import org.kie.kogito.codegen.JsonSchemaGenerator;
 import org.kie.kogito.codegen.context.QuarkusKogitoBuildContext;
 import org.kie.kogito.codegen.decision.DecisionCodegen;
 import org.kie.kogito.codegen.di.CDIDependencyInjectionAnnotator;
+import org.kie.kogito.codegen.io.CollectedResource;
 import org.kie.kogito.codegen.prediction.PredictionCodegen;
 import org.kie.kogito.codegen.process.ProcessCodegen;
 import org.kie.kogito.codegen.process.persistence.PersistenceGenerator;
@@ -59,34 +65,42 @@ import org.kie.kogito.codegen.rules.IncrementalRuleCodegen;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.function.BiFunction;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
 public class KogitoAssetsProcessor {
 
-    private static final String generatedResourcesDir = System.getProperty("kogito.codegen.resources.directory", "target/generated-resources/kogito/");
-    private static final String generatedSourcesDir = "target/generated-sources/kogito/";
-    private static final String generatedCustomizableSourcesDir = System.getProperty("kogito.codegen.sources.directory", "target/generated-sources/kogito/");
     private static final Logger logger = LoggerFactory.getLogger(KogitoAssetsProcessor.class);
-    private final transient String appPackageName = "org.kie.kogito.app";
-    private final transient String persistenceFactoryClass = "org.kie.kogito.persistence.KogitoProcessInstancesFactory";
-    private final transient String metricsClass = "org.kie.kogito.monitoring.rest.MetricsResource";
-    private final transient String tracingClass = "org.kie.kogito.tracing.decision.DecisionTracingListener";
-    private final transient String knativeEventingClass = "org.kie.kogito.events.knative.ce.http.HttpRequestConverter";
+
+    public static final String targetClassesDir = "target/classes";
+
+    // since quarkus-maven-plugin is later phase of maven-resources-plugin,
+    // need to manually late-provide the resource in the expected location for quarkus:dev phase --so not: writeGeneratedFile( f, resourcePath );
+    private static final GeneratedFileWriter.Builder generatedFileWriterBuilder =
+            new GeneratedFileWriter.Builder(
+                    targetClassesDir,
+                    System.getProperty("kogito.codegen.sources.directory", "target/generated-sources/kogito/"),
+                    System.getProperty("kogito.codegen.resources.directory", "target/generated-resources/kogito/"),
+                    "target/generated-sources/kogito/");
+
+    private static final String appPackageName = "org.kie.kogito.app";
+    private static final DotName persistenceFactoryClass = DotName.createSimple("org.kie.kogito.persistence.KogitoProcessInstancesFactory");
+    private static final DotName metricsClass = DotName.createSimple("org.kie.kogito.monitoring.rest.MetricsResource");
+    private static final DotName tracingClass = DotName.createSimple("org.kie.kogito.tracing.decision.DecisionTracingListener");
+
+    @Inject
+    ArchiveRootBuildItem root;
+    @Inject
+    LiveReloadBuildItem liveReload;
+    @Inject
+    CurateOutcomeBuildItem curateOutcomeBuildItem;
+    @Inject
+    CombinedIndexBuildItem combinedIndexBuildItem;
+    @Inject
+    BuildProducer<GeneratedBeanBuildItem> generatedBeans;
+    @Inject
+    BuildProducer<NativeImageResourceBuildItem> resource;
+    @Inject
+    BuildProducer<ReflectiveClassBuildItem> reflectiveClass;
+    @Inject
+    BuildProducer<GeneratedResourceBuildItem> genResBI;
 
     @BuildStep
     CapabilityBuildItem capability() {
@@ -98,16 +112,125 @@ public class KogitoAssetsProcessor {
         return new FeatureBuildItem("kogito");
     }
 
-    private void generatePersistenceInfo(AppPaths appPaths,
-                                         BuildProducer<GeneratedBeanBuildItem> generatedBeans,
-                                         IndexView index,
-                                         LaunchModeBuildItem launchMode,
-                                         BuildProducer<NativeImageResourceBuildItem> resource,
-                                         CurateOutcomeBuildItem curateOutcomeBuildItem) throws IOException, BootstrapDependencyProcessingException {
+    @BuildStep
+    public void generateModel() throws IOException {
+
+        if (liveReload.isLiveReload()) {
+            return;
+        }
+
+        AppPaths appPaths = new AppPaths(root.getPaths());
+
+        boolean usePersistence = combinedIndexBuildItem.getIndex()
+                .getClassByName(persistenceFactoryClass) != null;
+        boolean useMonitoring = combinedIndexBuildItem.getIndex()
+                .getClassByName(metricsClass) != null;
+        boolean useTracing = !combinedIndexBuildItem.getIndex()
+                .getAllKnownSubclasses(tracingClass).isEmpty();
+
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        GeneratorContext context = buildContext(appPaths, combinedIndexBuildItem.getIndex());
+        AddonsConfig addonsConfig = new AddonsConfig()
+                .withPersistence(usePersistence)
+                .withMonitoring(useMonitoring)
+                .withTracing(useTracing);
+
+        Path[] paths = appPaths.getPath();
+
+        // configure the application generator
+
+        ApplicationGenerator appGen =
+                new ApplicationGenerator(
+                        appPackageName,
+                        new File(appPaths.getFirstProjectPath().toFile(), "target"))
+                        .withDependencyInjection(new CDIDependencyInjectionAnnotator())
+                        .withAddons(addonsConfig)
+                        .withGeneratorContext(context);
+
+        appGen.withGenerator(ProcessCodegen.ofCollectedResources(CollectedResource.fromPaths(paths)))
+                .withAddons(addonsConfig)
+                .withClassLoader(classLoader);
+
+        appGen.withGenerator(IncrementalRuleCodegen.ofCollectedResources(CollectedResource.fromPaths(paths)))
+                .withKModule(findKieModuleModel(appPaths))
+                .withAddons(addonsConfig)
+                .withClassLoader(classLoader);
+
+        appGen.withGenerator(PredictionCodegen.ofCollectedResources(CollectedResource.fromPaths(paths)))
+                .withAddons(addonsConfig);
+
+        appGen.withGenerator(DecisionCodegen.ofCollectedResources(CollectedResource.fromPaths(paths)))
+                .withAddons(addonsConfig);
+
+        // invoke the generation procedure
+        Collection<GeneratedFile> generatedFiles = appGen.generate();
+
+        for (Path projectPath : appPaths.projectPaths) {
+            generatedFileWriterBuilder
+                    .build(projectPath)
+                    .writeAll(generatedFiles);
+        }
+
+        registerResources(generatedFiles);
+
+        Index index = processGeneratedJavaSourceCode(
+                appPaths,
+                generatedFiles);
+
+        if (index == null) {
+            return;
+        }
+
+        generatePersistenceInfo(appPaths, index);
+
+        registerDataEventsForReflection(index);
+
+        writeJsonSchema(appPaths, index);
+    }
+
+    private void registerResources(Collection<GeneratedFile> generatedFiles) {
+        for (GeneratedFile f : generatedFiles) {
+            if (f.getType() == GeneratedFile.Type.GENERATED_CP_RESOURCE) {
+                genResBI.produce(new GeneratedResourceBuildItem(f.relativePath(), f.contents()));
+                resource.produce(new NativeImageResourceBuildItem(f.relativePath()));
+            }
+        }
+    }
+
+    private Index processGeneratedJavaSourceCode(
+            AppPaths appPaths,
+            Collection<GeneratedFile> generatedFiles) throws IOException {
+
+        // we are currently filtering on file extension,
+        // but we should tag GeneratedFile properly
+        Collection<GeneratedFile> javaFiles =
+                generatedFiles.stream()
+                        .filter(f -> f.relativePath().endsWith(".java"))
+                        .collect(Collectors.toList());
+
+        if (javaFiles.isEmpty()) {
+            return null;
+        }
+
+        InMemoryCompiler inMemoryCompiler = new InMemoryCompiler(
+                appPaths.classesPaths,
+                curateOutcomeBuildItem.getEffectiveModel().getUserDependencies());
+        inMemoryCompiler.compile(javaFiles);
+
+        MemoryFileSystem trgMfs = inMemoryCompiler.getTargetFileSystem();
+        Collection<GeneratedBeanBuildItem> generatedBeanBuildItems = makeBuildItems(appPaths, trgMfs);
+        generatedBeanBuildItems.forEach(generatedBeans::produce);
+        return indexBuildItems(generatedBeanBuildItems);
+    }
+
+    private void generatePersistenceInfo(AppPaths appPaths, IndexView inputIndex) throws IOException {
+
+        CompositeIndex index = CompositeIndex.create(combinedIndexBuildItem.getIndex(), inputIndex);
 
         ClassInfo persistenceClass = index
-                .getClassByName(createDotName(persistenceFactoryClass));
+                .getClassByName(persistenceFactoryClass);
         boolean usePersistence = persistenceClass != null;
+
         List<String> parameters = new ArrayList<>();
         if (usePersistence) {
             for (MethodInfo mi : persistenceClass.methods()) {
@@ -118,12 +241,17 @@ public class KogitoAssetsProcessor {
             }
         }
 
-        Collection<GeneratedFile> generatedFiles = getGeneratedPersistenceFiles(appPaths, index, usePersistence, parameters);
+        Collection<GeneratedFile> generatedFiles = getGeneratedPersistenceFiles(
+                appPaths, index, usePersistence, parameters);
 
         if (!generatedFiles.isEmpty()) {
             MemoryFileSystem trgMfs = new MemoryFileSystem();
-            CompilationResult result = compile(appPaths, trgMfs, curateOutcomeBuildItem.getEffectiveModel(), generatedFiles, launchMode.getLaunchMode());
-            register(appPaths, trgMfs, generatedBeans, GeneratedBeanBuildItem::new, launchMode.getLaunchMode(), result);
+            InMemoryCompiler inMemoryCompiler = new InMemoryCompiler(
+                    appPaths.classesPaths,
+                    curateOutcomeBuildItem.getEffectiveModel().getUserDependencies());
+            inMemoryCompiler.compile(generatedFiles);
+            Collection<GeneratedBeanBuildItem> generatedBeanBuildItems = makeBuildItems(appPaths, trgMfs);
+            generatedBeanBuildItems.forEach(generatedBeans::produce);
         }
 
         if (usePersistence) {
@@ -131,33 +259,65 @@ public class KogitoAssetsProcessor {
         }
     }
 
-    private Collection<GeneratedFile> getGeneratedPersistenceFiles(AppPaths appPaths, IndexView index, boolean usePersistence, List<String> parameters) {
+    private Collection<GeneratedFile> getGeneratedPersistenceFiles(
+            AppPaths appPaths,
+            IndexView index,
+            boolean usePersistence,
+            List<String> parameters) {
         GeneratorContext context = buildContext(appPaths, index);
 
+        JandexProtoGenerator jandexProtoGenerator =
+                new JandexProtoGenerator(
+                        index,
+                        DotName.createSimple(Generated.class.getCanonicalName()),
+                        DotName.createSimple(VariableInfo.class.getCanonicalName()));
         Collection<ClassInfo> modelClasses = index
-                .getAllKnownImplementors(createDotName(Model.class.getCanonicalName()));
+                .getAllKnownImplementors(DotName.createSimple(Model.class.getCanonicalName()));
 
         Collection<GeneratedFile> generatedFiles = new ArrayList<>();
 
         for (Path projectPath : appPaths.projectPaths) {
-            PersistenceGenerator persistenceGenerator = new PersistenceGenerator( new File( projectPath.toFile(), "target" ),
-                                                                                  modelClasses, usePersistence,
-                                                                                  new JandexProtoGenerator( index, createDotName( Generated.class.getCanonicalName() ),
-                                                                                                            createDotName( VariableInfo.class.getCanonicalName() ) ),
-                                                                                  parameters );
-            persistenceGenerator.setDependencyInjection( new CDIDependencyInjectionAnnotator() );
-            persistenceGenerator.setPackageName( appPackageName );
-            persistenceGenerator.setContext( context );
+            PersistenceGenerator persistenceGenerator =
+                    makePersistenceGenerator(
+                            usePersistence,
+                            parameters,
+                            context,
+                            modelClasses,
+                            jandexProtoGenerator,
+                            projectPath);
 
             generatedFiles.addAll(persistenceGenerator.generate());
         }
         return generatedFiles;
     }
 
-    private Collection<GeneratedFile> getJsonSchemaFiles(Index index, MemoryFileSystem trgMfs) throws IOException {
-        MemoryClassLoader cl = new MemoryClassLoader(trgMfs, Thread.currentThread().getContextClassLoader());
+    private PersistenceGenerator makePersistenceGenerator(
+            boolean usePersistence,
+            List<String> parameters,
+            GeneratorContext context,
+            Collection<ClassInfo> modelClasses,
+            JandexProtoGenerator jandexProtoGenerator,
+            Path projectPath) {
+        PersistenceGenerator persistenceGenerator =
+                new PersistenceGenerator(
+                        new File(projectPath.toFile(), "target"),
+                        modelClasses,
+                        usePersistence,
+                        jandexProtoGenerator,
+                        parameters);
+        persistenceGenerator.setDependencyInjection(new CDIDependencyInjectionAnnotator());
+        persistenceGenerator.setPackageName(appPackageName);
+        persistenceGenerator.setContext(context);
+        return persistenceGenerator;
+    }
+
+    private Collection<GeneratedFile> getJsonSchemaFiles(Path path, Index index) throws IOException {
+        URL[] urls = {path.toUri().toURL()};
+        URLClassLoader cl = new URLClassLoader(
+                urls,
+                Thread.currentThread().getContextClassLoader());
         List<AnnotationInstance> annotations =
-                index.getAnnotations(createDotName(UserTask.class.getCanonicalName()));
+                index.getAnnotations(DotName.createSimple(UserTask.class.getCanonicalName()));
 
         JsonSchemaGenerator.SimpleBuilder simpleBuilder =
                 new JsonSchemaGenerator.SimpleBuilder(cl)
@@ -175,16 +335,16 @@ public class KogitoAssetsProcessor {
     @BuildStep
     public List<ReflectiveHierarchyIgnoreWarningBuildItem> reflectiveDMNREST() {
         List<ReflectiveHierarchyIgnoreWarningBuildItem> result = new ArrayList<>();
-        result.add(new ReflectiveHierarchyIgnoreWarningBuildItem(createDotName("org.kie.api.builder.Message$Level")));
-        result.add(new ReflectiveHierarchyIgnoreWarningBuildItem(createDotName("org.kie.dmn.api.core.DMNContext")));
-        result.add(new ReflectiveHierarchyIgnoreWarningBuildItem(createDotName("org.kie.dmn.api.core.DMNDecisionResult")));
+        result.add(new ReflectiveHierarchyIgnoreWarningBuildItem(DotName.createSimple("org.kie.api.builder.Message$Level")));
+        result.add(new ReflectiveHierarchyIgnoreWarningBuildItem(DotName.createSimple("org.kie.dmn.api.core.DMNContext")));
+        result.add(new ReflectiveHierarchyIgnoreWarningBuildItem(DotName.createSimple("org.kie.dmn.api.core.DMNDecisionResult")));
         result.add(new ReflectiveHierarchyIgnoreWarningBuildItem(
-                createDotName("org.kie.dmn.api.core.DMNDecisionResult$DecisionEvaluationStatus")));
-        result.add(new ReflectiveHierarchyIgnoreWarningBuildItem(createDotName("org.kie.dmn.api.core.DMNMessage")));
-        result.add(new ReflectiveHierarchyIgnoreWarningBuildItem(createDotName("org.kie.dmn.api.core.DMNMessage$Severity")));
-        result.add(new ReflectiveHierarchyIgnoreWarningBuildItem(createDotName("org.kie.dmn.api.core.DMNMessageType")));
+                DotName.createSimple("org.kie.dmn.api.core.DMNDecisionResult$DecisionEvaluationStatus")));
+        result.add(new ReflectiveHierarchyIgnoreWarningBuildItem(DotName.createSimple("org.kie.dmn.api.core.DMNMessage")));
+        result.add(new ReflectiveHierarchyIgnoreWarningBuildItem(DotName.createSimple("org.kie.dmn.api.core.DMNMessage$Severity")));
+        result.add(new ReflectiveHierarchyIgnoreWarningBuildItem(DotName.createSimple("org.kie.dmn.api.core.DMNMessageType")));
         result.add(
-                new ReflectiveHierarchyIgnoreWarningBuildItem(createDotName("org.kie.dmn.api.feel.runtime.events.FEELEvent")));
+                new ReflectiveHierarchyIgnoreWarningBuildItem(DotName.createSimple("org.kie.dmn.api.feel.runtime.events.FEELEvent")));
         return result;
     }
 
@@ -193,259 +353,96 @@ public class KogitoAssetsProcessor {
         return new RuntimeInitializedClassBuildItem(ClassFieldAccessorFactory.class.getName());
     }
 
-    @BuildStep
-    public void generateModel(ArchiveRootBuildItem root,
-                              BuildProducer<GeneratedBeanBuildItem> generatedBeans,
-                              CombinedIndexBuildItem combinedIndexBuildItem,
-                              LaunchModeBuildItem launchMode,
-                              LiveReloadBuildItem liveReload,
-                              BuildProducer<NativeImageResourceBuildItem> resource,
-                              BuildProducer<GeneratedResourceBuildItem> genResBI,
-                              BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
-                              CurateOutcomeBuildItem curateOutcomeBuildItem) throws IOException, BootstrapDependencyProcessingException {
+    private void writeJsonSchema(AppPaths appPaths, Index index) throws IOException {
+        Path relativePath = JsonSchemaUtil.getJsonDir();
+        Path targetClasses = appPaths.getFirstProjectPath().resolve(targetClassesDir);
+        Collection<GeneratedFile> jsonFiles = getJsonSchemaFiles(targetClasses, index);
+        Path jsonSchemaPath = targetClasses.resolve(relativePath);
+        Files.createDirectories(jsonSchemaPath);
 
-        if (liveReload.isLiveReload()) {
-            return;
-        }
-
-        AppPaths appPaths = new AppPaths(root.getPaths());
-
-        ApplicationGenerator appGen = createApplicationGenerator(appPaths, combinedIndexBuildItem);
-        Collection<GeneratedFile> generatedFiles = appGen.generate();
-
-        Collection<GeneratedFile> javaFiles = generatedFiles.stream().filter( f -> f.relativePath().endsWith( ".java" ) ).collect( Collectors.toCollection( ArrayList::new ));
-        writeGeneratedFiles(appPaths, generatedFiles, resource, genResBI);
-
-        if (!javaFiles.isEmpty()) {
-
-            Indexer kogitoIndexer = new Indexer();
-            Set<DotName> kogitoIndex = new HashSet<>();
-
-            MemoryFileSystem trgMfs = new MemoryFileSystem();
-            CompilationResult result = compile(appPaths, trgMfs, curateOutcomeBuildItem.getEffectiveModel(), javaFiles, launchMode.getLaunchMode());
-            register(appPaths, trgMfs, generatedBeans,
-                     (className, data) -> generateBeanBuildItem( combinedIndexBuildItem, kogitoIndexer, kogitoIndex, className, data ),
-                     launchMode.getLaunchMode(), result);
-
-
-            Index index = kogitoIndexer.complete();
-
-            generatePersistenceInfo(appPaths, generatedBeans, CompositeIndex.create(combinedIndexBuildItem.getIndex(), index),
-                                    launchMode, resource, curateOutcomeBuildItem);
-
-
-            reflectiveClass.produce(
-                    new ReflectiveClassBuildItem(true, true, "org.kie.kogito.event.AbstractDataEvent"));
-            reflectiveClass.produce(
-                    new ReflectiveClassBuildItem(true, true, "org.kie.kogito.services.event.AbstractProcessDataEvent"));
-            reflectiveClass.produce(
-                    new ReflectiveClassBuildItem(true, true, "org.kie.kogito.services.event.ProcessInstanceDataEvent"));
-            reflectiveClass.produce(
-                    new ReflectiveClassBuildItem(true, true, "org.kie.kogito.services.event.VariableInstanceDataEvent"));
-            reflectiveClass.produce(
-                    new ReflectiveClassBuildItem(true, true, "org.kie.kogito.services.event.impl.ProcessInstanceEventBody"));
-            reflectiveClass.produce(
-                    new ReflectiveClassBuildItem(true, true, "org.kie.kogito.services.event.impl.NodeInstanceEventBody"));
-            reflectiveClass.produce(
-                    new ReflectiveClassBuildItem(true, true, "org.kie.kogito.services.event.impl.ProcessErrorEventBody"));
-            reflectiveClass.produce(
-                    new ReflectiveClassBuildItem(true, true, "org.kie.kogito.services.event.impl.VariableInstanceEventBody"));
-            reflectiveClass.produce(
-                    new ReflectiveClassBuildItem(true, true, "org.kie.kogito.services.event.UserTaskInstanceDataEvent"));
-            reflectiveClass.produce(
-                    new ReflectiveClassBuildItem(true, true, "org.kie.kogito.services.event.impl.UserTaskInstanceEventBody"));
-
-            addChildrenClasses(index, org.kie.kogito.services.event.AbstractProcessDataEvent.class, reflectiveClass);
-            // not sure there is any generated class directly inheriting from AbstractDataEvent, keeping just in case
-            addChildrenClasses(index, org.kie.kogito.event.AbstractDataEvent.class, reflectiveClass);
-            
-            Collection<GeneratedFile> jsonFiles = getJsonSchemaFiles(index, trgMfs);
-            Path relativePath = JsonSchemaUtil.getJsonDir();
-            Path jsonSchemaPath = appPaths.getFirstProjectPath().resolve("target").resolve("classes").resolve(relativePath);
-            Files.createDirectories(jsonSchemaPath);
-
-            for (GeneratedFile jsonFile : jsonFiles) {
-                Files.write(jsonSchemaPath.resolve(jsonFile.relativePath()), jsonFile.contents());
-                resource.produce(new NativeImageResourceBuildItem(relativePath.resolve(jsonFile.relativePath()).toString()));
-            }
-        }
-    }
-    
-    private void addChildrenClasses(Index index,
-                                    Class<?> superClass,
-                                    BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
-        index.getAllKnownSubclasses(createDotName(superClass.getName()))
-             .forEach(c -> reflectiveClass.produce(
-                                                   new ReflectiveClassBuildItem(true,
-                                                                                true,
-                                                                                c.name().toString())));
-    }
-
-    private void writeGeneratedFiles(AppPaths appPaths, Collection<GeneratedFile> resourceFiles, BuildProducer<NativeImageResourceBuildItem> niResBI, BuildProducer<GeneratedResourceBuildItem> genResBI) {
-        for (Path projectPath : appPaths.projectPaths) {
-            String restResourcePath = projectPath.resolve( generatedCustomizableSourcesDir ).toString();
-            String resourcePath = projectPath.resolve( generatedResourcesDir ).toString();
-            String sourcePath = projectPath.resolve( generatedSourcesDir ).toString();
-
-            for (GeneratedFile f : resourceFiles) {
-                try {
-                    if ( f.getType() == GeneratedFile.Type.RESOURCE ) {
-                        writeGeneratedFile( f, resourcePath );
-                    } else if (f.getType() == GeneratedFile.Type.GENERATED_CP_RESOURCE) { // since quarkus-maven-plugin is later phase of maven-resources-plugin, need to manually late-provide the resource in the expected location for quarkus:dev phase --so not: writeGeneratedFile( f, resourcePath );
-                        Path resolve = appPaths.getFirstProjectPath().resolve("target").resolve("classes").resolve(f.relativePath());
-                        resolve.getParent().toFile().mkdirs();
-                        Files.write(resolve, f.contents());
-                        genResBI.produce(new GeneratedResourceBuildItem(f.relativePath(), f.contents()));
-                        niResBI.produce(new NativeImageResourceBuildItem(f.relativePath()));
-                    } else if (f.getType().isCustomizable()) {
-                        writeGeneratedFile(f, restResourcePath);
-                    } else {
-                        writeGeneratedFile(f, sourcePath);
-                    }
-                } catch (IOException e) {
-                    logger.warn(String.format("Could not write file '%s'", f.toString()), e);
-                }
-            }
+        for (GeneratedFile jsonFile : jsonFiles) {
+            Files.write(jsonSchemaPath.resolve(jsonFile.relativePath()), jsonFile.contents());
+            resource.produce(new NativeImageResourceBuildItem(relativePath.resolve(jsonFile.relativePath()).toString()));
         }
     }
 
-    private GeneratedBeanBuildItem generateBeanBuildItem(CombinedIndexBuildItem combinedIndexBuildItem, Indexer kogitoIndexer, Set<DotName> kogitoIndex, String className, byte[] data) {
-        IndexingUtil.indexClass(className, kogitoIndexer, combinedIndexBuildItem.getIndex(), kogitoIndex,
-                                Thread.currentThread().getContextClassLoader(), data);
-        return new GeneratedBeanBuildItem(className, data);
+    private void registerDataEventsForReflection(Index index) {
+        reflectiveClass.produce(
+                new ReflectiveClassBuildItem(true, true, "org.kie.kogito.event.AbstractDataEvent"));
+        reflectiveClass.produce(
+                new ReflectiveClassBuildItem(true, true, "org.kie.kogito.services.event.AbstractProcessDataEvent"));
+        reflectiveClass.produce(
+                new ReflectiveClassBuildItem(true, true, "org.kie.kogito.services.event.ProcessInstanceDataEvent"));
+        reflectiveClass.produce(
+                new ReflectiveClassBuildItem(true, true, "org.kie.kogito.services.event.VariableInstanceDataEvent"));
+        reflectiveClass.produce(
+                new ReflectiveClassBuildItem(true, true, "org.kie.kogito.services.event.impl.ProcessInstanceEventBody"));
+        reflectiveClass.produce(
+                new ReflectiveClassBuildItem(true, true, "org.kie.kogito.services.event.impl.NodeInstanceEventBody"));
+        reflectiveClass.produce(
+                new ReflectiveClassBuildItem(true, true, "org.kie.kogito.services.event.impl.ProcessErrorEventBody"));
+        reflectiveClass.produce(
+                new ReflectiveClassBuildItem(true, true, "org.kie.kogito.services.event.impl.VariableInstanceEventBody"));
+        reflectiveClass.produce(
+                new ReflectiveClassBuildItem(true, true, "org.kie.kogito.services.event.UserTaskInstanceDataEvent"));
+        reflectiveClass.produce(
+                new ReflectiveClassBuildItem(true, true, "org.kie.kogito.services.event.impl.UserTaskInstanceEventBody"));
+
+        // not sure there is any generated class directly inheriting from AbstractDataEvent, keeping just in case
+        index.getAllKnownSubclasses(DotName.createSimple(org.kie.kogito.event.AbstractDataEvent.class.getCanonicalName()))
+                .forEach(c -> reflectiveClass.produce(
+                        new ReflectiveClassBuildItem(true, true, c.name().toString())));
+
+        index.getAllKnownSubclasses(DotName.createSimple(org.kie.kogito.services.event.AbstractProcessDataEvent.class.getCanonicalName()))
+                .forEach(c -> reflectiveClass.produce(
+                        new ReflectiveClassBuildItem(true, true, c.name().toString())));
+
     }
 
-    private CompilationResult compile(AppPaths appPaths, MemoryFileSystem trgMfs,
-                                      AppModel appModel,
-                                      Collection<GeneratedFile> generatedFiles,
-                                      LaunchMode launchMode) throws IOException {
+    private Index indexBuildItems(Collection<GeneratedBeanBuildItem> buildItems) {
+        Indexer kogitoIndexer = new Indexer();
+        Set<DotName> kogitoIndex = new HashSet<>();
 
-        JavaCompiler javaCompiler = JavaParserCompiler.getCompiler();
-        JavaCompilerSettings compilerSettings = javaCompiler.createDefaultSettings();
-        compilerSettings.addOption("-proc:none"); // force disable annotation processing
-        for (Path classPath : appPaths.classesPaths) {
-            compilerSettings.addClasspath(classPath.toString());
-        }
-        if (appModel != null) {
-            for (AppDependency i : appModel.getUserDependencies()) {
-                compilerSettings.addClasspath(i.getArtifact().getPaths().getSinglePath().toAbsolutePath().toString());
-            }
+        for (GeneratedBeanBuildItem generatedBeanBuildItem : buildItems) {
+            IndexingUtil.indexClass(
+                    generatedBeanBuildItem.getName(),
+                    kogitoIndexer,
+                    combinedIndexBuildItem.getIndex(),
+                    kogitoIndex,
+                    Thread.currentThread().getContextClassLoader(),
+                    generatedBeanBuildItem.getData());
         }
 
-        MemoryFileSystem srcMfs = new MemoryFileSystem();
-
-        String[] sources = new String[generatedFiles.size()];
-        int index = 0;
-        String location = appPaths.getFirstProjectPath().resolve("target").resolve("classes").toString();
-        for (GeneratedFile entry : generatedFiles) {
-            String generatedClassFile = entry.relativePath().replace("src/main/java/", "");
-            String fileName = toRuntimeSource(toClassName(generatedClassFile));
-            sources[index++] = fileName;
-
-            srcMfs.write(fileName, entry.contents());
-
-
-            writeGeneratedFile(entry, location);
-        }
-
-        return javaCompiler.compile(sources, srcMfs, trgMfs,
-                                    Thread.currentThread().getContextClassLoader(), compilerSettings);
+        return kogitoIndexer.complete();
     }
 
-    private void register(AppPaths appPaths, MemoryFileSystem trgMfs,
-                          BuildProducer<GeneratedBeanBuildItem> generatedBeans,
-                          BiFunction<String, byte[], GeneratedBeanBuildItem> bif,
-                          LaunchMode launchMode,
-                          CompilationResult result) throws IOException {
-        if (result.getErrors().length > 0) {
-            StringBuilder errorInfo = new StringBuilder();
-            for (CompilationProblem compilationProblem : result.getErrors()) {
-                errorInfo.append(compilationProblem.toString());
-                errorInfo.append("\n");
-                logger.error(compilationProblem.toString());
-            }
-            Arrays.stream(result.getErrors()).forEach(cp -> errorInfo.append(cp.toString()));
-            throw new IllegalStateException(errorInfo.toString());
-        }
+    private Collection<GeneratedBeanBuildItem> makeBuildItems(
+            AppPaths appPaths, MemoryFileSystem trgMfs) throws IOException {
 
+        ArrayList<GeneratedBeanBuildItem> buildItems = new ArrayList<>();
+        Path location = appPaths.getFirstProjectPath().resolve(targetClassesDir);
         for (String fileName : trgMfs.getFileNames()) {
             byte[] data = trgMfs.getBytes(fileName);
             String className = toClassName(fileName);
-            generatedBeans.produce(bif.apply(className, data));
-        }
+            buildItems.add(new GeneratedBeanBuildItem(className, data));
 
-        if (appPaths.isJar) {
-            return;
-        }
-        for (String fileName : trgMfs.getFileNames()) {
-            byte[] data = trgMfs.getBytes(fileName);
-            Path path = writeFile(Paths.get(appPaths.getFirstClassesPath().toString(), fileName).toString(), data);
+            Path path = pathOf(location.toString(), fileName);
+            Files.write(path, data);
 
-            String sourceFile = path.toString().replaceFirst("\\.class", ".java");
+            String sourceFile = location.toString().replaceFirst("\\.class", ".java");
             if (sourceFile.contains("$")) {
                 sourceFile = sourceFile.substring(0, sourceFile.indexOf("$")) + ".java";
             }
             KogitoCompilationProvider.classToSource.put(path, Paths.get(sourceFile));
         }
+
+        return buildItems;
     }
 
-    private Path writeFile(String fileName, byte[] data) throws IOException {
-        Path path = Paths.get(fileName);
-        if (!Files.exists(path.getParent())) {
-            Files.createDirectories(path.getParent());
-        }
-        Files.write(path, data);
-
-        return path;
-    }
-
-    private ApplicationGenerator createApplicationGenerator(AppPaths appPaths, CombinedIndexBuildItem combinedIndexBuildItem) throws IOException {
-
-        boolean usePersistence = combinedIndexBuildItem.getIndex()
-                .getClassByName(createDotName(persistenceFactoryClass)) != null;
-        boolean useMonitoring = combinedIndexBuildItem.getIndex()
-                .getClassByName(createDotName(metricsClass)) != null;
-        boolean useTracing = !combinedIndexBuildItem.getIndex()
-                .getAllKnownSubclasses(createDotName(tracingClass)).isEmpty();
-        boolean useKnativeEventing = combinedIndexBuildItem.getIndex()
-                .getClassByName(createDotName(knativeEventingClass)) != null;
-
-        AddonsConfig addonsConfig = new AddonsConfig()
-                .withPersistence(usePersistence)
-                .withMonitoring(useMonitoring)
-                .withTracing(useTracing)
-                .withKnativeEventing(useKnativeEventing);
-
-        GeneratorContext context = buildContext(appPaths, combinedIndexBuildItem.getIndex());
-
-        ApplicationGenerator appGen = new ApplicationGenerator(appPackageName, new File(appPaths.getFirstProjectPath().toFile(), "target"))
-                .withDependencyInjection(new CDIDependencyInjectionAnnotator())
-                .withAddons(addonsConfig)
-                .withGeneratorContext(context);
-
-        addProcessGenerator(appPaths, addonsConfig, appGen);
-        addRuleGenerator(appPaths, appGen, addonsConfig);
-        addPredictionGenerator(appPaths, appGen, addonsConfig);
-        addDecisionGenerator(appPaths, appGen, addonsConfig);
-
-        return appGen;
-    }
-
-    private void addRuleGenerator(AppPaths appPaths, ApplicationGenerator appGen, AddonsConfig addonsConfig) throws IOException {
-        IncrementalRuleCodegen generator = appPaths.isJar ?
-                IncrementalRuleCodegen.ofJar(appPaths.getJarPath()) :
-                IncrementalRuleCodegen.ofPath(appPaths.getSourcePaths());
-
-        appGen.withGenerator(generator)
-                .withKModule(findKieModuleModel(appPaths))
-                .withAddons(addonsConfig)
-                .withClassLoader(Thread.currentThread().getContextClassLoader());
-    }
-
-    private KieModuleModel findKieModuleModel( AppPaths appPaths ) throws IOException {
-        for ( Path resourcePath : appPaths.getResourcePaths() ) {
-            Path moduleXmlPath = resourcePath.resolve( KogitoKieModuleModelImpl.KMODULE_JAR_PATH );
-            if ( Files.exists( moduleXmlPath ) ) {
+    private KieModuleModel findKieModuleModel(AppPaths appPaths) throws IOException {
+        for (Path resourcePath : appPaths.getResourcePaths()) {
+            Path moduleXmlPath = resourcePath.resolve(KogitoKieModuleModelImpl.KMODULE_JAR_PATH);
+            if (Files.exists(moduleXmlPath)) {
                 return KogitoKieModuleModelImpl.fromXML(
                         new ByteArrayInputStream(
                                 Files.readAllBytes(moduleXmlPath)));
@@ -454,36 +451,6 @@ public class KogitoAssetsProcessor {
 
         return KogitoKieModuleModelImpl.fromXML(
                 "<kmodule xmlns=\"http://www.drools.org/xsd/kmodule\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"/>");
-    }
-
-    private void addProcessGenerator(AppPaths appPaths, AddonsConfig addonsConfig, ApplicationGenerator appGen) throws IOException {
-        ProcessCodegen generator = appPaths.isJar ?
-                ProcessCodegen.ofJar(appPaths.getJarPath()) :
-                ProcessCodegen.ofPath(appPaths.getProjectPaths());
-
-        appGen.withGenerator(generator)
-                .withAddons(addonsConfig)
-                .withClassLoader(Thread.currentThread().getContextClassLoader());
-    }
-
-    private void addPredictionGenerator(AppPaths appPaths, ApplicationGenerator appGen, AddonsConfig addonsConfig) throws IOException {
-        PredictionCodegen generator = appPaths.isJar ?
-                PredictionCodegen.ofJar(appPaths.getJarPath()) :
-                PredictionCodegen.ofPath(appPaths.getResourcePaths());
-
-        appGen.withGenerator(generator.withAddons(addonsConfig));
-    }
-
-    private void addDecisionGenerator( AppPaths appPaths, ApplicationGenerator appGen, AddonsConfig addonsConfig ) throws IOException {
-        DecisionCodegen generator = appPaths.isJar ?
-                DecisionCodegen.ofJar(appPaths.getJarPath()) :
-                DecisionCodegen.ofPath(appPaths.getResourcePaths());
-
-        appGen.withGenerator(generator.withAddons(addonsConfig));
-    }
-
-    private String toRuntimeSource(String className) {
-        return "src/main/java/" + className.replace('.', '/') + ".java";
     }
 
     private String toClassName(String sourceName) {
@@ -515,137 +482,13 @@ public class KogitoAssetsProcessor {
         return path;
     }
 
-    private DotName createDotName(String name) {
-        int lastDot = name.indexOf('.');
-        if (lastDot < 0) {
-            return DotName.createComponentized(null, name);
-        }
-
-        DotName lastDotName = null;
-        while (lastDot > 0) {
-            String local = name.substring(0, lastDot);
-            name = name.substring(lastDot + 1);
-            lastDot = name.indexOf('.');
-            lastDotName = DotName.createComponentized(lastDotName, local);
-        }
-
-        int lastDollar = name.indexOf('$');
-        if (lastDollar < 0) {
-            return DotName.createComponentized(lastDotName, name);
-        }
-        DotName lastDollarName = null;
-        while (lastDollar > 0) {
-            String local = name.substring(0, lastDollar);
-            name = name.substring(lastDollar + 1);
-            lastDollar = name.indexOf('$');
-            if (lastDollarName == null) {
-                lastDollarName = DotName.createComponentized(lastDotName, local);
-            } else {
-                lastDollarName = DotName.createComponentized(lastDollarName, local, true);
-            }
-        }
-        return DotName.createComponentized(lastDollarName, name, true);
-    }
-
     private GeneratorContext buildContext(AppPaths appPaths, IndexView index) {
         GeneratorContext context = GeneratorContext.ofResourcePath(appPaths.getResourceFiles());
         context.withBuildContext(new QuarkusKogitoBuildContext(className -> {
-            DotName classDotName = createDotName(className);
+            DotName classDotName = DotName.createSimple(className);
             return !index.getAnnotations(classDotName).isEmpty() || index.getClassByName(classDotName) != null;
-
         }));
 
         return context;
-    }
-
-    private static class AppPaths {
-
-        private final Set<Path> projectPaths = new LinkedHashSet<>();
-        private final List<Path> classesPaths = new ArrayList<>();
-
-        private boolean isJar = false;
-
-        private AppPaths(PathsCollection paths) {
-            for (Path path : paths) {
-                PathType pathType = getPathType(path);
-                switch (pathType) {
-                    case CLASSES: {
-                        classesPaths.add(path);
-                        projectPaths.add(path.getParent().getParent());
-                        break;
-                    }
-                    case TEST_CLASSES: {
-                        projectPaths.add(path.getParent().getParent());
-                        break;
-                    }
-                    case JAR: {
-                        isJar = true;
-                        classesPaths.add(path);
-                        projectPaths.add(path.getParent().getParent());
-                        break;
-                    }
-                    case UNKNOWN: {
-                        classesPaths.add(path);
-                        projectPaths.add(path);
-                        break;
-                    }
-                }
-            }
-        }
-
-        public Path getFirstProjectPath() {
-            return projectPaths.iterator().next();
-        }
-
-        public Path getFirstClassesPath() {
-            return classesPaths.get(0);
-        }
-
-        public Path[] getJarPath() {
-            if (!isJar) {
-                throw new IllegalStateException("Not a jar");
-            }
-            return classesPaths.toArray(new Path[classesPaths.size()]);
-        }
-
-        public File[] getResourceFiles() {
-            return projectPaths.stream().map(p -> p.resolve("src/main/resources").toFile()).toArray(File[]::new);
-        }
-
-        public Path[] getResourcePaths() {
-            return transformPaths(projectPaths, p -> p.resolve("src/main/resources"));
-        }
-
-        public Path[] getSourcePaths() {
-            return transformPaths(projectPaths, p -> p.resolve("src"));
-        }
-
-        public Path[] getProjectPaths() {
-            return transformPaths(projectPaths, Function.identity());
-        }
-
-        private Path[] transformPaths(Collection<Path> paths, Function<Path, Path> f) {
-            return paths.stream().map(f).toArray(Path[]::new);
-        }
-
-        private PathType getPathType(Path archiveLocation) {
-            String path = archiveLocation.toString();
-            if (path.endsWith("target" + File.separator + "classes")) {
-                return PathType.CLASSES;
-            }
-            if (path.endsWith("target" + File.separator + "test-classes")) {
-                return PathType.TEST_CLASSES;
-            }
-            // Quarkus generates a file with extension .jar.original when doing a native compilation of a uberjar
-            // TODO replace ".jar.original" with constant JarResultBuildStep.RENAMED_JAR_EXTENSION when it will be avialable in Quakrus 1.7
-            if (path.endsWith(".jar") || path.endsWith(".jar.original")) {
-                return PathType.JAR;
-            }
-            return PathType.UNKNOWN;
-        }
-
-        private enum PathType {
-            CLASSES, TEST_CLASSES, JAR, UNKNOWN
-        }
     }
 }

--- a/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/KogitoAssetsProcessor.java
+++ b/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/KogitoAssetsProcessor.java
@@ -422,14 +422,16 @@ public class KogitoAssetsProcessor {
                 new ReflectiveClassBuildItem(true, true, "org.kie.kogito.services.event.impl.UserTaskInstanceEventBody"));
 
         // not sure there is any generated class directly inheriting from AbstractDataEvent, keeping just in case
-        index.getAllKnownSubclasses(DotName.createSimple(org.kie.kogito.event.AbstractDataEvent.class.getCanonicalName()))
-                .forEach(c -> reflectiveClass.produce(
-                        new ReflectiveClassBuildItem(true, true, c.name().toString())));
-
-        index.getAllKnownSubclasses(DotName.createSimple(org.kie.kogito.services.event.AbstractProcessDataEvent.class.getCanonicalName()))
-                .forEach(c -> reflectiveClass.produce(
-                        new ReflectiveClassBuildItem(true, true, c.name().toString())));
-
+        addChildrenClasses(index, org.kie.kogito.event.AbstractDataEvent.class, reflectiveClass);
+        addChildrenClasses(index, org.kie.kogito.services.event.AbstractProcessDataEvent.class, reflectiveClass);
+    }
+    
+    private void addChildrenClasses(Index index,
+                                    Class<?> superClass,
+                                    BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
+        index.getAllKnownSubclasses(DotName.createSimple(superClass.getCanonicalName()))
+             .forEach(c -> reflectiveClass.produce(
+                      new ReflectiveClassBuildItem(true, true, c.name().toString())));
     }
 
     private Index indexBuildItems(Collection<GeneratedBeanBuildItem> buildItems) {

--- a/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/KogitoAssetsProcessor.java
+++ b/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/KogitoAssetsProcessor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.kogito.quarkus.deployment;
 
 import java.io.ByteArrayInputStream;


### PR DESCRIPTION
I'll be away until end of August, so I invite you to take a look, and if something looks off, I would still encourage you to merge __and then__ amend with further PRs, because I believe this refactor is long overdue -- unless there are larger issues. Alternatively, whoever has right may push on top of this. 

- I have moved and renamed a lot of code into methods and/or their own classes. It is a bit tidier, although it can be further improved. E.g. I have created a Quarkus-specific InMemoryCompiler that delegates to the Drools' Java Compiler wrapper hiding some internal flags.

- I have also removed usages of the `XGenerator#fromJar()` method; instead I have added an utility method to read a <Path, Resource> pair (called CollectedResource for lack of a better name) from Paths. If a Path is actually a Jar, then the the resource is read from the Jar directly into a Resource, transparently.

   The new usage pattern is `XGenerator.fromCollectedResources(CollectedResources.fromPaths(Path...))`. This is cleaner and more transparent.
 
   We can probably deprecate most of the `XGenerator.fromY()` methods in favor of this one.

- I have also added a new ResourceType SW (serverless workflow). Because SW uses a double extension (sw.yaml, sw.json etc.) I have removed the check that raised an exception if the extension contained a dot (because now it does).
Incidentally, this also means that the method to match a file name to a resource type is a bit less cheap because you cannot just do lastIndexOf('.').

