### PR TITLE
KOGITO-3036: Remove KafkaClient randomly failing test from Kogito Runtimes

### DIFF
--- a/kogito-test-utils/src/test/java/org/kie/kogito/kafka/KafkaClientTest.java
+++ b/kogito-test-utils/src/test/java/org/kie/kogito/kafka/KafkaClientTest.java
@@ -40,7 +40,6 @@ import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -89,14 +88,6 @@ public class KafkaClientTest {
         thenConsumerIsClosed();
     }
 
-    @Test
-    public void shouldNotConsumeMessageIfShutdown() {
-        givenKafkaClient();
-        whenShutdown();
-        whenConsume();
-        thenMessageIsNotReceived();
-    }
-
     private void givenKafkaClient() {
         client = new KafkaClient(producer, consumer);
     }
@@ -143,10 +134,6 @@ public class KafkaClientTest {
         waiter.await(5000, TimeUnit.MILLISECONDS);
         verify(consumer, Mockito.atLeastOnce()).commitSync();
         assertTrue(messages.contains(MESSAGE_TO_CONSUME));
-    }
-
-    private void thenMessageIsNotReceived() {
-        verify(consumer, never()).commitSync();
     }
 
 }


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/KOGITO-3036
Description: Remove KafkaClient utility as it's causing issues running the pipelines and does not bring up any particular functionality. 

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket