### PR TITLE
KOGITO-3031 Error log displayed with bpmn process

### DIFF
--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/XmlProcessReader.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/XmlProcessReader.java
@@ -56,6 +56,19 @@ public class XmlProcessReader {
             protected String buildPrintMessage(final SAXParseException x) {
                 return processParserMessage(super.getParents(), super.getAttrs(), super.buildPrintMessage(x));
             }
+
+            public void warning(final SAXParseException x) {
+                logger.debug( buildPrintMessage( x ) );
+            }
+
+            public void error(final SAXParseException x) {
+                logger.debug( buildPrintMessage( x ) );
+            }
+
+            public void fatalError(final SAXParseException x) throws SAXParseException {
+                logger.debug( buildPrintMessage( x ) );
+                throw x;
+            }
         };
 
         if(parser != null) {


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-3031

Yeah, I know what you're thinking; complain with this commit, I am just an executor https://github.com/kiegroup/kogito-runtimes/commit/9b62b4b66880d19e78382873726031dcc322b770#diff-9a0b59684704d04412ddab34e4b8ac7c

#YOLO 

"proper" solution may be to configure the logger so that it is silent, but I think that would require shipping a default `logback.xml` ? I don't think that's something we usually do