### PR TITLE
KOGITO-3035 add UPDATE_STABLE_BRANCH param

### DIFF
--- a/Jenkinsfile.promote
+++ b/Jenkinsfile.promote
@@ -33,6 +33,7 @@ pipeline {
         string(name: 'PROJECT_VERSION', defaultValue: '', description: 'Override `deployment.properties`. Optional if not RELEASE. If RELEASE, cannot be empty.')
         string(name: 'STAGING_REPO_URL', defaultValue: '', description: 'Override `deployment.properties`.')
         string(name: 'GIT_TAG', defaultValue: '', description: 'Git tag to set, if different from PROJECT_VERSION')
+        booleanParam(name: 'UPDATE_STABLE_BRANCH', defaultValue: false, description: 'Set to true if you want to update the `stable` branch to new created Git tag.')
     }
 
     environment {
@@ -124,8 +125,10 @@ pipeline {
                         mergeAndPush('kogito-examples', getDeployPrLink('kogito-examples'))
                         tagLatest()
 
-                        githubscm.createBranch('stable')
-                        forcePushProtectedBranch('kogito-examples', 'stable', 'master')
+                        if(params.UPDATE_STABLE_BRANCH) {
+                            githubscm.createBranch('stable')
+                            forcePushProtectedBranch('kogito-examples', 'stable', 'master')
+                        }
                     }
                 }
             }


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-3035

So that the default branch is moved only for `latest` version (goes in hand as well with `latest` of images)

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket