### PR TITLE
[KOGITO-1942] tasks endpoint to return a list work item

### DIFF
--- a/integration-tests/integration-tests-quarkus/src/test/java/org/kie/kogito/integrationtests/quarkus/BasicRestTest.java
+++ b/integration-tests/integration-tests-quarkus/src/test/java/org/kie/kogito/integrationtests/quarkus/BasicRestTest.java
@@ -27,9 +27,9 @@ import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.emptyOrNullString;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 @QuarkusTest
@@ -186,7 +186,6 @@ class BasicRestTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     void testGetTasks() {
         Map<String, String> params = new HashMap<>();
         params.put("var1", "Kermit");
@@ -202,16 +201,12 @@ class BasicRestTest {
             .extract()
                 .path("id");
 
-        Map<String, String> tasks = given()
-                .contentType(ContentType.JSON)
+        given()
             .when()
-                .get("/AdHocFragments/{id}/tasks", id)
+            .get("/AdHocFragments/{id}/tasks", id)
             .then()
-                .statusCode(200)
-            .extract()
-                .body()
-                .as(Map.class);
-        assertEquals(1, tasks.size());
-        assertEquals("Task", tasks.values().iterator().next());
+            .statusCode(200)
+            .body("$.size", is(1))
+            .body("[0].name", is("Task"));
     }
 }

--- a/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/test/java/org/kie/kogito/integrationtests/springboot/BasicRestTest.java
+++ b/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/test/java/org/kie/kogito/integrationtests/springboot/BasicRestTest.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import io.restassured.http.ContentType;
+import org.drools.core.process.instance.WorkItem;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -197,7 +198,7 @@ class BasicRestTest extends BaseRestTest {
             .extract()
                 .path("id");
 
-        Map<String, String> tasks = given()
+        WorkItem[] tasks = given()
                 .contentType(ContentType.JSON)
             .when()
                 .get("/AdHocFragments/{id}/tasks", id)
@@ -205,8 +206,8 @@ class BasicRestTest extends BaseRestTest {
                 .statusCode(200)
             .extract()
                 .body()
-                .as(Map.class);
-        assertEquals(1, tasks.size());
-        assertEquals("Task", tasks.values().iterator().next());
+                .as(TestWorkItem[].class);
+        assertEquals(1, tasks.length);
+        assertEquals("Task", tasks[0].getName());
     }
 }

--- a/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/test/java/org/kie/kogito/integrationtests/springboot/TestWorkItem.java
+++ b/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/test/java/org/kie/kogito/integrationtests/springboot/TestWorkItem.java
@@ -1,0 +1,91 @@
+package org.kie.kogito.integrationtests.quarkus;
+
+import java.util.Map;
+
+import org.kie.kogito.process.WorkItem;
+
+
+public class TestWorkItem implements WorkItem {
+/*
+ * It is interesting to have an implementation of WorkItem for testing that
+ * the information returned by REST API is consistent with the interface definition. 
+ * This will force us to change this class every time we change the interface and
+ * will automatically test that the serialization/deserialization process is ok when
+ * that unlikely event occurs. 
+ */
+
+    private String id;
+    private String nodeInstanceId;
+    private String name;
+    private int state;
+    private String phase;
+    private String phaseStatus;
+    private Map<String, Object> parameters;
+    private Map<String, Object> results;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getNodeInstanceId() {
+        return nodeInstanceId;
+    }
+
+    public void setNodeInstanceId(String nodeInstanceId) {
+        this.nodeInstanceId = nodeInstanceId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getState() {
+        return state;
+    }
+
+    public void setState(int state) {
+        this.state = state;
+    }
+
+    public String getPhase() {
+        return phase;
+    }
+
+    public void setPhase(String phase) {
+        this.phase = phase;
+    }
+
+    public String getPhaseStatus() {
+        return phaseStatus;
+    }
+
+    public void setPhaseStatus(String phaseStatus) {
+        this.phaseStatus = phaseStatus;
+    }
+
+    public Map<String, Object> getParameters() {
+        return parameters;
+    }
+
+    public void setParameters(Map<String, Object> parameters) {
+        this.parameters = parameters;
+    }
+
+    public Map<String, Object> getResults() {
+        return results;
+    }
+
+    public void setResults(Map<String, Object> results) {
+        this.results = results;
+    }
+
+
+}

--- a/kogito-codegen/src/main/resources/class-templates/ReactiveRestResourceTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/ReactiveRestResourceTemplate.java
@@ -128,7 +128,7 @@ public class $Type$ReactiveResource {
     @GET()
     @Path("/{id}/tasks")
     @Produces(MediaType.APPLICATION_JSON)
-    public CompletionStage<Map<String, String>> getTasks_$name$(@PathParam("id") String id,
+    public CompletionStage<List<WorkItem>> getTasks_$name$(@PathParam("id") String id,
                                                                 @QueryParam("user") final String user,
                                                                 @QueryParam("group") final List<String> groups) {
         return CompletableFuture
@@ -137,7 +137,6 @@ public class $Type$ReactiveResource {
                     .instances()
                     .findById(id, ProcessInstanceReadMode.READ_ONLY)
                     .map(pi -> pi.workItems(Policies.of(user, groups)))
-                    .map(l -> l.stream().collect(Collectors.toMap(WorkItem::getId, WorkItem::getName)))
                     .orElse(null));
     }
 }

--- a/kogito-codegen/src/main/resources/class-templates/RestResourceTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/RestResourceTemplate.java
@@ -120,13 +120,12 @@ public class $Type$Resource {
     @GET
     @Path("/{id}/tasks")
     @Produces(MediaType.APPLICATION_JSON)
-    public Map<String, String> getTasks_$name$(@PathParam("id") String id,
+    public List<WorkItem> getTasks_$name$(@PathParam("id") String id,
                                                @QueryParam("user") final String user,
                                                @QueryParam("group") final List<String> groups) {
         return process.instances()
                       .findById(id, ProcessInstanceReadMode.READ_ONLY)
                       .map(pi -> pi.workItems(Policies.of(user, groups)))
-                      .map(l -> l.stream().collect(Collectors.toMap(WorkItem::getId, WorkItem::getName)))
                       .orElseThrow(() -> new NotFoundException());
     }
 

--- a/kogito-codegen/src/main/resources/class-templates/spring/SpringRestResourceTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/spring/SpringRestResourceTemplate.java
@@ -18,6 +18,7 @@ package com.myspace.demo;
 
 import java.net.URI;
 import java.util.List;
+
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -132,14 +133,13 @@ public class $Type$Resource {
     }
 
     @GetMapping(value = "/{id}/tasks", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<Map<String, String>> getTasks_$name$(@PathVariable("id") String id,
+    public ResponseEntity<List<WorkItem>> getTasks_$name$(@PathVariable("id") String id,
                                                @RequestParam(value = "user", required = false) final String user,
                                                @RequestParam(value = "group",
                                                              required = false) final List<String> groups) {
         return process.instances()
                       .findById(id, ProcessInstanceReadMode.READ_ONLY)
                       .map(pi -> pi.workItems(Policies.of(user, groups)))
-                      .map(l -> l.stream().collect(Collectors.toMap(WorkItem::getId, WorkItem::getName)))
                       .map(m -> ResponseEntity.ok(m))
                       .orElseGet(() -> ResponseEntity.notFound().build());
     }


### PR DESCRIPTION
Changins tasks endpoint to return list of work items rather than a map with id and name
Merge with https://github.com/kiegroup/kogito-examples/pull/347