### PR TITLE
KOGITO-3173 - kogito-runtimes-jenkins-tests parent has wrong relative path

### DIFF
--- a/jenkins-tests/pom.xml
+++ b/jenkins-tests/pom.xml
@@ -6,6 +6,7 @@
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-build-parent</artifactId>
         <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../kogito-build-parent/pom.xml</relativePath>
     </parent>
     <artifactId>kogito-runtimes-jenkins-tests</artifactId>
     <name>Kogito :: Jenkins Spock Tests</name>


### PR DESCRIPTION
[KOGITO-3173](https://issues.redhat.com/browse/KOGITO-3173)

Many thanks for submitting your Pull Request :heart: :racing_car: ! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket