### PR TITLE
[KOGITO-2893] Detach Business Key from ID - follow-up cleaning

### DIFF
--- a/api/kogito-internal/src/main/java/org/kie/internal/process/CorrelationAwareProcessRuntime.java
+++ b/api/kogito-internal/src/main/java/org/kie/internal/process/CorrelationAwareProcessRuntime.java
@@ -55,14 +55,4 @@ public interface CorrelationAwareProcessRuntime {
      */
     ProcessInstance createProcessInstance(String processId, CorrelationKey correlationKey,
                                           Map<String, Object> parameters);
-
-    /**
-     * Returns the process instance with the given correlationKey.  Note that only active process instances
-     * will be returned.  If a process instance has been completed already, this method will return
-     * <code>null</code>.
-     *
-     * @param correlationKey the custom correlation key assigned when process instance was created
-     * @return the process instance with the given id or <code>null</code> if it cannot be found
-     */
-    ProcessInstance getProcessInstance(CorrelationKey correlationKey);
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/AbstractProcessInstanceFactory.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/AbstractProcessInstanceFactory.java
@@ -38,8 +38,7 @@ public abstract class AbstractProcessInstanceFactory implements ProcessInstanceF
         	processInstance.getMetaData().put("CorrelationKey", correlationKey);
         }
         
-        ((InternalProcessRuntime) kruntime.getProcessRuntime()).getProcessInstanceManager()
-    		.addProcessInstance( processInstance, correlationKey );
+        ((InternalProcessRuntime) kruntime.getProcessRuntime()).getProcessInstanceManager().addProcessInstance(processInstance);
 
         // set variable default values
         // TODO: should be part of processInstanceImpl?

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/LightProcessRuntime.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/LightProcessRuntime.java
@@ -130,7 +130,7 @@ public class LightProcessRuntime implements InternalProcessRuntime {
     public ProcessInstance startProcess(String processId, Map<String, Object> parameters, String trigger) {
         ProcessInstance processInstance = createProcessInstance(processId, parameters);
         if (processInstance != null) {
-            processInstanceManager.addProcessInstance(processInstance, null);
+            processInstanceManager.addProcessInstance(processInstance);
             return startProcessInstance(processInstance.getId(), trigger);
         }
         return null;
@@ -163,7 +163,7 @@ public class LightProcessRuntime implements InternalProcessRuntime {
     public ProcessInstance startProcess(String processId, CorrelationKey correlationKey, Map<String, Object> parameters) {
         ProcessInstance processInstance = createProcessInstance(processId, correlationKey, parameters);
         if (processInstance != null) {
-            processInstanceManager.addProcessInstance(processInstance, correlationKey);
+            processInstanceManager.addProcessInstance(processInstance);
             return startProcessInstance(processInstance.getId());
         }
         return null;
@@ -183,11 +183,6 @@ public class LightProcessRuntime implements InternalProcessRuntime {
         } finally {
             runtimeContext.endOperation();
         }
-    }
-
-    @Override
-    public ProcessInstance getProcessInstance(CorrelationKey correlationKey) {
-        return processInstanceManager.getProcessInstance(correlationKey);
     }
 
     private org.jbpm.process.instance.ProcessInstance createProcessInstance(Process process, CorrelationKey correlationKey, Map<String, Object> parameters) {

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/ProcessInstanceManager.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/ProcessInstanceManager.java
@@ -18,7 +18,6 @@ package org.jbpm.process.instance;
 
 import java.util.Collection;
 
-import org.kie.internal.process.CorrelationKey;
 import org.kie.api.runtime.process.ProcessInstance;
 
 public interface ProcessInstanceManager {
@@ -26,12 +25,10 @@ public interface ProcessInstanceManager {
     ProcessInstance getProcessInstance(String id);
     
     ProcessInstance getProcessInstance(String id, boolean readOnly);
-
-    ProcessInstance getProcessInstance(CorrelationKey correlationKey);
     
     Collection<ProcessInstance> getProcessInstances();
 
-    void addProcessInstance(ProcessInstance processInstance, CorrelationKey correlationKey);
+    void addProcessInstance(ProcessInstance processInstance);
     
     void internalAddProcessInstance(ProcessInstance processInstance);
 

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/ProcessRuntimeImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/ProcessRuntimeImpl.java
@@ -227,11 +227,6 @@ public class ProcessRuntimeImpl implements InternalProcessRuntime {
         }
     }
 
-    @Override
-    public ProcessInstance getProcessInstance(CorrelationKey correlationKey) {
-        return processInstanceManager.getProcessInstance(correlationKey);
-    }
-
     private org.jbpm.process.instance.ProcessInstance startProcess(Process process, CorrelationKey correlationKey, Map<String, Object> parameters) {
         ProcessInstanceFactory conf = ProcessInstanceFactoryRegistry.INSTANCE.getProcessInstanceFactory(process);
         if (conf == null) {

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/DefaultProcessInstanceManager.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/DefaultProcessInstanceManager.java
@@ -19,20 +19,17 @@ package org.jbpm.process.instance.impl;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.jbpm.process.instance.ProcessInstanceManager;
 import org.kie.api.runtime.process.ProcessInstance;
-import org.kie.internal.process.CorrelationKey;
 
 public class DefaultProcessInstanceManager implements ProcessInstanceManager {
 
     private Map<String, ProcessInstance> processInstances = new ConcurrentHashMap<>();
-    private Map<CorrelationKey, ProcessInstance> processInstancesByCorrelationKey = new ConcurrentHashMap<>();
 
-    public void addProcessInstance(ProcessInstance processInstance, CorrelationKey correlationKey) {
+    public void addProcessInstance(ProcessInstance processInstance) {
         String id = UUID.randomUUID().toString();
         ((org.jbpm.process.instance.ProcessInstance) processInstance).setId(id);
         internalAddProcessInstance(processInstance);
@@ -60,11 +57,6 @@ public class DefaultProcessInstanceManager implements ProcessInstanceManager {
 
     public void internalRemoveProcessInstance(ProcessInstance processInstance) {
         processInstances.remove(processInstance.getId());
-        for (Entry<CorrelationKey, ProcessInstance> entry : processInstancesByCorrelationKey.entrySet()) {
-            if (entry.getValue().getId().equals(processInstance.getId())) {
-                processInstancesByCorrelationKey.remove(entry.getKey());
-            }
-        }
     }
 
     public void clearProcessInstances() {
@@ -73,10 +65,5 @@ public class DefaultProcessInstanceManager implements ProcessInstanceManager {
 
     public void clearProcessInstancesState() {
 
-    }
-
-    @Override
-    public ProcessInstance getProcessInstance(CorrelationKey correlationKey) {
-        return processInstancesByCorrelationKey.get(correlationKey);
     }
 }

--- a/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcessInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcessInstance.java
@@ -52,7 +52,6 @@ import org.kie.kogito.process.NodeNotFoundException;
 import org.kie.kogito.process.Process;
 import org.kie.kogito.process.ProcessError;
 import org.kie.kogito.process.ProcessInstance;
-import org.kie.kogito.process.ProcessInstanceDuplicatedException;
 import org.kie.kogito.process.ProcessInstanceNotFoundException;
 import org.kie.kogito.process.Signal;
 import org.kie.kogito.process.WorkItem;
@@ -204,11 +203,8 @@ public abstract class AbstractProcessInstance<T extends Model> implements Proces
             processInstance.setReferenceId(referenceId);
         }
 
-        ((InternalProcessRuntime) getProcessRuntime()).getProcessInstanceManager().addProcessInstance(this.processInstance, this.correlationKey);
+        ((InternalProcessRuntime) getProcessRuntime()).getProcessInstanceManager().addProcessInstance(this.processInstance);
         this.id = processInstance.getId();
-        if (correlationKey != null && process.instances.exists(id)) {
-            throw new ProcessInstanceDuplicatedException(id);
-        }
         addCompletionEventListener();
         org.kie.api.runtime.process.ProcessInstance processInstance = getProcessRuntime().startProcessInstance(this.id, trigger);
         addToUnitOfWork(pi -> ((MutableProcessInstances<T>) process.instances()).create(pi.id(), pi));
@@ -314,7 +310,7 @@ public abstract class AbstractProcessInstance<T extends Model> implements Proces
     public void startFrom(String nodeId, String referenceId) {
         processInstance.setStartDate(new Date());
         processInstance.setState(STATE_ACTIVE);
-        ((InternalProcessRuntime) getProcessRuntime()).getProcessInstanceManager().addProcessInstance(this.processInstance, this.correlationKey);
+        ((InternalProcessRuntime) getProcessRuntime()).getProcessInstanceManager().addProcessInstance(this.processInstance);
         this.id = processInstance.getId();
         addCompletionEventListener();
         if (referenceId != null) {

--- a/jbpm/jbpm-flow/src/test/java/org/kie/kogito/process/impl/AbstractProcessInstanceTest.java
+++ b/jbpm/jbpm-flow/src/test/java/org/kie/kogito/process/impl/AbstractProcessInstanceTest.java
@@ -83,7 +83,7 @@ public class AbstractProcessInstanceTest {
         assertThat(processInstance.id()).isNull();
         assertThat(processInstance.businessKey()).isNull();
 
-        verify(pim, never()).addProcessInstance(any(), any());
+        verify(pim, never()).addProcessInstance(any());
     }
 
     @Test


### PR DESCRIPTION
Follow-up of [KOGITO-2893](https://issues.redhat.com/browse/KOGITO-2893) (as it got merged before I had a chance to review it)

As we discussed with @ruromero business key is now just set and used only when querying using data index. This means that methods removed in this PR are no longer needed.
