### PR TITLE
KOGITO-3216: Fix mismatch version when building Quarkus archetypes

### DIFF
--- a/archetypes/kogito-quarkus-archetype/pom.xml
+++ b/archetypes/kogito-quarkus-archetype/pom.xml
@@ -25,6 +25,12 @@
         <filtering>true</filtering>
       </resource>
     </resources>
+    <testResources>
+      <testResource>
+        <directory>src/test/resources</directory>
+        <filtering>true</filtering>
+      </testResource>
+    </testResources>
 
     <extensions>
       <extension>

--- a/archetypes/kogito-quarkus-archetype/src/test/resources/projects/it-basic/goal.txt
+++ b/archetypes/kogito-quarkus-archetype/src/test/resources/projects/it-basic/goal.txt
@@ -1,1 +1,1 @@
-verify
+verify -Dversion.io.quarkus=${version.io.quarkus}


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/KOGITO-3216
Description: Making the examples to use the same quarkus version from the command line, made the above issue be gone.

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket