### PR TITLE
KOGITO-3230: Increase the timeout of pipelines

### DIFF
--- a/Jenkinsfile-sonarcloud-daily
+++ b/Jenkinsfile-sonarcloud-daily
@@ -13,7 +13,7 @@ pipeline {
     }
     options {
         buildDiscarder logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10')
-        timeout(time: 120, unit: 'MINUTES')
+        timeout(time: 360, unit: 'MINUTES')
     }
     environment {
         KOGITO_CI_EMAIL_TO = credentials('KOGITO_CI_EMAIL_TO')

--- a/Jenkinsfile.drools
+++ b/Jenkinsfile.drools
@@ -13,7 +13,7 @@ pipeline {
     }
     options {
         buildDiscarder logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '5')
-        timeout(time: 120, unit: 'MINUTES')
+        timeout(time: 360, unit: 'MINUTES')
     }
     parameters {
         string(name: 'BRANCH_NAME', defaultValue: "master", description: 'Set the branch to build&test')

--- a/Jenkinsfile.quarkus
+++ b/Jenkinsfile.quarkus
@@ -17,7 +17,7 @@ pipeline {
     }
     options {
         buildDiscarder logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '5')
-        timeout(time: 120, unit: 'MINUTES')
+        timeout(time: 360, unit: 'MINUTES')
     }
     stages {
         stage('Build quarkus') {


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/KOGITO-3230
Description: The kogito runtime pipeline has a timeout of 360 minutes, nevertheless the drools, quarkus and sonar pipelines remains with 120 minutes leading with the build being aborted by Jenkins when the time exceeded this timeout.

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket