### PR TITLE
KOGITO-3110 Refactor ofCollectedResources methods in *Codegen

### DIFF
--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionContainerGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionContainerGenerator.java
@@ -16,6 +16,8 @@
 package org.kie.kogito.codegen.decision;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
@@ -91,9 +93,13 @@ public class DecisionContainerGenerator extends AbstractApplicationSection {
 
     private String getDecisionModelRelativeResourcePath(CollectedResource resource) {
         String source = getDecisionModelJarResourcePath(resource);
-        Path sourcePath = Paths.get(source).toAbsolutePath();
-        Path relativizedPath = resource.basePath().toAbsolutePath().relativize(sourcePath);
-        return "/" + relativizedPath.toString().replace(File.separatorChar, '/');
+        try {
+            Path sourcePath = Paths.get(source).toAbsolutePath().toRealPath();
+            Path relativizedPath = resource.basePath().toAbsolutePath().toRealPath().relativize(sourcePath);
+            return "/" + relativizedPath.toString().replace(File.separatorChar, '/');
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     private void setupExecIdSupplierVariable(ClassOrInterfaceDeclaration typeDeclaration) {

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionContainerGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionContainerGenerator.java
@@ -91,7 +91,8 @@ public class DecisionContainerGenerator extends AbstractApplicationSection {
 
     private String getDecisionModelRelativeResourcePath(CollectedResource resource) {
         String source = getDecisionModelJarResourcePath(resource);
-        Path relativizedPath = resource.basePath().relativize(Paths.get(source));
+        Path sourcePath = Paths.get(source).toAbsolutePath();
+        Path relativizedPath = resource.basePath().toAbsolutePath().relativize(sourcePath);
         return "/" + relativizedPath.toString().replace(File.separatorChar, '/');
     }
 

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/io/CollectedResource.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/io/CollectedResource.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -127,6 +128,11 @@ public class CollectedResource {
     private final Resource resource;
 
     public CollectedResource(Path basePath, Resource resource) {
+        if (! Paths.get(resource.getSourcePath()).toAbsolutePath().startsWith(basePath.toAbsolutePath())) {
+            throw new IllegalArgumentException(
+                    String.format("basePath %s is not a prefix to the resource sourcePath %s",
+                                  basePath, resource.getSourcePath()));
+        }
         this.basePath = basePath;
         this.resource = resource;
     }

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/io/CollectedResource.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/io/CollectedResource.java
@@ -129,8 +129,8 @@ public class CollectedResource {
 
     public CollectedResource(Path basePath, Resource resource) {
         // basePath must be a prefix of sourcePath
-        // unless sourcePath is a jar file, then the check is ignored
-        if (! resource.getSourcePath().endsWith(".jar") &&
+        // unless it is a jar file, then the check is ignored
+        if (! basePath.toString().endsWith(".jar") &&
                 ! Paths.get(resource.getSourcePath()).toAbsolutePath().startsWith(basePath.toAbsolutePath())) {
             throw new IllegalArgumentException(
                     String.format("basePath %s is not a prefix to the resource sourcePath %s",

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/io/CollectedResource.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/io/CollectedResource.java
@@ -128,7 +128,10 @@ public class CollectedResource {
     private final Resource resource;
 
     public CollectedResource(Path basePath, Resource resource) {
-        if (! Paths.get(resource.getSourcePath()).toAbsolutePath().startsWith(basePath.toAbsolutePath())) {
+        // basePath must be a prefix of sourcePath
+        // unless sourcePath is a jar file, then the check is ignored
+        if (! resource.getSourcePath().endsWith(".jar") &&
+                ! Paths.get(resource.getSourcePath()).toAbsolutePath().startsWith(basePath.toAbsolutePath())) {
             throw new IllegalArgumentException(
                     String.format("basePath %s is not a prefix to the resource sourcePath %s",
                                   basePath, resource.getSourcePath()));

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/io/CollectedResource.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/io/CollectedResource.java
@@ -16,13 +16,16 @@
 
 package org.kie.kogito.codegen.io;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Enumeration;
+import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -91,9 +94,11 @@ public class CollectedResource {
      */
     public static Collection<CollectedResource> fromDirectory(Path path) {
         Collection<CollectedResource> resources = new ArrayList<>();
-        try {
-            Files.walk(path).map(Path::toFile)
-                    .map(f -> new FileSystemResource(f).setResourceType(determineResourceType(f.getName())))
+        try (Stream<Path> paths = Files.walk(path)) {
+            paths.filter(Files::isRegularFile)
+                    .map(Path::toFile)
+                    .map(f -> new FileSystemResource(f)
+                            .setResourceType(determineResourceType(f.getName())))
                     .map(f -> new CollectedResource(path, f))
                     .forEach(resources::add);
         } catch (IOException e) {
@@ -101,6 +106,22 @@ public class CollectedResource {
         }
         return resources;
     }
+
+    /**
+     * Returns a collection of CollectedResource from the given files
+     */
+    public static Collection<CollectedResource> fromFiles(Path basePath, File... files) {
+        Collection<CollectedResource> resources = new ArrayList<>();
+        try (Stream<File> paths = Arrays.stream(files)) {
+            paths.filter(File::isFile)
+                    .map(f -> new FileSystemResource(f)
+                            .setResourceType(determineResourceType(f.getName())))
+                    .map(f -> new CollectedResource(basePath, f))
+                    .forEach(resources::add);
+        }
+        return resources;
+    }
+
 
     private final Path basePath;
     private final Resource resource;

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/prediction/PredictionCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/prediction/PredictionCodegen.java
@@ -96,30 +96,11 @@ public class PredictionCodegen extends AbstractGenerator {
         return ofPredictions(dmnResources);
     }
 
-    public static PredictionCodegen ofJar(Path... jarPaths) throws IOException {
-        List<PMMLResource> pmmlResources = new ArrayList<>();
-        for (Path jarPath : jarPaths) {
-            List<Resource> resources = new ArrayList<>();
-            try (ZipFile zipFile = new ZipFile(jarPath.toFile())) {
-                Enumeration<? extends ZipEntry> entries = zipFile.entries();
-                while (entries.hasMoreElements()) {
-                    ZipEntry entry = entries.nextElement();
-                    ResourceType resourceType = determineResourceType(entry.getName());
-                    if (resourceType == ResourceType.PMML) {
-                        InternalResource resource =
-                                new ByteArrayResource(readBytesFromInputStream(zipFile.getInputStream(entry)));
-                        resource.setResourceType(resourceType);
-                        resource.setSourcePath(entry.getName());
-                        resources.add(resource);
-                    }
-                }
-            }
-            pmmlResources.addAll(parsePredictions(jarPath, resources));
-        }
-        return ofPredictions(pmmlResources);
-    }
-
-    public static PredictionCodegen ofPath(Path... paths) throws IOException {
+    /**
+     *
+     * @deprecated use DecisionCodegen.ofCollectedResources(CollectedResource.fromPaths(...))
+     */
+    @Deprecated    public static PredictionCodegen ofPath(Path... paths) throws IOException {
         List<PMMLResource> resources = new ArrayList<>();
         for (Path path : paths) {
             Path srcPath = Paths.get(path.toString());
@@ -133,6 +114,11 @@ public class PredictionCodegen extends AbstractGenerator {
         return ofPredictions(resources);
     }
 
+    /**
+     *
+     * @deprecated use DecisionCodegen.ofCollectedResources(CollectedResource.fromFiles(...))
+     */
+    @Deprecated
     public static PredictionCodegen ofFiles(Path basePath, List<File> files) {
         return ofPredictions(parseFiles(basePath, files));
     }

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/prediction/PredictionCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/prediction/PredictionCodegen.java
@@ -16,21 +16,13 @@
 package org.kie.kogito.codegen.prediction;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
 
 import org.drools.compiler.builder.impl.KnowledgeBuilderConfigurationImpl;
 import org.drools.compiler.builder.impl.KnowledgeBuilderImpl;
@@ -39,10 +31,7 @@ import org.drools.compiler.kproject.ReleaseIdImpl;
 import org.drools.compiler.lang.descr.PackageDescr;
 import org.drools.core.impl.InternalKnowledgeBase;
 import org.drools.core.impl.KnowledgeBaseImpl;
-import org.drools.core.io.impl.ByteArrayResource;
 import org.drools.core.io.impl.DescrResource;
-import org.drools.core.io.impl.FileSystemResource;
-import org.drools.core.io.internal.InternalResource;
 import org.drools.modelcompiler.builder.ModelBuilderImpl;
 import org.kie.api.io.Resource;
 import org.kie.api.io.ResourceType;
@@ -64,8 +53,6 @@ import org.kie.pmml.commons.model.KiePMMLModel;
 import org.kie.pmml.models.drools.commons.model.KiePMMLDroolsModelWithSources;
 
 import static java.util.stream.Collectors.toList;
-import static org.drools.core.util.IoUtils.readBytesFromInputStream;
-import static org.kie.api.io.ResourceType.determineResourceType;
 import static org.kie.kogito.codegen.ApplicationGenerator.log;
 import static org.kie.kogito.codegen.ApplicationGenerator.logger;
 import static org.kie.pmml.evaluator.assembler.service.PMMLCompilerService.getKiePMMLModelsFromResourceFromPlugin;

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/prediction/PredictionCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/prediction/PredictionCodegen.java
@@ -96,21 +96,8 @@ public class PredictionCodegen extends AbstractGenerator {
         return ofPredictions(dmnResources);
     }
 
-    /**
-     *
-     * @deprecated use DecisionCodegen.ofCollectedResources(CollectedResource.fromFiles(...))
-     */
-    @Deprecated
-    public static PredictionCodegen ofFiles(Path basePath, List<File> files) {
-        return ofPredictions(parseFiles(basePath, files));
-    }
-
     private static PredictionCodegen ofPredictions(List<PMMLResource> resources) {
         return new PredictionCodegen(resources);
-    }
-
-    private static List<PMMLResource> parseFiles(Path path, List<File> files) {
-        return parsePredictions(path, files.stream().map(FileSystemResource::new).collect(toList()));
     }
 
     private static List<PMMLResource> parsePredictions(Path path, List<Resource> resources) {

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/prediction/PredictionCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/prediction/PredictionCodegen.java
@@ -98,24 +98,6 @@ public class PredictionCodegen extends AbstractGenerator {
 
     /**
      *
-     * @deprecated use DecisionCodegen.ofCollectedResources(CollectedResource.fromPaths(...))
-     */
-    @Deprecated    public static PredictionCodegen ofPath(Path... paths) throws IOException {
-        List<PMMLResource> resources = new ArrayList<>();
-        for (Path path : paths) {
-            Path srcPath = Paths.get(path.toString());
-            try (Stream<Path> filesStream = Files.walk(srcPath)) {
-                List<File> files = filesStream.filter(p -> p.toString().endsWith(".pmml"))
-                        .map(Path::toFile)
-                        .collect(Collectors.toList());
-                resources.addAll(parseFiles(srcPath, files));
-            }
-        }
-        return ofPredictions(resources);
-    }
-
-    /**
-     *
      * @deprecated use DecisionCodegen.ofCollectedResources(CollectedResource.fromFiles(...))
      */
     @Deprecated

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ProcessCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ProcessCodegen.java
@@ -131,27 +131,6 @@ public class ProcessCodegen extends AbstractGenerator {
 
     /**
      *
-     * @deprecated use DecisionCodegen.ofCollectedResources(CollectedResource.fromPaths(...))
-     */
-    @Deprecated
-    public static ProcessCodegen ofPath(Path... paths) throws IOException {
-        List<Process> allProcesses = new ArrayList<>();
-        for (Path path : paths) {
-            Path srcPath = Paths.get( path.toString() );
-            try (Stream<Path> filesStream = Files.walk( srcPath )) {
-                List<File> files = filesStream
-                        .filter( p -> SUPPORTED_BPMN_EXTENSIONS.stream().anyMatch( p.toString()::endsWith ) ||
-                                SUPPORTED_SW_EXTENSIONS.keySet().stream().anyMatch( p.toString()::endsWith ) )
-                        .map( Path::toFile )
-                        .collect( Collectors.toList() );
-                allProcesses.addAll( parseProcesses(files) );
-            }
-        }
-        return ofProcesses(allProcesses);
-    }
-
-    /**
-     *
      * @deprecated use DecisionCodegen.ofCollectedResources(CollectedResource.fromFiles(...))
      */
     @Deprecated

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ProcessCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ProcessCodegen.java
@@ -162,6 +162,8 @@ public class ProcessCodegen extends AbstractGenerator {
             return workflowParser.parseWorkFlow(r.getReader());
         } catch (IOException e) {
             throw new ProcessParsingException("Could not parse file " + r.getSourcePath(), e);
+        } catch (RuntimeException e) {
+            throw new ProcessCodegenException(r.getSourcePath(), e);
         }
     }
 
@@ -173,6 +175,8 @@ public class ProcessCodegen extends AbstractGenerator {
             return xmlReader.read(r.getReader());
         } catch (SAXException | IOException e) {
             throw new ProcessParsingException("Could not parse file " + r.getSourcePath(), e);
+        } catch (RuntimeException e) {
+            throw new ProcessCodegenException(r.getSourcePath(), e);
         }
     }
 

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ProcessCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ProcessCodegen.java
@@ -17,30 +17,19 @@ package org.kie.kogito.codegen.process;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
 
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
-import org.drools.core.io.impl.ByteArrayResource;
 import org.drools.core.io.impl.FileSystemResource;
-import org.drools.core.io.internal.InternalResource;
 import org.drools.core.util.StringUtils;
 import org.drools.core.xml.SemanticModules;
 import org.jbpm.bpmn2.xml.BPMNDISemanticModule;
@@ -56,7 +45,6 @@ import org.jbpm.serverless.workflow.parser.ServerlessWorkflowParser;
 import org.kie.api.definition.process.Process;
 import org.kie.api.definition.process.WorkflowProcess;
 import org.kie.api.io.Resource;
-import org.kie.api.io.ResourceType;
 import org.kie.kogito.codegen.AbstractGenerator;
 import org.kie.kogito.codegen.AddonsConfig;
 import org.kie.kogito.codegen.ApplicationGenerator;
@@ -71,15 +59,12 @@ import org.kie.kogito.codegen.io.CollectedResource;
 import org.kie.kogito.codegen.process.config.ProcessConfigGenerator;
 import org.kie.kogito.codegen.process.events.CloudEventsMessageProducerGenerator;
 import org.kie.kogito.codegen.process.events.CloudEventsResourceGenerator;
-import org.kie.kogito.codegen.rules.IncrementalRuleCodegen;
 import org.kie.kogito.rules.units.UndefinedGeneratedRuleUnitVariable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
 
 import static java.util.stream.Collectors.toList;
-import static org.drools.core.util.IoUtils.readBytesFromInputStream;
-import static org.kie.api.io.ResourceType.determineResourceType;
 import static org.kie.kogito.codegen.ApplicationGenerator.log;
 
 /**

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ProcessCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ProcessCodegen.java
@@ -129,48 +129,11 @@ public class ProcessCodegen extends AbstractGenerator {
         return ofProcesses(processes);
     }
 
-    public static ProcessCodegen ofJar(Path... jarPaths) {
-        List<Process> processes = new ArrayList<>();
-
-        for (Path jarPath : jarPaths) {
-            try (ZipFile zipFile = new ZipFile(jarPath.toFile())) {
-                Enumeration<? extends ZipEntry> entries = zipFile.entries();
-                while (entries.hasMoreElements()) {
-                    ZipEntry entry = entries.nextElement();
-                    ResourceType resourceType = determineResourceType(entry.getName());
-                    if (SUPPORTED_BPMN_EXTENSIONS.stream().anyMatch(entry.getName()::endsWith)) {
-                        InternalResource resource = makeResourceFromZipEntry(zipFile, entry, resourceType);
-                        processes.addAll(parseProcessFile(resource));
-                    } else {
-                        SUPPORTED_SW_EXTENSIONS.entrySet()
-                                .stream()
-                                .filter(e -> entry.getName().endsWith(e.getKey()))
-                                .forEach(e -> {
-                                    InternalResource r = makeResourceFromZipEntry(zipFile, entry, resourceType);
-                                    processes.add(parseWorkflowFile(r, e.getValue()));
-                                });
-                    }
-                }
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
-        }
-
-        return ofProcesses(processes);
-    }
-
-    private static InternalResource makeResourceFromZipEntry(ZipFile zipFile, ZipEntry entry, ResourceType resourceType) {
-        try {
-            InternalResource resource = null;
-            resource = new ByteArrayResource(readBytesFromInputStream(zipFile.getInputStream(entry)));
-            resource.setResourceType(resourceType);
-            resource.setSourcePath(entry.getName());
-            return resource;
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
-
+    /**
+     *
+     * @deprecated use DecisionCodegen.ofCollectedResources(CollectedResource.fromPaths(...))
+     */
+    @Deprecated
     public static ProcessCodegen ofPath(Path... paths) throws IOException {
         List<Process> allProcesses = new ArrayList<>();
         for (Path path : paths) {
@@ -187,6 +150,11 @@ public class ProcessCodegen extends AbstractGenerator {
         return ofProcesses(allProcesses);
     }
 
+    /**
+     *
+     * @deprecated use DecisionCodegen.ofCollectedResources(CollectedResource.fromFiles(...))
+     */
+    @Deprecated
     public static ProcessCodegen ofFiles(Collection<File> processFiles) {
         List<Process> allProcesses = parseProcesses(processFiles);
         return ofProcesses(allProcesses);

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ProcessCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ProcessCodegen.java
@@ -129,16 +129,6 @@ public class ProcessCodegen extends AbstractGenerator {
         return ofProcesses(processes);
     }
 
-    /**
-     *
-     * @deprecated use DecisionCodegen.ofCollectedResources(CollectedResource.fromFiles(...))
-     */
-    @Deprecated
-    public static ProcessCodegen ofFiles(Collection<File> processFiles) {
-        List<Process> allProcesses = parseProcesses(processFiles);
-        return ofProcesses(allProcesses);
-    }
-
     private static ProcessCodegen ofProcesses(List<Process> processes) {
         return new ProcessCodegen(processes);
     }

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
@@ -17,7 +17,6 @@ package org.kie.kogito.codegen.rules;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -26,8 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
-import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.github.javaparser.ast.CompilationUnit;
@@ -40,7 +37,6 @@ import org.drools.compiler.compiler.DecisionTableFactory;
 import org.drools.compiler.compiler.DroolsError;
 import org.drools.compiler.kproject.ReleaseIdImpl;
 import org.drools.compiler.kproject.models.KieModuleModelImpl;
-import org.drools.core.io.impl.FileSystemResource;
 import org.drools.modelcompiler.builder.GeneratedFile;
 import org.drools.modelcompiler.builder.ModelBuilderImpl;
 import org.kie.api.builder.model.KieBaseModel;

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
@@ -98,54 +98,13 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
         return ofResources(dmnResources);
     }
 
-    /**
-     *
-     * @deprecated use DecisionCodegen.ofCollectedResources(CollectedResource.fromPaths(...))
-     */
-    @Deprecated
-    public static IncrementalRuleCodegen ofPath(Path... paths) {
-        Set<Resource> resources = new HashSet<>();
-        for (Path path : paths) {
-            try (Stream<File> files = Files.walk( path ).map( Path::toFile )) {
-                resources.addAll( toResources( files ) );
-            } catch (IOException e) {
-                throw new UncheckedIOException( e );
-            }
-        }
-        return new IncrementalRuleCodegen(resources);
-    }
-
-    /**
-     *
-     * @deprecated use DecisionCodegen.ofCollectedResources(CollectedResource.fromPaths(...))
-     */
-    @Deprecated
-    public static IncrementalRuleCodegen ofPath(Path basePath, ResourceType resourceType) {
-        try (Stream<File> files = Files.walk(basePath).map(Path::toFile)) {
-            Set<Resource> resources = toResources(files, resourceType);
-            return new IncrementalRuleCodegen(resources);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
-
-    /**
-     *
-     * @deprecated use DecisionCodegen.ofCollectedResources(CollectedResource.fromFiles(...))
-     */
-    @Deprecated
-    public static IncrementalRuleCodegen ofFiles(Collection<File> files, ResourceType resourceType) {
-        return new IncrementalRuleCodegen(toResources(files.stream(), resourceType));
-    }
-
-    /**
-     *
-     * @deprecated no alternative
-     */
-    @Deprecated
-    public static IncrementalRuleCodegen ofJavaFiles(Collection<File> files) {
+    public static IncrementalRuleCodegen ofJavaResources(Collection<CollectedResource> resources) {
         List<Resource> generatedRules =
-                AnnotatedClassPostProcessor.scan(files.stream().map(File::toPath)).generate();
+                AnnotatedClassPostProcessor.scan(
+                        resources.stream()
+                                .filter(r -> r.resource().getResourceType() == ResourceType.JAVA)
+                                .map(r -> new File(r.resource().getSourcePath()))
+                                .map(File::toPath)).generate();
         return ofResources(generatedRules);
     }
 
@@ -158,11 +117,7 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
         return new IncrementalRuleCodegen(toResources(files.stream()));
     }
 
-    /**
-     *
-     * @deprecated use DecisionCodegen.ofCollectedResources()
-     */
-    @Deprecated public static IncrementalRuleCodegen ofResources(Collection<Resource> resources) {
+    public static IncrementalRuleCodegen ofResources(Collection<Resource> resources) {
         return new IncrementalRuleCodegen(resources);
     }
 

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
@@ -98,30 +98,11 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
         return ofResources(dmnResources);
     }
 
-    public static IncrementalRuleCodegen ofJar(Path... jarPaths) {
-        Collection<Resource> resources = new ArrayList<>();
-
-        for (Path jarPath : jarPaths) {
-            try (ZipFile zipFile = new ZipFile( jarPath.toFile() )) {
-                Enumeration<? extends ZipEntry> entries = zipFile.entries();
-                while (entries.hasMoreElements()) {
-                    ZipEntry entry = entries.nextElement();
-                    ResourceType resourceType = determineResourceType( entry.getName() );
-                    if ( resourceType != null ) {
-                        InternalResource resource = new ByteArrayResource( readBytesFromInputStream( zipFile.getInputStream( entry ) ) );
-                        resource.setResourceType( resourceType );
-                        resource.setSourcePath( entry.getName() );
-                        resources.add( resource );
-                    }
-                }
-            } catch (IOException e) {
-                throw new UncheckedIOException( e );
-            }
-        }
-
-        return new IncrementalRuleCodegen(resources);
-    }
-
+    /**
+     *
+     * @deprecated use DecisionCodegen.ofCollectedResources(CollectedResource.fromPaths(...))
+     */
+    @Deprecated
     public static IncrementalRuleCodegen ofPath(Path... paths) {
         Set<Resource> resources = new HashSet<>();
         for (Path path : paths) {
@@ -134,6 +115,11 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
         return new IncrementalRuleCodegen(resources);
     }
 
+    /**
+     *
+     * @deprecated use DecisionCodegen.ofCollectedResources(CollectedResource.fromPaths(...))
+     */
+    @Deprecated
     public static IncrementalRuleCodegen ofPath(Path basePath, ResourceType resourceType) {
         try (Stream<File> files = Files.walk(basePath).map(Path::toFile)) {
             Set<Resource> resources = toResources(files, resourceType);
@@ -143,21 +129,40 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
         }
     }
 
+    /**
+     *
+     * @deprecated use DecisionCodegen.ofCollectedResources(CollectedResource.fromFiles(...))
+     */
+    @Deprecated
     public static IncrementalRuleCodegen ofFiles(Collection<File> files, ResourceType resourceType) {
         return new IncrementalRuleCodegen(toResources(files.stream(), resourceType));
     }
 
+    /**
+     *
+     * @deprecated no alternative
+     */
+    @Deprecated
     public static IncrementalRuleCodegen ofJavaFiles(Collection<File> files) {
         List<Resource> generatedRules =
                 AnnotatedClassPostProcessor.scan(files.stream().map(File::toPath)).generate();
         return ofResources(generatedRules);
     }
 
+    /**
+     *
+     * @deprecated use DecisionCodegen.ofCollectedResources(CollectedResource.fromFiles(...))
+     */
+    @Deprecated
     public static IncrementalRuleCodegen ofFiles(Collection<File> files) {
         return new IncrementalRuleCodegen(toResources(files.stream()));
     }
 
-    public static IncrementalRuleCodegen ofResources(Collection<Resource> resources) {
+    /**
+     *
+     * @deprecated use DecisionCodegen.ofCollectedResources()
+     */
+    @Deprecated public static IncrementalRuleCodegen ofResources(Collection<Resource> resources) {
         return new IncrementalRuleCodegen(resources);
     }
 

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
@@ -16,17 +16,12 @@
 package org.kie.kogito.codegen.rules;
 
 import java.io.File;
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Enumeration;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -34,8 +29,6 @@ import java.util.OptionalInt;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
 
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
@@ -47,9 +40,7 @@ import org.drools.compiler.compiler.DecisionTableFactory;
 import org.drools.compiler.compiler.DroolsError;
 import org.drools.compiler.kproject.ReleaseIdImpl;
 import org.drools.compiler.kproject.models.KieModuleModelImpl;
-import org.drools.core.io.impl.ByteArrayResource;
 import org.drools.core.io.impl.FileSystemResource;
-import org.drools.core.io.internal.InternalResource;
 import org.drools.modelcompiler.builder.GeneratedFile;
 import org.drools.modelcompiler.builder.ModelBuilderImpl;
 import org.kie.api.builder.model.KieBaseModel;
@@ -79,12 +70,9 @@ import org.kie.kogito.rules.RuleUnitConfig;
 import org.kie.kogito.rules.units.AssignableChecker;
 import org.kie.kogito.rules.units.ReflectiveRuleUnitDescription;
 
-import static java.util.stream.Collectors.toList;
-
 import static com.github.javaparser.StaticJavaParser.parse;
+import static java.util.stream.Collectors.toList;
 import static org.drools.compiler.kie.builder.impl.KieBuilderImpl.setDefaultsforEmptyKieModule;
-import static org.drools.core.util.IoUtils.readBytesFromInputStream;
-import static org.kie.api.io.ResourceType.determineResourceType;
 import static org.kie.kogito.codegen.ApplicationGenerator.log;
 import static org.kie.kogito.codegen.ApplicationGenerator.logger;
 
@@ -106,15 +94,6 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
                                 .map(r -> new File(r.resource().getSourcePath()))
                                 .map(File::toPath)).generate();
         return ofResources(generatedRules);
-    }
-
-    /**
-     *
-     * @deprecated use DecisionCodegen.ofCollectedResources(CollectedResource.fromFiles(...))
-     */
-    @Deprecated
-    public static IncrementalRuleCodegen ofFiles(Collection<File> files) {
-        return new IncrementalRuleCodegen(toResources(files.stream()));
     }
 
     public static IncrementalRuleCodegen ofResources(Collection<Resource> resources) {

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
@@ -81,7 +81,7 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
     public static IncrementalRuleCodegen ofCollectedResources(Collection<CollectedResource> resources) {
         List<Resource> dmnResources = resources.stream()
                 .map(CollectedResource::resource)
-                .filter(IncrementalRuleCodegen::isSupportedResourceType)
+                .filter(r -> r.getResourceType() == ResourceType.DRL || r.getResourceType() == ResourceType.DTABLE)
                 .collect(toList());
         return ofResources(dmnResources);
     }
@@ -100,37 +100,6 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
         return new IncrementalRuleCodegen(resources);
     }
 
-    private static Set<Resource> toResources(Stream<File> files, ResourceType resourceType) {
-        return files.filter(f -> resourceType.matchesExtension(f.getName())).map(FileSystemResource::new).peek(r -> r.setResourceType(resourceType)).collect(Collectors.toSet());
-    }
-
-    private static Set<Resource> toResources(Stream<File> files) {
-        return files.map(FileSystemResource::new).peek(r -> r.setResourceType(typeOf(r))).filter(r -> r.getResourceType() != null).collect(Collectors.toSet());
-    }
-
-    private static boolean isSupportedResourceType(Resource r) {
-        for (ResourceType rt : resourceTypes) {
-            if (r.getResourceType() == rt) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private static ResourceType typeOf(FileSystemResource r) {
-        for (ResourceType rt : resourceTypes) {
-            if (rt.matchesExtension(r.getFile().getName())) {
-                return rt;
-            }
-        }
-        return null;
-    }
-
-
-    private static final ResourceType[] resourceTypes = {
-            ResourceType.DRL,
-            ResourceType.DTABLE
-    };
     private static final String operationalDashboardDmnTemplate = "/grafana-dashboard-template/operational-dashboard-template.json";
     private final Collection<Resource> resources;
     private RuleUnitContainerGenerator moduleGenerator;
@@ -149,11 +118,6 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
     private final boolean decisionTableSupported;
     private final Map<String, RuleUnitConfig> configs;
 
-
-    @Deprecated
-    public IncrementalRuleCodegen(Path basePath, Collection<File> files, ResourceType resourceType) {
-        this(toResources(files.stream(), resourceType));
-    }
 
     private IncrementalRuleCodegen(Collection<Resource> resources) {
         this.resources = resources;

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/AbstractCodegenTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/AbstractCodegenTest.java
@@ -40,7 +40,6 @@ import org.drools.compiler.commons.jci.compilers.JavaCompiler;
 import org.drools.compiler.commons.jci.compilers.JavaCompilerFactory;
 import org.drools.compiler.compiler.io.memory.MemoryFileSystem;
 import org.drools.compiler.rule.builder.dialect.java.JavaDialectConfiguration;
-import org.drools.core.io.impl.FileSystemResource;
 import org.kie.kogito.Application;
 import org.kie.kogito.codegen.context.KogitoBuildContext;
 import org.kie.kogito.codegen.context.QuarkusKogitoBuildContext;
@@ -80,34 +79,28 @@ public class AbstractCodegenTest {
     private static final Map<TYPE, Function<List<String>, Generator>> generatorTypeMap = new HashMap<>();
 
     static {
-        generatorTypeMap.put(TYPE.PROCESS, strings -> ProcessCodegen.ofFiles(strings
-                                                                                     .stream()
-                                                                                     .map(resource -> new File(TEST_RESOURCES, resource))
-                                                                                     .collect(Collectors.toList())));
-        generatorTypeMap.put(TYPE.RULES, strings -> IncrementalRuleCodegen.ofFiles(strings
-                                                                                           .stream()
-                                                                                           .map(resource -> new File(
-                                                                                                   TEST_RESOURCES, resource))
-                                                                                           .collect(Collectors.toList())));
-        generatorTypeMap.put(TYPE.DECISION,
-                             strings -> {
-                                 List<CollectedResource> cResources = strings.stream()
-                                                                             .map(s -> new CollectedResource(Paths.get(TEST_RESOURCES).toAbsolutePath(),
-                                                                                                             new FileSystemResource(Paths.get(TEST_RESOURCES, s).toAbsolutePath().toFile())))
-                                                                             .collect(Collectors.toList());
-                                 return DecisionCodegen.ofCollectedResources(cResources);
-                             });
+        generatorTypeMap.put(TYPE.PROCESS, strings -> ProcessCodegen.ofCollectedResources(toCollectedResources(TEST_RESOURCES, strings)));
+        generatorTypeMap.put(TYPE.RULES, strings -> IncrementalRuleCodegen.ofCollectedResources(toCollectedResources(TEST_RESOURCES, strings)));
+        generatorTypeMap.put(TYPE.DECISION, strings -> DecisionCodegen.ofCollectedResources(toCollectedResources(TEST_RESOURCES, strings)));
 
-        generatorTypeMap.put(TYPE.JAVA, strings -> IncrementalRuleCodegen.ofJavaFiles(strings
-                                                                                              .stream()
-                                                                                              .map(resource -> new File(TEST_JAVA, resource))
-                                                                                              .collect(Collectors.toList())));
-        generatorTypeMap.put(TYPE.PREDICTION,
-                             strings -> PredictionCodegen.ofFiles(Paths.get(TEST_RESOURCES).toAbsolutePath(),
-                                                                  strings
-                                                                          .stream()
-                                                                          .map(resource -> new File(TEST_RESOURCES, resource))
-                                                                          .collect(Collectors.toList())));
+        generatorTypeMap.put(TYPE.JAVA, strings -> IncrementalRuleCodegen.ofJavaResources(toCollectedResources(TEST_JAVA, strings)));
+        generatorTypeMap.put(TYPE.PREDICTION, strings -> PredictionCodegen.ofCollectedResources(toCollectedResources(TEST_RESOURCES, strings)));
+    }
+
+    private static Collection<CollectedResource> toCollectedResources(String basePath, List<String> strings) {
+        File[] files = strings
+                .stream()
+                .map(resource -> new File(basePath, resource))
+                .toArray(File[]::new);
+        return CollectedResource.fromFiles(Paths.get(basePath), files);
+    }
+
+
+    private static List<File> toFiles(List<String> strings, String path) {
+        return strings
+                .stream()
+                .map(resource -> new File(path, resource))
+                .collect(Collectors.toList());
     }
 
     private boolean withSpringContext;

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/decision/DecisionCodegenTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/decision/DecisionCodegenTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.kie.kogito.codegen.AddonsConfig;
 import org.kie.kogito.codegen.GeneratedFile;
 import org.kie.kogito.codegen.GeneratorContext;
+import org.kie.kogito.codegen.io.CollectedResource;
 import org.kie.kogito.grafana.JGrafana;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,7 +42,7 @@ public class DecisionCodegenTest {
 
         GeneratorContext context = stronglyTypedContext();
 
-        DecisionCodegen codeGenerator = DecisionCodegen.ofPath(Paths.get("src/test/resources/decision/models/vacationDays").toAbsolutePath());
+        DecisionCodegen codeGenerator = DecisionCodegen.ofCollectedResources(CollectedResource.fromPaths(Paths.get("src/test/resources/decision/models/vacationDays").toAbsolutePath()));
         codeGenerator.setContext(context);
 
         List<GeneratedFile> generatedFiles = codeGenerator.generate();
@@ -71,7 +72,7 @@ public class DecisionCodegenTest {
     public void doNotGenerateTypesafeInfo() throws Exception {
         GeneratorContext context = stronglyTypedContext();
 
-        DecisionCodegen codeGenerator = DecisionCodegen.ofPath(Paths.get("src/test/resources/decision/alltypes/").toAbsolutePath());
+        DecisionCodegen codeGenerator = DecisionCodegen.ofCollectedResources(CollectedResource.fromPaths(Paths.get("src/test/resources/decision/alltypes/").toAbsolutePath()));
         codeGenerator.setContext(context);
 
         List<GeneratedFile> generatedFiles = codeGenerator.generate();
@@ -114,7 +115,7 @@ public class DecisionCodegenTest {
 
     @Test
     public void resilientToDuplicateDMNIDs() throws Exception {
-        DecisionCodegen codeGenerator = DecisionCodegen.ofPath(Paths.get("src/test/resources/decision-test20200507").toAbsolutePath());
+        DecisionCodegen codeGenerator = DecisionCodegen.ofCollectedResources(CollectedResource.fromPaths(Paths.get("src/test/resources/decision-test20200507").toAbsolutePath()));
 
         List<GeneratedFile> generatedFiles = codeGenerator.generate();
         assertThat(generatedFiles.size()).isGreaterThanOrEqualTo(3);
@@ -125,7 +126,7 @@ public class DecisionCodegenTest {
 
     @Test
     public void emptyName() throws Exception {
-        DecisionCodegen codeGenerator = DecisionCodegen.ofPath(Paths.get("src/test/resources/decision-empty-name").toAbsolutePath());
+        DecisionCodegen codeGenerator = DecisionCodegen.ofCollectedResources(CollectedResource.fromPaths(Paths.get("src/test/resources/decision-empty-name").toAbsolutePath()));
         RuntimeException re = Assertions.assertThrows(RuntimeException.class, () -> {
             codeGenerator.generate();
         });
@@ -133,7 +134,7 @@ public class DecisionCodegenTest {
     }
 
     private List<GeneratedFile> generateTestDashboards(AddonsConfig addonsConfig) throws IOException {
-        DecisionCodegen codeGenerator = DecisionCodegen.ofPath(Paths.get("src/test/resources/decision/models/vacationDays").toAbsolutePath())
+        DecisionCodegen codeGenerator = DecisionCodegen.ofCollectedResources(CollectedResource.fromPaths(Paths.get("src/test/resources/decision/models/vacationDays").toAbsolutePath()))
                 .withAddons(addonsConfig);
 
         List<GeneratedFile> generatedFiles = codeGenerator.generate();
@@ -148,7 +149,7 @@ public class DecisionCodegenTest {
     @Test
     public void testNSEW_positive() throws Exception {
         // This test is meant to check that IFF Eclipse MP OpenAPI annotations are available on Build/CP of Kogito application, annotation is used with codegen
-        DecisionCodegen codeGenerator = DecisionCodegen.ofPath(Paths.get("src/test/resources/decision-NSEW").toAbsolutePath());
+        DecisionCodegen codeGenerator = DecisionCodegen.ofCollectedResources(CollectedResource.fromPaths(Paths.get("src/test/resources/decision-NSEW").toAbsolutePath()));
         GeneratorContext context = stronglyTypedContext();
         codeGenerator.setContext(context);
         codeGenerator.withClassLoader(new ClassLoader() {
@@ -165,7 +166,7 @@ public class DecisionCodegenTest {
 
     @Test
     public void testNSEW_negative() throws Exception {
-        DecisionCodegen codeGenerator = DecisionCodegen.ofPath(Paths.get("src/test/resources/decision-NSEW").toAbsolutePath());
+        DecisionCodegen codeGenerator = DecisionCodegen.ofCollectedResources(CollectedResource.fromPaths(Paths.get("src/test/resources/decision-NSEW").toAbsolutePath()));
         GeneratorContext context = stronglyTypedContext();
         codeGenerator.setContext(context);
 

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/decision/DecisionModelResourcesProviderCodegenTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/decision/DecisionModelResourcesProviderCodegenTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.kie.kogito.codegen.AddonsConfig;
 import org.kie.kogito.codegen.GeneratedFile;
 import org.kie.kogito.codegen.GeneratorContext;
+import org.kie.kogito.codegen.io.CollectedResource;
 
 import static com.github.javaparser.StaticJavaParser.parse;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -47,7 +48,7 @@ public class DecisionModelResourcesProviderCodegenTest {
         final GeneratorContext context = GeneratorContext.ofProperties(new Properties());
 
         final DecisionCodegen codeGenerator = DecisionCodegen
-                .ofPath(Paths.get("src/test/resources/decision/models/vacationDays").toAbsolutePath())
+                .ofCollectedResources(CollectedResource.fromPaths(Paths.get("src/test/resources/decision/models/vacationDays").toAbsolutePath()))
                 .withAddons(new AddonsConfig().withTracing(true));
         codeGenerator.setContext(context);
 

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/io/CollectedResourceTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/io/CollectedResourceTest.java
@@ -1,0 +1,24 @@
+package org.kie.kogito.codegen.io;
+
+import java.io.File;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.Test;
+import org.kie.api.io.Resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CollectedResourceTest {
+
+    @Test
+    void shouldNotContainDirectories() {
+        assertThat(
+                CollectedResource.fromDirectory(Paths.get("src/main/resources"))
+                        .stream()
+                        .map(CollectedResource::resource)
+                        .map(Resource::getSourcePath)
+                        .map(File::new)
+                        .filter(File::isDirectory)
+                        .count()).isZero();
+    }
+}

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/prediction/PredictionCodegenTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/prediction/PredictionCodegenTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.kie.kogito.codegen.AbstractCodegenTest;
 import org.kie.kogito.codegen.GeneratedFile;
 import org.kie.kogito.codegen.GeneratorContext;
+import org.kie.kogito.codegen.io.CollectedResource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -38,7 +39,7 @@ public class PredictionCodegenTest extends AbstractCodegenTest {
 
         GeneratorContext context = GeneratorContext.ofProperties(new Properties());
 
-        PredictionCodegen codeGenerator = PredictionCodegen.ofPath(Paths.get(FULL_SOURCE).toAbsolutePath());
+        PredictionCodegen codeGenerator = PredictionCodegen.ofCollectedResources(CollectedResource.fromPaths(Paths.get(FULL_SOURCE).toAbsolutePath()));
         codeGenerator.setContext(context);
 
         List<GeneratedFile> generatedFiles = codeGenerator.generate();

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/prediction/PredictionCodegenTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/prediction/PredictionCodegenTest.java
@@ -15,6 +15,7 @@
 
 package org.kie.kogito.codegen.prediction;
 
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Properties;
@@ -32,14 +33,16 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 public class PredictionCodegenTest extends AbstractCodegenTest {
 
     private static final String SOURCE = "prediction/test_regression.pmml";
-    private static final String FULL_SOURCE = "src/test/resources/" + SOURCE;
+    private static final Path BASE_PATH = Paths.get("src/test/resources/").toAbsolutePath();
+    private static final Path FULL_SOURCE = BASE_PATH.resolve(SOURCE);
 
     @Test
     public void generateAllFiles() throws Exception {
 
         GeneratorContext context = GeneratorContext.ofProperties(new Properties());
 
-        PredictionCodegen codeGenerator = PredictionCodegen.ofCollectedResources(CollectedResource.fromPaths(Paths.get(FULL_SOURCE).toAbsolutePath()));
+        PredictionCodegen codeGenerator = PredictionCodegen.ofCollectedResources(
+                CollectedResource.fromFiles(BASE_PATH, FULL_SOURCE.toFile()));
         codeGenerator.setContext(context);
 
         List<GeneratedFile> generatedFiles = codeGenerator.generate();

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegenTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegenTest.java
@@ -44,10 +44,9 @@ public class IncrementalRuleCodegenTest {
     @Test
     public void generateSingleFile() {
         IncrementalRuleCodegen incrementalRuleCodegen =
-                IncrementalRuleCodegen.ofFiles(
-                        Collections.singleton(
-                                new File("src/test/resources/org/kie/kogito/codegen/rules/pkg1/file1.drl")),
-                        ResourceType.DRL);
+                IncrementalRuleCodegen.ofCollectedResources(
+                        CollectedResource.fromFiles(Paths.get("src/test/resources"),
+                                                    new File("src/test/resources/org/kie/kogito/codegen/rules/pkg1/file1.drl")));
         incrementalRuleCodegen.setPackageName("com.acme");
 
         List<GeneratedFile> generatedFiles = incrementalRuleCodegen.withHotReloadMode().generate();
@@ -57,22 +56,23 @@ public class IncrementalRuleCodegenTest {
     @Test
     public void generateSinglePackage() {
         IncrementalRuleCodegen incrementalRuleCodegen =
-                IncrementalRuleCodegen.ofFiles(
-                        asList(new File("src/test/resources/org/kie/kogito/codegen/rules/pkg1").listFiles()),
-                        ResourceType.DRL);
+                IncrementalRuleCodegen.ofCollectedResources(
+                        CollectedResource.fromFiles(
+                                Paths.get("src/test/resources"),
+                                new File("src/test/resources/org/kie/kogito/codegen/rules/pkg1").listFiles()));
         incrementalRuleCodegen.setPackageName("com.acme");
 
         List<GeneratedFile> generatedFiles = incrementalRuleCodegen.withHotReloadMode().generate();
         assertRules(5, 1, generatedFiles.size());
     }
 
-
     @Test
     public void generateSinglePackageSingleUnit() {
         IncrementalRuleCodegen incrementalRuleCodegen =
-                IncrementalRuleCodegen.ofFiles(
-                        asList(new File("src/test/resources/org/kie/kogito/codegen/rules/multiunit").listFiles()),
-                        ResourceType.DRL);
+                IncrementalRuleCodegen.ofCollectedResources(
+                        CollectedResource.fromFiles(
+                                Paths.get("src/test/resources"),
+                                new File("src/test/resources/org/kie/kogito/codegen/rules/multiunit").listFiles()));
         incrementalRuleCodegen.setPackageName("org.kie.kogito.codegen.rules.multiunit");
 
         List<GeneratedFile> generatedFiles = incrementalRuleCodegen.withHotReloadMode().generate();
@@ -93,8 +93,9 @@ public class IncrementalRuleCodegenTest {
     @Test
     public void generateSingleDtable() {
         IncrementalRuleCodegen incrementalRuleCodegen =
-                IncrementalRuleCodegen.ofFiles(
-                        Collections.singleton(
+                IncrementalRuleCodegen.ofCollectedResources(
+                        CollectedResource.fromFiles(
+                                Paths.get("src/test/resources"),
                                 new File("src/test/resources/org/drools/simple/candrink/CanDrink.xls")));
         incrementalRuleCodegen.setPackageName("com.acme");
 
@@ -117,8 +118,9 @@ public class IncrementalRuleCodegenTest {
     @Test
     public void generateCepRule() {
         IncrementalRuleCodegen incrementalRuleCodegen =
-                IncrementalRuleCodegen.ofFiles(
-                        Collections.singleton(
+                IncrementalRuleCodegen.ofCollectedResources(
+                        CollectedResource.fromFiles(
+                                Paths.get("src/test/resources"),
                                 new File("src/test/resources/org/drools/simple/cep/cep.drl")));
         incrementalRuleCodegen.setPackageName("com.acme");
 
@@ -130,8 +132,9 @@ public class IncrementalRuleCodegenTest {
     @Test
     public void raiseErrorOnSyntaxError() {
         IncrementalRuleCodegen incrementalRuleCodegen =
-                IncrementalRuleCodegen.ofFiles(
-                        Collections.singleton(
+                IncrementalRuleCodegen.ofCollectedResources(
+                        CollectedResource.fromFiles(
+                                Paths.get("src/test/resources"),
                                 new File("src/test/resources/org/drools/simple/broken.drl")));
         incrementalRuleCodegen.setPackageName("com.acme");
         assertThrows(RuleCodegenError.class, incrementalRuleCodegen.withHotReloadMode()::generate);
@@ -140,20 +143,21 @@ public class IncrementalRuleCodegenTest {
     @Test
     public void raiseErrorOnBadOOPath() {
         IncrementalRuleCodegen incrementalRuleCodegen =
-                IncrementalRuleCodegen.ofFiles(
-                        Collections.singleton(
+                IncrementalRuleCodegen.ofCollectedResources(
+                        CollectedResource.fromFiles(
+                                Paths.get("src/test/resources"),
                                 new File("src/test/resources/org/kie/kogito/codegen/brokenrules/brokenunit/ABrokenUnit.drl")));
         incrementalRuleCodegen.setPackageName("com.acme");
         assertThrows(RuleCodegenError.class, incrementalRuleCodegen.withHotReloadMode()::generate);
     }
 
-
     @Test
     public void throwWhenDtableDependencyMissing() {
         DecisionTableFactory.setDecisionTableProvider(null);
         IncrementalRuleCodegen incrementalRuleCodegen =
-                IncrementalRuleCodegen.ofFiles(
-                        Collections.singleton(
+                IncrementalRuleCodegen.ofCollectedResources(
+                        CollectedResource.fromFiles(
+                                Paths.get("src/test/resources"),
                                 new File("src/test/resources/org/drools/simple/candrink/CanDrink.xls")));
         incrementalRuleCodegen.setPackageName("com.acme");
         assertThrows(MissingDecisionTableDependencyError.class, incrementalRuleCodegen.withHotReloadMode()::generate);
@@ -162,8 +166,9 @@ public class IncrementalRuleCodegenTest {
     @Test
     public void generateGrafanaDashboards() {
         IncrementalRuleCodegen incrementalRuleCodegen =
-                IncrementalRuleCodegen.ofFiles(
-                        Collections.singleton(
+                IncrementalRuleCodegen.ofCollectedResources(
+                        CollectedResource.fromFiles(
+                                Paths.get("src/test/resources"),
                                 new File("src/test/resources/org/kie/kogito/codegen/unit/RuleUnitQuery.drl")))
                         .withAddons(new AddonsConfig().withMonitoring(true));
         incrementalRuleCodegen.setPackageName("com.acme");
@@ -176,12 +181,12 @@ public class IncrementalRuleCodegenTest {
         assertEquals(expectedRules +
                              expectedPackages * 2 + // package descriptor for rules + package metadata 
                              expectedUnits * 3, // ruleUnit + ruleUnit instance + unit model
-                             actualGeneratedFiles - 2); // ignore ProjectModel and ProjectRuntime classes
+                     actualGeneratedFiles - 2); // ignore ProjectModel and ProjectRuntime classes
     }
 
     private static void assertRules(int expectedRules, int expectedPackages, int actualGeneratedFiles) {
         assertEquals(expectedRules +
                              expectedPackages * 2, // package descriptor for rules + package metadata
-                             actualGeneratedFiles - 2); // ignore ProjectModel and ProjectRuntime classes
+                     actualGeneratedFiles - 2); // ignore ProjectModel and ProjectRuntime classes
     }
 }

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegenTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegenTest.java
@@ -28,6 +28,7 @@ import org.kie.api.internal.utils.ServiceRegistry;
 import org.kie.api.io.ResourceType;
 import org.kie.kogito.codegen.AddonsConfig;
 import org.kie.kogito.codegen.GeneratedFile;
+import org.kie.kogito.codegen.io.CollectedResource;
 
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -81,9 +82,8 @@ public class IncrementalRuleCodegenTest {
     @Test
     public void generateDirectoryRecursively() {
         IncrementalRuleCodegen incrementalRuleCodegen =
-                IncrementalRuleCodegen.ofPath(
-                        Paths.get("src/test/resources/org/kie/kogito/codegen/rules"),
-                        ResourceType.DRL);
+                IncrementalRuleCodegen.ofCollectedResources(CollectedResource.fromPaths(
+                        Paths.get("src/test/resources/org/kie/kogito/codegen/rules")));
         incrementalRuleCodegen.setPackageName("com.acme");
 
         List<GeneratedFile> generatedFiles = incrementalRuleCodegen.withHotReloadMode().generate();
@@ -106,9 +106,8 @@ public class IncrementalRuleCodegenTest {
     @Test
     public void generateSingleUnit() {
         IncrementalRuleCodegen incrementalRuleCodegen =
-                IncrementalRuleCodegen.ofPath(
-                        Paths.get("src/test/resources/org/kie/kogito/codegen/rules/myunit"),
-                        ResourceType.DRL);
+                IncrementalRuleCodegen.ofCollectedResources(CollectedResource.fromPaths(
+                        Paths.get("src/test/resources/org/kie/kogito/codegen/rules/myunit")));
         incrementalRuleCodegen.setPackageName("com.acme");
 
         List<GeneratedFile> generatedFiles = incrementalRuleCodegen.withHotReloadMode().generate();

--- a/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
+++ b/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
@@ -48,6 +48,7 @@ import org.kie.kogito.codegen.GeneratedFile;
 import org.kie.kogito.codegen.GeneratedFile.Type;
 import org.kie.kogito.codegen.GeneratorContext;
 import org.kie.kogito.codegen.decision.DecisionCodegen;
+import org.kie.kogito.codegen.io.CollectedResource;
 import org.kie.kogito.codegen.prediction.PredictionCodegen;
 import org.kie.kogito.codegen.process.ProcessCodegen;
 import org.kie.kogito.codegen.rules.IncrementalRuleCodegen;
@@ -259,25 +260,25 @@ public class GenerateModelMojo extends AbstractKieMojo {
         // if not null, the property has been overridden, and we should use the specified value
 
         if (generateProcesses()) {
-            appGen.withGenerator(ProcessCodegen.ofPath(kieSourcesDirectory.toPath()))
+            appGen.withGenerator(ProcessCodegen.ofCollectedResources(CollectedResource.fromDirectory(kieSourcesDirectory.toPath())))
                     .withAddons(addonsConfig)
                     .withClassLoader(projectClassLoader);
         }
 
         if (generateRules()) {
             boolean useRestServices = hasClassOnClasspath(project, "javax.ws.rs.Path");
-            appGen.withGenerator(IncrementalRuleCodegen.ofPath(kieSourcesDirectory.toPath()))
+            appGen.withGenerator(IncrementalRuleCodegen.ofCollectedResources(CollectedResource.fromDirectory(kieSourcesDirectory.toPath())))
                     .withKModule(getKModuleModel())
                     .withClassLoader(projectClassLoader)
                     .withAddons(addonsConfig)
                     .withRestServices(useRestServices);
         }
 
-        appGen.withGenerator(PredictionCodegen.ofPath(kieSourcesDirectory.toPath()))
+        appGen.withGenerator(PredictionCodegen.ofCollectedResources(CollectedResource.fromDirectory(kieSourcesDirectory.toPath())))
                 .withAddons(addonsConfig);
 
         if (generateDecisions()) {
-            appGen.withGenerator(DecisionCodegen.ofPath(kieSourcesDirectory.toPath()))
+            appGen.withGenerator(DecisionCodegen.ofCollectedResources(CollectedResource.fromDirectory(kieSourcesDirectory.toPath())))
                   .withAddons(addonsConfig)
                   .withClassLoader(projectClassLoader);
         }

--- a/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/DMNCompilationProvider.java
+++ b/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/DMNCompilationProvider.java
@@ -18,12 +18,14 @@ package org.kie.kogito.quarkus.deployment;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Set;
 
 import org.kie.kogito.codegen.ApplicationGenerator;
 import org.kie.kogito.codegen.Generator;
 import org.kie.kogito.codegen.decision.DecisionCodegen;
+import org.kie.kogito.codegen.io.CollectedResource;
 
 public class DMNCompilationProvider extends KogitoCompilationProvider {
 
@@ -34,7 +36,9 @@ public class DMNCompilationProvider extends KogitoCompilationProvider {
 
     @Override
     protected Generator addGenerator(ApplicationGenerator appGen, Set<File> filesToCompile, Context context, ClassLoader cl) throws IOException {
-        return appGen.withGenerator(DecisionCodegen.ofPath(context.getProjectDirectory().toPath().resolve("src" + File.separator + "main" + File.separator + "resources")))
-                     .withClassLoader(cl);
+        Path path = context.getProjectDirectory().toPath().resolve("src").resolve("main").resolve("resources");
+        return appGen.withGenerator(DecisionCodegen.ofCollectedResources(
+                CollectedResource.fromDirectory(path)))
+                .withClassLoader(cl);
     }
 }

--- a/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/DecisionTablesCompilationProvider.java
+++ b/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/DecisionTablesCompilationProvider.java
@@ -24,7 +24,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.kie.api.io.ResourceType;
 import org.kie.kogito.codegen.ApplicationGenerator;
 import org.kie.kogito.codegen.Generator;
 import org.kie.kogito.codegen.io.CollectedResource;

--- a/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/DecisionTablesCompilationProvider.java
+++ b/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/DecisionTablesCompilationProvider.java
@@ -17,6 +17,7 @@
 package org.kie.kogito.quarkus.deployment;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -26,6 +27,7 @@ import java.util.Set;
 import org.kie.api.io.ResourceType;
 import org.kie.kogito.codegen.ApplicationGenerator;
 import org.kie.kogito.codegen.Generator;
+import org.kie.kogito.codegen.io.CollectedResource;
 import org.kie.kogito.codegen.rules.IncrementalRuleCodegen;
 
 public class DecisionTablesCompilationProvider extends KogitoCompilationProvider {
@@ -39,11 +41,11 @@ public class DecisionTablesCompilationProvider extends KogitoCompilationProvider
 
     @Override
     protected Generator addGenerator(ApplicationGenerator appGen, Set<File> filesToCompile, Context context, ClassLoader cl) {
+        Path resources = context.getProjectDirectory().toPath().resolve("src").resolve("main").resolve("resources");
         Collection<File> files = PackageWalker.getAllSiblings(filesToCompile);
         return appGen.withGenerator(
-                IncrementalRuleCodegen.ofFiles(
-                        files,
-                        ResourceType.DTABLE))
+                IncrementalRuleCodegen.ofCollectedResources(
+                        CollectedResource.fromFiles(resources, files.toArray(new File[0]))))
                 .withClassLoader(cl)
                 .withHotReloadMode();
     }

--- a/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/ProcessCompilationProvider.java
+++ b/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/ProcessCompilationProvider.java
@@ -18,7 +18,6 @@ package org.kie.kogito.quarkus.deployment;
 
 import java.io.File;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 

--- a/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/ProcessCompilationProvider.java
+++ b/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/ProcessCompilationProvider.java
@@ -17,12 +17,14 @@
 package org.kie.kogito.quarkus.deployment;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 
 import org.kie.kogito.codegen.ApplicationGenerator;
 import org.kie.kogito.codegen.Generator;
+import org.kie.kogito.codegen.io.CollectedResource;
 import org.kie.kogito.codegen.process.ProcessCodegen;
 
 import static java.util.Arrays.asList;
@@ -36,8 +38,9 @@ public class ProcessCompilationProvider extends KogitoCompilationProvider {
 
     @Override
     protected Generator addGenerator(ApplicationGenerator appGen, Set<File> filesToCompile, Context context, ClassLoader cl) {
+        Path resources = context.getProjectDirectory().toPath().resolve("src").resolve("main").resolve("resources");
         return appGen.withGenerator(
-                ProcessCodegen.ofFiles(new ArrayList<>(filesToCompile)))
+                ProcessCodegen.ofCollectedResources(CollectedResource.fromFiles(resources, filesToCompile.toArray(new File[0]))))
                 .withClassLoader(cl);
     }
 }

--- a/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/RulesCompilationProvider.java
+++ b/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/RulesCompilationProvider.java
@@ -22,7 +22,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
 
-import org.kie.api.io.ResourceType;
 import org.kie.kogito.codegen.ApplicationGenerator;
 import org.kie.kogito.codegen.Generator;
 import org.kie.kogito.codegen.io.CollectedResource;

--- a/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/RulesCompilationProvider.java
+++ b/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/RulesCompilationProvider.java
@@ -17,6 +17,7 @@
 package org.kie.kogito.quarkus.deployment;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
@@ -24,6 +25,7 @@ import java.util.Set;
 import org.kie.api.io.ResourceType;
 import org.kie.kogito.codegen.ApplicationGenerator;
 import org.kie.kogito.codegen.Generator;
+import org.kie.kogito.codegen.io.CollectedResource;
 import org.kie.kogito.codegen.rules.IncrementalRuleCodegen;
 
 public class RulesCompilationProvider extends KogitoCompilationProvider {
@@ -35,11 +37,11 @@ public class RulesCompilationProvider extends KogitoCompilationProvider {
 
     @Override
     protected Generator addGenerator(ApplicationGenerator appGen, Set<File> filesToCompile, Context context, ClassLoader cl) {
+        Path resources = context.getProjectDirectory().toPath().resolve("src").resolve("main").resolve("resources");
         Collection<File> files = PackageWalker.getAllSiblings(filesToCompile);
         return appGen.withGenerator(
-                IncrementalRuleCodegen.ofFiles(
-                        files,
-                        ResourceType.DRL))
+                IncrementalRuleCodegen.ofCollectedResources(
+                        CollectedResource.fromFiles(resources, files.toArray(new File[0]))))
                 .withClassLoader(cl)
                 .withHotReloadMode();
     }


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-3110

The method ofCollectedResources is almost exactly the same in DecisionCodegen, PredictionCodegen, ProcessCodegen and IncrementalRuleCodegen.
Remove all other variations of the ofPath, ofFiles etc. and use ofCollectedResources everywhere (where applicable)
