### PR TITLE
KOGITO-3267  Disable test NativeJavaFNctxIT (breaks with native image)

### DIFF
--- a/integration-tests/integration-tests-quarkus/src/test/java/org/kie/kogito/integrationtests/quarkus/NativeJavaFNctxIT.java
+++ b/integration-tests/integration-tests-quarkus/src/test/java/org/kie/kogito/integrationtests/quarkus/NativeJavaFNctxIT.java
@@ -21,7 +21,7 @@ import io.quarkus.test.junit.NativeImageTest;
 import org.junit.jupiter.api.Disabled;
 import org.kie.kogito.testcontainers.quarkus.InfinispanQuarkusTestResource;
 
-@Disabled("Currently not working in native mode")
+@Disabled("KOGITO-3269 NativeJavaFNctxIT not working in native mode (Quarkus 1.8 CR1 + GraalVM 20.2)")
 @NativeImageTest
 @QuarkusTestResource(InfinispanQuarkusTestResource.Conditional.class)
 class NativeJavaFNctxIT extends JavaFNctxTest {

--- a/integration-tests/integration-tests-quarkus/src/test/java/org/kie/kogito/integrationtests/quarkus/NativeJavaFNctxIT.java
+++ b/integration-tests/integration-tests-quarkus/src/test/java/org/kie/kogito/integrationtests/quarkus/NativeJavaFNctxIT.java
@@ -18,8 +18,10 @@ package org.kie.kogito.integrationtests.quarkus;
 
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.NativeImageTest;
+import org.junit.jupiter.api.Disabled;
 import org.kie.kogito.testcontainers.quarkus.InfinispanQuarkusTestResource;
 
+@Disabled("Currently not working in native mode")
 @NativeImageTest
 @QuarkusTestResource(InfinispanQuarkusTestResource.Conditional.class)
 class NativeJavaFNctxIT extends JavaFNctxTest {


### PR DESCRIPTION
Temporarily disabling because it breaks in native mode with Quarkus master / graalvm 20.2