### PR TITLE
KOGITO-3292 KNative eventing is not enabled with Quarkus Extension (fix template)

### DIFF
--- a/kogito-codegen/src/main/resources/class-templates/events/CloudEventsMessageProducerTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/events/CloudEventsMessageProducerTemplate.java
@@ -11,7 +11,6 @@ import org.kie.kogito.services.event.EventMarshaller;
 
 
 import java.util.Optional;
-import java.util.TimeZone;
 
 public class MessageProducer {
 


### PR DESCRIPTION
minor follow up to https://github.com/kiegroup/kogito-runtimes/pull/748, just remove a useless import in the fixed template 