### PR TITLE
KOGITO-3330 Hotfix: Conditional eager reading of resources on native-image

### DIFF
--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionContainerGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionContainerGenerator.java
@@ -68,14 +68,14 @@ public class DecisionContainerGenerator extends AbstractApplicationSection {
         CompilationUnit clazz = StaticJavaParser.parse(this.getClass().getResourceAsStream(TEMPLATE_JAVA));
         ClassOrInterfaceDeclaration typeDeclaration = (ClassOrInterfaceDeclaration) clazz.getTypes().get(0);
         ClassOrInterfaceType applicationClass = StaticJavaParser.parseClassOrInterfaceType(applicationCanonicalName);
-        ClassOrInterfaceType inputStreamReaderClass = StaticJavaParser.parseClassOrInterfaceType(java.io.InputStreamReader.class.getCanonicalName());
+//        ClassOrInterfaceType inputStreamReaderClass = StaticJavaParser.parseClassOrInterfaceType(java.io.InputStreamReader.class.getCanonicalName());
         for (CollectedResource resource : resources) {
             MethodCallExpr getResAsStream = getReadResourceMethod(applicationClass, resource);
-            ObjectCreationExpr isr = new ObjectCreationExpr().setType(inputStreamReaderClass).addArgument(getResAsStream);
+//            ObjectCreationExpr isr = new ObjectCreationExpr().setType(inputStreamReaderClass).addArgument(getResAsStream);
             Optional<FieldDeclaration> dmnRuntimeField = typeDeclaration.getFieldByName("dmnRuntime");
             Optional<Expression> initalizer = dmnRuntimeField.flatMap(x -> x.getVariable(0).getInitializer());
             if (initalizer.isPresent()) {
-                initalizer.get().asMethodCallExpr().addArgument(isr);
+                initalizer.get().asMethodCallExpr().addArgument(new MethodCallExpr("readResource").addArgument(getResAsStream));
             } else {
                 throw new RuntimeException("The template " + TEMPLATE_JAVA + " has been modified.");
             }

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionContainerGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionContainerGenerator.java
@@ -68,14 +68,13 @@ public class DecisionContainerGenerator extends AbstractApplicationSection {
         CompilationUnit clazz = StaticJavaParser.parse(this.getClass().getResourceAsStream(TEMPLATE_JAVA));
         ClassOrInterfaceDeclaration typeDeclaration = (ClassOrInterfaceDeclaration) clazz.getTypes().get(0);
         ClassOrInterfaceType applicationClass = StaticJavaParser.parseClassOrInterfaceType(applicationCanonicalName);
-//        ClassOrInterfaceType inputStreamReaderClass = StaticJavaParser.parseClassOrInterfaceType(java.io.InputStreamReader.class.getCanonicalName());
         for (CollectedResource resource : resources) {
             MethodCallExpr getResAsStream = getReadResourceMethod(applicationClass, resource);
-//            ObjectCreationExpr isr = new ObjectCreationExpr().setType(inputStreamReaderClass).addArgument(getResAsStream);
+            MethodCallExpr isr = new MethodCallExpr("readResource").addArgument(getResAsStream);
             Optional<FieldDeclaration> dmnRuntimeField = typeDeclaration.getFieldByName("dmnRuntime");
             Optional<Expression> initalizer = dmnRuntimeField.flatMap(x -> x.getVariable(0).getInitializer());
             if (initalizer.isPresent()) {
-                initalizer.get().asMethodCallExpr().addArgument(new MethodCallExpr("readResource").addArgument(getResAsStream));
+                initalizer.get().asMethodCallExpr().addArgument(isr);
             } else {
                 throw new RuntimeException("The template " + TEMPLATE_JAVA + " has been modified.");
             }

--- a/kogito-codegen/src/main/resources/class-templates/DecisionContainerTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/DecisionContainerTemplate.java
@@ -1,6 +1,6 @@
 public class DecisionModels implements org.kie.kogito.decision.DecisionModels {
 
-    private final static boolean IS_JDK = System.getProperty("org.graalvm.nativeimage.imagecode") == null;
+    private final static boolean IS_JDK = System.getProperty("org.graalvm.nativeimage.imagecode") != null;
 
     private final static java.util.function.Function<java.lang.String, org.kie.api.runtime.KieRuntimeFactory> kieRuntimeFactoryFunction = PredictionModels.kieRuntimeFactoryFunction;
     private final static org.kie.dmn.api.core.DMNRuntime dmnRuntime = org.kie.kogito.dmn.DMNKogito.createGenericDMNRuntime(kieRuntimeFactoryFunction);
@@ -15,7 +15,7 @@ public class DecisionModels implements org.kie.kogito.decision.DecisionModels {
     }
 
     private static java.io.InputStreamReader readResource(java.io.InputStream stream) {
-        if (IS_JDK) {
+        if (!IS_NATIVE_IMAGE) {
             return new java.io.InputStreamReader(stream);
         }
 

--- a/kogito-codegen/src/main/resources/class-templates/DecisionContainerTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/DecisionContainerTemplate.java
@@ -1,8 +1,6 @@
-import java.util.function.Function;
-
-import org.kie.api.runtime.KieRuntimeFactory;
-
 public class DecisionModels implements org.kie.kogito.decision.DecisionModels {
+
+    private final static boolean IS_JDK = System.getProperty("org.graalvm.nativeimage.imagecode") == null;
 
     private final static java.util.function.Function<java.lang.String, org.kie.api.runtime.KieRuntimeFactory> kieRuntimeFactoryFunction = PredictionModels.kieRuntimeFactoryFunction;
     private final static org.kie.dmn.api.core.DMNRuntime dmnRuntime = org.kie.kogito.dmn.DMNKogito.createGenericDMNRuntime(kieRuntimeFactoryFunction);
@@ -14,6 +12,20 @@ public class DecisionModels implements org.kie.kogito.decision.DecisionModels {
 
     public org.kie.kogito.decision.DecisionModel getDecisionModel(java.lang.String namespace, java.lang.String name) {
         return new org.kie.kogito.dmn.DmnDecisionModel(dmnRuntime, namespace, name, execIdSupplier);
+    }
+
+    private static java.io.InputStreamReader readResource(java.io.InputStream stream) {
+        if (IS_JDK) {
+            return new java.io.InputStreamReader(stream);
+        }
+
+        try {
+            byte[] bytes = stream.readAllBytes();
+            java.io.ByteArrayInputStream byteArrayInputStream = new java.io.ByteArrayInputStream(bytes);
+            return new java.io.InputStreamReader(byteArrayInputStream);
+        } catch (java.io.IOException e) {
+            throw new java.io.UncheckedIOException(e);
+        }
     }
 
 }

--- a/kogito-codegen/src/main/resources/class-templates/DecisionContainerTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/DecisionContainerTemplate.java
@@ -1,6 +1,6 @@
 public class DecisionModels implements org.kie.kogito.decision.DecisionModels {
 
-    private final static boolean IS_JDK = System.getProperty("org.graalvm.nativeimage.imagecode") != null;
+    private final static boolean IS_NATIVE_IMAGE = System.getProperty("org.graalvm.nativeimage.imagecode") != null;
 
     private final static java.util.function.Function<java.lang.String, org.kie.api.runtime.KieRuntimeFactory> kieRuntimeFactoryFunction = PredictionModels.kieRuntimeFactoryFunction;
     private final static org.kie.dmn.api.core.DMNRuntime dmnRuntime = org.kie.kogito.dmn.DMNKogito.createGenericDMNRuntime(kieRuntimeFactoryFunction);


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-3330

In GraalVM 20.2 under certain conditions, it is not possible to hold onto an input stream reader that has been generated from a classpath resource -- see https://github.com/quarkusio/quarkus/issues/8694#issuecomment-691828808

The hotfix consists in eagerly reading the entire resource when native mode is detected at build time (detected via special System property).

in other words, instead of:

```
new InputStreamReader(...getResourceAsStream())
```

for native image we do 

```
bytes = getResourceAsStream().readAllBytes()
new InputStreamReader(new ByteArrayInputStream(bytes))
```


We may have to revisit the issue to see if there are "better" ways to fix it (e.g. Quarkus has most probably a "proper" way to handle resources); in the meantime, we need to merge this to proceed with the release today.

(tested locally with native-image. You can double check integration-tests/integration-tests-quarkus  if you want)
