### PR TITLE
[KOGITO-3078] DMN strongly typed: output definition

### DIFF
--- a/drools/kogito-dmn/src/main/java/org/kie/kogito/dmn/util/StronglyTypedUtils.java
+++ b/drools/kogito-dmn/src/main/java/org/kie/kogito/dmn/util/StronglyTypedUtils.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.dmn.util;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.kie.dmn.api.core.DMNResult;
+import org.kie.dmn.api.core.FEELPropertyAccessible;
+
+public class StronglyTypedUtils {
+
+    private StronglyTypedUtils() {
+    }
+
+    public static FEELPropertyAccessible convertToOutputSet(FEELPropertyAccessible inputSet,
+            Class<? extends FEELPropertyAccessible> outputSetClass) {
+        FEELPropertyAccessible outputSet;
+        try {
+            outputSet = outputSetClass.getDeclaredConstructor().newInstance();
+        } catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException
+                | NoSuchMethodException | SecurityException e) {
+            throw new RuntimeException(e);
+        }
+        outputSet.fromMap(inputSet.allFEELProperties());
+        return outputSet;
+    }
+
+    public static FEELPropertyAccessible extractOutputSet(DMNResult result,
+            Class<? extends FEELPropertyAccessible> outputSetClass) {
+        FEELPropertyAccessible outputSet;
+        try {
+            outputSet = outputSetClass.getDeclaredConstructor().newInstance();
+        } catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException
+                | NoSuchMethodException | SecurityException e) {
+            throw new RuntimeException(e);
+        }
+        outputSet.fromMap(result.getContext().getAll());
+        return outputSet;
+    }
+}

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionRestResourceGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionRestResourceGenerator.java
@@ -206,7 +206,7 @@ public class DecisionRestResourceGenerator {
     }
 
     private void interpolateInputData(ClassOrInterfaceDeclaration template) {
-        String inputData = isStronglyTyped ? "outputSet" : "variables";
+        String inputData = "variables"; // use "outputSet" if stronglyTyped when drools 7.44 is available
         template.findAll(NameExpr.class, expr -> expr.getNameAsString().equals("$inputData$"))
                 .forEach(expr -> expr.setName(inputData));
     }

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionRestResourceGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionRestResourceGenerator.java
@@ -16,8 +16,10 @@
 package org.kie.kogito.codegen.decision;
 
 import java.net.URLEncoder;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.ImportDeclaration;
@@ -33,6 +35,7 @@ import com.github.javaparser.ast.expr.SimpleName;
 import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.ExpressionStmt;
 import com.github.javaparser.ast.stmt.ReturnStmt;
 import com.github.javaparser.ast.stmt.Statement;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
@@ -90,6 +93,10 @@ public class DecisionRestResourceGenerator {
         template.findAll(MethodDeclaration.class).forEach(this::interpolateMethods);
 
         interpolateInputType(template);
+        interpolateInputData(template);
+        interpolateExtractContextMethod(template);
+        modifyDmnMethodForStronglyTyped(template);
+        chooseMethodForStronglyTyped(template);
 
         if (useInjection()) {
             template.findAll(FieldDeclaration.class,
@@ -116,7 +123,7 @@ public class DecisionRestResourceGenerator {
             ReturnStmt returnStmt = clonedMethod.findFirst(ReturnStmt.class).orElseThrow(TEMPLATE_WAS_MODIFIED);
             if (ds.getOutputDecision().size() == 1) {
                 MethodCallExpr rewrittenReturnExpr = returnStmt.findFirst(MethodCallExpr.class,
-                                                                          mce -> mce.getNameAsString().equals("extractContextIfSucceded"))
+                                                                          mce -> mce.getNameAsString().equals("extractContextIfSucceded") || mce.getNameAsString().equals("extractStronglyTypedContextIfSucceded"))
                                                                .orElseThrow(TEMPLATE_WAS_MODIFIED);
                 rewrittenReturnExpr.setName("extractSingletonDSIfSucceded");
             }
@@ -129,6 +136,8 @@ public class DecisionRestResourceGenerator {
             template.addMember(cloneForDMNResult(clonedMethod, name + "_dmnresult", ds.getName() + "/dmnresult"));
         }
 
+        interpolateOutputType(template);
+
         if (addonsConfig.useMonitoring()) {
             addMonitoringImports(clazz);
             ClassOrInterfaceDeclaration exceptionClazz = clazz.findFirst(ClassOrInterfaceDeclaration.class, x -> "DMNEvaluationErrorExceptionMapper".equals(x.getNameAsString()))
@@ -139,6 +148,24 @@ public class DecisionRestResourceGenerator {
 
         template.getMembers().sort(new BodyDeclarationComparator());
         return clazz.toString();
+    }
+
+    private void chooseMethodForStronglyTyped(ClassOrInterfaceDeclaration template) {
+        if (isStronglyTyped) {
+            MethodDeclaration extractContextIfSucceded = template.findAll(MethodDeclaration.class, x -> x.getName().toString().equals("extractContextIfSucceded")).get(0);
+            extractContextIfSucceded.remove();
+        } else {
+            MethodDeclaration extractContextIfSucceded = template.findAll(MethodDeclaration.class, x -> x.getName().toString().equals("extractStronglyTypedContextIfSucceded")).get(0);
+            extractContextIfSucceded.remove();
+        }
+    }
+
+    private void modifyDmnMethodForStronglyTyped(ClassOrInterfaceDeclaration template) {
+        MethodDeclaration dmnMethod = template.findAll(MethodDeclaration.class, x -> x.getName().toString().equals("dmn")).get(0);
+        if (!isStronglyTyped) {
+            List<ExpressionStmt> convertStatement = dmnMethod.findAll(ExpressionStmt.class, stmt -> stmt.findFirst(MethodCallExpr.class, mce -> mce.getNameAsString().equals("convertToOutputSet")).isPresent());
+            convertStatement.get(0).remove();
+        }
     }
 
     private MethodDeclaration cloneForDMNResult(MethodDeclaration dmnMethod, String name, String pathName) {
@@ -156,6 +183,38 @@ public class DecisionRestResourceGenerator {
         String inputType = isStronglyTyped ? "InputSet" : "java.util.Map<String, Object>";
         template.findAll(ClassOrInterfaceType.class, t -> t.asString().equals("$inputType$"))
                 .forEach(type -> type.setName(inputType));
+    }
+
+    private void interpolateOutputType(ClassOrInterfaceDeclaration template) {
+        String outputType = isStronglyTyped ? "OutputSet" : "Object";
+
+        List<ClassOrInterfaceType> outputTypeOccurrences = template.findAll(ClassOrInterfaceType.class, t -> t.asString().equals("$outputType$"));
+
+        List<ClassOrInterfaceType> objectReturnTypes = outputTypeOccurrences
+                .stream()
+                .filter(t -> t.getParentNode().isPresent() && t.getParentNode().get() instanceof MethodDeclaration)
+                .filter(t -> {
+                    MethodDeclaration parent = (MethodDeclaration)t.getParentNode().get();
+                    return parent.getNameAsString().endsWith("dmnresult") || parent.getNameAsString().startsWith("decisionService_");
+                })
+                .collect(Collectors.toList());
+
+        objectReturnTypes.forEach(type -> type.setName("Object"));
+
+        outputTypeOccurrences.removeAll(objectReturnTypes);
+        outputTypeOccurrences.forEach(type -> type.setName(outputType));
+    }
+
+    private void interpolateInputData(ClassOrInterfaceDeclaration template) {
+        String inputData = isStronglyTyped ? "outputSet" : "variables";
+        template.findAll(NameExpr.class, expr -> expr.getNameAsString().equals("$inputData$"))
+                .forEach(expr -> expr.setName(inputData));
+    }
+
+    private void interpolateExtractContextMethod(ClassOrInterfaceDeclaration template) {
+        String extractContextMethod = isStronglyTyped ? "extractStronglyTypedContextIfSucceded" : "extractContextIfSucceded";
+        template.findAll(MethodCallExpr.class, expr -> expr.getNameAsString().equals("$extractContextMethod$"))
+                .forEach(expr -> expr.setName(extractContextMethod));
     }
 
     public String getNameURL() {

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/decision/DecisionCodegenTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/decision/DecisionCodegenTest.java
@@ -163,7 +163,7 @@ public class DecisionCodegenTest {
         List<GeneratedFile> generatedFiles = codeGenerator.generate();
         assertThat(generatedFiles).anyMatch(x -> x.relativePath().endsWith("InputSet.java"));
         GeneratedFile inputSetFile = generatedFiles.stream().filter(x -> x.relativePath().endsWith("InputSet.java")).findFirst().get();
-        assertThat(new String(inputSetFile.contents())).contains("@org.eclipse.microprofile.openapi.annotations.media.Schema(", "enumeration");
+        assertThat(new String(inputSetFile.contents())).containsPattern("@org\\.eclipse\\.microprofile\\.openapi\\.annotations\\.media\\.Schema\\(.*enumeration");
     }
 
     @Test
@@ -175,6 +175,6 @@ public class DecisionCodegenTest {
         List<GeneratedFile> generatedFiles = codeGenerator.generate();
         assertThat(generatedFiles).anyMatch(x -> x.relativePath().endsWith("InputSet.java"));
         GeneratedFile inputSetFile = generatedFiles.stream().filter(x -> x.relativePath().endsWith("InputSet.java")).findFirst().get();
-        assertThat(new String(inputSetFile.contents())).doesNotContain("@org.eclipse.microprofile.openapi.annotations.media.Schema(enumeration");
+        assertThat(new String(inputSetFile.contents())).doesNotContain("@org.eclipse.microprofile.openapi.annotations.media.Schema");
     }
 }

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/decision/DecisionCodegenTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/decision/DecisionCodegenTest.java
@@ -48,6 +48,7 @@ public class DecisionCodegenTest {
         List<GeneratedFile> generatedFiles = codeGenerator.generate();
         assertThat(generatedFiles.size()).isGreaterThanOrEqualTo(6);
         assertThat(fileNames(generatedFiles)).containsAll(Arrays.asList("decision/InputSet.java",
+                                                                        "decision/OutputSet.java",
                                                                         "decision/TEmployee.java",
                                                                         "decision/TAddress.java",
                                                                         "decision/TPayroll.java",
@@ -78,6 +79,7 @@ public class DecisionCodegenTest {
         List<GeneratedFile> generatedFiles = codeGenerator.generate();
         assertThat(generatedFiles.size()).isGreaterThanOrEqualTo(3);
         assertThat(fileNames(generatedFiles)).containsAll(Arrays.asList("http_58_47_47www_46trisotech_46com_47definitions_47__4f5608e9_454d74_454c22_45a47e_45ab657257fc9c/InputSet.java",
+                                                                        "http_58_47_47www_46trisotech_46com_47definitions_47__4f5608e9_454d74_454c22_45a47e_45ab657257fc9c/OutputSet.java",
                                                                         "http_58_47_47www_46trisotech_46com_47definitions_47__4f5608e9_454d74_454c22_45a47e_45ab657257fc9c/OneOfEachTypeResource.java",
                                                                         "org/kie/kogito/app/DecisionModelResourcesProvider.java"));
 
@@ -161,7 +163,7 @@ public class DecisionCodegenTest {
         List<GeneratedFile> generatedFiles = codeGenerator.generate();
         assertThat(generatedFiles).anyMatch(x -> x.relativePath().endsWith("InputSet.java"));
         GeneratedFile inputSetFile = generatedFiles.stream().filter(x -> x.relativePath().endsWith("InputSet.java")).findFirst().get();
-        assertThat(new String(inputSetFile.contents())).contains("@org.eclipse.microprofile.openapi.annotations.media.Schema(enumeration");
+        assertThat(new String(inputSetFile.contents())).contains("@org.eclipse.microprofile.openapi.annotations.media.Schema(", "enumeration");
     }
 
     @Test


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-3078

This PR is to have `OutputSet` as a return type of DMN REST endpoint when stronglytyped is enabled. So swagger-ui can provide type information and proper payload example.

- [x ] You have read the [contributors guide](CONTRIBUTING.md)
- [x ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x ] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x ] Pull Request contains link to the JIRA issue
- [x ] Pull Request contains link to any dependent or related Pull Request
- [x ] Pull Request contains description of the issue
- [x ] Pull Request does not include fixes for issues other than the main ticket