### PR TITLE
[KOGITO-3158] Adding RestTaskHandler

### DIFF
--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/RestTaskDescriptor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/RestTaskDescriptor.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.jbpm.compiler.canonical;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.ConstructorDeclaration;
+
+import static com.github.javaparser.StaticJavaParser.parse;
+
+public class RestTaskDescriptor {
+
+    private RestTaskDescriptor() {}
+
+    public static String getClassName(ProcessMetaData processMetadata) {
+        return processMetadata.getProcessId() + "RestWorkItemHandler";
+    }
+
+    public static CompilationUnit generateHandlerClassForService(String className) {
+        CompilationUnit compilationUnit =
+                parse(RestTaskDescriptor.class.getResourceAsStream("/class-templates/RestWorkItemHandlerTemplate.java"));
+        compilationUnit.setPackageDeclaration("org.kie.kogito.handlers");
+        compilationUnit.findFirst(ClassOrInterfaceDeclaration.class).ifPresent(c -> c.setName(className));
+        compilationUnit.findAll(ConstructorDeclaration.class).forEach(c -> c.setName(className));
+        return compilationUnit;
+    }
+}

--- a/jbpm/jbpm-flow-builder/src/main/resources/class-templates/RestWorkItemHandlerTemplate.java
+++ b/jbpm/jbpm-flow-builder/src/main/resources/class-templates/RestWorkItemHandlerTemplate.java
@@ -1,0 +1,16 @@
+package org.jbpm.process.codegen;
+
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.core.Vertx;
+import org.kogito.workitem.rest.RestWorkItemHandler;
+
+public class xxxRestWorkItemHandler extends RestWorkItemHandler {
+
+    public xxxRestWorkItemHandler() {
+        this(Vertx.vertx());
+    }
+
+    public xxxRestWorkItemHandler(Vertx vertx) {
+        super(WebClient.create(vertx));
+    }
+}

--- a/jbpm/jbpm-serverless-workflow/pom.xml
+++ b/jbpm/jbpm-serverless-workflow/pom.xml
@@ -35,6 +35,10 @@
       <groupId>org.kie.kogito</groupId>
       <artifactId>jbpm-flow</artifactId>
     </dependency>
+     <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-rest-workitem</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-api</artifactId>

--- a/jbpm/jbpm-serverless-workflow/src/main/java/org/jbpm/serverless/workflow/parser/util/ServerlessWorkflowUtils.java
+++ b/jbpm/jbpm-serverless-workflow/src/main/java/org/jbpm/serverless/workflow/parser/util/ServerlessWorkflowUtils.java
@@ -14,9 +14,14 @@
  */
 package org.jbpm.serverless.workflow.parser.util;
 
+import java.io.Reader;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.stream.Collectors;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.drools.core.util.StringUtils;
 import org.jbpm.serverless.workflow.api.Workflow;
 import org.jbpm.serverless.workflow.api.branches.Branch;
@@ -33,11 +38,6 @@ import org.jbpm.serverless.workflow.api.switchconditions.DataCondition;
 import org.jbpm.serverless.workflow.parser.core.ServerlessWorkflowFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.Reader;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.stream.Collectors;
 
 public class ServerlessWorkflowUtils {
 
@@ -142,7 +142,7 @@ public class ServerlessWorkflowUtils {
 
     public static String sysOutFunctionScript(String script) {
         String retStr = DEFAULT_JSONPATH_CONFIG;
-        retStr += "java.lang.String toPrint = \"\";";
+        retStr += "java.lang.String toPrint = \"\";com.fasterxml.jackson.databind.JsonNode jsonNode;";
         retStr += getJsonPathScript(script);
         retStr += "System.out.println(toPrint);";
 
@@ -187,9 +187,9 @@ public class ServerlessWorkflowUtils {
 
         if (script.indexOf("$") >= 0) {
 
-            String replacement = "toPrint += com.jayway.jsonpath.JsonPath.using(jsonPathConfig)" +
+            String replacement = "jsonNode = com.jayway.jsonpath.JsonPath.using(jsonPathConfig)" +
                     ".parse(((com.fasterxml.jackson.databind.JsonNode)kcontext.getVariable(\"workflowdata\")))" +
-                    ".read(\"@@.$1\", com.fasterxml.jackson.databind.JsonNode.class).textValue();";
+                    ".read(\"@@.$1\", com.fasterxml.jackson.databind.JsonNode.class); toPrint+= jsonNode.isTextual() ? jsonNode.asText() : jsonNode;";
             script = script.replaceAll("\\$.([A-Za-z]+)", replacement);
             script = script.replaceAll("@@", Matcher.quoteReplacement("$"));
             return script;

--- a/kogito-bom/pom.xml
+++ b/kogito-bom/pom.xml
@@ -910,6 +910,17 @@
         <version>${project.version}</version>
         <classifier>sources</classifier>
       </dependency>
+       <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-rest-workitem</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-rest-workitem</artifactId>
+        <version>${project.version}</version>
+        <classifier>sources</classifier>
+      </dependency>
       <dependency>
         <groupId>org.kie.kogito</groupId>
         <artifactId>jbpm-serverless-workflow</artifactId>

--- a/kogito-build-parent/pom.xml
+++ b/kogito-build-parent/pom.xml
@@ -75,6 +75,7 @@
     <version.taglist.plugin>2.4</version.taglist.plugin>
     <version.versions.plugin>2.1</version.versions.plugin>
     <version.jayway.jsonpath>2.4.0</version.jayway.jsonpath>
+    <version.vertx.web.client>3.9.2</version.vertx.web.client>
 
     <!-- this version property is used in plugins but also in dependencies too -->
     <version.io.quarkus>1.8.0.Final</version.io.quarkus>
@@ -349,6 +350,12 @@
         <groupId>com.jayway.jsonpath</groupId>
         <artifactId>json-path-assert</artifactId>
         <version>${version.jayway.jsonpath}</version>
+      </dependency>
+      
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-web-client</artifactId>
+        <version>${version.vertx.web.client}</version>
       </dependency>
 
       <!-- http communication -->
@@ -712,7 +719,6 @@
         <artifactId>mongodb-driver-sync</artifactId>
         <version>${version.org.mongo}</version>
       </dependency>
-
     </dependencies>
   </dependencyManagement>
 

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ProcessGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ProcessGenerator.java
@@ -388,38 +388,19 @@ public class ProcessGenerator {
                 Parameter parameter = new Parameter(clazzNameType, varName);
                 if (useInjection()) {
                     annotator.withApplicationComponent(handlerClazz);
+                    annotator
+                        .withInjection(
+                                       handlerClazz
+                                           .getConstructors()
+                                           .stream()
+                                           .filter(c -> !c.getParameters().isEmpty())
+                                           .findFirst()
+                                           .orElseThrow(
+                                                        () -> new IllegalStateException(
+                                                            "Cannot find a non empty constructor to annotate in handler class " +
+                                                                                        handlerClazz)),true);
                 }
-                // generate constructor with handler parameters
-                for (FieldDeclaration fd : handler.getValue().findAll(FieldDeclaration.class)) {
-                    String fieldName = fd.getVariable(0).getNameAsString();
-                    handlerClazz
-                        .addConstructor(Keyword.PUBLIC)
-                        .setBody(
-                                 new BlockStmt()
-                                     .addStatement(
-                                                   new AssignExpr(
-                                                       new FieldAccessExpr(
-                                                           new ThisExpr(),
-                                                           fd.getVariable(0).getNameAsString()),
-                                                       new ObjectCreationExpr()
-                                                           .setType(fd.getVariable(0).getType().toString()),
-                                                       AssignExpr.Operator.ASSIGN)));
-                    ConstructorDeclaration handlerConstructor = handlerClazz
-                        .addConstructor(Keyword.PUBLIC)
-                        .addParameter(fd.getVariable(0).getType(), fieldName)
-                        .setBody(
-                                 new BlockStmt()
-                                     .addStatement(
-                                                   new AssignExpr(
-                                                       new FieldAccessExpr(
-                                                           new ThisExpr(),
-                                                           fieldName),
-                                                       new NameExpr(fieldName),
-                                                       AssignExpr.Operator.ASSIGN)));
-                    if (useInjection()) {
-                        annotator.withInjection(handlerConstructor, true);
-                    }
-                }
+             
                 initMethodCall
                     .addArgument(
                                  new ObjectCreationExpr(

--- a/kogito-quarkus-extension/runtime/pom.xml
+++ b/kogito-quarkus-extension/runtime/pom.xml
@@ -82,6 +82,10 @@
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-pmml</artifactId>
     </dependency>
+     <dependency>
+      <groupId>com.jayway.jsonpath</groupId>
+      <artifactId>json-path</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/kogito-quarkus-extension/runtime/src/main/java/org/kie/kogito/quarkus/runtime/graal/graal/JsonSmartSubstitutions.java
+++ b/kogito-quarkus-extension/runtime/src/main/java/org/kie/kogito/quarkus/runtime/graal/graal/JsonSmartSubstitutions.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.kie.kogito.quarkus.runtime.graal.graal;
+
+import java.io.IOException;
+
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.spi.mapper.JsonSmartMappingProvider;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+import net.minidev.json.JSONStyle;
+import net.minidev.json.reader.BeansWriterASM;
+
+
+@TargetClass(JsonSmartMappingProvider.class)
+final class JsonSmartMappingProviderTarget {
+
+    @Substitute
+    public <T> T map(Object source, Class<T> targetType, Configuration configuration) {
+        throw new UnsupportedOperationException("this path is never taken");
+    }
+}
+
+@TargetClass(BeansWriterASM.class)
+final class BeansWriterASMTarget {
+    @Substitute
+    public <E> void writeJSONString(E value, Appendable out, JSONStyle compression) throws IOException {
+        out.append(value.toString());
+    }
+}

--- a/kogito-workitems/kogito-rest-workitem/pom.xml
+++ b/kogito-workitems/kogito-rest-workitem/pom.xml
@@ -1,0 +1,44 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.kie.kogito</groupId>
+    <artifactId>kogito-workitems</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>kogito-rest-workitem</artifactId>
+  <name>Kogito :: Workitems :: RestWorkItem</name>
+
+  <description>Rest task workitem handler</description>
+  <dependencies>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>jbpm-flow</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.jayway.jsonpath</groupId>
+      <artifactId>json-path</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/kogito-workitems/kogito-rest-workitem/src/main/java/org/kogito/workitem/rest/RestWorkItemHandler.java
+++ b/kogito-workitems/kogito-rest-workitem/src/main/java/org/kogito/workitem/rest/RestWorkItemHandler.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kogito.workitem.rest;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.client.HttpRequest;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+import org.kie.api.runtime.process.WorkItem;
+import org.kie.api.runtime.process.WorkItemHandler;
+import org.kie.api.runtime.process.WorkItemManager;
+
+public class RestWorkItemHandler implements WorkItemHandler {
+
+    public static final String REST_TASK_TYPE = "Rest Task";
+    public static final String ENDPOINT = "endpoint";
+    public static final String METHOD = "method";
+    public static final String PARAMETER = "Parameter";
+    public static final String RESULT = "Result";
+    public static final String RESULT_HANDLER = "ResultHandler";
+    public static final String USER = "user";
+    public static final String PASSWORD = "password";
+    public static final String HOST = "host";
+    public static final String PORT = "port";
+
+    // package scoped to allow unit test
+    static class RestUnaryOperator implements UnaryOperator<Object> {
+
+        private Object inputModel;
+
+        public RestUnaryOperator(Object inputModel) {
+            this.inputModel = inputModel;
+        }
+
+        @Override
+        public Object apply(Object value) {
+            return value instanceof RestWorkItemHandlerParamResolver
+                    ? ((RestWorkItemHandlerParamResolver) value).apply(inputModel) : value;
+        }
+    }
+
+    private WebClient client;
+
+    public RestWorkItemHandler(WebClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public void executeWorkItem(WorkItem workItem, WorkItemManager manager) {
+        // retrieving parameters
+        Map<String, Object> parameters = new HashMap<>(workItem.getParameters());
+        String endPoint = getParam(parameters, ENDPOINT, String.class);
+        HttpMethod method = HttpMethod.valueOf(getParam(parameters, METHOD, String.class).toUpperCase());
+        Object inputModel = getParam(parameters, PARAMETER, Object.class);
+        String user = (String) parameters.remove(USER);
+        String password = (String) parameters.remove(PASSWORD);
+        String hostProp = (String) parameters.remove(HOST);
+        String portProp = (String) parameters.remove(PORT);
+        RestWorkItemHandlerResult resultHandler = getParam(parameters, RESULT_HANDLER, RestWorkItemHandlerResult.class);
+        // create request
+        UnaryOperator<Object> resolver = new RestUnaryOperator(inputModel);
+        endPoint = resolvePathParams(endPoint, parameters, resolver);
+        URI uri = URI.create(endPoint);
+        String host = uri.getHost() != null ? uri.getHost() : hostProp;
+        int port = uri.getPort() > 0? uri.getPort() : Integer.parseInt(portProp);
+        HttpRequest<Buffer> request = client.request(method, port, host, uri.getPath());
+        if (user != null && !user.trim().isEmpty() && password != null && !password.trim().isEmpty()) {
+            request.basicAuthentication(user, password);
+        }
+        // execute request
+         Handler<AsyncResult<HttpResponse<Buffer>>> handler = event -> 
+                manager
+                .completeWorkItem(
+                                  workItem.getId(),
+                                  Collections
+                                      .singletonMap(RESULT, resultHandler.apply(inputModel, event.result().bodyAsJsonObject())));
+        if (method == HttpMethod.POST || method == HttpMethod.PUT) {
+            // if parameters is empty at this stage, assume post content is the whole input model
+            // if not, build a map from parameters remaining
+            Object body = parameters.isEmpty() ? inputModel : parameters
+                .entrySet()
+                .stream()
+                .collect(
+                         Collectors
+                             .toMap(Entry::getKey, e -> resolver.apply(e.getValue())));
+           
+            request.sendJson(body, handler);
+        } else {
+            request.send(handler);
+        }
+    }
+
+    @Override
+    public void abortWorkItem(WorkItem workItem, WorkItemManager manager) {
+        // rest item handler does not support abort
+    }
+
+    //  package scoped to allow unit test
+    static String resolvePathParams(String endPoint, Map<String, Object> parameters, UnaryOperator<Object> resolver) {
+        Set<String> toRemove = new HashSet<>();
+        int start = endPoint.indexOf('{');
+        if (start == -1) {
+            return endPoint;
+        }
+        StringBuilder sb = new StringBuilder(endPoint);
+        while (start != -1) {
+            int end = sb.indexOf("}", start);
+            if (end == -1) {
+                throw new IllegalArgumentException("malformed endpoint should contain enclosing '}' " + endPoint);
+            }
+            String key = sb.substring(start + 1, end);
+            Object value = resolver.apply(parameters.get(key));
+            if (value == null) {
+                throw new IllegalArgumentException("missing parameter " + key);
+            }
+            toRemove.add(key);
+            sb.replace(start, end + 1, resolver.apply(parameters.get(key)).toString());
+            start = sb.indexOf("{", end);
+        }
+        parameters.keySet().removeAll(toRemove);
+        return sb.toString();
+    }
+
+    private <T> T getParam(Map<String, Object> parameters, String paramName, Class<T> type) {
+        Object value = parameters.remove(paramName);
+        if (value == null) {
+            throw new IllegalArgumentException("Missing required parameter " + paramName);
+        }
+        if (!type.isAssignableFrom(value.getClass())) {
+            throw new IllegalArgumentException(
+                "Parameter paramName should be of type " + type + " but it is of type " + value.getClass());
+        }
+        return type.cast(value);
+    }
+
+}

--- a/kogito-workitems/kogito-rest-workitem/src/main/java/org/kogito/workitem/rest/RestWorkItemHandlerParamResolver.java
+++ b/kogito-workitems/kogito-rest-workitem/src/main/java/org/kogito/workitem/rest/RestWorkItemHandlerParamResolver.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kogito.workitem.rest;
+
+import java.util.function.UnaryOperator;
+
+/* Added to make it easier to search for ParamResolver function implementations, 
+ * see https://github.com/kiegroup/kogito-runtimes/pull/778#pullrequestreview-493382982 */ 
+public interface RestWorkItemHandlerParamResolver extends UnaryOperator<Object> {
+}

--- a/kogito-workitems/kogito-rest-workitem/src/main/java/org/kogito/workitem/rest/RestWorkItemHandlerResult.java
+++ b/kogito-workitems/kogito-rest-workitem/src/main/java/org/kogito/workitem/rest/RestWorkItemHandlerResult.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kogito.workitem.rest;
+
+import java.util.function.BiFunction;
+
+import io.vertx.core.json.JsonObject;
+
+
+/* Added to make it easier to search for ResultHandler bifunction implementations, 
+ * see https://github.com/kiegroup/kogito-runtimes/pull/778#pullrequestreview-493382982 */ 
+public interface RestWorkItemHandlerResult extends BiFunction<Object, JsonObject, Object> {
+}

--- a/kogito-workitems/kogito-rest-workitem/src/main/java/org/kogito/workitem/rest/jsonpath/functions/JSonPathResultHandler.java
+++ b/kogito-workitems/kogito-rest-workitem/src/main/java/org/kogito/workitem/rest/jsonpath/functions/JSonPathResultHandler.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kogito.workitem.rest.jsonpath.functions;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.kogito.workitem.rest.RestWorkItemHandlerResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JSonPathResultHandler implements RestWorkItemHandlerResult {
+
+    private static final Logger logger = LoggerFactory.getLogger(JSonPathResultHandler.class);
+
+    @Override
+    public Object apply(Object inputParameter, JsonObject node) {
+        return transform(node, (ObjectNode) inputParameter);
+    }
+
+    private ObjectNode transform(JsonObject src, ObjectNode target) {
+        src.forEach(e -> setValue(target, e.getKey(), e.getValue()));
+        return target;
+    }
+
+    private void setValue(ObjectNode result, String key, Object value) {
+        if (value instanceof Double) {
+            result.put(key, (Double) value);
+        } else if (value instanceof Float) {
+            result.put(key, (Float) value);
+        } else if (value instanceof Long) {
+            result.put(key, (Long) value);
+        } else if (value instanceof Integer) {
+            result.put(key, (Integer) value);
+        } else if (value instanceof Short) {
+            result.put(key, (Short) value);
+        } else if (value instanceof Boolean) {
+            result.put(key, (Boolean) value);
+        } else if (value instanceof String) {
+            result.put(key, (String) value);
+        } else if (value instanceof JsonObject) {
+            result.set(key, transform((JsonObject) value, result.objectNode()));
+        } else if (value instanceof JsonArray) {
+            ArrayNode array = result.arrayNode();
+            ((JsonArray) value).forEach(v -> addValue(array, v));
+            result.set(key, array);
+        } else {
+            logger.warn("Unrecognized data type for object {} class {}", value, value.getClass());
+        }
+    }
+
+    private void addValue(ArrayNode result, Object value) {
+        if (value instanceof Double) {
+            result.add((Double) value);
+        } else if (value instanceof Float) {
+            result.add((Float) value);
+        } else if (value instanceof Long) {
+            result.add((Long) value);
+        } else if (value instanceof Integer) {
+            result.add((Integer) value);
+        } else if (value instanceof Short) {
+            result.add((Short) value);
+        } else if (value instanceof Boolean) {
+            result.add((Boolean) value);
+        } else if (value instanceof String) {
+            result.add((String) value);
+        } else if (value instanceof JsonObject) {
+            result.add(transform((JsonObject) value, result.objectNode()));
+        } else if (value instanceof JsonArray) {
+            ArrayNode array = result.arrayNode();
+            ((JsonArray) value).forEach(v -> addValue(array, v));
+            result.add(array);
+        } else {
+            logger.warn("Unrecognized data type for object {} class {}", value, value.getClass());
+        }
+    }
+}

--- a/kogito-workitems/kogito-rest-workitem/src/main/java/org/kogito/workitem/rest/jsonpath/functions/JsonPathResolver.java
+++ b/kogito-workitems/kogito-rest-workitem/src/main/java/org/kogito/workitem/rest/jsonpath/functions/JsonPathResolver.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kogito.workitem.rest.jsonpath.functions;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.spi.json.JacksonJsonNodeJsonProvider;
+import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
+import org.kogito.workitem.rest.RestWorkItemHandlerParamResolver;
+
+public class JsonPathResolver implements RestWorkItemHandlerParamResolver {
+
+    private static final Configuration jsonPathConfig = Configuration
+        .builder()
+        .mappingProvider(new JacksonMappingProvider())
+        .jsonProvider(new JacksonJsonNodeJsonProvider())
+        .build();
+
+    private String jsonPathExpr;
+
+    public JsonPathResolver(String jsonPathExpr) {
+        this.jsonPathExpr = jsonPathExpr;
+    }
+
+    @Override
+    public Object apply(Object context) {
+        JsonNode node = JsonPath
+            .using(jsonPathConfig)
+            .parse(context)
+            .read(jsonPathExpr, JsonNode.class);
+        return readValue(node);
+    }
+
+    private Object readValue(JsonNode node) {
+        switch (node.getNodeType()) {
+            case NUMBER:
+                if (node.isInt()) {
+                    return node.asInt();
+                } else if (node.isLong()) {
+                    return node.asLong();
+                } else {
+                    return node.asDouble();
+                }
+            case BOOLEAN:
+                return node.asBoolean();
+            case NULL:
+                return null;
+            case ARRAY:
+                return readArray((ArrayNode) node);
+            default:
+            case STRING:
+                return node.asText();
+        }
+    }
+
+    private Object readArray(ArrayNode node) {
+        Iterator<JsonNode> elements = node.elements();
+        Collection<Object> result = new ArrayList<>();
+        while (elements.hasNext()) {
+            result.add(readValue(elements.next()));
+        }
+        return result;
+    }
+}

--- a/kogito-workitems/kogito-rest-workitem/src/main/java/org/kogito/workitem/rest/jsonpath/suppliers/JsonPathExprSupplier.java
+++ b/kogito-workitems/kogito-rest-workitem/src/main/java/org/kogito/workitem/rest/jsonpath/suppliers/JsonPathExprSupplier.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kogito.workitem.rest.jsonpath.suppliers;
+
+import java.util.function.Supplier;
+
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.ast.expr.StringLiteralExpr;
+import org.kogito.workitem.rest.jsonpath.functions.JsonPathResolver;
+
+public class JsonPathExprSupplier implements Supplier<Expression> {
+
+    private String jsonPathExpr;
+
+    public JsonPathExprSupplier(String jsonPathExpr) {
+        this.jsonPathExpr = jsonPathExpr;
+    }
+
+    @Override
+    public Expression get() {
+        return new ObjectCreationExpr()
+            .setType(JsonPathResolver.class.getCanonicalName())
+            .addArgument(new StringLiteralExpr(jsonPathExpr));
+    }
+
+}

--- a/kogito-workitems/kogito-rest-workitem/src/main/java/org/kogito/workitem/rest/jsonpath/suppliers/JsonPathResultExprSupplier.java
+++ b/kogito-workitems/kogito-rest-workitem/src/main/java/org/kogito/workitem/rest/jsonpath/suppliers/JsonPathResultExprSupplier.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kogito.workitem.rest.jsonpath.suppliers;
+
+import java.util.function.Supplier;
+
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import org.kogito.workitem.rest.jsonpath.functions.JSonPathResultHandler;
+
+public class JsonPathResultExprSupplier implements Supplier<Expression> {
+
+    @Override
+    public Expression get() {
+        return new ObjectCreationExpr().setType(JSonPathResultHandler.class.getCanonicalName());
+    }
+}

--- a/kogito-workitems/kogito-rest-workitem/src/test/java/org/kogito/workitem/rest/RestTaskHandlerTest.java
+++ b/kogito-workitems/kogito-rest-workitem/src/test/java/org/kogito/workitem/rest/RestTaskHandlerTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kogito.workitem.rest;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.HttpRequest;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+import org.junit.jupiter.api.Test;
+import org.kie.api.runtime.process.WorkItem;
+import org.kie.api.runtime.process.WorkItemManager;
+import org.kogito.workitem.rest.jsonpath.functions.JSonPathResultHandler;
+import org.kogito.workitem.rest.jsonpath.functions.JsonPathResolver;
+import org.mockito.ArgumentCaptor;
+import org.mockito.stubbing.Answer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class RestTaskHandlerTest {
+
+    @Test
+    public void testReplaceTemplateTrivial() {
+        Map<String, Object> parameters = Collections.emptyMap();
+        String endPoint = "http://pepe:password@www.google.com/results/id/?user=pepe#at_point";
+        assertEquals(
+                     "http://pepe:password@www.google.com/results/id/?user=pepe#at_point",
+                     RestWorkItemHandler.resolvePathParams(endPoint, parameters, e -> e));
+    }
+
+    @Test
+    public void testReplaceTemplate() {
+        Map<String, Object> parameters = new HashMap<>();
+        // no use singletonMap here since the map must be mutable
+        parameters.put("id", "pepe");
+        String endPoint = "http://pepe:password@www.google.com/results/{id}/?user=pepe#at_point";
+        assertEquals(
+                     "http://pepe:password@www.google.com/results/pepe/?user=pepe#at_point",
+                     RestWorkItemHandler.resolvePathParams(endPoint, parameters, e -> e));
+    }
+
+    @Test
+    public void testReplaceTemplateMultiple() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("id", 26);
+        parameters.put("name", "pepe");
+        String endPoint = "http://pepe:password@www.google.com/results/{id}/names/{name}/?user=pepe#at_point";
+        assertEquals(
+                     "http://pepe:password@www.google.com/results/26/names/pepe/?user=pepe#at_point",
+                     RestWorkItemHandler.resolvePathParams(endPoint, parameters, e -> e));
+    }
+
+    @Test
+    public void testReplaceTemplateMissing() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("id", 26);
+        String endPoint = "http://pepe:password@www.google.com/results/{id}/names/{name}/?user=pepe#at_point";
+        assertTrue(
+                   assertThrows(
+                                IllegalArgumentException.class,
+                                () -> RestWorkItemHandler.resolvePathParams(endPoint, parameters, e -> e))
+                                    .getMessage()
+                                    .contains("name"));
+    }
+
+    @Test
+    public void testReplaceTemplateBadEnpoint() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("id", 26);
+        parameters.put("name", "pepe");
+        String endPoint = "http://pepe:password@www.google.com/results/{id}/names/{name/?user=pepe#at_point";
+        assertTrue(
+                   assertThrows(
+                                IllegalArgumentException.class,
+                                () -> RestWorkItemHandler.resolvePathParams(endPoint, parameters, e -> e))
+                                    .getMessage()
+                                    .contains("}"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testGetRestTaskHandler() {
+        WebClient webClient = mock(WebClient.class);
+        ObjectMapper mapper = new ObjectMapper();
+        HttpRequest<Buffer> request = mock(HttpRequest.class);
+        HttpResponse<Buffer> response = mock(HttpResponse.class);
+        AsyncResult<HttpResponse<Buffer>> event = mock(AsyncResult.class);
+        when(event.result()).thenReturn(response);
+
+        when(webClient.request(HttpMethod.GET, 8080, "localhost", "/results/26/names/pepe"))
+            .thenReturn(request);
+        doAnswer((Answer<Void>) invocation -> {
+            Handler<AsyncResult<HttpResponse<Buffer>>> handler =
+                    (Handler<AsyncResult<HttpResponse<Buffer>>>) invocation.getArgument(0);
+            handler.handle(event);
+            return null;
+        }).when(request).send(any(Handler.class));
+        when(response.bodyAsJsonObject()).thenReturn(JsonObject.mapFrom(Collections.singletonMap("num", 1)));
+
+        Map<String, Object> parameters =
+                new HashMap<>();
+        parameters.put("id", new JsonPathResolver("$.id"));
+        parameters.put("name", new JsonPathResolver("$.name"));
+        parameters.put(RestWorkItemHandler.ENDPOINT, "http://localhost:8080/results/{id}/names/{name}");
+        parameters.put(RestWorkItemHandler.METHOD, "GET");
+        parameters.put(RestWorkItemHandler.RESULT_HANDLER, new JSonPathResultHandler());
+        parameters.put(RestWorkItemHandler.PARAMETER, mapper.createObjectNode().put("id", 26).put("name", "pepe"));
+
+        WorkItem workItem = mock(WorkItem.class);
+        when(workItem.getId()).thenReturn("2");
+        when(workItem.getParameters()).thenReturn(parameters);
+        WorkItemManager manager = mock(WorkItemManager.class);
+
+        ArgumentCaptor<Map<String, Object>> argCaptor = ArgumentCaptor.forClass(Map.class);
+
+        RestWorkItemHandler handler = new RestWorkItemHandler(
+            webClient);
+        handler.executeWorkItem(workItem, manager);
+        verify(manager).completeWorkItem(anyString(), argCaptor.capture());
+        Map<String, Object> results = argCaptor.getValue();
+
+        assertEquals(1, results.size());
+        assertTrue(results.containsKey(RestWorkItemHandler.RESULT));
+        Object result = results.get(RestWorkItemHandler.RESULT);
+        assertTrue(result instanceof ObjectNode);
+        assertEquals(1, ((ObjectNode) result).get("num").asInt());
+    }
+}

--- a/kogito-workitems/pom.xml
+++ b/kogito-workitems/pom.xml
@@ -1,0 +1,29 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.kie.kogito</groupId>
+    <artifactId>kogito-build-parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <relativePath>../kogito-build-parent/pom.xml</relativePath>
+  </parent>
+  <artifactId>kogito-workitems</artifactId>
+  <packaging>pom</packaging>
+  <name>Kogito :: Workitems</name>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-bom</artifactId>
+        <version>${project.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <description>Kogito work items handlers</description>
+  <modules>
+    <module>kogito-rest-workitem</module>
+  </modules>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,7 @@
     <module>grafana-api</module>
     <module>integration-tests</module>
     <module>jenkins-tests</module>
+    <module>kogito-workitems</module>
   </modules>
 
 </project>


### PR DESCRIPTION
Changes for adding a RestWorkItemHandler

Please check example at [#369](https://github.com/kiegroup/kogito-examples/pull/369)

Summary of changes:

-  Using vert.x both for Quarkus and Springboot (jax-rs client is not working on native mode, check https://github.com/quarkusio/quarkus/issues/6151). It is used in async mode, so do not block the thread while the rest invocation is being performed and handler is completed when the response arrive
- New work item handler for Rest invocations (RestTaskHandler) has been added. Required parameters are endpoint (read from function defintion), method (read from function metadata) and ResultHandler (this one is auto generated by serverless parser). User and password for basic authentication are optional. 
-  Since input/output parameters can be Json objects (when serverless) or Pojo (when bpmn), rather than putting that knowledge in the handler, I have tried to encapsulate the details using Function, Supplier, Bifunction generated by code generator, but where the runtime part is not visible to RestTaskHandler class: 
       - Supplier is used when generating code to fill the work iterm parameter with objects (either function or bifunction)
       - Function is used to calculate the objects to be used in different parts of the request from the input model
       - Bifunction is used to format the ouputs of the task (in case of jsonobject a non deep merge is performed) 
