### PR TITLE
KOGITO-3421 Fix variable name generation in CloudEvents resource router

### DIFF
--- a/kogito-codegen/src/main/resources/class-templates/events/CloudEventsListenerResource.java
+++ b/kogito-codegen/src/main/resources/class-templates/events/CloudEventsListenerResource.java
@@ -49,6 +49,9 @@ public class CloudEventListenerResource {
                 // convert CloudEvent to JSON and send to internal channels
                 emitters.get(event.getType()).send(objectMapper.writeValueAsString(event));
                 return javax.ws.rs.core.Response.ok().build();
+            } else if (emitters.get(event.getSource().toString()) != null) { // try the source instead
+                emitters.get(event.getSource().toString()).send(objectMapper.writeValueAsString(event));
+                return javax.ws.rs.core.Response.ok().build();
             } else {
                 return Responses.channelNotBound(event.getType(), event);
             }


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

See: https://issues.redhat.com/browse/KOGITO-3421
Tested with: https://github.com/kiegroup/kogito-examples/pull/372

In this PR we generate a random name for the `emiiter` variable since in SW engine we are using CE `source` as the name of the trigger, which is an URI. We can't use that as var name.

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket