### PR TITLE
KOGITO-3447 Sanitizing codegen variable names for Knative Addon

### DIFF
--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/events/CloudEventsMessageProducerGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/events/CloudEventsMessageProducerGenerator.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.kogito.codegen.process.events;
 
 import com.github.javaparser.ast.body.MethodDeclaration;

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/events/CloudEventsResourceGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/events/CloudEventsResourceGenerator.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.kogito.codegen.process.events;
 
 import java.util.ArrayList;
@@ -26,7 +41,7 @@ import static com.github.javaparser.StaticJavaParser.parse;
 
 public class CloudEventsResourceGenerator {
 
-    private static final String EMITTER_PREFIX = "emitter_";
+    static final String EMITTER_PREFIX = "emitter_";
     static final String EMITTER_TYPE = "Emitter<String>";
     private static final String RESOURCE_TEMPLATE = "/class-templates/events/CloudEventsListenerResource.java";
     private static final String CLASS_NAME = "CloudEventListenerResource";
@@ -128,7 +143,7 @@ public class CloudEventsResourceGenerator {
         setup.getAllContainedComments().forEach(Comment::remove);
         // declaring Emitters
         this.triggers.forEach(t -> {
-            final String emitterField = this.generateRandomEmitterName();
+            final String emitterField = this.sanitizeEmitterName(t.getName());
             // fields to be injected
             annotator.withOutgoingMessage(template.addField(EMITTER_TYPE, new StringLiteralExpr(emitterField).asString()), t.getName());
             // hashmap setup
@@ -142,7 +157,7 @@ public class CloudEventsResourceGenerator {
                 .forEach(annotator::withInjection);
     }
 
-    String generateRandomEmitterName() {
-        return String.join("", EMITTER_PREFIX, Long.toHexString(Double.doubleToLongBits(random.nextLong())));
+    String sanitizeEmitterName(String triggerName) {
+        return String.join("", EMITTER_PREFIX, triggerName.replaceAll("[^a-zA-Z0-9]+", ""));
     }
 }

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/process/events/CloudEventsMessageProducerGeneratorTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/process/events/CloudEventsMessageProducerGeneratorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.kogito.codegen.process.events;
 
 import org.assertj.core.api.Assertions;

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/process/events/CloudEventsResourceGeneratorTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/process/events/CloudEventsResourceGeneratorTest.java
@@ -1,22 +1,36 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.kie.kogito.codegen.process.events;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.ImportDeclaration;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.kie.kogito.codegen.process.ProcessGenerationUtils;
 
-import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.kie.kogito.codegen.process.events.CloudEventsResourceGenerator.EMITTER_PREFIX;
 
 class CloudEventsResourceGeneratorTest {
 
@@ -51,24 +65,21 @@ class CloudEventsResourceGeneratorTest {
                 .orElseThrow(() -> new IllegalArgumentException("Class does not exists"));
 
         assertThat(clazz.getFields().stream()
-                                      .filter(f -> f.getAnnotationByName("Channel").isPresent())
-                                      .count()).isEqualTo(1L);
+                           .filter(f -> f.getAnnotationByName("Channel").isPresent())
+                           .count()).isEqualTo(1L);
         assertThat(clazz.getFields().stream()
-                                      .filter(f -> f.getAnnotationByName("Inject").isPresent())
-                                      .count()).isEqualTo(2L);
+                           .filter(f -> f.getAnnotationByName("Inject").isPresent())
+                           .count()).isEqualTo(2L);
     }
 
     @Test
     void verifyEmitterVariableNameGen() {
         final CloudEventsResourceGenerator generator = new CloudEventsResourceGenerator(Collections.emptyList());
-        final List<String> names = new ArrayList<>();
-        // 50 message nodes in one process won't clash their names?
-        for (int i = 1; i <= 50; i++) {
-            final String name = generator.generateRandomEmitterName();
-            assertThat(names.stream().anyMatch(n -> n.equals(name))).isFalse();
-            names.add(name);
-        }
-        assertThat(names).hasSize(50);
+        final Map<String, String> tableTest = new HashMap<>();
+        tableTest.put("http://github.com/me/myrepo", EMITTER_PREFIX + "httpgithubcommemyrepo");
+        tableTest.put("$%@1234whatever123", EMITTER_PREFIX + "1234whatever123");
+        tableTest.put("123.12.34.56", EMITTER_PREFIX + "123123456");
+        tableTest.put("this_is_a_test", EMITTER_PREFIX + "thisisatest");
+        tableTest.forEach((key, value) -> assertThat(generator.sanitizeEmitterName(key)).isEqualTo(value));
     }
-
 }


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

See: https://issues.redhat.com/browse/KOGITO-3447

End up that the random variable strategy wouldn't work with IDE testing nor with `mvn clean install`, since Arc is linked before testing and the files are generated again before building the final jar. Codegen MUST be idempotent.

This is a MUST for Knative demos.

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket