### PR TITLE
KOGITO-3601 DMN integrate programmatically generated OAS definitions

### DIFF
--- a/drools/kogito-dmn/src/main/java/org/kie/kogito/dmn/rest/DMNJSONUtils.java
+++ b/drools/kogito-dmn/src/main/java/org/kie/kogito/dmn/rest/DMNJSONUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/drools/kogito-dmn/src/main/java/org/kie/kogito/dmn/rest/DMNJSONUtils.java
+++ b/drools/kogito-dmn/src/main/java/org/kie/kogito/dmn/rest/DMNJSONUtils.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.dmn.rest;
+
+import java.util.Map;
+
+import org.kie.dmn.api.core.DMNContext;
+import org.kie.dmn.api.core.FEELPropertyAccessible;
+import org.kie.kogito.decision.DecisionModel;
+
+/**
+ * Internal Utility class.<br/>
+ * Used to simplify generated/scaffolded code to create a DMNContext accordingly to JSON un-marshalling semantic
+ */
+public class DMNJSONUtils {
+
+    /**
+     * Internal Utility method.<br/>
+     * Used to simplify generated/scaffolded code to create a DMNContext accordingly to JSON un-marshalling semantic
+     */
+    public static DMNContext ctx(DecisionModel dm, Map<String, Object> variables) {
+        if (variables != null && variables.size() > 0) {
+            return new org.kie.dmn.core.internal.utils.DynamicDMNContextBuilder(new org.kie.dmn.core.impl.DMNContextImpl(), dm.getDMNModel()).populateContextWith(variables);
+        } else {
+            return dm.newContext(variables);
+        }
+    }
+
+    /**
+     * Internal Utility method.<br/>
+     * Used to simplify generated/scaffolded code to create a DMNContext accordingly to JSON un-marshalling semantic
+     */
+    public static DMNContext ctx(DecisionModel dm, FEELPropertyAccessible variables) {
+        return dm.newContext(variables);
+    }
+
+    /**
+     * Internal Utility method.<br/>
+     * Used to simplify generated/scaffolded code to create a DMNContext accordingly to JSON un-marshalling semantic
+     */
+    public static DMNContext ctx(DecisionModel dm, Map<String, Object> variables, String decisionServiceName) {
+        if (variables != null && variables.size() > 0) {
+            return new org.kie.dmn.core.internal.utils.DynamicDMNContextBuilder(new org.kie.dmn.core.impl.DMNContextImpl(), dm.getDMNModel()).populateContextForDecisionServiceWith(decisionServiceName, variables);
+        } else {
+            return dm.newContext(variables);
+        }
+    }
+
+    /**
+     * Internal Utility method.<br/>
+     * Used to simplify generated/scaffolded code to create a DMNContext accordingly to JSON un-marshalling semantic
+     */
+    public static DMNContext ctx(DecisionModel dm, FEELPropertyAccessible variables, String decisionServiceName) {
+        return dm.newContext(variables);
+    }
+
+    private DMNJSONUtils() {
+        // intentionally private.
+    }
+}

--- a/integration-tests/integration-tests-quarkus-decisions/src/main/resources/OneOfEachType.dmn
+++ b/integration-tests/integration-tests-quarkus-decisions/src/main/resources/OneOfEachType.dmn
@@ -1,0 +1,210 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<semantic:definitions xmlns:semantic="http://www.omg.org/spec/DMN/20180521/MODEL/"  xmlns:triso="http://www.trisotech.com/2015/triso/modeling"  xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"  xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"  xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"  xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn"  xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/"  xmlns:tc="http://www.omg.org/spec/DMN/20160719/testcase"  xmlns:drools="http://www.drools.org/kie/dmn/1.1"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns:rss="http://purl.org/rss/2.0/"  xmlns:openapi="https://openapis.org/omg/extension/1.0"  xmlns:xsd="http://www.w3.org/2001/XMLSchema"  xmlns="http://www.trisotech.com/definitions/_4f5608e9-4d74-4c22-a47e-ab657257fc9c" id="_4f5608e9-4d74-4c22-a47e-ab657257fc9c" name="OneOfEachType" namespace="http://www.trisotech.com/definitions/_4f5608e9-4d74-4c22-a47e-ab657257fc9c" exporter="Decision Modeler" exporterVersion="6.9.3" triso:logoChoice="Default">
+    <semantic:inputData id="_ebb7462c-c105-4aba-bd19-1782e4c510e2" name="InputString">
+        <semantic:variable name="InputString" id="_7c07dd9a-9369-415f-bb5a-357ba0216bb5" typeRef="string"/>
+    </semantic:inputData>
+    <semantic:inputData id="_0e9dae7c-08ac-432e-9a68-a410b14ee8a7" name="InputNumber">
+        <semantic:variable name="InputNumber" id="_d09e3e5c-7351-4265-8485-502cf03ca7c4" typeRef="number"/>
+    </semantic:inputData>
+    <semantic:inputData id="_dadc21c3-5303-4ee5-8178-df24066fda92" name="InputBoolean">
+        <semantic:variable name="InputBoolean" id="_12869250-3a52-481c-87d2-3e1a4efe0e9c" typeRef="boolean"/>
+    </semantic:inputData>
+    <semantic:inputData id="_39423931-0ee8-4b05-9b9a-fe0d3dbcd194" name="InputDTDuration">
+        <semantic:variable name="InputDTDuration" id="_e5ca3cf8-0d01-4be4-be5e-94f7237b1253" typeRef="dayTimeDuration"/>
+    </semantic:inputData>
+    <semantic:inputData id="_04f72806-b802-4102-94b6-a22b183f725d" name="InputYMDuration">
+        <semantic:variable name="InputYMDuration" id="_b165e339-66a7-4526-94c9-b09fac80e52c" typeRef="yearMonthDuration"/>
+    </semantic:inputData>
+    <semantic:inputData id="_8ec09edc-45db-465c-ad77-2ad837e153b7" name="InputDateAndTime">
+        <semantic:variable name="InputDateAndTime" id="_c5b97039-7ce2-4417-8b20-c81e46b7bcac" typeRef="dateTime"/>
+    </semantic:inputData>
+    <semantic:inputData id="_f9b51960-ca8d-4bbc-adfd-6ee6aac308e0" name="InputDate">
+        <semantic:variable name="InputDate" id="_8cfb2a54-60c1-4cf7-88dd-29c0cdc424ac" typeRef="date"/>
+    </semantic:inputData>
+    <semantic:inputData id="_1ecc413e-d383-4382-a6f5-847ff2efac2e" name="InputTime">
+        <semantic:variable name="InputTime" id="_c3458a29-312f-46ea-adab-43b86137e549" typeRef="time"/>
+    </semantic:inputData>
+    <semantic:decision id="_09daf449-41a3-4d97-8fe0-f96d3f073ce9" name="DecisionString">
+        <semantic:variable name="DecisionString" id="_f091c3bb-b084-47e6-980c-30e2af3613c0" typeRef="string"/>
+        <semantic:informationRequirement id="_0526d9ff-d33d-4e79-80f5-b9428c872ef6">
+            <semantic:requiredInput href="#_ebb7462c-c105-4aba-bd19-1782e4c510e2"/>
+        </semantic:informationRequirement>
+        <semantic:literalExpression id="_5fb0d581-c6b9-4ed6-aec5-c0d4adaf8781" typeRef="string" triso:expressionId="_bc740351-1835-41b3-8d97-66374237f4f0">
+            <semantic:text>"Hello, "+InputString</semantic:text>
+        </semantic:literalExpression>
+    </semantic:decision>
+    <semantic:decision id="_5b39519d-914b-40ba-a37c-ae1a0ea0b220" name="DecisionNumber">
+        <semantic:variable name="DecisionNumber" id="_572bdcf5-7f9f-4bdd-932c-288cad2f991c" typeRef="number"/>
+        <semantic:informationRequirement id="_019aca4c-dfcf-4eec-b45c-5c6220502944">
+            <semantic:requiredInput href="#_0e9dae7c-08ac-432e-9a68-a410b14ee8a7"/>
+        </semantic:informationRequirement>
+        <semantic:literalExpression id="_c33e8964-73fa-47f5-bc03-fa20df8e1b49" typeRef="number" triso:expressionId="_33479aab-1ab5-4c6c-80dc-40cbaf28becc">
+            <semantic:text>InputNumber+1</semantic:text>
+        </semantic:literalExpression>
+    </semantic:decision>
+    <semantic:decision id="_650b8eec-0862-42f1-8e5e-5f98e8dd1aa5" name="DecisionBoolean">
+        <semantic:variable name="DecisionBoolean" id="_d62aa522-7580-4988-b8f9-05f3a8e40a4f" typeRef="boolean"/>
+        <semantic:informationRequirement id="_c8f80670-265e-449f-b28f-28471e9f664d">
+            <semantic:requiredInput href="#_dadc21c3-5303-4ee5-8178-df24066fda92"/>
+        </semantic:informationRequirement>
+        <semantic:literalExpression id="_e4cf5da6-195e-41de-9bd8-22d9c80dde02" typeRef="boolean" triso:expressionId="_fa787d3e-d46f-4d02-8aaa-0de29b4b1b97">
+            <semantic:text>not(InputBoolean)</semantic:text>
+        </semantic:literalExpression>
+    </semantic:decision>
+    <semantic:decision id="_8799a148-6a59-4e9d-b405-33259a0f9e14" name="DecisionDTDuration">
+        <semantic:variable name="DecisionDTDuration" id="_d3a315c4-134c-4baa-b8a0-10f4e4195e71" typeRef="dayTimeDuration"/>
+        <semantic:informationRequirement id="_724e45b8-2f9a-45f7-aa93-d76ecfa4eb62">
+            <semantic:requiredInput href="#_39423931-0ee8-4b05-9b9a-fe0d3dbcd194"/>
+        </semantic:informationRequirement>
+        <semantic:literalExpression id="_8dba1335-5475-4569-a1e3-c4842ab95d71" typeRef="dayTimeDuration" triso:expressionId="_d8044631-d49c-4b2b-9ce1-6faacfc323dd">
+            <semantic:text>InputDTDuration + duration("P1D")</semantic:text>
+        </semantic:literalExpression>
+    </semantic:decision>
+    <semantic:decision id="_89288ead-5f78-48de-a8a9-59af71b71c9c" name="DecisionYMDuration">
+        <semantic:variable name="DecisionYMDuration" id="_c4fe080d-4da4-42e2-878c-d3e828cbc7d7" typeRef="yearMonthDuration"/>
+        <semantic:informationRequirement id="_25eb0b77-8ca2-476b-bf03-87ff563a8c9d">
+            <semantic:requiredInput href="#_04f72806-b802-4102-94b6-a22b183f725d"/>
+        </semantic:informationRequirement>
+        <semantic:literalExpression id="_a41a3ca1-15d7-4c88-883b-748f956bd0fe" typeRef="yearMonthDuration" triso:expressionId="_51b95509-fe9c-4b81-bd57-6ee337d18a0e">
+            <semantic:text>InputYMDuration + duration("P1M")</semantic:text>
+        </semantic:literalExpression>
+    </semantic:decision>
+    <semantic:decision id="_6224c7f2-1dc8-42fb-af51-b20d7f961a1c" name="DecisionDateAndTime">
+        <semantic:variable name="DecisionDateAndTime" id="_87b50245-5ea6-4f9b-bcea-955629f77d26" typeRef="dateTime"/>
+        <semantic:informationRequirement id="_a125869d-0c2e-4c59-b62d-9d8ba765e3cf">
+            <semantic:requiredInput href="#_8ec09edc-45db-465c-ad77-2ad837e153b7"/>
+        </semantic:informationRequirement>
+        <semantic:literalExpression id="_38448368-4a76-4dc0-878b-9cfc0eda2cde" typeRef="dateTime" triso:expressionId="_6f6252fb-1b1e-4dc1-9f05-1fe8107e2367">
+            <semantic:text>InputDateAndTime+duration("PT1H")</semantic:text>
+        </semantic:literalExpression>
+    </semantic:decision>
+    <semantic:decision id="_3d108366-d681-48aa-84b8-81a19ff8c6ec" name="DecisionDate">
+        <semantic:variable name="DecisionDate" id="_ac9cd205-8df2-4a55-8de4-5cbb135efa78" typeRef="date"/>
+        <semantic:informationRequirement id="_a745f1f0-9653-46c3-a2e6-de04c7ca5821">
+            <semantic:requiredInput href="#_f9b51960-ca8d-4bbc-adfd-6ee6aac308e0"/>
+        </semantic:informationRequirement>
+        <semantic:literalExpression id="_5f78af03-b624-4844-87bc-cfaba03235bc" typeRef="date" triso:expressionId="_4f0f90dc-2756-4721-9d3a-5bb4444ee685">
+            <semantic:text>InputDate+duration("P1D")</semantic:text>
+        </semantic:literalExpression>
+    </semantic:decision>
+    <semantic:decision id="_c86ce320-a211-4846-b57d-a2339a963c1e" name="DecisionTime">
+        <semantic:variable name="DecisionTime" id="_92a2c68e-9674-4445-b272-3a5b5c57c49b" typeRef="time"/>
+        <semantic:informationRequirement id="_9d9ed0aa-c77b-48a9-9227-470a7f4a540a">
+            <semantic:requiredInput href="#_1ecc413e-d383-4382-a6f5-847ff2efac2e"/>
+        </semantic:informationRequirement>
+        <semantic:literalExpression id="_9b06c371-311d-4c33-9b40-0634c73a4cb9" typeRef="time" triso:expressionId="_99282e41-5570-4e04-90c4-9c5384357fbc">
+            <semantic:text>InputTime+duration("PT1H")</semantic:text>
+        </semantic:literalExpression>
+    </semantic:decision>
+    <dmndi:DMNDI>
+        <dmndi:DMNDiagram id="_947b0ae8-74af-4949-a849-ad11c5973a43" triso:modelElementRef="_48a05074-9da0-4743-99eb-03c624ad4aae" name="Page 1">
+            <di:extension/>
+            <dmndi:Size height="1050" width="1485"/>
+            <dmndi:DMNShape id="_7822265c-7b48-4217-9863-5fd3993710fa" dmnElementRef="_ebb7462c-c105-4aba-bd19-1782e4c510e2">
+                <dc:Bounds x="92.75882911682129" y="37" width="135.48234176635742" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0" trisodmn:defaultBounds="true"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_ae527417-ad57-4a7b-a535-ca6c2cdee340" dmnElementRef="_0e9dae7c-08ac-432e-9a68-a410b14ee8a7">
+                <dc:Bounds x="92.75882911682129" y="122" width="135.48234176635742" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0" trisodmn:defaultBounds="true"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_d473c3ec-9551-49a8-9312-c148319dbf6c" dmnElementRef="_dadc21c3-5303-4ee5-8178-df24066fda92">
+                <dc:Bounds x="92.75882911682129" y="212" width="135.48234176635742" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0" trisodmn:defaultBounds="true"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_64779d7c-71b9-4476-8dcb-662b7e0ba907" dmnElementRef="_39423931-0ee8-4b05-9b9a-fe0d3dbcd194">
+                <dc:Bounds x="92.75882911682129" y="299" width="135.48234176635742" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0" trisodmn:defaultBounds="true"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_1f146de5-62a8-4e3e-a4e3-d8e8d2247dc7" dmnElementRef="_04f72806-b802-4102-94b6-a22b183f725d">
+                <dc:Bounds x="92.75882911682129" y="386" width="135.48234176635742" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0" trisodmn:defaultBounds="true"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_4f9f4990-9a50-49e3-876d-af064209e04c" dmnElementRef="_8ec09edc-45db-465c-ad77-2ad837e153b7">
+                <dc:Bounds x="92.75882911682129" y="471" width="135.48234176635742" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0" trisodmn:defaultBounds="true"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_8c31b4a6-3321-45c5-adda-c9373ae2b317" dmnElementRef="_f9b51960-ca8d-4bbc-adfd-6ee6aac308e0">
+                <dc:Bounds x="92.75882911682129" y="547" width="135.48234176635742" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0" trisodmn:defaultBounds="true"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_ab13033c-073a-4ed9-9de1-28e99b117a04" dmnElementRef="_1ecc413e-d383-4382-a6f5-847ff2efac2e">
+                <dc:Bounds x="92.75882911682129" y="624" width="135.48234176635742" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0" trisodmn:defaultBounds="true"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_dfa56ad9-ab17-4230-acea-c4e61d156c6f" dmnElementRef="_09daf449-41a3-4d97-8fe0-f96d3f073ce9">
+                <dc:Bounds x="283.2411708831787" y="37" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0" trisodmn:defaultBounds="true"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_242b4456-54d8-4243-8e69-0452b9f8d2c7" dmnElementRef="_5b39519d-914b-40ba-a37c-ae1a0ea0b220">
+                <dc:Bounds x="283.2411708831787" y="122" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0" trisodmn:defaultBounds="true"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_49898acf-c31e-49da-b2fe-3fece0d2eb22" dmnElementRef="_650b8eec-0862-42f1-8e5e-5f98e8dd1aa5">
+                <dc:Bounds x="283.2411708831787" y="212" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0" trisodmn:defaultBounds="true"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_04850ff5-418a-41f1-bd25-86d936ca1655" dmnElementRef="_8799a148-6a59-4e9d-b405-33259a0f9e14">
+                <dc:Bounds x="283.2411708831787" y="299" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0" trisodmn:defaultBounds="true"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_10b4b571-18c8-424d-96ea-e73344c299bf" dmnElementRef="_89288ead-5f78-48de-a8a9-59af71b71c9c">
+                <dc:Bounds x="283.2411708831787" y="386" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0" trisodmn:defaultBounds="true"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_2abd8b60-1834-417e-8a7e-b6d3a888e323" dmnElementRef="_6224c7f2-1dc8-42fb-af51-b20d7f961a1c">
+                <dc:Bounds x="283.2411708831787" y="471" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0" trisodmn:defaultBounds="true"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_ee466858-948d-494f-9b57-81b3d90d85b2" dmnElementRef="_3d108366-d681-48aa-84b8-81a19ff8c6ec">
+                <dc:Bounds x="283.2411708831787" y="547" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0" trisodmn:defaultBounds="true"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_d86dc3f2-7b5c-48d2-9359-76e94a2fd20e" dmnElementRef="_c86ce320-a211-4846-b57d-a2339a963c1e">
+                <dc:Bounds x="283.2411708831787" y="624" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0" trisodmn:defaultBounds="true"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNEdge id="_a9b95201-7a32-4b1d-b1c1-f4f0e75f6b54" dmnElementRef="_0526d9ff-d33d-4e79-80f5-b9428c872ef6">
+                <di:waypoint x="228.99680137634277" y="67"/>
+                <di:waypoint x="283.2411708831787" y="67"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_45955d48-9c04-4f59-94ec-c5d3b585bc8d" dmnElementRef="_019aca4c-dfcf-4eec-b45c-5c6220502944">
+                <di:waypoint x="228.99680137634277" y="152"/>
+                <di:waypoint x="283.2411708831787" y="152"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_f52f24c0-5a6e-4e6b-b71c-cd6407ec3bfe" dmnElementRef="_c8f80670-265e-449f-b28f-28471e9f664d">
+                <di:waypoint x="228.99680137634277" y="242"/>
+                <di:waypoint x="283.2411708831787" y="242"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_1c269e56-378b-45c8-8303-88548f4eac34" dmnElementRef="_724e45b8-2f9a-45f7-aa93-d76ecfa4eb62">
+                <di:waypoint x="228.99680137634277" y="329"/>
+                <di:waypoint x="283.2411708831787" y="329"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_0c255b71-3186-430d-b51d-bb63fbfc446f" dmnElementRef="_25eb0b77-8ca2-476b-bf03-87ff563a8c9d">
+                <di:waypoint x="228.99680137634277" y="416"/>
+                <di:waypoint x="283.2411708831787" y="416"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_c9a76fa9-21d7-412c-848b-9a9496dc5e1b" dmnElementRef="_a125869d-0c2e-4c59-b62d-9d8ba765e3cf">
+                <di:waypoint x="228.99680137634277" y="501"/>
+                <di:waypoint x="283.2411708831787" y="501"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_66ef1deb-d6a8-499d-bf10-8b6c15db2ab0" dmnElementRef="_a745f1f0-9653-46c3-a2e6-de04c7ca5821">
+                <di:waypoint x="228.99680137634277" y="577"/>
+                <di:waypoint x="283.2411708831787" y="577"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_3462b3b2-febb-4177-9ada-df69705ef7fc" dmnElementRef="_9d9ed0aa-c77b-48a9-9227-470a7f4a540a">
+                <di:waypoint x="228.99680137634277" y="654"/>
+                <di:waypoint x="283.2411708831787" y="654"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0"/>
+            </dmndi:DMNEdge>
+        </dmndi:DMNDiagram>
+        <dmndi:DMNStyle id="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0" fontFamily="arial,helvetica,sans-serif" fontSize="11" fontBold="false" fontItalic="false" fontUnderline="false" fontStrikeThrough="false"/>
+    </dmndi:DMNDI>
+</semantic:definitions>

--- a/integration-tests/integration-tests-quarkus-decisions/src/main/resources/application.properties
+++ b/integration-tests/integration-tests-quarkus-decisions/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+# for these tests, we do NOT want stronglytyped to be enabled, leave it as default disabled.
+# kogito.decisions.stronglytyped=false

--- a/integration-tests/integration-tests-quarkus-decisions/src/test/java/org/kie/kogito/integrationtests/quarkus/OASTest.java
+++ b/integration-tests/integration-tests-quarkus-decisions/src/test/java/org/kie/kogito/integrationtests/quarkus/OASTest.java
@@ -1,0 +1,41 @@
+/**
+ *  Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.kie.kogito.integrationtests.quarkus;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.greaterThan;
+
+@QuarkusTest
+class OASTest {
+
+    static {
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+    }
+
+    @Test
+    public void testOASdmnDefinitions() {
+        RestAssured.given()
+                   .get("/dmnDefinitions.json")
+                   .then()
+                   .statusCode(200)
+                   .body("definitions", aMapWithSize(greaterThan(0)));
+    }
+}

--- a/integration-tests/integration-tests-quarkus-decisions/src/test/java/org/kie/kogito/integrationtests/quarkus/OneOfEachTypeTest.java
+++ b/integration-tests/integration-tests-quarkus-decisions/src/test/java/org/kie/kogito/integrationtests/quarkus/OneOfEachTypeTest.java
@@ -13,6 +13,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+
 package org.kie.kogito.integrationtests.quarkus;
 
 import io.quarkus.test.junit.QuarkusTest;

--- a/integration-tests/integration-tests-quarkus-decisions/src/test/java/org/kie/kogito/integrationtests/quarkus/OneOfEachTypeTest.java
+++ b/integration-tests/integration-tests-quarkus-decisions/src/test/java/org/kie/kogito/integrationtests/quarkus/OneOfEachTypeTest.java
@@ -1,0 +1,62 @@
+/**
+ *  Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.kie.kogito.integrationtests.quarkus;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+
+@QuarkusTest
+class OneOfEachTypeTest {
+
+    static {
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+    }
+
+    @Test
+    public void allTypes() {
+        final String JSON = "{\n" +
+                            "    \"InputBoolean\": true,\n" +
+                            "    \"InputDate\": \"2020-04-02\",\n" +
+                            "    \"InputDTDuration\": \"P1D\",\n" +
+                            "    \"InputDateAndTime\": \"2020-04-02T09:00:00\",\n" +
+                            "    \"InputNumber\": 1,\n" +
+                            "    \"InputString\": \"John Doe\",\n" +
+                            "    \"InputTime\": \"09:00\",\n" +
+                            "    \"InputYMDuration\": \"P1M\"\n" +
+                            "}";
+
+        RestAssured.given()
+                   .contentType(ContentType.JSON)
+                   .accept(ContentType.JSON)
+                   .body(JSON)
+                   .post("/OneOfEachType")
+                   .then()
+                   .statusCode(200)
+                   .body("DecisionBoolean", is(Boolean.FALSE))
+                   .body("DecisionDate", is("2020-04-03")) // as JSON is not schema aware, here we assert the RAW string
+                   .body("DecisionDTDuration", is("PT48H"))
+                   .body("DecisionDateAndTime", is("2020-04-02T10:00:00"))
+                   .body("DecisionNumber", is(2))
+                   .body("DecisionString", is("Hello, John Doe"))
+                   .body("DecisionTime", is("10:00:00"))
+                   .body("DecisionYMDuration", is("P2M"))
+        ;
+    }
+}

--- a/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/pom.xml
+++ b/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/pom.xml
@@ -48,6 +48,11 @@
             <groupId>org.kie.kogito</groupId>
             <artifactId>kogito-springboot-starter</artifactId>
         </dependency>
+        
+        <dependency>
+          <groupId>io.swagger.core.v3</groupId>
+          <artifactId>swagger-annotations</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.kie.kogito</groupId>

--- a/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/main/resources/OneOfEachType.dmn
+++ b/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/main/resources/OneOfEachType.dmn
@@ -1,0 +1,210 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<semantic:definitions xmlns:semantic="http://www.omg.org/spec/DMN/20180521/MODEL/"  xmlns:triso="http://www.trisotech.com/2015/triso/modeling"  xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/"  xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"  xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"  xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn"  xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/"  xmlns:tc="http://www.omg.org/spec/DMN/20160719/testcase"  xmlns:drools="http://www.drools.org/kie/dmn/1.1"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns:rss="http://purl.org/rss/2.0/"  xmlns:openapi="https://openapis.org/omg/extension/1.0"  xmlns:xsd="http://www.w3.org/2001/XMLSchema"  xmlns="http://www.trisotech.com/definitions/_4f5608e9-4d74-4c22-a47e-ab657257fc9c" id="_4f5608e9-4d74-4c22-a47e-ab657257fc9c" name="OneOfEachType" namespace="http://www.trisotech.com/definitions/_4f5608e9-4d74-4c22-a47e-ab657257fc9c" exporter="Decision Modeler" exporterVersion="6.9.3" triso:logoChoice="Default">
+    <semantic:inputData id="_ebb7462c-c105-4aba-bd19-1782e4c510e2" name="InputString">
+        <semantic:variable name="InputString" id="_7c07dd9a-9369-415f-bb5a-357ba0216bb5" typeRef="string"/>
+    </semantic:inputData>
+    <semantic:inputData id="_0e9dae7c-08ac-432e-9a68-a410b14ee8a7" name="InputNumber">
+        <semantic:variable name="InputNumber" id="_d09e3e5c-7351-4265-8485-502cf03ca7c4" typeRef="number"/>
+    </semantic:inputData>
+    <semantic:inputData id="_dadc21c3-5303-4ee5-8178-df24066fda92" name="InputBoolean">
+        <semantic:variable name="InputBoolean" id="_12869250-3a52-481c-87d2-3e1a4efe0e9c" typeRef="boolean"/>
+    </semantic:inputData>
+    <semantic:inputData id="_39423931-0ee8-4b05-9b9a-fe0d3dbcd194" name="InputDTDuration">
+        <semantic:variable name="InputDTDuration" id="_e5ca3cf8-0d01-4be4-be5e-94f7237b1253" typeRef="dayTimeDuration"/>
+    </semantic:inputData>
+    <semantic:inputData id="_04f72806-b802-4102-94b6-a22b183f725d" name="InputYMDuration">
+        <semantic:variable name="InputYMDuration" id="_b165e339-66a7-4526-94c9-b09fac80e52c" typeRef="yearMonthDuration"/>
+    </semantic:inputData>
+    <semantic:inputData id="_8ec09edc-45db-465c-ad77-2ad837e153b7" name="InputDateAndTime">
+        <semantic:variable name="InputDateAndTime" id="_c5b97039-7ce2-4417-8b20-c81e46b7bcac" typeRef="dateTime"/>
+    </semantic:inputData>
+    <semantic:inputData id="_f9b51960-ca8d-4bbc-adfd-6ee6aac308e0" name="InputDate">
+        <semantic:variable name="InputDate" id="_8cfb2a54-60c1-4cf7-88dd-29c0cdc424ac" typeRef="date"/>
+    </semantic:inputData>
+    <semantic:inputData id="_1ecc413e-d383-4382-a6f5-847ff2efac2e" name="InputTime">
+        <semantic:variable name="InputTime" id="_c3458a29-312f-46ea-adab-43b86137e549" typeRef="time"/>
+    </semantic:inputData>
+    <semantic:decision id="_09daf449-41a3-4d97-8fe0-f96d3f073ce9" name="DecisionString">
+        <semantic:variable name="DecisionString" id="_f091c3bb-b084-47e6-980c-30e2af3613c0" typeRef="string"/>
+        <semantic:informationRequirement id="_0526d9ff-d33d-4e79-80f5-b9428c872ef6">
+            <semantic:requiredInput href="#_ebb7462c-c105-4aba-bd19-1782e4c510e2"/>
+        </semantic:informationRequirement>
+        <semantic:literalExpression id="_5fb0d581-c6b9-4ed6-aec5-c0d4adaf8781" typeRef="string" triso:expressionId="_bc740351-1835-41b3-8d97-66374237f4f0">
+            <semantic:text>"Hello, "+InputString</semantic:text>
+        </semantic:literalExpression>
+    </semantic:decision>
+    <semantic:decision id="_5b39519d-914b-40ba-a37c-ae1a0ea0b220" name="DecisionNumber">
+        <semantic:variable name="DecisionNumber" id="_572bdcf5-7f9f-4bdd-932c-288cad2f991c" typeRef="number"/>
+        <semantic:informationRequirement id="_019aca4c-dfcf-4eec-b45c-5c6220502944">
+            <semantic:requiredInput href="#_0e9dae7c-08ac-432e-9a68-a410b14ee8a7"/>
+        </semantic:informationRequirement>
+        <semantic:literalExpression id="_c33e8964-73fa-47f5-bc03-fa20df8e1b49" typeRef="number" triso:expressionId="_33479aab-1ab5-4c6c-80dc-40cbaf28becc">
+            <semantic:text>InputNumber+1</semantic:text>
+        </semantic:literalExpression>
+    </semantic:decision>
+    <semantic:decision id="_650b8eec-0862-42f1-8e5e-5f98e8dd1aa5" name="DecisionBoolean">
+        <semantic:variable name="DecisionBoolean" id="_d62aa522-7580-4988-b8f9-05f3a8e40a4f" typeRef="boolean"/>
+        <semantic:informationRequirement id="_c8f80670-265e-449f-b28f-28471e9f664d">
+            <semantic:requiredInput href="#_dadc21c3-5303-4ee5-8178-df24066fda92"/>
+        </semantic:informationRequirement>
+        <semantic:literalExpression id="_e4cf5da6-195e-41de-9bd8-22d9c80dde02" typeRef="boolean" triso:expressionId="_fa787d3e-d46f-4d02-8aaa-0de29b4b1b97">
+            <semantic:text>not(InputBoolean)</semantic:text>
+        </semantic:literalExpression>
+    </semantic:decision>
+    <semantic:decision id="_8799a148-6a59-4e9d-b405-33259a0f9e14" name="DecisionDTDuration">
+        <semantic:variable name="DecisionDTDuration" id="_d3a315c4-134c-4baa-b8a0-10f4e4195e71" typeRef="dayTimeDuration"/>
+        <semantic:informationRequirement id="_724e45b8-2f9a-45f7-aa93-d76ecfa4eb62">
+            <semantic:requiredInput href="#_39423931-0ee8-4b05-9b9a-fe0d3dbcd194"/>
+        </semantic:informationRequirement>
+        <semantic:literalExpression id="_8dba1335-5475-4569-a1e3-c4842ab95d71" typeRef="dayTimeDuration" triso:expressionId="_d8044631-d49c-4b2b-9ce1-6faacfc323dd">
+            <semantic:text>InputDTDuration + duration("P1D")</semantic:text>
+        </semantic:literalExpression>
+    </semantic:decision>
+    <semantic:decision id="_89288ead-5f78-48de-a8a9-59af71b71c9c" name="DecisionYMDuration">
+        <semantic:variable name="DecisionYMDuration" id="_c4fe080d-4da4-42e2-878c-d3e828cbc7d7" typeRef="yearMonthDuration"/>
+        <semantic:informationRequirement id="_25eb0b77-8ca2-476b-bf03-87ff563a8c9d">
+            <semantic:requiredInput href="#_04f72806-b802-4102-94b6-a22b183f725d"/>
+        </semantic:informationRequirement>
+        <semantic:literalExpression id="_a41a3ca1-15d7-4c88-883b-748f956bd0fe" typeRef="yearMonthDuration" triso:expressionId="_51b95509-fe9c-4b81-bd57-6ee337d18a0e">
+            <semantic:text>InputYMDuration + duration("P1M")</semantic:text>
+        </semantic:literalExpression>
+    </semantic:decision>
+    <semantic:decision id="_6224c7f2-1dc8-42fb-af51-b20d7f961a1c" name="DecisionDateAndTime">
+        <semantic:variable name="DecisionDateAndTime" id="_87b50245-5ea6-4f9b-bcea-955629f77d26" typeRef="dateTime"/>
+        <semantic:informationRequirement id="_a125869d-0c2e-4c59-b62d-9d8ba765e3cf">
+            <semantic:requiredInput href="#_8ec09edc-45db-465c-ad77-2ad837e153b7"/>
+        </semantic:informationRequirement>
+        <semantic:literalExpression id="_38448368-4a76-4dc0-878b-9cfc0eda2cde" typeRef="dateTime" triso:expressionId="_6f6252fb-1b1e-4dc1-9f05-1fe8107e2367">
+            <semantic:text>InputDateAndTime+duration("PT1H")</semantic:text>
+        </semantic:literalExpression>
+    </semantic:decision>
+    <semantic:decision id="_3d108366-d681-48aa-84b8-81a19ff8c6ec" name="DecisionDate">
+        <semantic:variable name="DecisionDate" id="_ac9cd205-8df2-4a55-8de4-5cbb135efa78" typeRef="date"/>
+        <semantic:informationRequirement id="_a745f1f0-9653-46c3-a2e6-de04c7ca5821">
+            <semantic:requiredInput href="#_f9b51960-ca8d-4bbc-adfd-6ee6aac308e0"/>
+        </semantic:informationRequirement>
+        <semantic:literalExpression id="_5f78af03-b624-4844-87bc-cfaba03235bc" typeRef="date" triso:expressionId="_4f0f90dc-2756-4721-9d3a-5bb4444ee685">
+            <semantic:text>InputDate+duration("P1D")</semantic:text>
+        </semantic:literalExpression>
+    </semantic:decision>
+    <semantic:decision id="_c86ce320-a211-4846-b57d-a2339a963c1e" name="DecisionTime">
+        <semantic:variable name="DecisionTime" id="_92a2c68e-9674-4445-b272-3a5b5c57c49b" typeRef="time"/>
+        <semantic:informationRequirement id="_9d9ed0aa-c77b-48a9-9227-470a7f4a540a">
+            <semantic:requiredInput href="#_1ecc413e-d383-4382-a6f5-847ff2efac2e"/>
+        </semantic:informationRequirement>
+        <semantic:literalExpression id="_9b06c371-311d-4c33-9b40-0634c73a4cb9" typeRef="time" triso:expressionId="_99282e41-5570-4e04-90c4-9c5384357fbc">
+            <semantic:text>InputTime+duration("PT1H")</semantic:text>
+        </semantic:literalExpression>
+    </semantic:decision>
+    <dmndi:DMNDI>
+        <dmndi:DMNDiagram id="_947b0ae8-74af-4949-a849-ad11c5973a43" triso:modelElementRef="_48a05074-9da0-4743-99eb-03c624ad4aae" name="Page 1">
+            <di:extension/>
+            <dmndi:Size height="1050" width="1485"/>
+            <dmndi:DMNShape id="_7822265c-7b48-4217-9863-5fd3993710fa" dmnElementRef="_ebb7462c-c105-4aba-bd19-1782e4c510e2">
+                <dc:Bounds x="92.75882911682129" y="37" width="135.48234176635742" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0" trisodmn:defaultBounds="true"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_ae527417-ad57-4a7b-a535-ca6c2cdee340" dmnElementRef="_0e9dae7c-08ac-432e-9a68-a410b14ee8a7">
+                <dc:Bounds x="92.75882911682129" y="122" width="135.48234176635742" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0" trisodmn:defaultBounds="true"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_d473c3ec-9551-49a8-9312-c148319dbf6c" dmnElementRef="_dadc21c3-5303-4ee5-8178-df24066fda92">
+                <dc:Bounds x="92.75882911682129" y="212" width="135.48234176635742" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0" trisodmn:defaultBounds="true"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_64779d7c-71b9-4476-8dcb-662b7e0ba907" dmnElementRef="_39423931-0ee8-4b05-9b9a-fe0d3dbcd194">
+                <dc:Bounds x="92.75882911682129" y="299" width="135.48234176635742" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0" trisodmn:defaultBounds="true"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_1f146de5-62a8-4e3e-a4e3-d8e8d2247dc7" dmnElementRef="_04f72806-b802-4102-94b6-a22b183f725d">
+                <dc:Bounds x="92.75882911682129" y="386" width="135.48234176635742" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0" trisodmn:defaultBounds="true"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_4f9f4990-9a50-49e3-876d-af064209e04c" dmnElementRef="_8ec09edc-45db-465c-ad77-2ad837e153b7">
+                <dc:Bounds x="92.75882911682129" y="471" width="135.48234176635742" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0" trisodmn:defaultBounds="true"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_8c31b4a6-3321-45c5-adda-c9373ae2b317" dmnElementRef="_f9b51960-ca8d-4bbc-adfd-6ee6aac308e0">
+                <dc:Bounds x="92.75882911682129" y="547" width="135.48234176635742" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0" trisodmn:defaultBounds="true"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_ab13033c-073a-4ed9-9de1-28e99b117a04" dmnElementRef="_1ecc413e-d383-4382-a6f5-847ff2efac2e">
+                <dc:Bounds x="92.75882911682129" y="624" width="135.48234176635742" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0" trisodmn:defaultBounds="true"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_dfa56ad9-ab17-4230-acea-c4e61d156c6f" dmnElementRef="_09daf449-41a3-4d97-8fe0-f96d3f073ce9">
+                <dc:Bounds x="283.2411708831787" y="37" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0" trisodmn:defaultBounds="true"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_242b4456-54d8-4243-8e69-0452b9f8d2c7" dmnElementRef="_5b39519d-914b-40ba-a37c-ae1a0ea0b220">
+                <dc:Bounds x="283.2411708831787" y="122" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0" trisodmn:defaultBounds="true"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_49898acf-c31e-49da-b2fe-3fece0d2eb22" dmnElementRef="_650b8eec-0862-42f1-8e5e-5f98e8dd1aa5">
+                <dc:Bounds x="283.2411708831787" y="212" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0" trisodmn:defaultBounds="true"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_04850ff5-418a-41f1-bd25-86d936ca1655" dmnElementRef="_8799a148-6a59-4e9d-b405-33259a0f9e14">
+                <dc:Bounds x="283.2411708831787" y="299" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0" trisodmn:defaultBounds="true"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_10b4b571-18c8-424d-96ea-e73344c299bf" dmnElementRef="_89288ead-5f78-48de-a8a9-59af71b71c9c">
+                <dc:Bounds x="283.2411708831787" y="386" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0" trisodmn:defaultBounds="true"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_2abd8b60-1834-417e-8a7e-b6d3a888e323" dmnElementRef="_6224c7f2-1dc8-42fb-af51-b20d7f961a1c">
+                <dc:Bounds x="283.2411708831787" y="471" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0" trisodmn:defaultBounds="true"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_ee466858-948d-494f-9b57-81b3d90d85b2" dmnElementRef="_3d108366-d681-48aa-84b8-81a19ff8c6ec">
+                <dc:Bounds x="283.2411708831787" y="547" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0" trisodmn:defaultBounds="true"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="_d86dc3f2-7b5c-48d2-9359-76e94a2fd20e" dmnElementRef="_c86ce320-a211-4846-b57d-a2339a963c1e">
+                <dc:Bounds x="283.2411708831787" y="624" width="153" height="60"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0" trisodmn:defaultBounds="true"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNEdge id="_a9b95201-7a32-4b1d-b1c1-f4f0e75f6b54" dmnElementRef="_0526d9ff-d33d-4e79-80f5-b9428c872ef6">
+                <di:waypoint x="228.99680137634277" y="67"/>
+                <di:waypoint x="283.2411708831787" y="67"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_45955d48-9c04-4f59-94ec-c5d3b585bc8d" dmnElementRef="_019aca4c-dfcf-4eec-b45c-5c6220502944">
+                <di:waypoint x="228.99680137634277" y="152"/>
+                <di:waypoint x="283.2411708831787" y="152"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_f52f24c0-5a6e-4e6b-b71c-cd6407ec3bfe" dmnElementRef="_c8f80670-265e-449f-b28f-28471e9f664d">
+                <di:waypoint x="228.99680137634277" y="242"/>
+                <di:waypoint x="283.2411708831787" y="242"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_1c269e56-378b-45c8-8303-88548f4eac34" dmnElementRef="_724e45b8-2f9a-45f7-aa93-d76ecfa4eb62">
+                <di:waypoint x="228.99680137634277" y="329"/>
+                <di:waypoint x="283.2411708831787" y="329"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_0c255b71-3186-430d-b51d-bb63fbfc446f" dmnElementRef="_25eb0b77-8ca2-476b-bf03-87ff563a8c9d">
+                <di:waypoint x="228.99680137634277" y="416"/>
+                <di:waypoint x="283.2411708831787" y="416"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_c9a76fa9-21d7-412c-848b-9a9496dc5e1b" dmnElementRef="_a125869d-0c2e-4c59-b62d-9d8ba765e3cf">
+                <di:waypoint x="228.99680137634277" y="501"/>
+                <di:waypoint x="283.2411708831787" y="501"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_66ef1deb-d6a8-499d-bf10-8b6c15db2ab0" dmnElementRef="_a745f1f0-9653-46c3-a2e6-de04c7ca5821">
+                <di:waypoint x="228.99680137634277" y="577"/>
+                <di:waypoint x="283.2411708831787" y="577"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="_3462b3b2-febb-4177-9ada-df69705ef7fc" dmnElementRef="_9d9ed0aa-c77b-48a9-9227-470a7f4a540a">
+                <di:waypoint x="228.99680137634277" y="654"/>
+                <di:waypoint x="283.2411708831787" y="654"/>
+                <dmndi:DMNLabel sharedStyle="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0"/>
+            </dmndi:DMNEdge>
+        </dmndi:DMNDiagram>
+        <dmndi:DMNStyle id="LS_4f5608e9-4d74-4c22-a47e-ab657257fc9c_0" fontFamily="arial,helvetica,sans-serif" fontSize="11" fontBold="false" fontItalic="false" fontUnderline="false" fontStrikeThrough="false"/>
+    </dmndi:DMNDI>
+</semantic:definitions>

--- a/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/main/resources/application.properties
+++ b/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/main/resources/application.properties
@@ -3,3 +3,6 @@ server.address=0.0.0.0
 spring.mvc.servlet.path=/docs
 
 resteasy.jaxrs.scan-packages=org.kie.kogito.**,http*
+
+# for these tests, we do NOT want stronglytyped to be enabled, leave it as default disabled.
+# kogito.decisions.stronglytyped=false

--- a/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/test/java/org/kie/kogito/integrationtests/springboot/OASTest.java
+++ b/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/test/java/org/kie/kogito/integrationtests/springboot/OASTest.java
@@ -1,0 +1,60 @@
+/**
+ *  Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.kie.kogito.integrationtests.springboot;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.Period;
+
+import io.restassured.http.ContentType;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.kie.kogito.testcontainers.springboot.InfinispanSpringBootTestResource;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.ContextConfiguration;
+
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.greaterThan;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = KogitoSpringbootApplication.class)
+@ContextConfiguration(initializers = InfinispanSpringBootTestResource.Conditional.class)
+class OASTest extends BaseRestTest {
+
+    static {
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+    }
+
+    @Test
+    public void testOASdmnDefinitions() {
+        RestAssured.given()
+                   .get("/docs/dmnDefinitions.json")
+                   .then()
+                   .statusCode(200)
+                   .body("definitions", aMapWithSize(greaterThan(0)));
+    }
+}

--- a/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/test/java/org/kie/kogito/integrationtests/springboot/OneOfEachTypeTest.java
+++ b/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/test/java/org/kie/kogito/integrationtests/springboot/OneOfEachTypeTest.java
@@ -1,0 +1,78 @@
+/**
+ *  Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.kie.kogito.integrationtests.springboot;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.Period;
+
+import io.restassured.http.ContentType;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.kie.kogito.testcontainers.springboot.InfinispanSpringBootTestResource;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.ContextConfiguration;
+
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = KogitoSpringbootApplication.class)
+@ContextConfiguration(initializers = InfinispanSpringBootTestResource.Conditional.class)
+class OneOfEachTypeTest extends BaseRestTest {
+
+    static {
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+    }
+
+    @Test
+    public void allTypes() {
+        final String JSON = "{\n" +
+                            "    \"InputBoolean\": true,\n" +
+                            "    \"InputDate\": \"2020-04-02\",\n" +
+                            "    \"InputDTDuration\": \"P1D\",\n" +
+                            "    \"InputDateAndTime\": \"2020-04-02T09:00:00\",\n" +
+                            "    \"InputNumber\": 1,\n" +
+                            "    \"InputString\": \"John Doe\",\n" +
+                            "    \"InputTime\": \"09:00\",\n" +
+                            "    \"InputYMDuration\": \"P1M\"\n" +
+                            "}";
+
+        RestAssured.given()
+                   .contentType(ContentType.JSON)
+                   .accept(ContentType.JSON)
+                   .body(JSON)
+                   .post("/OneOfEachType")
+                   .then()
+                   .statusCode(200)
+                   .body("DecisionBoolean", is(Boolean.FALSE))
+                   .body("DecisionDate", is("2020-04-03")) // as JSON is not schema aware, here we assert the RAW string
+                   .body("DecisionDTDuration", is("PT48H"))
+                   .body("DecisionDateAndTime", is("2020-04-02T10:00:00"))
+                   .body("DecisionNumber", is(2))
+                   .body("DecisionString", is("Hello, John Doe"))
+                   .body("DecisionTime", is("10:00:00"))
+                   .body("DecisionYMDuration", is("P2M"))
+        ;
+    }
+}

--- a/kogito-build-parent/pom.xml
+++ b/kogito-build-parent/pom.xml
@@ -111,6 +111,7 @@
     <version.io.restassured>4.3.0</version.io.restassured>
     <version.io.restassured.springboot>3.3.0</version.io.restassured.springboot>    <!-- Manually override to 3.3.0 because Spring boot uses rest-assured-common@3.3.0, otherwise error: The type io.restassured.common.mapper.TypeRef cannot be resolved. It is indirectly referenced from required .class files -->
     <version.io.smallrye.reactive>2.1.1</version.io.smallrye.reactive>
+    <version.io.swagger.core.v3>2.0.6</version.io.swagger.core.v3>
 
     <version.org.antlr>3.5.2</version.org.antlr>
     <version.org.antlr4>4.8</version.org.antlr4>
@@ -618,6 +619,12 @@
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-reactive-messaging-http</artifactId>
         <version>${version.io.smallrye.reactive}</version>
+      </dependency>
+      
+      <dependency>
+        <groupId>io.swagger.core.v3</groupId>
+        <artifactId>swagger-annotations</artifactId>
+        <version>${version.io.swagger.core.v3}</version>
       </dependency>
 
       <dependency>

--- a/kogito-build-parent/pom.xml
+++ b/kogito-build-parent/pom.xml
@@ -168,6 +168,11 @@
       </dependency>
       <dependency>
         <groupId>org.kie</groupId>
+        <artifactId>kie-dmn-openapi</artifactId>
+        <version>${version.org.kie7}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie</groupId>
         <artifactId>kie-dmn-jpmml</artifactId>
         <version>${version.org.kie7}</version>
       </dependency>

--- a/kogito-codegen/pom.xml
+++ b/kogito-codegen/pom.xml
@@ -72,6 +72,10 @@
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-dmn</artifactId> <!-- depend on the utility wrapper module to avoid repeating dependency exclusions -->
     </dependency>
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kie-dmn-openapi</artifactId>
+    </dependency>
     <!-- Json schema generator -->  
     <dependency>
       <groupId>com.github.victools</groupId>

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionCodegen.java
@@ -28,6 +28,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.microprofile.openapi.spi.OASFactoryResolver;
 import org.kie.api.io.Resource;
 import org.kie.api.io.ResourceType;
 import org.kie.dmn.api.core.DMNModel;
@@ -70,6 +71,7 @@ public class DecisionCodegen extends AbstractGenerator {
     public static String VALIDATION_CONFIGURATION_KEY = "kogito.decisions.validation";
 
     public static DecisionCodegen ofCollectedResources(Collection<CollectedResource> resources) {
+        OASFactoryResolver.instance(); // manually invoke SPI, o/w Kogito CodeGen Kogito Quarkus extension failure at NewFileHotReloadTest due to java.util.ServiceConfigurationError: org.eclipse.microprofile.openapi.spi.OASFactoryResolver: io.smallrye.openapi.spi.OASFactoryResolverImpl not a subtype
         List<CollectedResource> dmnResources = resources.stream()
                 .filter(r -> r.resource().getResourceType() == ResourceType.DMN)
                 .collect(toList());
@@ -149,7 +151,7 @@ public class DecisionCodegen extends AbstractGenerator {
         try {
             List<DMNModel> models = resources.stream().map(DMNResource::getDmnModel).collect(Collectors.toList());
             oasResult = DMNOASGeneratorFactory.generator(models).build();
-            String jsonContent = new ObjectMapper().writeValueAsString(oasResult.jsonSchemaNode);
+            String jsonContent = new ObjectMapper().writeValueAsString(oasResult.getJsonSchemaNode());
             storeFile(GeneratedFile.Type.GENERATED_CP_RESOURCE, "META-INF/resources/dmnDefinitions.json", jsonContent);
         } catch (Exception e) {
             LOG.error("Error while trying to generate OpenAPI specification for the DMN models", e);

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionCodegen.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.kie.api.io.Resource;
 import org.kie.api.io.ResourceType;
 import org.kie.dmn.api.core.DMNModel;
@@ -39,6 +40,8 @@ import org.kie.dmn.model.api.BusinessKnowledgeModel;
 import org.kie.dmn.model.api.DRGElement;
 import org.kie.dmn.model.api.Decision;
 import org.kie.dmn.model.api.Definitions;
+import org.kie.dmn.openapi.DMNOASGeneratorFactory;
+import org.kie.dmn.openapi.model.DMNOASResult;
 import org.kie.dmn.typesafe.DMNAllTypesIndex;
 import org.kie.dmn.typesafe.DMNTypeSafePackageName;
 import org.kie.dmn.typesafe.DMNTypeSafeTypeGenerator;
@@ -90,7 +93,8 @@ public class DecisionCodegen extends AbstractGenerator {
     private final List<DMNResource> resources = new ArrayList<>();
     private final List<GeneratedFile> generatedFiles = new ArrayList<>();
     private AddonsConfig addonsConfig = AddonsConfig.DEFAULT;
-    private ClassLoader projectClassLoader;
+    private ClassLoader notPCLClassloader; // Kogito CodeGen design as of 2020-10-09
+    private PCLResolverFn pclResolverFn = this::trueIFFClassIsPresent;
 
     public DecisionCodegen(List<CollectedResource> cResources) {
         this.cResources = cResources;
@@ -140,6 +144,16 @@ public class DecisionCodegen extends AbstractGenerator {
 
     private void generateAndStoreRestResources() {
         List<DecisionRestResourceGenerator> rgs = new ArrayList<>(); // REST resources
+        
+        DMNOASResult oasResult = null;
+        try {
+            List<DMNModel> models = resources.stream().map(DMNResource::getDmnModel).collect(Collectors.toList());
+            oasResult = DMNOASGeneratorFactory.generator(models).build();
+            String jsonContent = new ObjectMapper().writeValueAsString(oasResult.jsonSchemaNode);
+            storeFile(GeneratedFile.Type.GENERATED_CP_RESOURCE, "META-INF/resources/dmnDefinitions.json", jsonContent);
+        } catch (Exception e) {
+            LOG.error("Error while trying to generate OpenAPI specification for the DMN models", e);
+        }
 
         for (DMNResource resource : resources) {
             DMNModel model = resource.getDmnModel();
@@ -155,10 +169,10 @@ public class DecisionCodegen extends AbstractGenerator {
             if (stronglyTypedEnabled) {
                 generateStronglyTypedInput(model);
             }
-            DecisionRestResourceGenerator resourceGenerator = new DecisionRestResourceGenerator(model, applicationCanonicalName)
-                    .withDependencyInjection(annotator)
-                    .withAddons(addonsConfig)
-                    .withStronglyTyped(stronglyTypedEnabled);
+            DecisionRestResourceGenerator resourceGenerator = new DecisionRestResourceGenerator(model, applicationCanonicalName).withDependencyInjection(annotator)
+                                                                                                                                .withAddons(addonsConfig)
+                                                                                                                                .withStronglyTyped(stronglyTypedEnabled)
+                                                                                                                                .withOASResult(oasResult, isMPAnnotationsPresent(), isIOSwaggerOASv3AnnotationsPresent());
             rgs.add(resourceGenerator);
         }
 
@@ -203,14 +217,14 @@ public class DecisionCodegen extends AbstractGenerator {
             DMNAllTypesIndex index = new DMNAllTypesIndex(factory, model);
 
             DMNTypeSafeTypeGenerator generator = new DMNTypeSafeTypeGenerator(model, index, factory).withJacksonAnnotation();
-            boolean useMPAnnotations = trueIFFClassIsPresent("org.eclipse.microprofile.openapi.models.OpenAPI");
+            boolean useMPAnnotations = isMPAnnotationsPresent();
             if (useMPAnnotations) {
                 logger.debug("useMPAnnotations");
                 generator.withMPAnnotation();
             } else {
                 logger.debug("NO useMPAnnotations");
             }
-            boolean useIOSwaggerOASv3Annotations = trueIFFClassIsPresent("io.swagger.v3.oas.annotations.media.Schema");
+            boolean useIOSwaggerOASv3Annotations = isIOSwaggerOASv3AnnotationsPresent();
             if (useIOSwaggerOASv3Annotations) {
                 logger.debug("useIOSwaggerOASv3Annotations");
                 generator.withIOSwaggerOASv3();
@@ -228,10 +242,18 @@ public class DecisionCodegen extends AbstractGenerator {
         }
     }
 
+    private boolean isMPAnnotationsPresent() {
+        return this.pclResolverFn.apply("org.eclipse.microprofile.openapi.models.OpenAPI");
+    }
+
+    private boolean isIOSwaggerOASv3AnnotationsPresent() {
+        return this.pclResolverFn.apply("io.swagger.v3.oas.annotations.media.Schema");
+    }
+
     private boolean trueIFFClassIsPresent(String fqn) {
-        if (projectClassLoader != null) {
+        if (notPCLClassloader != null) {
             try {
-                Class<?> c = projectClassLoader.loadClass(fqn);
+                Class<?> c = notPCLClassloader.loadClass(fqn);
                 if (c != null) {
                     return true;
                 }
@@ -283,8 +305,13 @@ public class DecisionCodegen extends AbstractGenerator {
         return this;
     }
 
-    public DecisionCodegen withClassLoader(ClassLoader projectClassLoader) {
-        this.projectClassLoader = projectClassLoader;
+    public DecisionCodegen withClassLoader(ClassLoader classLoader) {
+        this.notPCLClassloader = classLoader;
+        return this;
+    }
+
+    public DecisionCodegen withPCLResolverFn(PCLResolverFn fn) {
+        this.pclResolverFn = fn;
         return this;
     }
 }

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionRestResourceGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionRestResourceGenerator.java
@@ -30,6 +30,7 @@ import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.Name;
 import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.expr.NormalAnnotationExpr;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
 import com.github.javaparser.ast.expr.SimpleName;
 import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
@@ -43,6 +44,7 @@ import org.drools.core.util.StringUtils;
 import org.kie.dmn.api.core.DMNModel;
 import org.kie.dmn.feel.codegen.feel11.CodegenStringUtil;
 import org.kie.dmn.model.api.DecisionService;
+import org.kie.dmn.openapi.model.DMNOASResult;
 import org.kie.kogito.codegen.AddonsConfig;
 import org.kie.kogito.codegen.BodyDeclarationComparator;
 import org.kie.kogito.codegen.CodegenUtils;
@@ -64,6 +66,9 @@ public class DecisionRestResourceGenerator {
     private DependencyInjectionAnnotator annotator;
     private AddonsConfig addonsConfig = AddonsConfig.DEFAULT;
     private boolean isStronglyTyped = false;
+    private DMNOASResult withOASResult;
+    private boolean mpAnnPresent;
+    private boolean swaggerAnnPresent;
 
     private static final Supplier<RuntimeException> TEMPLATE_WAS_MODIFIED = () -> new RuntimeException("Template was modified!");
 
@@ -107,6 +112,7 @@ public class DecisionRestResourceGenerator {
         }
 
         MethodDeclaration dmnMethod = template.findAll(MethodDeclaration.class, x -> x.getName().toString().equals("dmn")).get(0);
+        processOASAnn(dmnMethod);
         template.addMember(cloneForDMNResult(dmnMethod, "dmn_dmnresult", "dmnresult"));
         for (DecisionService ds : dmnModel.getDefinitions().getDecisionService()) {
             if (ds.getAdditionalAttributes().keySet().stream().anyMatch(qn -> qn.getLocalPart().equals("dynamicDecisionService"))) {
@@ -114,6 +120,11 @@ public class DecisionRestResourceGenerator {
             }
 
             MethodDeclaration clonedMethod = dmnMethod.clone();
+            // currently DS methods do not support $ref lookup
+            removeAnnFromMethod(clonedMethod, "org.eclipse.microprofile.openapi.annotations.parameters.RequestBody");
+            removeAnnFromMethod(clonedMethod, "io.swagger.v3.oas.annotations.parameters.RequestBody");
+            removeAnnFromMethod(clonedMethod, "org.eclipse.microprofile.openapi.annotations.responses.APIResponse");
+            removeAnnFromMethod(clonedMethod, "io.swagger.v3.oas.annotations.responses.ApiResponse");
             String name = CodegenStringUtil.escapeIdentifier("decisionService_" + ds.getName());
             clonedMethod.setName(name);
             MethodCallExpr evaluateCall = clonedMethod.findFirst(MethodCallExpr.class, x -> x.getNameAsString().equals("evaluateAll")).orElseThrow(TEMPLATE_WAS_MODIFIED);
@@ -150,6 +161,56 @@ public class DecisionRestResourceGenerator {
         return clazz.toString();
     }
 
+    private void processOASAnn(MethodDeclaration dmnMethod) {
+        String inputRef = null;
+        String outputRef = null;
+        if (withOASResult!= null) {
+            inputRef = withOASResult.namingPolicy.getRef(withOASResult.lookupIOSetsByModel(dmnModel).getInputSet());
+            outputRef = withOASResult.namingPolicy.getRef(withOASResult.lookupIOSetsByModel(dmnModel).getOutputSet());
+        }
+        // MP / Quarkus
+        processAnnForRef(dmnMethod,
+                         "org.eclipse.microprofile.openapi.annotations.parameters.RequestBody",
+                         "org.eclipse.microprofile.openapi.annotations.media.Schema",
+                         "/dmnDefinitions.json" + inputRef,
+                         !mpAnnPresent);
+        processAnnForRef(dmnMethod,
+                         "org.eclipse.microprofile.openapi.annotations.responses.APIResponse",
+                         "org.eclipse.microprofile.openapi.annotations.media.Schema",
+                         "/dmnDefinitions.json" + outputRef,
+                         !mpAnnPresent);
+        // io.swagger / SB
+        processAnnForRef(dmnMethod,
+                         "io.swagger.v3.oas.annotations.parameters.RequestBody",
+                         "io.swagger.v3.oas.annotations.media.Schema",
+                         "/docs/dmnDefinitions.json" + inputRef,
+                         !swaggerAnnPresent);
+        processAnnForRef(dmnMethod,
+                         "io.swagger.v3.oas.annotations.responses.ApiResponse",
+                         "io.swagger.v3.oas.annotations.media.Schema",
+                         "/docs/dmnDefinitions.json" + outputRef,
+                         !swaggerAnnPresent);
+    }
+
+    private void processAnnForRef(MethodDeclaration dmnMethod, String parentName, String innerName, String ref, boolean removeIt) {
+        NormalAnnotationExpr mpInput = dmnMethod.findAll(NormalAnnotationExpr.class, x -> x.getName().toString().equals(parentName))
+                                                .get(0);
+        if (removeIt || ref == null) {
+            mpInput.remove();
+        } else {
+            NormalAnnotationExpr schemaAnn = mpInput.findAll(NormalAnnotationExpr.class, x -> x.getName().toString().equals(innerName))
+                                                    .get(0);
+            schemaAnn.getPairs().removeIf(x -> true);
+            schemaAnn.addPair("ref", new StringLiteralExpr(ref));
+        }
+    }
+
+    private void removeAnnFromMethod(MethodDeclaration dmnMethod, String fqn) {
+        for (NormalAnnotationExpr ann : dmnMethod.findAll(NormalAnnotationExpr.class, x -> x.getName().toString().equals(fqn))) {
+            dmnMethod.remove(ann);
+        }
+    }
+
     private void chooseMethodForStronglyTyped(ClassOrInterfaceDeclaration template) {
         if (isStronglyTyped) {
             MethodDeclaration extractContextIfSucceded = template.findAll(MethodDeclaration.class, x -> x.getName().toString().equals("extractContextIfSucceded")).get(0);
@@ -170,6 +231,9 @@ public class DecisionRestResourceGenerator {
 
     private MethodDeclaration cloneForDMNResult(MethodDeclaration dmnMethod, String name, String pathName) {
         MethodDeclaration clonedDmnMethod = dmnMethod.clone();
+        // a DMNResult-returning method doesn't need the OAS annotations for the $ref of return type.
+        removeAnnFromMethod(clonedDmnMethod, "org.eclipse.microprofile.openapi.annotations.responses.APIResponse");
+        removeAnnFromMethod(clonedDmnMethod, "io.swagger.v3.oas.annotations.responses.ApiResponse");
         clonedDmnMethod.setName(name);
         final Name jaxrsPathAnnName = new Name("javax.ws.rs.Path");
         clonedDmnMethod.getAnnotations().removeIf(ae -> ae.getName().equals(jaxrsPathAnnName));
@@ -311,6 +375,13 @@ public class DecisionRestResourceGenerator {
 
     public DecisionRestResourceGenerator withStronglyTyped(boolean stronglyTyped) {
         this.isStronglyTyped = stronglyTyped;
+        return this;
+    }
+
+    public DecisionRestResourceGenerator withOASResult(DMNOASResult oasResult, boolean mpAnnPresent, boolean swaggerAnnPresent) {
+        this.withOASResult = oasResult;
+        this.mpAnnPresent = mpAnnPresent;
+        this.swaggerAnnPresent = swaggerAnnPresent;
         return this;
     }
 }

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionRestResourceGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionRestResourceGenerator.java
@@ -130,6 +130,8 @@ public class DecisionRestResourceGenerator {
             MethodCallExpr evaluateCall = clonedMethod.findFirst(MethodCallExpr.class, x -> x.getNameAsString().equals("evaluateAll")).orElseThrow(TEMPLATE_WAS_MODIFIED);
             evaluateCall.setName(new SimpleName("evaluateDecisionService"));
             evaluateCall.addArgument(new StringLiteralExpr(ds.getName()));
+            MethodCallExpr ctxCall = clonedMethod.findFirst(MethodCallExpr.class, x -> x.getNameAsString().equals("ctx")).orElseThrow(TEMPLATE_WAS_MODIFIED);
+            ctxCall.addArgument(new StringLiteralExpr(ds.getName()));
             clonedMethod.addAnnotation(new SingleMemberAnnotationExpr(new Name("javax.ws.rs.Path"), new StringLiteralExpr(ds.getName())));
             ReturnStmt returnStmt = clonedMethod.findFirst(ReturnStmt.class).orElseThrow(TEMPLATE_WAS_MODIFIED);
             if (ds.getOutputDecision().size() == 1) {

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionRestResourceGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionRestResourceGenerator.java
@@ -165,8 +165,8 @@ public class DecisionRestResourceGenerator {
         String inputRef = null;
         String outputRef = null;
         if (withOASResult!= null) {
-            inputRef = withOASResult.namingPolicy.getRef(withOASResult.lookupIOSetsByModel(dmnModel).getInputSet());
-            outputRef = withOASResult.namingPolicy.getRef(withOASResult.lookupIOSetsByModel(dmnModel).getOutputSet());
+            inputRef = withOASResult.getNamingPolicy().getRef(withOASResult.lookupIOSetsByModel(dmnModel).getInputSet());
+            outputRef = withOASResult.getNamingPolicy().getRef(withOASResult.lookupIOSetsByModel(dmnModel).getOutputSet());
         }
         // MP / Quarkus
         processAnnForRef(dmnMethod,

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionRestResourceGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionRestResourceGenerator.java
@@ -201,7 +201,7 @@ public class DecisionRestResourceGenerator {
             if (removeIt) {
                 return; // nothing to do
             } else {
-                throw new IllegalStateException();
+                throw new IllegalStateException("Impossible to find annotation " + parentName + " on method " + dmnMethod.toString());
             }
         }
         NormalAnnotationExpr parentExpr = findAll.get(0);

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/PCLResolverFn.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/PCLResolverFn.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.codegen.decision;
+
+import java.util.function.Function;
+
+/**
+ * Some Kogito CodeGen *Generator, like the DMN DecisionCodegen, might need to understand if certain class is available on the project's classpath dependencies
+ * in a Drools' Project ClassLoader (PCL) fashion.<br/>
+ * <br/>
+ * For example: we might use internally of Kogito CodeGen the Eclipse MP for OAS, which contains also annotations.
+ * However, a Kogito-maven-plugin (SB) based project, might opt NOT to use the Eclipse MP for OAS for its (generated) classes, and use io.swagger annotation instead.<br/>
+ * <br/>
+ * This function is meant to help understand which classes are available on the (kogito) project, Drools' PCL-style
+ */
+public interface PCLResolverFn extends Function<String, Boolean> {
+
+}

--- a/kogito-codegen/src/main/resources/class-templates/DecisionRestResourceTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/DecisionRestResourceTemplate.java
@@ -16,6 +16,7 @@ import org.kie.dmn.core.impl.DMNContextImpl;
 import org.kie.dmn.feel.lang.types.impl.ComparablePeriod;
 import org.kie.kogito.Application;
 import org.kie.kogito.dmn.rest.DMNEvaluationErrorException;
+import org.kie.kogito.dmn.rest.DMNJSONUtils;
 import org.kie.kogito.dmn.rest.DMNResult;
 import org.kie.kogito.dmn.util.StronglyTypedUtils;
 
@@ -39,7 +40,7 @@ public class DMNRestResourceTemplate {
     public $outputType$ dmn($inputType$ variables) {
         org.kie.kogito.decision.DecisionModel decision = application.decisionModels().getDecisionModel("$modelNamespace$", "$modelName$");
         OutputSet outputSet = (OutputSet)StronglyTypedUtils.convertToOutputSet(variables, OutputSet.class);
-        org.kie.kogito.dmn.rest.DMNResult result = new org.kie.kogito.dmn.rest.DMNResult("$modelNamespace$", "$modelName$", decision.evaluateAll(decision.newContext($inputData$)));
+        org.kie.kogito.dmn.rest.DMNResult result = new org.kie.kogito.dmn.rest.DMNResult("$modelNamespace$", "$modelName$", decision.evaluateAll(DMNJSONUtils.ctx(decision, $inputData$)));
         return $extractContextMethod$(result);
     }
     

--- a/kogito-codegen/src/main/resources/class-templates/DecisionRestResourceTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/DecisionRestResourceTemplate.java
@@ -32,6 +32,10 @@ public class DMNRestResourceTemplate {
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
+    @org.eclipse.microprofile.openapi.annotations.parameters.RequestBody(content = @org.eclipse.microprofile.openapi.annotations.media.Content(mediaType = "application/json",schema = @org.eclipse.microprofile.openapi.annotations.media.Schema(ref = "/dmnDefinitions.json#/definitions/InputSet1")))
+    @org.eclipse.microprofile.openapi.annotations.responses.APIResponse(content = @org.eclipse.microprofile.openapi.annotations.media.Content(mediaType = "application/json", schema = @org.eclipse.microprofile.openapi.annotations.media.Schema(ref = "/dmnDefinitions.json#/definitions/OutputSet1")))
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(content = @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json",schema = @io.swagger.v3.oas.annotations.media.Schema(ref = "/dmnDefinitions.json#/definitions/InputSet1")))
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(content = @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json",schema = @io.swagger.v3.oas.annotations.media.Schema(ref = "/dmnDefinitions.json#/definitions/OutputSet1")))
     public $outputType$ dmn($inputType$ variables) {
         org.kie.kogito.decision.DecisionModel decision = application.decisionModels().getDecisionModel("$modelNamespace$", "$modelName$");
         OutputSet outputSet = (OutputSet)StronglyTypedUtils.convertToOutputSet(variables, OutputSet.class);

--- a/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
+++ b/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
@@ -281,7 +281,8 @@ public class GenerateModelMojo extends AbstractKieMojo {
         if (generateDecisions()) {
             appGen.withGenerator(DecisionCodegen.ofCollectedResources(CollectedResource.fromDirectory(kieSourcesDirectory.toPath())))
                   .withAddons(addonsConfig)
-                  .withClassLoader(projectClassLoader);
+                  .withClassLoader(projectClassLoader)
+                  .withPCLResolverFn(x -> hasClassOnClasspath(project, x));
         }
 
         return appGen;

--- a/kogito-quarkus-extension/deployment/pom.xml
+++ b/kogito-quarkus-extension/deployment/pom.xml
@@ -40,6 +40,10 @@
             <artifactId>quarkus-resteasy-jackson-deployment</artifactId>
             <version>${version.io.quarkus}</version>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-undertow-deployment</artifactId>
+        </dependency>
 
         <!-- kogito -->
         <dependency>

--- a/kogito-quarkus-extension/deployment/pom.xml
+++ b/kogito-quarkus-extension/deployment/pom.xml
@@ -40,6 +40,8 @@
             <artifactId>quarkus-resteasy-jackson-deployment</artifactId>
             <version>${version.io.quarkus}</version>
         </dependency>
+        <!-- Undertow is needed so that the static resource serving can correctly locate CP resources from `META-INF/resources` of the application, as it would be normally expected.
+             See https://issues.redhat.com/browse/KOGITO-3477 -->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-undertow-deployment</artifactId>

--- a/kogito-quarkus-extension/integration-test/src/test/java/io/quarkus/it/kogito/dmn/DMNTest.java
+++ b/kogito-quarkus-extension/integration-test/src/test/java/io/quarkus/it/kogito/dmn/DMNTest.java
@@ -21,12 +21,23 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 
 @QuarkusTest
 public class DMNTest {
 
     static { RestAssured.enableLoggingOfRequestAndResponseIfValidationFails(); }
+
+    @Test
+    public void testOASdmnDefinitions() {
+        RestAssured.given()
+                   .get("/dmnDefinitions.json")
+                   .then()
+                   .statusCode(200)
+                   .body("definitions", aMapWithSize(greaterThan(0)));
+    }
 
     static final String ADULT_PAYLOAD = "{\n" +
                                         "  \"p\": {\n" +
@@ -43,6 +54,7 @@ public class DMNTest {
                                         "    \"name\": \"Luca\"\n" +
                                         "  }\n" +
                                         "}";
+
 
     @Test
     public void testAdult() {

--- a/kogito-quarkus-extension/runtime/pom.xml
+++ b/kogito-quarkus-extension/runtime/pom.xml
@@ -46,6 +46,11 @@
       <groupId>io.quarkus.arc</groupId>
       <artifactId>arc-processor</artifactId>
     </dependency>
+    
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-undertow</artifactId>
+    </dependency>
 
     <!-- kogito -->
     <dependency>

--- a/kogito-quarkus-extension/runtime/pom.xml
+++ b/kogito-quarkus-extension/runtime/pom.xml
@@ -46,7 +46,9 @@
       <groupId>io.quarkus.arc</groupId>
       <artifactId>arc-processor</artifactId>
     </dependency>
-    
+
+    <!-- Undertow is needed so that the static resource serving can correctly locate CP resources from `META-INF/resources` of the application, as it would be normally expected.
+         See https://issues.redhat.com/browse/KOGITO-3477 -->
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-undertow</artifactId>


### PR DESCRIPTION
This is a DRAFT PR for now, to better clarify one of the many usages of https://issues.redhat.com/browse/DROOLS-5714

**referenced Pull Requests**: part of an ensemble of PRs:

* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1493
* https://github.com/kiegroup/drools/pull/3155
* (DRAFT) this PR

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>