### PR TITLE
KOGITO-2773: Update scesim example enabling compatibility with BC

### DIFF
--- a/drools/kogito-scenario-simulation/src/test/resources/sampleTest/Violation Scenarios.scesim
+++ b/drools/kogito-scenario-simulation/src/test/resources/sampleTest/Violation Scenarios.scesim
@@ -73,7 +73,7 @@
             <name>Violation</name>
             <className>Violation</className>
           </factIdentifier>
-          <className>string</className>
+          <className>Type</className>
           <factAlias>Violation</factAlias>
           <expressionAlias>Type</expressionAlias>
           <genericTypes/>
@@ -752,7 +752,7 @@
     </scesimData>
   </background>
   <settings>
-    <dmnFilePath>src/main/resources/Traffic Violation.dmn</dmnFilePath>
+    <dmnFilePath>src/test/resources/sampleTest/Traffic Violation.dmn</dmnFilePath>
     <type>DMN</type>
     <dmnNamespace>https://github.com/kiegroup/drools/kie-dmn/_A4BCA8B8-CF08-433F-93B2-A2598F19ECFF</dmnNamespace>
     <dmnName>Traffic Violation</dmnName>


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-2773

The real name of "Type" column is "Type" and not "string". The editor will show "string" but, under the cover, "Type" is used because is a "Anonymous" DMNType (a type with allowed values). This change will enable the examples to be both compatible with Kogito channels and Business Central

In addition the DMNPath was wrong. Updated with the correct path.

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket