### PR TITLE
KOGITO-3269 Restore native test in integration-tests-quarkus-decisions

### DIFF
--- a/integration-tests/integration-tests-quarkus-decisions/pom.xml
+++ b/integration-tests/integration-tests-quarkus-decisions/pom.xml
@@ -114,15 +114,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <systemPropertyVariables>
-            <container.image.infinispan>${container.image.infinispan}</container.image.infinispan>
-          </systemPropertyVariables>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 

--- a/integration-tests/integration-tests-quarkus-decisions/src/test/java/org/kie/kogito/integrationtests/quarkus/BasicAddTest.java
+++ b/integration-tests/integration-tests-quarkus-decisions/src/test/java/org/kie/kogito/integrationtests/quarkus/BasicAddTest.java
@@ -15,18 +15,15 @@
  */
 package org.kie.kogito.integrationtests.quarkus;
 
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.Test;
-import org.kie.kogito.testcontainers.quarkus.InfinispanQuarkusTestResource;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;
 
 @QuarkusTest
-@QuarkusTestResource(InfinispanQuarkusTestResource.Conditional.class)
 class BasicAddTest {
 
     static {

--- a/integration-tests/integration-tests-quarkus-decisions/src/test/java/org/kie/kogito/integrationtests/quarkus/DSCoercionTest.java
+++ b/integration-tests/integration-tests-quarkus-decisions/src/test/java/org/kie/kogito/integrationtests/quarkus/DSCoercionTest.java
@@ -21,19 +21,16 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.Period;
 
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.Test;
-import org.kie.kogito.testcontainers.quarkus.InfinispanQuarkusTestResource;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 @QuarkusTest
-@QuarkusTestResource(InfinispanQuarkusTestResource.Conditional.class)
 class DSCoercionTest {
 
     static {

--- a/integration-tests/integration-tests-quarkus-decisions/src/test/java/org/kie/kogito/integrationtests/quarkus/ElementAtIndexTest.java
+++ b/integration-tests/integration-tests-quarkus-decisions/src/test/java/org/kie/kogito/integrationtests/quarkus/ElementAtIndexTest.java
@@ -15,12 +15,10 @@
  */
 package org.kie.kogito.integrationtests.quarkus;
 
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.Test;
-import org.kie.kogito.testcontainers.quarkus.InfinispanQuarkusTestResource;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;
@@ -28,7 +26,6 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
 @QuarkusTest
-@QuarkusTestResource(InfinispanQuarkusTestResource.Conditional.class)
 class ElementAtIndexTest {
 
     static {

--- a/integration-tests/integration-tests-quarkus-decisions/src/test/java/org/kie/kogito/integrationtests/quarkus/JavaFNctxTest.java
+++ b/integration-tests/integration-tests-quarkus-decisions/src/test/java/org/kie/kogito/integrationtests/quarkus/JavaFNctxTest.java
@@ -17,20 +17,17 @@ package org.kie.kogito.integrationtests.quarkus;
 
 import java.math.BigDecimal;
 
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.path.json.config.JsonPathConfig;
 import org.junit.jupiter.api.Test;
-import org.kie.kogito.testcontainers.quarkus.InfinispanQuarkusTestResource;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.config.JsonConfig.jsonConfig;
 import static org.hamcrest.Matchers.closeTo;
 
 @QuarkusTest
-@QuarkusTestResource(InfinispanQuarkusTestResource.Conditional.class)
 class JavaFNctxTest {
 
     static {

--- a/integration-tests/integration-tests-quarkus-decisions/src/test/java/org/kie/kogito/integrationtests/quarkus/NativeJavaFNctxIT.java
+++ b/integration-tests/integration-tests-quarkus-decisions/src/test/java/org/kie/kogito/integrationtests/quarkus/NativeJavaFNctxIT.java
@@ -16,14 +16,9 @@
 
 package org.kie.kogito.integrationtests.quarkus;
 
-import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.NativeImageTest;
-import org.junit.jupiter.api.Disabled;
-import org.kie.kogito.testcontainers.quarkus.InfinispanQuarkusTestResource;
 
-@Disabled("KOGITO-3269 NativeJavaFNctxIT not working in native mode (Quarkus 1.8 CR1 + GraalVM 20.2)")
 @NativeImageTest
-@QuarkusTestResource(InfinispanQuarkusTestResource.Conditional.class)
 class NativeJavaFNctxIT extends JavaFNctxTest {
 
     // Execute the same tests but in native mode.


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-3269

I believe since [KOGITO-3370](https://issues.redhat.com/browse/KOGITO-3370) the `integration-tests-quarkus-<vertical>` modules no longer require additional synthetic annotations such like 
```
@QuarkusTestResource(InfinispanQuarkusTestResource.Conditional.class)
```

Since `integration-tests-quarkus-decisions` for instance do NOT deal with Infinispan.

For the reason why that Infinispan synthetic test annotation broke Native Image, you can reference the log here: https://issues.redhat.com/browse/KOGITO-3269?focusedCommentId=15324521&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-15324521

In short

```
[ERROR] org.kie.kogito.integrationtests.quarkus.NativeJavaFNctxIT  Time elapsed: 0.1 s  <<< ERROR!
java.lang.RuntimeException: Unable to instantiate the test resource org.kie.kogito.testcontainers.quarkus.InfinispanQuarkusTestResource$Conditional
Caused by: java.lang.reflect.InvocationTargetException
Caused by: java.lang.NullPointerException: dockerImageName is marked non-null but is null
```

This PR restore what was a [previously-disabled](https://github.com/kiegroup/kogito-runtimes/pull/744) Native Image test.
It is working fine already locally both withOUT `-Pnative-image` profile, than with:
![image](https://user-images.githubusercontent.com/1699252/95864326-88a05900-0d65-11eb-9190-21accaa5e784.png)

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket