### PR TITLE
Revert "KOGITO-3570 No defaut settings.xml for release build"

### DIFF
--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -284,11 +284,6 @@ void runMaven(String command, String directory, boolean skipTests = false, List 
         mvnCmd += " ${extraArgs}"
     }
     dir(directory) {
-        if(isRelease()){
-            // In case of release, we already have the settings.xml
-            maven.runMaven(mvnCmd, skipTests, ['-fae'])
-        } else {
-            maven.runMavenWithSubmarineSettings(mvnCmd, skipTests)   
-        }
+        maven.runMavenWithSubmarineSettings(mvnCmd, skipTests)
     }
 }


### PR DESCRIPTION
Reverts kiegroup/kogito-runtimes#816

This is causing some issues with `jenkins-ci` libraries from spock testing due to another settings.xml used when using the deploy pipeline in release mode.
Another fix will come later. First reverting.