### PR TITLE
[KOGITO-3690] Fix DecisionModelResourcesProvider codegen in case of multiple DMN models

### DIFF
--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionModelResourcesProviderGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/decision/DecisionModelResourcesProviderGenerator.java
@@ -103,9 +103,9 @@ public class DecisionModelResourcesProviderGenerator {
         final MethodDeclaration getResourcesMethod = getResourcesMethods.get(0);
         final BlockStmt body = getResourcesMethod.getBody().orElseThrow(() -> new RuntimeException("Can't find the body of the \"get()\" method."));
         final VariableDeclarator resourcePathsVariable = getResourcesMethod.findFirst(VariableDeclarator.class).orElseThrow(() -> new RuntimeException("Can't find a variable declaration in the \"get()\" method."));
-        final MethodCallExpr add = new MethodCallExpr(resourcePathsVariable.getNameAsExpression(), "add");
 
         for (DMNResource resource : resources) {
+            final MethodCallExpr add = new MethodCallExpr(resourcePathsVariable.getNameAsExpression(), "add");
             final MethodCallExpr getResAsStream = getReadResourceMethod(applicationClass, resource.getCollectedResource());
             final MethodCallExpr isr = new MethodCallExpr("readResource").addArgument(getResAsStream);
             add.addArgument(newObject(DefaultDecisionModelResource.class,

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/decision/DecisionModelResourcesProviderGeneratorTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/decision/DecisionModelResourcesProviderGeneratorTest.java
@@ -107,12 +107,12 @@ public class DecisionModelResourcesProviderGeneratorTest {
         assertTrue(expression.getExpression() instanceof MethodCallExpr);
 
         final MethodCallExpr call = (MethodCallExpr) expression.getExpression();
-        assertEquals(call.getName().getIdentifier(), "add");
+        assertEquals("add", call.getName().getIdentifier());
         assertTrue(call.getScope().isPresent());
         assertTrue(call.getScope().get().isNameExpr());
 
         final NameExpr nameExpr = call.getScope().get().asNameExpr();
-        assertEquals(nameExpr.getName().getIdentifier(), "resourcePaths");
+        assertEquals("resourcePaths", nameExpr.getName().getIdentifier());
 
         long numberOfAddStms = body.getStatements().stream()
                 .filter(this::isAddStatement)

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/decision/DecisionModelResourcesProviderGeneratorTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/decision/DecisionModelResourcesProviderGeneratorTest.java
@@ -39,7 +39,10 @@ import org.kie.kogito.codegen.io.CollectedResource;
 import static com.github.javaparser.StaticJavaParser.parse;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DecisionModelResourcesProviderGeneratorTest {
 

--- a/kogito-codegen/src/test/resources/decision/models/dmnprocess.bpmn2
+++ b/kogito-codegen/src/test/resources/decision/models/dmnprocess.bpmn2
@@ -69,7 +69,7 @@
       <bpmn2:dataInputAssociation id="_Y5fXoR81EDiXeq2AO6t0ng">
         <bpmn2:targetRef>_3EDB5055-D95B-43D0-A87A-A827EE7229A7_modelInputX</bpmn2:targetRef>
         <bpmn2:assignment id="_Y5fXoh81EDiXeq2AO6t0ng">
-          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_Y5fXox81EDiXeq2AO6t0ng">VacationDays</bpmn2:from>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_Y5fXox81EDiXeq2AO6t0ng">VacationDaysAlt</bpmn2:from>
           <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_Y5fXpB81EDiXeq2AO6t0ng">_3EDB5055-D95B-43D0-A87A-A827EE7229A7_modelInputX</bpmn2:to>
         </bpmn2:assignment>
       </bpmn2:dataInputAssociation>

--- a/kogito-codegen/src/test/resources/decision/models/vacationDaysAlt/vacationDaysAlt.dmn
+++ b/kogito-codegen/src/test/resources/decision/models/vacationDaysAlt/vacationDaysAlt.dmn
@@ -7,7 +7,7 @@
                       xmlns:kie="https://www.drools.org/kie-dmn"
                       xmlns:semantic="http://www.omg.org/spec/DMN/20180521/MODEL/"
                       id="_0020_vacation_days"
-                      name="VacationDays"
+                      name="VacationDaysAlt"
                       namespace="decision">
    <semantic:inputData id="i_Age" name="Age">
       <semantic:variable name="Age" typeRef="number"/>


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-3690

From
```java
resourcePaths.add(new org.kie.kogito.dmn.DefaultDecisionModelResource(new org.kie.api.management.GAV("dummy", "dummy", "0.0"), "https://github.com/kiegroup/kogito-examples/dmn-quarkus-listener-example", "LoanEligibility", org.kie.kogito.decision.DecisionModelType.DMN, readResource(org.drools.core.util.IoUtils.class.getClassLoader().getResourceAsStream("LoanEligibility.dmn"))), new org.kie.kogito.dmn.DefaultDecisionModelResource(new org.kie.api.management.GAV("dummy", "dummy", "0.0"), "https://github.com/kiegroup/drools/kie-dmn/_A4BCA8B8-CF08-433F-93B2-A2598F19ECFF", "Traffic Violation", org.kie.kogito.decision.DecisionModelType.DMN, readResource(org.drools.core.util.IoUtils.class.getClassLoader().getResourceAsStream("Traffic Violation.dmn"))));
resourcePaths.add(new org.kie.kogito.dmn.DefaultDecisionModelResource(new org.kie.api.management.GAV("dummy", "dummy", "0.0"), "https://github.com/kiegroup/kogito-examples/dmn-quarkus-listener-example", "LoanEligibility", org.kie.kogito.decision.DecisionModelType.DMN, readResource(org.drools.core.util.IoUtils.class.getClassLoader().getResourceAsStream("LoanEligibility.dmn"))), new org.kie.kogito.dmn.DefaultDecisionModelResource(new org.kie.api.management.GAV("dummy", "dummy", "0.0"), "https://github.com/kiegroup/drools/kie-dmn/_A4BCA8B8-CF08-433F-93B2-A2598F19ECFF", "Traffic Violation", org.kie.kogito.decision.DecisionModelType.DMN, readResource(org.drools.core.util.IoUtils.class.getClassLoader().getResourceAsStream("Traffic Violation.dmn"))));
```

To
```java
resourcePaths.add(new org.kie.kogito.dmn.DefaultDecisionModelResource(new org.kie.api.management.GAV("dummy", "dummy", "0.0"), "https://github.com/kiegroup/kogito-examples/dmn-quarkus-listener-example", "LoanEligibility", org.kie.kogito.decision.DecisionModelType.DMN, readResource(org.drools.core.util.IoUtils.class.getClassLoader().getResourceAsStream("LoanEligibility.dmn"))));
resourcePaths.add(new org.kie.kogito.dmn.DefaultDecisionModelResource(new org.kie.api.management.GAV("dummy", "dummy", "0.0"), "https://github.com/kiegroup/drools/kie-dmn/_A4BCA8B8-CF08-433F-93B2-A2598F19ECFF", "Traffic Violation", org.kie.kogito.decision.DecisionModelType.DMN, readResource(org.drools.core.util.IoUtils.class.getClassLoader().getResourceAsStream("Traffic Violation.dmn"))));
```