### PR TITLE
KOGITO-3691 Disable local 'Download' logging in maven invoker plugin

### DIFF
--- a/integration-tests/integration-tests-kogito-plugin/src/it/integration-tests-kogito-plugin-it/invoker.properties
+++ b/integration-tests/integration-tests-kogito-plugin/src/it/integration-tests-kogito-plugin-it/invoker.properties
@@ -1,1 +1,3 @@
+# disable verbose local download output
+invoker.mavenOpts=-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 invoker.goals = clean compile kogito:scaffold compile verify -Dquarkus.version=${version.io.quarkus}

--- a/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/invoker.properties
+++ b/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/invoker.properties
@@ -1,0 +1,19 @@
+#
+#  Copyright 2020 Red Hat, Inc. and/or its affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#
+
+# disable verbose local download output
+invoker.mavenOpts=-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn

--- a/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-kafka-it/invoker.properties
+++ b/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-kafka-it/invoker.properties
@@ -1,0 +1,19 @@
+#
+#  Copyright 2020 Red Hat, Inc. and/or its affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#
+
+# disable verbose local download output
+invoker.mavenOpts=-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn


### PR DESCRIPTION
Maven invoker plugin is configured to not hit Central, but just use the local maven repository; yet it simulates the whole downloading routine, producing a lot of useless noise.

It turns out there is an incantation that you can use either in MAVEN_OPTS or at the CLI to disable such output:

```
-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
```

in recent Maven version there is also a CLI option: `--no-transfer-progress` or `-ntp`; we may want to consider adding it to our CI builds, as the output itself may slow down the build (I think the final error should be reported in case of missing dep) 

https://issues.redhat.com/browse/KOGITO-3691

----

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket