### PR TITLE
[KOGITO-3694] Configure Jboss LogManager for Quarkus integration tests

### DIFF
--- a/Jenkinsfile.quarkus
+++ b/Jenkinsfile.quarkus
@@ -25,7 +25,7 @@ pipeline {
                 checkout([$class: 'GitSCM', branches: [[name: 'master']], browser: [$class: 'GithubWeb', repoUrl: 'git@github.com:quarkusio/quarkus.git'], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'quarkus']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'kie-ci-user-key', url: 'git@github.com:quarkusio/quarkus.git']]])
                 dir("quarkus") {
                     script {
-                        maven.runMavenWithSubmarineSettings('clean install', true)
+                        maven.runMavenWithSubmarineSettings('clean install -Pquick-build', true)
                     }
                 }
             }
@@ -39,7 +39,7 @@ pipeline {
         }
         stage('Build kogito-apps') {
             steps {
-                checkout([$class: 'GitSCM', branches: [[name: env.BRANCH_NAME]], browser: [$class: 'GithubWeb', repoUrl: 'git@github.com:danielezonca/kogito-apps.git'], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'kogito-apps']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'kie-ci-user-key', url: 'git@github.com:danielezonca/kogito-apps.git']]])
+                checkout([$class: 'GitSCM', branches: [[name: env.BRANCH_NAME]], browser: [$class: 'GithubWeb', repoUrl: 'git@github.com:kiegroup/kogito-apps.git'], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'kogito-apps']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'kie-ci-user-key', url: 'git@github.com:kiegroup/kogito-apps.git']]])
                 dir("kogito-apps") {
                     script {
                       maven.runMavenWithSubmarineSettings('clean install', false)
@@ -49,7 +49,7 @@ pipeline {
         }
         stage('Build kogito-examples') {
             steps {
-                checkout([$class: 'GitSCM', branches: [[name: env.BRANCH_NAME]], browser: [$class: 'GithubWeb', repoUrl: 'git@github.com:danielezonca/kogito-examples.git'], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'kogito-examples']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'kie-ci-user-key', url: 'git@github.com:danielezonca/kogito-examples.git']]])
+                checkout([$class: 'GitSCM', branches: [[name: env.BRANCH_NAME]], browser: [$class: 'GithubWeb', repoUrl: 'git@github.com:kiegroup/kogito-examples.git'], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'kogito-examples']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'kie-ci-user-key', url: 'git@github.com:kiegroup/kogito-examples.git']]])
                 dir("kogito-examples") {
                     script {
                          maven.runMavenWithSubmarineSettings('clean install -Dversion.io.quarkus=999-SNAPSHOT', false)

--- a/Jenkinsfile.quarkus
+++ b/Jenkinsfile.quarkus
@@ -39,7 +39,7 @@ pipeline {
         }
         stage('Build kogito-apps') {
             steps {
-                checkout([$class: 'GitSCM', branches: [[name: env.BRANCH_NAME]], browser: [$class: 'GithubWeb', repoUrl: 'git@github.com:kiegroup/kogito-apps.git'], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'kogito-apps']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'kie-ci-user-key', url: 'git@github.com:kiegroup/kogito-apps.git']]])
+                checkout([$class: 'GitSCM', branches: [[name: env.BRANCH_NAME]], browser: [$class: 'GithubWeb', repoUrl: 'git@github.com:danielezonca/kogito-apps.git'], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'kogito-apps']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'kie-ci-user-key', url: 'git@github.com:danielezonca/kogito-apps.git']]])
                 dir("kogito-apps") {
                     script {
                       maven.runMavenWithSubmarineSettings('clean install', false)
@@ -49,7 +49,7 @@ pipeline {
         }
         stage('Build kogito-examples') {
             steps {
-                checkout([$class: 'GitSCM', branches: [[name: env.BRANCH_NAME]], browser: [$class: 'GithubWeb', repoUrl: 'git@github.com:kiegroup/kogito-examples.git'], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'kogito-examples']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'kie-ci-user-key', url: 'git@github.com:kiegroup/kogito-examples.git']]])
+                checkout([$class: 'GitSCM', branches: [[name: env.BRANCH_NAME]], browser: [$class: 'GithubWeb', repoUrl: 'git@github.com:danielezonca/kogito-examples.git'], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'kogito-examples']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'kie-ci-user-key', url: 'git@github.com:danielezonca/kogito-examples.git']]])
                 dir("kogito-examples") {
                     script {
                          maven.runMavenWithSubmarineSettings('clean install -Dversion.io.quarkus=999-SNAPSHOT', false)

--- a/integration-tests/integration-tests-quarkus-decisions/pom.xml
+++ b/integration-tests/integration-tests-quarkus-decisions/pom.xml
@@ -140,6 +140,7 @@
                 </goals>
                 <configuration>
                   <systemProperties>
+                    <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
                   </systemProperties>
                 </configuration>

--- a/integration-tests/integration-tests-quarkus-predictions/pom.xml
+++ b/integration-tests/integration-tests-quarkus-predictions/pom.xml
@@ -122,6 +122,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <systemPropertyVariables>
+            <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
             <container.image.infinispan>${container.image.infinispan}</container.image.infinispan>
           </systemPropertyVariables>
         </configuration>

--- a/integration-tests/integration-tests-quarkus-processes/pom.xml
+++ b/integration-tests/integration-tests-quarkus-processes/pom.xml
@@ -129,6 +129,7 @@
             <include>org/kie/kogito/integrationtests/quarkus/*</include>
           </includes>
           <systemPropertyVariables>
+            <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
             <container.image.infinispan>${container.image.infinispan}</container.image.infinispan>
           </systemPropertyVariables>
         </configuration>

--- a/integration-tests/integration-tests-quarkus-rules/pom.xml
+++ b/integration-tests/integration-tests-quarkus-rules/pom.xml
@@ -126,6 +126,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <systemPropertyVariables>
+            <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
             <container.image.infinispan>${container.image.infinispan}</container.image.infinispan>
           </systemPropertyVariables>
         </configuration>


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-3694

CI build using Quarkus snapshot failed on `org.kie.kogito.integrationtests.quarkus.DecisionTableTest.org.kie.kogito.integrationtests.quarkus.DecisionTableTest` with
```
used by: java.lang.ClassCastException: class java.util.logging.LogManager$RootLogger cannot be cast to class org.jboss.logmanager.Logger (java.util.logging.LogManager$RootLogger is in module java.logging of loader 'bootstrap'; org.jboss.logmanager.Logger is in unnamed module of loader 'app')
	at io.quarkus.test.QuarkusUnitTest.<clinit>(QuarkusUnitTest.java:81)
	... 46 more
```
So this PR ensure all Quarkus integration tests are using Jboss LogManager