### PR TITLE
[KOGITO-3610] - Updating TopicsResource to reflect Topics and CloudEv…

### DIFF
--- a/addons/cloudevents/cloudevents-common-addon/pom.xml
+++ b/addons/cloudevents/cloudevents-common-addon/pom.xml
@@ -21,19 +21,23 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.kie.kogito</groupId>
-    <artifactId>addons</artifactId>
+    <artifactId>cloudevents</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
-  <artifactId>cloudevents</artifactId>
-  <packaging>pom</packaging>
-  <name>Kogito :: Add-Ons :: Cloud Events</name>
 
-  <description>Kogito Cloud Events</description>
+  <artifactId>kogito-cloudevents-common-addon</artifactId>
+  <name>Kogito :: Add-Ons :: CloudEvents :: Common</name>
+  <description>CloudEvents AddOn Common Interfaces</description>
 
-  <modules>
-    <module>cloudevents-quarkus-addon</module>
-    <module>cloudevents-spring-boot-addon</module>
-    <module>cloudevents-common-addon</module>
-  </modules>
+  <dependencies>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-services</artifactId>
+    </dependency>
+  </dependencies>
 
 </project>

--- a/addons/cloudevents/cloudevents-common-addon/src/main/java/org/kie/kogito/addon/cloudevents/AbstractTopicDiscovery.java
+++ b/addons/cloudevents/cloudevents-common-addon/src/main/java/org/kie/kogito/addon/cloudevents/AbstractTopicDiscovery.java
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-package org.kie.kogito.services.event.impl;
+package org.kie.kogito.addon.cloudevents;
 
 import java.util.List;
 import java.util.stream.Collectors;

--- a/addons/cloudevents/cloudevents-quarkus-addon/pom.xml
+++ b/addons/cloudevents/cloudevents-quarkus-addon/pom.xml
@@ -40,8 +40,6 @@
     </dependencies>
   </dependencyManagement>
 
-
-
   <dependencies>
     <dependency>
       <groupId>org.kie.kogito</groupId>
@@ -76,6 +74,23 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit-pioneer</groupId>
+      <artifactId>junit-pioneer</artifactId>
+      <version>${version.org.junit.pioneer}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/addons/cloudevents/cloudevents-quarkus-addon/pom.xml
+++ b/addons/cloudevents/cloudevents-quarkus-addon/pom.xml
@@ -43,11 +43,7 @@
   <dependencies>
     <dependency>
       <groupId>org.kie.kogito</groupId>
-      <artifactId>kogito-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.kie.kogito</groupId>
-      <artifactId>kogito-services</artifactId>
+      <artifactId>kogito-cloudevents-common-addon</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.inject</groupId>

--- a/addons/cloudevents/cloudevents-quarkus-addon/src/main/java/org/kie/kogito/addon/cloudevents/quarkus/QuarkusTopicDiscovery.java
+++ b/addons/cloudevents/cloudevents-quarkus-addon/src/main/java/org/kie/kogito/addon/cloudevents/quarkus/QuarkusTopicDiscovery.java
@@ -23,10 +23,10 @@ import javax.annotation.Priority;
 import javax.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.config.ConfigProvider;
+import org.kie.kogito.addon.cloudevents.AbstractTopicDiscovery;
 import org.kie.kogito.event.ChannelType;
 import org.kie.kogito.event.KogitoEventStreams;
 import org.kie.kogito.event.Topic;
-import org.kie.kogito.services.event.impl.AbstractTopicDiscovery;
 
 @ApplicationScoped
 @Priority(0)

--- a/addons/cloudevents/cloudevents-quarkus-addon/src/main/java/org/kie/kogito/addon/cloudevents/quarkus/QuarkusTopicDiscovery.java
+++ b/addons/cloudevents/cloudevents-quarkus-addon/src/main/java/org/kie/kogito/addon/cloudevents/quarkus/QuarkusTopicDiscovery.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.addon.cloudevents.quarkus;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import javax.annotation.Priority;
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.kie.kogito.event.ChannelType;
+import org.kie.kogito.event.KogitoEventStreams;
+import org.kie.kogito.event.Topic;
+import org.kie.kogito.services.event.impl.AbstractTopicDiscovery;
+
+@ApplicationScoped
+@Priority(0)
+public class QuarkusTopicDiscovery extends AbstractTopicDiscovery {
+
+    private static final String OUTGOING_PREFIX = "mp.messaging.outgoing.";
+    private static final String INCOMING_PREFIX = "mp.messaging.incoming.";
+    private static final String TOPIC_SUFFIX = ".topic";
+
+    protected List<Topic> getTopics() {
+        final List<Topic> topics = new ArrayList<>();
+        ConfigProvider.getConfig().getPropertyNames().forEach(n -> {
+            if (n.startsWith(OUTGOING_PREFIX)) {
+                final String topicName = this.extractChannelName(n, OUTGOING_PREFIX, KogitoEventStreams.OUTGOING);
+                if (topics.stream().noneMatch(t -> t.getName().equals(topicName) && t.getType() == ChannelType.OUTGOING)) {
+                    final Topic topic = new Topic();
+                    topic.setType(ChannelType.OUTGOING);
+                    topic.setName(topicName);
+                    topics.add(topic);
+                }
+            } else if (n.startsWith(INCOMING_PREFIX)) {
+                final String topicName = this.extractChannelName(n, INCOMING_PREFIX, KogitoEventStreams.INCOMING);
+                if (topics.stream().noneMatch(t -> t.getName().equals(topicName) && t.getType() == ChannelType.INCOMING)) {
+                    final Topic topic = new Topic();
+                    topic.setType(ChannelType.INCOMING);
+                    topic.setName(topicName);
+                    topics.add(topic);
+                }
+            }
+        });
+        return topics;
+    }
+
+    private String extractChannelName(String property, String prefix, String defaultChannel) {
+        if (property.length() <= prefix.length()) {
+            return defaultChannel;
+        }
+        String channelName = property.substring(prefix.length());
+        if (channelName.contains(".")) {
+            channelName = channelName.substring(0, channelName.indexOf("."));
+        }
+        final Optional<String> topicName = ConfigProvider.getConfig().getOptionalValue(prefix + channelName + TOPIC_SUFFIX, String.class);
+        return topicName.orElse(channelName);
+    }
+}

--- a/addons/cloudevents/cloudevents-quarkus-addon/src/test/java/org/kie/kogito/addon/cloudevents/quarkus/QuarkusTopicDiscoveryTest.java
+++ b/addons/cloudevents/cloudevents-quarkus-addon/src/test/java/org/kie/kogito/addon/cloudevents/quarkus/QuarkusTopicDiscoveryTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.addon.cloudevents.quarkus;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.ClearSystemProperty;
+import org.junitpioneer.jupiter.SetSystemProperty;
+import org.kie.kogito.event.ChannelType;
+import org.kie.kogito.event.CloudEventMeta;
+import org.kie.kogito.event.EventKind;
+import org.kie.kogito.event.Topic;
+import org.kie.kogito.services.event.TopicDiscovery;
+import org.kie.kogito.services.event.impl.AbstractTopicDiscovery;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class QuarkusTopicDiscoveryTest {
+
+    @Test
+    @SetSystemProperty(key = "mp.messaging.outgoing.processedtravellers.connector", value = "smallrye-http")
+    @SetSystemProperty(key = "mp.messaging.outgoing.processedtravellers.url", value = "http://localhost:8080/")
+    @SetSystemProperty(key = "mp.messaging.incoming.kogito_incoming_stream.connector", value = "smallrye-kafka")
+    @SetSystemProperty(key = "mp.messaging.incoming.kogito_incoming_stream.topic", value = "mycooltopic")
+    void verifyTopicsWithPropertiesSet() {
+        final List<Topic> expectedTopics = new ArrayList<>();
+        expectedTopics.add(new Topic("processedtravellers", ChannelType.OUTGOING));
+        expectedTopics.add(new Topic("mycooltopic", ChannelType.INCOMING));
+
+        final TopicDiscovery discovery = new QuarkusTopicDiscovery();
+        final List<Topic> topics = discovery.getTopics(Collections.emptyList());
+        assertThat(topics).hasSize(2);
+        expectedTopics.forEach(e -> assertThat(topics.stream().anyMatch(t -> t.getName().equals(e.getName()) && t.getType() == e.getType())).isTrue());
+    }
+
+    @Test
+    @SetSystemProperty(key = "mp.messaging.outgoing.processedtravellers.connector", value = "smallrye-http")
+    @SetSystemProperty(key = "mp.messaging.outgoing.processedtravellers.url", value = "http://localhost:8080/")
+    @SetSystemProperty(key = "mp.messaging.outgoing.processedtravellers.topic", value = "mycooltopic")
+    @SetSystemProperty(key = "mp.messaging.incoming.kogito_incoming_stream.connector", value = "smallrye-kafka")
+    @SetSystemProperty(key = "mp.messaging.incoming.kogito_incoming_stream.topic", value = "mycooltopic")
+    void verifyTopicsWithPropertiesSameTopic() {
+        final List<Topic> expectedTopics = new ArrayList<>();
+        expectedTopics.add(new Topic("mycooltopic", ChannelType.OUTGOING));
+        expectedTopics.add(new Topic("mycooltopic", ChannelType.INCOMING));
+
+        final TopicDiscovery discovery = new QuarkusTopicDiscovery();
+        final List<Topic> topics = discovery.getTopics(Collections.emptyList());
+        assertThat(topics).hasSize(2);
+        expectedTopics.forEach(e -> assertThat(topics.stream().anyMatch(t -> t.getName().equals(e.getName()) && t.getType() == e.getType())).isTrue());
+    }
+
+    @Test
+    @ClearSystemProperty(key = "mp.messaging.outgoing.processedtravellers.connector")
+    @ClearSystemProperty(key = "mp.messaging.outgoing.processedtravellers.url")
+    @ClearSystemProperty(key = "mp.messaging.outgoing.processedtravellers.topic")
+    @ClearSystemProperty(key = "mp.messaging.incoming.kogito_incoming_stream.connector")
+    @ClearSystemProperty(key = "mp.messaging.incoming.kogito_incoming_stream.topic")
+    void verifyTopicsWithNoPropertiesSet() {
+        final List<Topic> expectedTopics = new ArrayList<>();
+        expectedTopics.add(AbstractTopicDiscovery.DEFAULT_OUTGOING_CHANNEL);
+        expectedTopics.add(AbstractTopicDiscovery.DEFAULT_INCOMING_CHANNEL);
+        final List<CloudEventMeta> eventsMeta = new ArrayList<>();
+        eventsMeta.add(new CloudEventMeta("event1", "", EventKind.CONSUMED));
+        eventsMeta.add(new CloudEventMeta("event2", "", EventKind.PRODUCED));
+
+        final TopicDiscovery discovery = new QuarkusTopicDiscovery();
+        final List<Topic> topics = discovery.getTopics(eventsMeta);
+        assertThat(topics).hasSize(2);
+        expectedTopics.forEach(e -> assertThat(topics.stream().anyMatch(t -> t.getName().equals(e.getName()) && t.getType() == e.getType())).isTrue());
+    }
+
+    @Test
+    @ClearSystemProperty(key = "mp.messaging.outgoing.processedtravellers.connector")
+    @ClearSystemProperty(key = "mp.messaging.outgoing.processedtravellers.url")
+    @ClearSystemProperty(key = "mp.messaging.outgoing.processedtravellers.topic")
+    @ClearSystemProperty(key = "mp.messaging.incoming.kogito_incoming_stream.connector")
+    @ClearSystemProperty(key = "mp.messaging.incoming.kogito_incoming_stream.topic")
+    void verifyTopicsWithPropertiesAndChannels() {
+        final TopicDiscovery discovery = new QuarkusTopicDiscovery();
+        final List<Topic> topics = discovery.getTopics(Collections.emptyList());
+        assertThat(topics).isEmpty();
+    }
+}

--- a/addons/cloudevents/cloudevents-quarkus-addon/src/test/java/org/kie/kogito/addon/cloudevents/quarkus/QuarkusTopicDiscoveryTest.java
+++ b/addons/cloudevents/cloudevents-quarkus-addon/src/test/java/org/kie/kogito/addon/cloudevents/quarkus/QuarkusTopicDiscoveryTest.java
@@ -22,12 +22,12 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.ClearSystemProperty;
 import org.junitpioneer.jupiter.SetSystemProperty;
+import org.kie.kogito.addon.cloudevents.AbstractTopicDiscovery;
 import org.kie.kogito.event.ChannelType;
 import org.kie.kogito.event.CloudEventMeta;
 import org.kie.kogito.event.EventKind;
 import org.kie.kogito.event.Topic;
 import org.kie.kogito.services.event.TopicDiscovery;
-import org.kie.kogito.services.event.impl.AbstractTopicDiscovery;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/addons/cloudevents/cloudevents-spring-boot-addon/pom.xml
+++ b/addons/cloudevents/cloudevents-spring-boot-addon/pom.xml
@@ -31,7 +31,7 @@
   <dependencies>
     <dependency>
       <groupId>org.kie.kogito</groupId>
-      <artifactId>kogito-api</artifactId>
+      <artifactId>kogito-cloudevents-common-addon</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.kafka</groupId>
@@ -53,10 +53,6 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.kie.kogito</groupId>
-      <artifactId>kogito-services</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/addons/cloudevents/cloudevents-spring-boot-addon/src/main/java/org/kie/kogito/addon/cloudevents/spring/SpringTopicDiscovery.java
+++ b/addons/cloudevents/cloudevents-spring-boot-addon/src/main/java/org/kie/kogito/addon/cloudevents/spring/SpringTopicDiscovery.java
@@ -1,0 +1,40 @@
+package org.kie.kogito.addon.cloudevents.spring;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.kie.kogito.event.KogitoEventStreams;
+import org.kie.kogito.event.Topic;
+import org.kie.kogito.services.event.impl.AbstractTopicDiscovery;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SpringTopicDiscovery extends AbstractTopicDiscovery {
+
+    // in the future we should be implementation agnostic
+    @Value(value = "${kogito.addon.cloudevents.kafka." + KogitoEventStreams.INCOMING + "}")
+    String incomingStreamTopic;
+
+    @Value(value = "${kogito.addon.cloudevents.kafka." + KogitoEventStreams.OUTGOING + "}")
+    String outgoingStreamTopic;
+
+    @Override
+    protected List<Topic> getTopics() {
+        final List<Topic> topics = new ArrayList<>();
+
+        if (incomingStreamTopic != null && !incomingStreamTopic.isEmpty()) {
+            final Topic incoming = DEFAULT_INCOMING_CHANNEL;
+            incoming.setName(incomingStreamTopic);
+            topics.add(incoming);
+        }
+
+        if (outgoingStreamTopic != null && !outgoingStreamTopic.isEmpty()) {
+            final Topic outgoing = DEFAULT_OUTGOING_CHANNEL;
+            outgoing.setName(outgoingStreamTopic);
+            topics.add(outgoing);
+        }
+
+        return topics;
+    }
+}

--- a/addons/cloudevents/cloudevents-spring-boot-addon/src/main/java/org/kie/kogito/addon/cloudevents/spring/SpringTopicDiscovery.java
+++ b/addons/cloudevents/cloudevents-spring-boot-addon/src/main/java/org/kie/kogito/addon/cloudevents/spring/SpringTopicDiscovery.java
@@ -3,9 +3,9 @@ package org.kie.kogito.addon.cloudevents.spring;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.kie.kogito.addon.cloudevents.AbstractTopicDiscovery;
 import org.kie.kogito.event.KogitoEventStreams;
 import org.kie.kogito.event.Topic;
-import org.kie.kogito.services.event.impl.AbstractTopicDiscovery;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 

--- a/api/kogito-api/src/main/java/org/kie/kogito/event/AbstractDataEvent.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/event/AbstractDataEvent.java
@@ -42,10 +42,11 @@ public abstract class AbstractDataEvent<T> implements DataEvent<T> {
     public static final String TYPE_FORMAT = TYPE_PREFIX + ".%s.%s";
     /**
      * String format for Kogito CloudEvents source fields.
-     * Since this is a required field, the constructor will fill them with default value, e.g.: /process/travelAgency/0982-1223-3121-1212
+     * Since this is a required field, the constructor will fill them with default value, e.g.: /process/travelagency
+     * See more about the source format: https://github.com/cloudevents/spec/blob/v1.0/spec.md#source-1
      */
-    public static final String SOURCE_FORMAT = "/process/%s/%s";
-    private static final String SPEC_VERSION = "1.0";
+    public static final String SOURCE_FORMAT = "/process/%s";
+    static final String SPEC_VERSION = "1.0";
     @JsonProperty("specversion")
     private String specVersion;
     private String id;
@@ -114,7 +115,7 @@ public abstract class AbstractDataEvent<T> implements DataEvent<T> {
             this.type = TYPE_PREFIX;
         }
         if (this.source == null || this.source.isEmpty()) {
-            this.source = String.format(SOURCE_FORMAT, kogitoProcessId, kogitoProcessinstanceId);
+            this.source = String.format(SOURCE_FORMAT, kogitoProcessId);
         }
     }
 

--- a/api/kogito-api/src/main/java/org/kie/kogito/event/ChannelType.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/event/ChannelType.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.event;
+
+public enum ChannelType {
+    OUTGOING,
+    INCOMING;
+}

--- a/api/kogito-api/src/main/java/org/kie/kogito/event/CloudEventMeta.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/event/CloudEventMeta.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.event;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+/**
+ * Represents the metadata definition for an event emitted or listened in the engine.
+ * It's based on the CloudEvents specification to help consumers and producers to be aware of the required events being
+ * consumed by the the runtime engine.
+ */
+public class CloudEventMeta implements EventMeta {
+
+    private String type;
+    private String source;
+    private EventKind kind;
+
+    public CloudEventMeta() {
+
+    }
+
+    public CloudEventMeta(final String type, final String source, final EventKind kind) {
+        this.source = source;
+        this.type = type;
+        this.kind = kind;
+    }
+
+    @Override
+    @JsonIgnore
+    public String getSpecVersion() {
+        return AbstractDataEvent.SPEC_VERSION;
+    }
+
+    /**
+     * Gets the source for an instance of a CloudEvent
+     *
+     * @return a String containing the source for a instance of a CloudEvent
+     * @see <a href="https://github.com/cloudevents/spec/blob/v1.0/spec.md#source-1">CloudEvents Source</a>
+     */
+    public String getSource() {
+        return source;
+    }
+
+    public void setSource(String source) {
+        this.source = source;
+    }
+
+    /**
+     * Gets the type for an instance of a CloudEvent
+     *
+     * @return a string containing the given type for this instance
+     * @see <a href="https://github.com/cloudevents/spec/blob/v1.0/spec.md#type">CloudEvents Type</a>
+     */
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    /**
+     * Signals with this event should be on an {@link ChannelType#INCOMING} or {@link ChannelType#OUTGOING} channel
+     *
+     * @return Gets the {@link EventKind} for this instance
+     */
+    public EventKind getKind() {
+        return kind;
+    }
+
+    public void setKind(EventKind kind) {
+        this.kind = kind;
+    }
+
+    @Override
+    public String toString() {
+        return "CloudEventMeta{" +
+                "type='" + type + '\'' +
+                ", source='" + source + '\'' +
+                ", kind=" + kind +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CloudEventMeta that = (CloudEventMeta) o;
+        return Objects.equals(type, that.type) &&
+                Objects.equals(source, that.source) &&
+                kind == that.kind;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, source, kind);
+    }
+}

--- a/api/kogito-api/src/main/java/org/kie/kogito/event/DataEvent.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/event/DataEvent.java
@@ -30,14 +30,7 @@ package org.kie.kogito.event;
  *
  * @param <T> type of the body of the event
  */
-public interface DataEvent<T> {
-
-    /**
-     * Returns specification version of the cloud event
-     *
-     * @return specification version
-     */
-    String getSpecVersion();
+public interface DataEvent<T> extends EventMeta {
 
     /**
      * Returns unique id of the event
@@ -45,20 +38,6 @@ public interface DataEvent<T> {
      * @return unique event id
      */
     String getId();
-
-    /**
-     * Returns type of the event this instance represents e.g. ProcessInstanceEvent
-     *
-     * @return type of the event
-     */
-    String getType();
-
-    /**
-     * Returns source of the event that is in URI syntax
-     *
-     * @return uri source
-     */
-    String getSource();
 
     /**
      * Returns returns time when the event was created

--- a/api/kogito-api/src/main/java/org/kie/kogito/event/EventKind.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/event/EventKind.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.event;
+
+public enum EventKind {
+    CONSUMED,
+    PRODUCED
+}

--- a/api/kogito-api/src/main/java/org/kie/kogito/event/EventMeta.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/event/EventMeta.java
@@ -15,7 +15,29 @@
 
 package org.kie.kogito.event;
 
-public enum TopicType {
-    PRODUCED,
-    CONSUMED;
+/**
+ * Interface for Event metadata information
+ */
+public interface EventMeta {
+
+    /**
+     * Returns specification version of the cloud event
+     *
+     * @return specification version
+     */
+    String getSpecVersion();
+
+    /**
+     * Returns type of the event this instance represents e.g. ProcessInstanceEvent
+     *
+     * @return type of the event
+     */
+    String getType();
+
+    /**
+     * Returns source of the event that is in URI syntax
+     *
+     * @return uri source
+     */
+    String getSource();
 }

--- a/api/kogito-api/src/main/java/org/kie/kogito/event/Topic.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/event/Topic.java
@@ -15,6 +15,9 @@
 
 package org.kie.kogito.event;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -23,13 +26,15 @@ import java.util.Objects;
 public class Topic {
 
     private String name;
-    private TopicType type;
+    private ChannelType type;
+    private List<CloudEventMeta> eventsMeta;
 
     public Topic() {
-
+        this.eventsMeta = new ArrayList<>();
     }
 
-    public Topic(final String name, final TopicType type) {
+    public Topic(final String name, final ChannelType type) {
+        this();
         this.name = name;
         this.type = type;
     }
@@ -42,12 +47,25 @@ public class Topic {
         this.name = name;
     }
 
-    public TopicType getType() {
+    public ChannelType getType() {
         return type;
     }
 
-    public void setType(TopicType type) {
+    public void setType(ChannelType type) {
         this.type = type;
+    }
+
+    /**
+     * A collection of meta information about events that can be consumed or published by this topic
+     *
+     * @return a list of events
+     */
+    public List<CloudEventMeta> getEventsMeta() {
+        return Collections.unmodifiableList(this.eventsMeta);
+    }
+
+    public void setEventsMeta(List<CloudEventMeta> eventsMeta) {
+        this.eventsMeta = new ArrayList<>(eventsMeta);
     }
 
     @Override
@@ -55,6 +73,7 @@ public class Topic {
         return "Topic{" +
                 "name='" + name + '\'' +
                 ", type=" + type +
+                ", events=" + eventsMeta +
                 '}';
     }
 
@@ -67,12 +86,13 @@ public class Topic {
             return false;
         }
         Topic topic = (Topic) o;
-        return name.equals(topic.name) &&
-                type == topic.type;
+        return Objects.equals(name, topic.name) &&
+                type == topic.type &&
+                Objects.equals(eventsMeta, topic.eventsMeta);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, type);
+        return Objects.hash(name, type, eventsMeta);
     }
 }

--- a/api/kogito-services/src/main/java/org/kie/kogito/services/event/DataEventAttrBuilder.java
+++ b/api/kogito-services/src/main/java/org/kie/kogito/services/event/DataEventAttrBuilder.java
@@ -16,7 +16,12 @@ public final class DataEventAttrBuilder {
 
     public static String toSource(final ProcessInstance process) {
         Objects.requireNonNull(process);
-        return String.format(AbstractDataEvent.SOURCE_FORMAT, process.getProcessId(), process.getId());
+        return String.format(AbstractDataEvent.SOURCE_FORMAT, process.getProcessId().toLowerCase());
+    }
+
+    public static String toSource(final String processId) {
+        Objects.requireNonNull(processId);
+        return String.format(AbstractDataEvent.SOURCE_FORMAT,processId.toLowerCase());
     }
 
     public static String toType(final String channelName, final ProcessInstance process) {

--- a/api/kogito-services/src/main/java/org/kie/kogito/services/event/TopicDiscovery.java
+++ b/api/kogito-services/src/main/java/org/kie/kogito/services/event/TopicDiscovery.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.services.event;
+
+import java.util.List;
+
+import org.kie.kogito.event.CloudEventMeta;
+import org.kie.kogito.event.Topic;
+
+public interface TopicDiscovery {
+
+    List<Topic> getTopics(List<CloudEventMeta> events);
+
+}

--- a/api/kogito-services/src/main/java/org/kie/kogito/services/event/impl/AbstractTopicDiscovery.java
+++ b/api/kogito-services/src/main/java/org/kie/kogito/services/event/impl/AbstractTopicDiscovery.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.services.event.impl;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.kie.kogito.event.ChannelType;
+import org.kie.kogito.event.CloudEventMeta;
+import org.kie.kogito.event.EventKind;
+import org.kie.kogito.event.KogitoEventStreams;
+import org.kie.kogito.event.Topic;
+import org.kie.kogito.services.event.TopicDiscovery;
+
+/**
+ * Base class for events Topic Discovery
+ */
+public abstract class AbstractTopicDiscovery implements TopicDiscovery {
+
+    public static final Topic DEFAULT_INCOMING_CHANNEL = new Topic(KogitoEventStreams.INCOMING, ChannelType.INCOMING);
+    public static final Topic DEFAULT_OUTGOING_CHANNEL = new Topic(KogitoEventStreams.OUTGOING, ChannelType.OUTGOING);
+
+    protected abstract List<Topic> getTopics();
+
+    @Override
+    public List<Topic> getTopics(final List<CloudEventMeta> events) {
+        final List<Topic> topics = getTopics();
+        if (events == null || events.isEmpty()) {
+            return topics;
+        }
+        // guarantees that we have CONSUMED or PRODUCED events with respective channels
+        events.forEach(e -> {
+            if (e.getKind() == EventKind.CONSUMED && topics.stream().noneMatch(t -> t.getType() == ChannelType.INCOMING)) {
+                topics.add(DEFAULT_INCOMING_CHANNEL);
+            } else if (e.getKind() == EventKind.PRODUCED && topics.stream().noneMatch(t -> t.getType() == ChannelType.OUTGOING)) {
+                topics.add(DEFAULT_OUTGOING_CHANNEL);
+            }
+        });
+        topics.forEach(t -> {
+            if (t.getType() == ChannelType.INCOMING) {
+                t.setEventsMeta(events.stream().filter(e -> e.getKind() == EventKind.CONSUMED).collect(Collectors.toList()));
+            } else {
+                t.setEventsMeta(events.stream().filter(e -> e.getKind() == EventKind.PRODUCED).collect(Collectors.toList()));
+            }
+        });
+        return topics;
+    }
+}

--- a/api/kogito-services/src/main/java/org/kie/kogito/services/event/impl/NoOpTopicDiscovery.java
+++ b/api/kogito-services/src/main/java/org/kie/kogito/services/event/impl/NoOpTopicDiscovery.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.services.event.impl;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.kie.kogito.event.CloudEventMeta;
+import org.kie.kogito.event.Topic;
+import org.kie.kogito.services.event.TopicDiscovery;
+
+/**
+ * Default {@link TopicDiscovery} implementation for services with no eventing requirement
+ */
+public class NoOpTopicDiscovery implements TopicDiscovery {
+
+    @Override
+    public List<Topic> getTopics(List<CloudEventMeta> events) {
+        return Collections.emptyList();
+    }
+}

--- a/api/kogito-services/src/test/java/org/kie/kogito/services/event/DataEventAttrBuilderTest.java
+++ b/api/kogito-services/src/test/java/org/kie/kogito/services/event/DataEventAttrBuilderTest.java
@@ -22,7 +22,7 @@ class DataEventAttrBuilderTest {
         when(pi.getProcessId()).thenReturn(processId);
         when(pi.getId()).thenReturn(instanceId);
         final String source = DataEventAttrBuilder.toSource(pi);
-        assertThat(source).isNotBlank().contains(processId).contains(instanceId);
+        assertThat(source).isNotBlank().contains(processId);
     }
 
     @Test

--- a/integration-tests/integration-tests-quarkus-processes/src/test/java/org/kie/kogito/integrationtests/quarkus/TopicInformationResourceTest.java
+++ b/integration-tests/integration-tests-quarkus-processes/src/test/java/org/kie/kogito/integrationtests/quarkus/TopicInformationResourceTest.java
@@ -40,6 +40,5 @@ public class TopicInformationResourceTest {
         LOGGER.info("Topics registered in the service are {}", topics);
         assertThat(topics).isNotEmpty();
         assertThat(topics.stream().anyMatch(t -> t.getType() == ChannelType.INCOMING && t.getName().equals("pingpong"))).isTrue();
-        assertThat(topics.stream().anyMatch(t -> t.getType() == ChannelType.OUTGOING && t.getName().equals("pingpong"))).isTrue();
     }
 }

--- a/integration-tests/integration-tests-quarkus-processes/src/test/java/org/kie/kogito/integrationtests/quarkus/TopicInformationResourceTest.java
+++ b/integration-tests/integration-tests-quarkus-processes/src/test/java/org/kie/kogito/integrationtests/quarkus/TopicInformationResourceTest.java
@@ -21,23 +21,25 @@ import java.util.List;
 
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
+import org.kie.kogito.event.ChannelType;
 import org.kie.kogito.event.Topic;
-import org.kie.kogito.event.TopicType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static io.restassured.RestAssured.given;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @QuarkusTest
 public class TopicInformationResourceTest {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(TopicInformationResourceTest.class);
+
     @Test
     void verifyTopicsInformation() {
         final List<Topic> topics = Arrays.asList(given().get("/messaging/topics").as(Topic[].class));
-        assertThat(topics, notNullValue());
-        assertThat(topics, hasItem(new Topic("pong_send_start", TopicType.PRODUCED)));
-        assertThat(topics, hasItem(new Topic("pong_receive_end", TopicType.CONSUMED)));
+        LOGGER.info("Topics registered in the service are {}", topics);
+        assertThat(topics).isNotEmpty();
+        assertThat(topics.stream().anyMatch(t -> t.getType() == ChannelType.INCOMING && t.getName().equals("pingpong"))).isTrue();
+        assertThat(topics.stream().anyMatch(t -> t.getType() == ChannelType.OUTGOING && t.getName().equals("pingpong"))).isTrue();
     }
-
 }

--- a/kogito-bom/pom.xml
+++ b/kogito-bom/pom.xml
@@ -73,6 +73,24 @@
 
       <dependency>
         <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-cloudevents-common-addon</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-cloudevents-common-addon</artifactId>
+        <version>${project.version}</version>
+        <classifier>sources</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-cloudevents-common-addon</artifactId>
+        <version>${project.version}</version>
+        <classifier>javadoc</classifier>
+      </dependency>
+
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-cloudevents-quarkus-addon</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/kogito-build-parent/pom.xml
+++ b/kogito-build-parent/pom.xml
@@ -128,6 +128,7 @@
     <version.org.junit.jupiter>${version.org.junit}</version.org.junit.jupiter>
     <version.org.junit.vintage>${version.org.junit}</version.org.junit.vintage>
     <version.org.junit.platform>1.${version.org.junit.minor}</version.org.junit.platform> <!-- otherwise Quarkus brings its own, silently disabling some tests -->
+    <version.org.junit.pioneer>1.0.0</version.org.junit.pioneer>
     <version.org.keycloak>11.0.1</version.org.keycloak>
     <version.org.mockito>3.5.13</version.org.mockito>
     <version.org.mvel>2.4.10.Final</version.org.mvel>

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/AddonsConfig.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/AddonsConfig.java
@@ -21,12 +21,14 @@ public class AddonsConfig {
             .withPersistence(false)
             .withTracing(false)
             .withMonitoring(false)
-            .withKnativeEventing(false);
+            .withKnativeEventing(false)
+            .withCloudEvents(false);
 
     private boolean usePersistence;
     private boolean useTracing;
     private boolean useMonitoring;
     private boolean useKnativeEventing;
+    private boolean useCloudEvents;
 
     public AddonsConfig withPersistence(boolean usePersistence) {
         this.usePersistence = usePersistence;
@@ -48,6 +50,11 @@ public class AddonsConfig {
         return this;
     }
 
+    public AddonsConfig withCloudEvents(boolean useCloudEvents) {
+        this.useCloudEvents = useCloudEvents;
+        return this;
+    }
+
     public boolean usePersistence() {
         return usePersistence;
     }
@@ -62,5 +69,9 @@ public class AddonsConfig {
 
     public boolean useKnativeEventing() {
         return useKnativeEventing;
+    }
+
+    public boolean useCloudEvents() {
+        return useCloudEvents;
     }
 }

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ProcessCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ProcessCodegen.java
@@ -455,7 +455,8 @@ public class ProcessCodegen extends AbstractGenerator {
             storeFile(Type.REST, ceGenerator.generatedFilePath(), ceGenerator.generate());
         }
 
-        final TopicsInformationResourceGenerator topicsGenerator = new TopicsInformationResourceGenerator(processExecutableModelGenerators);
+        final TopicsInformationResourceGenerator topicsGenerator =
+                new TopicsInformationResourceGenerator(processExecutableModelGenerators, annotator, addonsConfig);
         storeFile(Type.REST, topicsGenerator.generatedFilePath(), topicsGenerator.generate());
 
         for (ProcessInstanceGenerator pi : pis) {

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/events/TopicsInformationResourceGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/events/TopicsInformationResourceGenerator.java
@@ -15,29 +15,40 @@
 
 package org.kie.kogito.codegen.process.events;
 
-import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import org.jbpm.compiler.canonical.TriggerMetaData;
+import org.kie.kogito.codegen.AddonsConfig;
 import org.kie.kogito.codegen.BodyDeclarationComparator;
+import org.kie.kogito.codegen.di.DependencyInjectionAnnotator;
 import org.kie.kogito.codegen.process.ProcessExecutableModelGenerator;
-import org.kie.kogito.event.TopicType;
+import org.kie.kogito.event.EventKind;
+import org.kie.kogito.services.event.DataEventAttrBuilder;
 
 public class TopicsInformationResourceGenerator extends AbstractEventResourceGenerator {
 
     private static final String RESOURCE_TEMPLATE = "/class-templates/events/TopicsInformationResourceTemplate.java";
     private static final String CLASS_NAME = "TopicsInformationResource";
 
-    private final List<TriggerMetaData> triggers;
+    private final DependencyInjectionAnnotator annotator;
+    private final Map<String, List<TriggerMetaData>> triggers;
+    private final AddonsConfig addonsConfig;
 
-    public TopicsInformationResourceGenerator(final List<ProcessExecutableModelGenerator> generators) {
+    public TopicsInformationResourceGenerator(final List<ProcessExecutableModelGenerator> generators,
+                                              final DependencyInjectionAnnotator annotator,
+                                              final AddonsConfig addonsConfig) {
         this.triggers = this.filterTriggers(generators);
+        this.annotator = annotator;
+        this.addonsConfig = addonsConfig;
     }
 
     protected String getResourceTemplate() {
@@ -49,7 +60,7 @@ public class TopicsInformationResourceGenerator extends AbstractEventResourceGen
         return CLASS_NAME;
     }
 
-    List<TriggerMetaData> getTriggers() {
+    Map<String, List<TriggerMetaData>> getTriggers() {
         return triggers;
     }
 
@@ -59,38 +70,55 @@ public class TopicsInformationResourceGenerator extends AbstractEventResourceGen
                 .findFirst(ClassOrInterfaceDeclaration.class)
                 .orElseThrow(() -> new NoSuchElementException("Compilation unit doesn't contain a class or interface declaration!"));
         template.setName(CLASS_NAME);
-        this.addTopics(template);
+        this.addEventsMeta(template);
+
+        // in case we don't have the bean in the classpath, just ignore the injection that the generated class will use NoOp instead
+        if (annotator != null && addonsConfig.useCloudEvents()) {
+            annotator.withApplicationComponent(template);
+            template.findAll(FieldDeclaration.class, fd -> fd.getVariables().get(0).getNameAsString().contains("discovery"))
+                    .forEach(annotator::withInjection);
+        }
 
         template.getMembers().sort(new BodyDeclarationComparator());
 
         return clazz.toString();
     }
 
-    private void addTopics(final ClassOrInterfaceDeclaration template) {
+    private void addEventsMeta(final ClassOrInterfaceDeclaration template) {
         final BlockStmt constructorBlock = template.getDefaultConstructor().orElseThrow(() -> new IllegalArgumentException("No body found in setup method!")).getBody();
         final List<String> repeatLines = extractRepeatLinesFromMethod(constructorBlock);
-        this.triggers.forEach(t -> {
-            String topicType = TopicType.class.getName() + "." + TopicType.CONSUMED.name();
-            if (TriggerMetaData.TriggerType.ProduceMessage.equals(t.getType())) {
-                topicType = TopicType.class.getName() + "." + TopicType.PRODUCED.name();
-            }
-            for (String l : repeatLines) {
-                constructorBlock.addStatement(l.replace("$name$", t.getName()).replace("$type$", topicType));
-            }
+        this.triggers.forEach((processId, triggers) -> {
+            triggers.forEach(t -> {
+                String eventKind = EventKind.class.getName() + "." + EventKind.CONSUMED.name();
+                String eventType = t.getName();
+                // we don't know the source of a consumed event, should be provided by the producer
+                String eventSource = "";
+                if (TriggerMetaData.TriggerType.ProduceMessage.equals(t.getType())) {
+                    eventType = DataEventAttrBuilder.toType(t.getName(), processId);
+                    eventKind = EventKind.class.getName() + "." + EventKind.PRODUCED.name();
+                    eventSource = DataEventAttrBuilder.toSource(processId);
+                }
+                for (String l : repeatLines) {
+                    constructorBlock.addStatement(l.replace("$type$", eventType).replace("$source$", eventSource).replace("$kind$", eventKind));
+                }
+            });
         });
     }
 
-    private List<TriggerMetaData> filterTriggers(final List<ProcessExecutableModelGenerator> generators) {
+    private Map<String, List<TriggerMetaData>> filterTriggers(final List<ProcessExecutableModelGenerator> generators) {
         if (generators != null) {
-            final List<TriggerMetaData> filteredTriggers = new ArrayList<>();
+            final Map<String, List<TriggerMetaData>> filteredTriggers = new HashMap<>();
             generators
                     .stream()
-                    .filter(m -> m.generate().getTriggers() != null)
-                    .forEach(m -> filteredTriggers.addAll(m.generate().getTriggers().stream()
-                                                                  .filter(t -> !TriggerMetaData.TriggerType.Signal.equals(t.getType()))
-                                                                  .collect(Collectors.toList())));
+                    .filter(m -> m.generate().getTriggers() != null && !m.generate().getTriggers().isEmpty())
+                    .forEach(m -> {
+                        filteredTriggers.put(m.getProcessId(),
+                                             m.generate().getTriggers().stream()
+                                                     .filter(t -> !TriggerMetaData.TriggerType.Signal.equals(t.getType()))
+                                                     .collect(Collectors.toList()));
+                    });
             return filteredTriggers;
         }
-        return Collections.emptyList();
+        return Collections.emptyMap();
     }
 }

--- a/kogito-codegen/src/main/resources/class-templates/events/TopicsInformationResourceTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/events/TopicsInformationResourceTemplate.java
@@ -8,18 +8,22 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import org.kie.kogito.event.Topic;
+import org.kie.kogito.event.CloudEventMeta;
+import org.kie.kogito.services.event.TopicDiscovery;
+import org.kie.kogito.services.event.impl.NoOpTopicDiscovery;
 
 @Path("/messaging/topics")
 public class TopicsInformationResource {
 
-    private List<Topic> topics;
+    TopicDiscovery discovery;
+
+    private List<CloudEventMeta> eventsMeta;
 
     public TopicsInformationResource() {
-        topics = new ArrayList<>();
+        eventsMeta = new ArrayList<>();
         /*
          * $repeat$
-         * topics.add(new Topic("$name$", $type$));
+         * eventsMeta.add(new CloudEventMeta("$type$", "$source$", $kind$));
          * $end_repeat$
          */
     }
@@ -27,6 +31,9 @@ public class TopicsInformationResource {
     @GET()
     @Produces(MediaType.APPLICATION_JSON)
     public javax.ws.rs.core.Response getTopics() {
-        return javax.ws.rs.core.Response.ok(topics).build();
+        if (discovery == null) {
+            discovery = new NoOpTopicDiscovery();
+        }
+        return javax.ws.rs.core.Response.ok(discovery.getTopics(eventsMeta)).build();
     }
 }

--- a/kogito-codegen/src/main/resources/class-templates/events/TopicsInformationResourceTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/events/TopicsInformationResourceTemplate.java
@@ -10,7 +10,6 @@ import javax.ws.rs.core.MediaType;
 
 import org.kie.kogito.event.CloudEventMeta;
 import org.kie.kogito.services.event.TopicDiscovery;
-import org.kie.kogito.services.event.impl.NoOpTopicDiscovery;
 
 @Path("/messaging/topics")
 public class TopicsInformationResource {
@@ -31,9 +30,6 @@ public class TopicsInformationResource {
     @GET()
     @Produces(MediaType.APPLICATION_JSON)
     public javax.ws.rs.core.Response getTopics() {
-        if (discovery == null) {
-            discovery = new NoOpTopicDiscovery();
-        }
         return javax.ws.rs.core.Response.ok(discovery.getTopics(eventsMeta)).build();
     }
 }

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/AddonsConfigTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/AddonsConfigTest.java
@@ -44,5 +44,8 @@ public class AddonsConfigTest {
 
         assertThat(addonsConfig.useKnativeEventing()).isFalse();
         assertThat(addonsConfig.withKnativeEventing(true).useKnativeEventing()).isTrue();
+
+        assertThat(addonsConfig.useCloudEvents()).isFalse();
+        assertThat(addonsConfig.withCloudEvents(true).useCloudEvents()).isTrue();
     }
 }

--- a/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
+++ b/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
@@ -239,8 +239,7 @@ public class GenerateModelMojo extends AbstractKieMojo {
         boolean useMonitoring = hasClassOnClasspath(project, "org.kie.kogito.monitoring.rest.MetricsResource");
         boolean useTracing = hasClassOnClasspath(project, "org.kie.kogito.tracing.decision.DecisionTracingListener");
         boolean useKnativeEventing = hasClassOnClasspath(project, "org.kie.kogito.events.knative.ce.extensions.KogitoProcessExtension");
-        boolean useCloudEvents = hasClassOnClasspath(project, "org.kie.kogito.addon.cloudevents.spring.SpringKafkaCloudEventEmitter") ||
-                hasClassOnClasspath(project, "org.kie.kogito.addon.cloudevents.quarkus.QuarkusCloudEventEmitter");
+        boolean useCloudEvents = hasClassOnClasspath(project, "org.kie.kogito.addon.cloudevents.AbstractTopicDiscovery");
 
         AddonsConfig addonsConfig = new AddonsConfig()
                 .withPersistence(usePersistence)

--- a/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
+++ b/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
@@ -239,12 +239,15 @@ public class GenerateModelMojo extends AbstractKieMojo {
         boolean useMonitoring = hasClassOnClasspath(project, "org.kie.kogito.monitoring.rest.MetricsResource");
         boolean useTracing = hasClassOnClasspath(project, "org.kie.kogito.tracing.decision.DecisionTracingListener");
         boolean useKnativeEventing = hasClassOnClasspath(project, "org.kie.kogito.events.knative.ce.extensions.KogitoProcessExtension");
+        boolean useCloudEvents = hasClassOnClasspath(project, "org.kie.kogito.addon.cloudevents.spring.SpringKafkaCloudEventEmitter") ||
+                hasClassOnClasspath(project, "org.kie.kogito.addon.cloudevents.quarkus.QuarkusCloudEventEmitter");
 
         AddonsConfig addonsConfig = new AddonsConfig()
                 .withPersistence(usePersistence)
                 .withMonitoring(useMonitoring)
                 .withTracing(useTracing)
-                .withKnativeEventing(useKnativeEventing);
+                .withKnativeEventing(useKnativeEventing)
+                .withCloudEvents(useCloudEvents);
 
         ClassLoader projectClassLoader = MojoUtil.createProjectClassLoader(this.getClass().getClassLoader(),
                                                                            project,

--- a/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/KogitoAssetsProcessor.java
+++ b/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/KogitoAssetsProcessor.java
@@ -109,6 +109,7 @@ public class KogitoAssetsProcessor {
     private static final DotName tracingClass = DotName.createSimple("org.kie.kogito.tracing.decision.DecisionTracingListener");
     private static final DotName knativeEventingClass = DotName.createSimple("org.kie.kogito.events.knative.ce.extensions.KogitoProcessExtension");
     private static final DotName dmnJpmmlClass = DotName.createSimple( "org.kie.dmn.jpmml.DMNjPMMLInvocationEvaluator");
+    private static final DotName quarkusCloudEvents = DotName.createSimple("org.kie.kogito.addon.cloudevents.quarkus.QuarkusCloudEventEmitter");
 
     @Inject
     ArchiveRootBuildItem root;
@@ -162,12 +163,15 @@ public class KogitoAssetsProcessor {
                 .getClassByName(knativeEventingClass) != null;
         boolean isJPMMLAvailable =combinedIndexBuildItem.getIndex()
                 .getClassByName(dmnJpmmlClass) != null;
+        boolean useCloudEvents = combinedIndexBuildItem.getIndex()
+                .getClassByName(quarkusCloudEvents) != null;
 
         AddonsConfig addonsConfig = new AddonsConfig()
                 .withPersistence(usePersistence)
                 .withMonitoring(useMonitoring)
                 .withTracing(useTracing)
-                .withKnativeEventing(useKnativeEventing);
+                .withKnativeEventing(useKnativeEventing)
+                .withCloudEvents(useCloudEvents);
 
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         GeneratorContext context = buildContext(appPaths, combinedIndexBuildItem.getIndex());

--- a/kogito-test-utils/src/main/java/org/kie/kogito/resources/ConditionalQuarkusTestResource.java
+++ b/kogito-test-utils/src/main/java/org/kie/kogito/resources/ConditionalQuarkusTestResource.java
@@ -53,8 +53,8 @@ public abstract class ConditionalQuarkusTestResource implements QuarkusTestResou
     @Override
     public Map<String, String> start() {
         if (condition.isEnabled()) {
-            //testResource.start();
-            //return Collections.singletonMap(getKogitoProperty(), getKogitoPropertyValue());
+            testResource.start();
+            return Collections.singletonMap(getKogitoProperty(), getKogitoPropertyValue());
         }
 
         return Collections.emptyMap();
@@ -63,7 +63,7 @@ public abstract class ConditionalQuarkusTestResource implements QuarkusTestResou
     @Override
     public void stop() {
         if (condition.isEnabled()) {
-            //testResource.stop();
+            testResource.stop();
         }
     }
 

--- a/kogito-test-utils/src/main/java/org/kie/kogito/resources/ConditionalQuarkusTestResource.java
+++ b/kogito-test-utils/src/main/java/org/kie/kogito/resources/ConditionalQuarkusTestResource.java
@@ -53,8 +53,8 @@ public abstract class ConditionalQuarkusTestResource implements QuarkusTestResou
     @Override
     public Map<String, String> start() {
         if (condition.isEnabled()) {
-            testResource.start();
-            return Collections.singletonMap(getKogitoProperty(), getKogitoPropertyValue());
+            //testResource.start();
+            //return Collections.singletonMap(getKogitoProperty(), getKogitoPropertyValue());
         }
 
         return Collections.emptyMap();
@@ -63,7 +63,7 @@ public abstract class ConditionalQuarkusTestResource implements QuarkusTestResou
     @Override
     public void stop() {
         if (condition.isEnabled()) {
-            testResource.stop();
+            //testResource.stop();
         }
     }
 


### PR DESCRIPTION
…ents structure

See: https://issues.redhat.com/browse/KOGITO-3610

The idea is to have something like this:

```json
[
   {
      "name":"kogito_incoming_stream",
      "type":"INCOMING",
      "eventsMeta":[
         {
            "kind":"CONSUMED",
            "type":"travellers"
         }
      ]
   },
   {
      "name":"kogito_outgoing_stream",
      "type":"OUTGOING",
      "eventsMeta":[
         {
            "kind":"PRODUCED",
            "type":"process.examples.processedvisa"
         }
      ]
   }
]
```

Wondering if we should also add the prefix `process.<processId>` in the `CONSUMED` events. :thinking: 

Signed-off-by: Ricardo Zanini <zanini@redhat.com>

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains a link to the JIRA issue
- [x] Pull Request contains a link to any dependent or related Pull Request
- [x] Pull Request contains a description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket