### PR TITLE
KOGITO-3738 Use JDK8-compatible readBytes impl in DecisionModelResourcesProvider

### DIFF
--- a/kogito-codegen/src/main/resources/class-templates/DecisionModelResourcesProviderTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/DecisionModelResourcesProviderTemplate.java
@@ -9,7 +9,7 @@ public class DecisionModelResourcesProvider implements org.kie.internal.decision
         }
 
         try {
-            byte[] bytes = stream.readAllBytes();
+            byte[] bytes = readAllBytes(stream);
             java.io.ByteArrayInputStream byteArrayInputStream = new java.io.ByteArrayInputStream(bytes);
             return new java.io.InputStreamReader(byteArrayInputStream);
         } catch (java.io.IOException e) {
@@ -27,5 +27,30 @@ public class DecisionModelResourcesProvider implements org.kie.internal.decision
     private final static java.util.List<org.kie.internal.decision.DecisionModelResource> getResources() {
         java.util.List<org.kie.internal.decision.DecisionModelResource> resourcePaths = new java.util.ArrayList<>();
         return resourcePaths;
+    }
+
+    private static byte[] readAllBytes(java.io.InputStream inputStream) throws IOException {
+        java.io.BufferedInputStream bis = null;
+        java.io.ByteArrayOutputStream buf = null;
+        try {
+            bis = new java.io.BufferedInputStream(inputStream);
+            buf = new java.io.ByteArrayOutputStream();
+            int result = bis.read();
+            while (result != -1) {
+                buf.write((byte) result);
+                result = bis.read();
+            }
+            return buf.toByteArray();
+        } finally {
+            if (inputStream != null) {
+                inputStream.close();
+            }
+            if (bis != null) {
+                bis.close();
+            }
+            if (buf != null) {
+                buf.close();
+            }
+        }
     }
 }

--- a/kogito-codegen/src/main/resources/class-templates/DecisionModelResourcesProviderTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/DecisionModelResourcesProviderTemplate.java
@@ -9,7 +9,7 @@ public class DecisionModelResourcesProvider implements org.kie.internal.decision
         }
 
         try {
-            byte[] bytes = readAllBytes(stream);
+            byte[] bytes = org.drools.core.util.IoUtils.readBytesFromInputStream(stream);
             java.io.ByteArrayInputStream byteArrayInputStream = new java.io.ByteArrayInputStream(bytes);
             return new java.io.InputStreamReader(byteArrayInputStream);
         } catch (java.io.IOException e) {
@@ -29,28 +29,4 @@ public class DecisionModelResourcesProvider implements org.kie.internal.decision
         return resourcePaths;
     }
 
-    private static byte[] readAllBytes(java.io.InputStream inputStream) throws IOException {
-        java.io.BufferedInputStream bis = null;
-        java.io.ByteArrayOutputStream buf = null;
-        try {
-            bis = new java.io.BufferedInputStream(inputStream);
-            buf = new java.io.ByteArrayOutputStream();
-            int result = bis.read();
-            while (result != -1) {
-                buf.write((byte) result);
-                result = bis.read();
-            }
-            return buf.toByteArray();
-        } finally {
-            if (inputStream != null) {
-                inputStream.close();
-            }
-            if (bis != null) {
-                bis.close();
-            }
-            if (buf != null) {
-                buf.close();
-            }
-        }
-    }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-3738

My IDE freaks out every time the code is generated in `integration-test` because the root project is set to 8 compatibility, and all children inherits from it. For now I am just inserting a stock "readAllBytes()" impl,

1) but we can move most of this stock logic to an abstract class and inherit from there
2) alternative: we can set the pom.xml of the submodule to 11 -- don't know if this works especially with upstream Quarkus, so I am doing (1)

-----

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket