### PR TITLE
KOGITO-3765 Kogito core should not depend on drools-mvel

### DIFF
--- a/drools/kogito-pmml/pom.xml
+++ b/drools/kogito-pmml/pom.xml
@@ -43,6 +43,12 @@
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-pmml-dependencies</artifactId>
       <type>pom</type>
+      <exclusions>
+          <exclusion>
+              <groupId>org.drools</groupId>
+              <artifactId>drools-mvel</artifactId>
+          </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- test -->

--- a/jbpm/jbpm-flow/pom.xml
+++ b/jbpm/jbpm-flow/pom.xml
@@ -67,6 +67,7 @@
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-mvel</artifactId>
+      <optional>true</optional>
       <exclusions>
         <exclusion>
           <groupId>org.kie</groupId>
@@ -85,6 +86,7 @@
     <dependency>
       <groupId>org.mvel</groupId>
       <artifactId>mvel2</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/jbpm/jbpm-flow/pom.xml
+++ b/jbpm/jbpm-flow/pom.xml
@@ -62,6 +62,10 @@
           <groupId>org.drools</groupId>
           <artifactId>drools-core</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.drools</groupId>
+          <artifactId>drools-mvel</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
jbpm is bringing the dependency. We make it optional so that it won't break native compilation.
https://issues.redhat.com/browse/KOGITO-3765

---

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket