### PR TITLE
[1.0.x] KOGITO-3790 - Exclude apps-integration-tests class files from codecov analysis

### DIFF
--- a/kogito-build-parent/pom.xml
+++ b/kogito-build-parent/pom.xml
@@ -1317,6 +1317,7 @@
                               <!-- To avoid a complaint about duplicate classes created by code generation in IT tests. -->
                               <exclude name="**/it/integration-tests-springboot-it/target/classes/**/*.class"/>
                               <exclude name="**/it/integration-tests-kogito-plugin-it/target/classes/**/*.class"/>
+                              <exclude name="**/apps-integration-tests/**/target/classes/**/*.class"/>
                               <exclude name="**/integration-tests/**/target/classes/**/*.class"/>
                               <exclude name="**/integration-test/**/target/classes/**/*.class"/>
                               <exclude name="**/integration-test-legacy/**/target/classes/**/*.class"/>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/KOGITO-3790

Currently only some paths are excluded from the codecov analysis (see below)

![Screenshot from 2020-11-06 13-21-54](https://user-images.githubusercontent.com/18282531/98367429-e3ac2f80-2035-11eb-8d4c-44f5ca5a5125.png)

Since we have to rename the `kogito-apps` `integration-tests` module (for example to `apps-integration-tests`) so to avoid conficts with the `integration-tests` module already present here in `kogito-runtimes`, we have to exclude the class files generated from that new module as well. 

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket