### PR TITLE
[KOGITO-3834] Update daily job scheduling to minimize overlapping

### DIFF
--- a/Jenkinsfile.drools
+++ b/Jenkinsfile.drools
@@ -9,7 +9,7 @@ pipeline {
         jdk 'kie-jdk11'
     }
     triggers {
-        cron ('H 4 * * *')
+        cron ('H 2 * * *')
     }
     options {
         buildDiscarder logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '5')

--- a/Jenkinsfile.drools
+++ b/Jenkinsfile.drools
@@ -9,7 +9,7 @@ pipeline {
         jdk 'kie-jdk11'
     }
     triggers {
-        cron ('H 10 * * *')
+        cron ('H 8 * * *')
     }
     options {
         buildDiscarder logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '5')

--- a/Jenkinsfile.drools
+++ b/Jenkinsfile.drools
@@ -9,7 +9,7 @@ pipeline {
         jdk 'kie-jdk11'
     }
     triggers {
-        cron ('H 8 * * *')
+        cron ('H 4 * * *')
     }
     options {
         buildDiscarder logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '5')

--- a/Jenkinsfile.native
+++ b/Jenkinsfile.native
@@ -9,7 +9,7 @@ pipeline {
         jdk 'kie-jdk11'
     }
     triggers {
-        cron ('H 12 * * *')
+        cron ('H 8 * * *')
     }
     options {
         buildDiscarder logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '5')

--- a/Jenkinsfile.native
+++ b/Jenkinsfile.native
@@ -9,7 +9,7 @@ pipeline {
         jdk 'kie-jdk11'
     }
     triggers {
-        cron ('H 8 * * *')
+        cron ('H 6 * * *')
     }
     options {
         buildDiscarder logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '5')

--- a/Jenkinsfile.native
+++ b/Jenkinsfile.native
@@ -9,7 +9,7 @@ pipeline {
         jdk 'kie-jdk11'
     }
     triggers {
-        cron ('H 10 * * *')
+        cron ('H 12 * * *')
     }
     options {
         buildDiscarder logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '5')

--- a/Jenkinsfile.quarkus
+++ b/Jenkinsfile.quarkus
@@ -13,7 +13,7 @@ pipeline {
         jdk 'kie-jdk11'
     }
     triggers {
-        cron ('H 10 * * *')
+        cron ('H 4 * * *')
     }
     options {
         buildDiscarder logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '5')

--- a/Jenkinsfile.quarkus
+++ b/Jenkinsfile.quarkus
@@ -13,7 +13,7 @@ pipeline {
         jdk 'kie-jdk11'
     }
     triggers {
-        cron ('H 10 * * *')
+        cron ('H 12 * * *')
     }
     options {
         buildDiscarder logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '5')

--- a/Jenkinsfile.quarkus
+++ b/Jenkinsfile.quarkus
@@ -13,7 +13,7 @@ pipeline {
         jdk 'kie-jdk11'
     }
     triggers {
-        cron ('H 12 * * *')
+        cron ('H 10 * * *')
     }
     options {
         buildDiscarder logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '5')


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-3834

Now we have three jobs scheduled at the same time (10am UTC).
New proposed schedule:
- Jenkinsfile.drools: 2am UTC (~1 hour of execution time)
- Jenkinsfile.quarkus: 4am UTC (~1 hour of execution time)
- Jenkinsfile.native: 6am UTC (~2.5 hours of execution time)