### PR TITLE
[1.0.x] KOGITO-3868 TestContainer dependency in BOM causes issues in quarkus-platform

### DIFF
--- a/addons/persistence/mongodb-persistence-addon/pom.xml
+++ b/addons/persistence/mongodb-persistence-addon/pom.xml
@@ -72,6 +72,7 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>junit-jupiter</artifactId>
+      <version>${version.testcontainers}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/addons/persistence/mongodb-persistence-addon/pom.xml
+++ b/addons/persistence/mongodb-persistence-addon/pom.xml
@@ -66,6 +66,7 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
+      <version>${version.testcontainers}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-build-parent/pom.xml
+++ b/kogito-build-parent/pom.xml
@@ -529,31 +529,6 @@
       </dependency>
 
       <dependency>
-        <groupId>org.testcontainers</groupId>
-        <artifactId>testcontainers</artifactId>
-        <version>${version.testcontainers}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.testcontainers</groupId>
-        <artifactId>kafka</artifactId>
-        <version>${version.testcontainers}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.testcontainers</groupId>
-        <artifactId>junit-jupiter</artifactId>
-        <version>${version.testcontainers}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.testcontainers</groupId>
-        <artifactId>mongodb</artifactId>
-        <version>${version.testcontainers}</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-artifact</artifactId>
         <version>${version.maven}</version>

--- a/kogito-test-utils/pom.xml
+++ b/kogito-test-utils/pom.xml
@@ -39,6 +39,7 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
+      <version>${version.testcontainers}</version>
       <scope>compile</scope>
     </dependency>
 

--- a/kogito-test-utils/pom.xml
+++ b/kogito-test-utils/pom.xml
@@ -46,18 +46,21 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>junit-jupiter</artifactId>
+      <version>${version.testcontainers}</version>
       <scope>compile</scope>
     </dependency>
 
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>kafka</artifactId>
+      <version>${version.testcontainers}</version>
       <scope>compile</scope>
     </dependency>
     
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>mongodb</artifactId>
+      <version>${version.testcontainers}</version>
       <scope>compile</scope>
     </dependency>
 


### PR DESCRIPTION
Our BOM is published to platform and therefore end-users get our version of test containers. It would be better to NOT publish our test container dependency. 

Final solution: test bom
Workaround: use version property explicitly

related https://github.com/kiegroup/kogito-apps/pull/536