### PR TITLE
KOGITO-3862 - Make Docker images used by TestContainers compatible with Docker registry mirror

### DIFF
--- a/kogito-build-parent/pom.xml
+++ b/kogito-build-parent/pom.xml
@@ -135,7 +135,7 @@
     <version.org.kie7>7.46.0.Beta1</version.org.kie7>
     <version.org.reflections>0.9.11</version.org.reflections>
     <version.org.slf4j>1.7.30</version.org.slf4j>
-    <version.testcontainers>1.14.3</version.testcontainers>
+    <version.testcontainers>1.15.0</version.testcontainers>
     <version.resteasy.springboot>4.6.0.Final</version.resteasy.springboot>
     <version.springboot>2.3.1.RELEASE</version.springboot>
     <version.spring.kafka>2.5.2.RELEASE</version.spring.kafka>
@@ -150,8 +150,8 @@
     <version.org.mongo>4.1.0</version.org.mongo>
 
     <!-- container images for testing -->
-    <container.image.infinispan>quay.io/infinispan/server:${version.org.infinispan}</container.image.infinispan>
-    <container.image.keycloak>quay.io/keycloak/keycloak:${version.org.keycloak}</container.image.keycloak>
+    <container.image.infinispan>infinispan/server:${version.org.infinispan}</container.image.infinispan>
+    <container.image.keycloak>jboss/keycloak:${version.org.keycloak}</container.image.keycloak>
   </properties>
 
   <dependencyManagement>

--- a/kogito-test-utils/src/main/java/org/kie/kogito/testcontainers/KogitoImageNameSubstitutor.java
+++ b/kogito-test-utils/src/main/java/org/kie/kogito/testcontainers/KogitoImageNameSubstitutor.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.testcontainers;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.ImageNameSubstitutor;
+
+public class KogitoImageNameSubstitutor extends ImageNameSubstitutor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(KogitoImageNameSubstitutor.class);
+
+    @Override
+    public DockerImageName apply(DockerImageName original) {
+        LOGGER.debug("Original Docker image used by TestContainers: {}", original);
+        String canonicalName = original.asCanonicalNameString();
+
+        if (canonicalName.startsWith("mongo:")) {
+            return getMongoImageSubstitute(canonicalName);
+        } else {
+            return original;
+        }
+    }
+
+    private DockerImageName getMongoImageSubstitute(String canonicalName) {
+        return DockerImageName.parse("library/" + canonicalName).asCompatibleSubstituteFor("mongo");
+    }
+
+    @Override
+    protected String getDescription() {
+        return "Kogito Image Name Substitutor";
+    }
+}

--- a/kogito-test-utils/src/main/resources/testcontainers.properties
+++ b/kogito-test-utils/src/main/resources/testcontainers.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2020 Red Hat, Inc. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+image.substitutor=org.kie.kogito.testcontainers.KogitoImageNameSubstitutor


### PR DESCRIPTION
Assembly:
- https://github.com/kiegroup/kogito-runtimes/pull/892
- https://github.com/kiegroup/kogito-examples/pull/457