### PR TITLE
[1.0.x] KOGITO-3897 Use JDK8-compatible readBytes impl in DecisionContainerTemplate

### DIFF
--- a/kogito-codegen/src/main/resources/class-templates/DecisionContainerTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/DecisionContainerTemplate.java
@@ -20,7 +20,7 @@ public class DecisionModels implements org.kie.kogito.decision.DecisionModels {
         }
 
         try {
-            byte[] bytes = stream.readAllBytes();
+            byte[] bytes = org.drools.core.util.IoUtils.readBytesFromInputStream(stream);
             java.io.ByteArrayInputStream byteArrayInputStream = new java.io.ByteArrayInputStream(bytes);
             return new java.io.InputStreamReader(byteArrayInputStream);
         } catch (java.io.IOException e) {


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-3897

blocks quarkus-platform build due to JDK8 incompat.

Follow up to  https://github.com/kiegroup/kogito-runtimes/pull/860/

I don't know why we have 2 templates, but that's another issue


---


Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket