### PR TITLE
[KOGITO-3840] Forward transport headers

### DIFF
--- a/api/kogito-api/pom.xml
+++ b/api/kogito-api/pom.xml
@@ -89,5 +89,10 @@
       <artifactId>jackson-databind</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/api/kogito-api/src/main/java/org/kie/kogito/conf/StaticConfigBean.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/conf/StaticConfigBean.java
@@ -18,12 +18,14 @@ package org.kie.kogito.conf;
 import java.util.Optional;
 
 import org.kie.kogito.KogitoGAV;
+import org.kie.kogito.transport.TransportConfig;
 
 public class StaticConfigBean implements ConfigBean {
 
     private String serviceUrl;
     private boolean useCloudEvents = true;
     private KogitoGAV gav;
+    private TransportConfig transportConfig = new TransportConfig();
 
     public StaticConfigBean() {
     }
@@ -46,6 +48,10 @@ public class StaticConfigBean implements ConfigBean {
         this.gav = gav;
     }
 
+    protected void setTransportConfig(TransportConfig transportConfig) {
+        this.transportConfig = transportConfig;
+    }
+
     @Override
     public boolean useCloudEvents() {
         return useCloudEvents;
@@ -59,5 +65,10 @@ public class StaticConfigBean implements ConfigBean {
     @Override
     public Optional<KogitoGAV> getGav() {
         return Optional.ofNullable(gav);
+    }
+
+    @Override
+    public TransportConfig transportConfig() {
+        return transportConfig;
     }
 }

--- a/api/kogito-api/src/main/java/org/kie/kogito/internal/process/runtime/KogitoProcessInstance.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/internal/process/runtime/KogitoProcessInstance.java
@@ -86,4 +86,17 @@ public interface KogitoProcessInstance extends ProcessInstance, KogitoEventListe
      * @return the process instance description
      */
     String getDescription();
+
+    /**
+     * @return the ProcessInstance metadata
+     */
+    Map<String, Object> getMetaData();
+
+    /**
+     * Sets a ProcessInstance metadata entry
+     * 
+     * @param name Name of the Metadata key
+     * @param data Data identified by the provided Metadata Key
+     */
+    void setMetaData(String name, Object data);
 }

--- a/api/kogito-api/src/main/java/org/kie/kogito/process/ProcessInstance.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/process/ProcessInstance.java
@@ -99,6 +99,10 @@ public interface ProcessInstance<T> {
      */
     T updateVariables(T updates);
 
+    Object getContextAttr(String name);
+
+    void setContextAttr(String name, Object value);
+
     /**
      * Returns current status of this process instance
      *

--- a/api/kogito-api/src/main/java/org/kie/kogito/process/ProcessService.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/process/ProcessService.java
@@ -34,6 +34,11 @@ public interface ProcessService {
             T model,
             String startFromNodeId);
 
+    <T extends Model> ProcessInstance<T> createProcessInstance(Process<T> process, String businessKey,
+            T model,
+            String startFromNodeId,
+            Map<String, String> transportContext);
+
     <T extends MappableToModel<R>, R> List<R> getProcessInstanceOutput(Process<T> process);
 
     <T extends MappableToModel<R>, R> Optional<R> findById(Process<T> process, String id);

--- a/api/kogito-api/src/main/java/org/kie/kogito/transport/TransportConfig.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/transport/TransportConfig.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.transport;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class TransportConfig {
+
+    public static final String TRANSPORT_CONTEXT = "transportContext";
+
+    private final Collection<TransportFilter> filters;
+
+    public TransportConfig() {
+        this.filters = new ArrayList<>();
+    }
+
+    public TransportConfig(Iterable<TransportFilter> filters) {
+        this.filters = new ArrayList<>();
+        if (filters != null) {
+            filters.forEach(this.filters::add);
+        }
+    }
+
+    public boolean accepts(String paramName) {
+        if (paramName == null || paramName.trim().isEmpty()) {
+            return false;
+        }
+        return this.filters.stream().anyMatch(c -> c.accepts(paramName));
+    }
+
+    public Map<String, String> buildContext(Map<String, List<String>> params) {
+        return params.entrySet()
+                .stream()
+                .filter(e -> accepts(e.getKey()))
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> String.join(",", e.getValue())));
+    }
+}

--- a/api/kogito-api/src/main/java/org/kie/kogito/transport/TransportFilter.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/transport/TransportFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.kie.kogito.conf;
 
-import java.util.Optional;
+package org.kie.kogito.transport;
 
-import org.kie.kogito.KogitoConfig;
-import org.kie.kogito.KogitoGAV;
-import org.kie.kogito.transport.TransportConfig;
+import java.util.Collection;
 
-public interface ConfigBean extends KogitoConfig {
+public interface TransportFilter {
 
-    boolean useCloudEvents();
+    Collection<String> getValues();
 
-    String getServiceUrl();
+    default boolean accepts(String key) {
+        return getValues().stream().anyMatch(v -> key != null && key.equalsIgnoreCase(v));
+    }
 
-    Optional<KogitoGAV> getGav();
-
-    TransportConfig transportConfig();
 }

--- a/api/kogito-api/src/test/java/org/kie/kogito/transport/TransportConfigTest.java
+++ b/api/kogito-api/src/test/java/org/kie/kogito/transport/TransportConfigTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.transport;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TransportConfigTest {
+
+    @Test
+    void testEmptyConfig() {
+        TransportConfig service = new TransportConfig();
+        assertThat(service.accepts(null)).isFalse();
+        assertThat(service.accepts("")).isFalse();
+        assertThat(service.accepts("     ")).isFalse();
+        assertThat(service.accepts("x")).isFalse();
+    }
+
+    @Test
+    void testConfig() {
+        TransportConfig service = new TransportConfig(buildConfigurations());
+        assertThat(service.accepts(null)).isFalse();
+        assertThat(service.accepts("")).isFalse();
+        assertThat(service.accepts("     ")).isFalse();
+        assertThat(service.accepts("x")).isFalse();
+        assertThat(service.accepts("foo")).isTrue();
+        assertThat(service.accepts("bar")).isTrue();
+        assertThat(service.accepts("baz")).isTrue();
+        assertThat(service.accepts("FoO")).isTrue();
+    }
+
+    private Collection<TransportFilter> buildConfigurations() {
+        Collection<TransportFilter> configurations = new ArrayList<>();
+        configurations.add(() -> Collections.emptyList());
+        configurations.add(() -> Arrays.asList("foo", "bar"));
+        configurations.add(() -> Collections.singletonList("baz"));
+        return configurations;
+    }
+}

--- a/integration-tests/integration-tests-quarkus-processes/src/main/java/org/kie/kogito/integrationtests/ExampleTransportFilter.java
+++ b/integration-tests/integration-tests-quarkus-processes/src/main/java/org/kie/kogito/integrationtests/ExampleTransportFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.kie.kogito.conf;
 
-import java.util.Optional;
+package org.kie.kogito.integrationtests;
 
-import org.kie.kogito.KogitoConfig;
-import org.kie.kogito.KogitoGAV;
-import org.kie.kogito.transport.TransportConfig;
+import java.util.Arrays;
+import java.util.Collection;
 
-public interface ConfigBean extends KogitoConfig {
+import javax.enterprise.context.ApplicationScoped;
 
-    boolean useCloudEvents();
+import org.kie.kogito.transport.TransportFilter;
 
-    String getServiceUrl();
+@ApplicationScoped
+public class ExampleTransportFilter implements TransportFilter {
 
-    Optional<KogitoGAV> getGav();
-
-    TransportConfig transportConfig();
+    @Override
+    public Collection<String> getValues() {
+        return Arrays.asList("example1", "example2");
+    }
 }

--- a/integration-tests/integration-tests-quarkus-processes/src/main/java/org/kie/kogito/integrationtests/OtherTransportFilter.java
+++ b/integration-tests/integration-tests-quarkus-processes/src/main/java/org/kie/kogito/integrationtests/OtherTransportFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.kie.kogito.conf;
 
-import java.util.Optional;
+package org.kie.kogito.integrationtests;
 
-import org.kie.kogito.KogitoConfig;
-import org.kie.kogito.KogitoGAV;
-import org.kie.kogito.transport.TransportConfig;
+import java.util.Collection;
+import java.util.Collections;
 
-public interface ConfigBean extends KogitoConfig {
+import javax.enterprise.context.ApplicationScoped;
 
-    boolean useCloudEvents();
+import org.kie.kogito.transport.TransportFilter;
 
-    String getServiceUrl();
+@ApplicationScoped
+public class OtherTransportFilter implements TransportFilter {
 
-    Optional<KogitoGAV> getGav();
-
-    TransportConfig transportConfig();
+    @Override
+    public Collection<String> getValues() {
+        return Collections.singletonList("other");
+    }
 }

--- a/integration-tests/integration-tests-quarkus-processes/src/test/java/org/kie/kogito/integrationtests/quarkus/TransportFilterTest.java
+++ b/integration-tests/integration-tests-quarkus-processes/src/test/java/org/kie/kogito/integrationtests/quarkus/TransportFilterTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.integrationtests.quarkus;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.junit.jupiter.api.Test;
+import org.kie.kogito.process.Process;
+import org.kie.kogito.process.ProcessInstance;
+import org.kie.kogito.testcontainers.quarkus.InfinispanQuarkusTestResource;
+import org.kie.kogito.transport.TransportConfig;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.emptyOrNullString;
+
+@QuarkusTest
+@QuarkusTestResource(InfinispanQuarkusTestResource.Conditional.class)
+class TransportFilterTest {
+
+    static {
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+    }
+
+    @Inject
+    @Named("AdHocFragments")
+    Process<?> process;
+
+    @Test
+    void testTransportHeaders() {
+        Map<String, String> params = new HashMap<>();
+        params.put("var1", "Kermit");
+
+        String id = given()
+                .contentType(ContentType.JSON)
+                .header("example1", "x")
+                .header("Bar", "y")
+                .header("OTHER", "z")
+                .when()
+                .body(params)
+                .post("/AdHocFragments")
+                .then()
+                .statusCode(201)
+                .body("id", not(emptyOrNullString()))
+                .body("var1", equalTo("Kermit"))
+                .header("Location", not(emptyOrNullString()))
+                .extract()
+                .path("id");
+
+        Optional<? extends ProcessInstance<?>> processInstance = process.instances().findById(id);
+        assertThat(processInstance).isPresent();
+        Object context = processInstance.get().getContextAttr(TransportConfig.TRANSPORT_CONTEXT);
+        assertThat(context).isInstanceOf(Map.class).isNotNull();
+        Map<String, String> transportContext = (Map<String, String>) context;
+        assertThat(transportContext).containsKeys("example1", "OTHER").doesNotContainKey("Bar");
+    }
+}

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/ProcessInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/ProcessInstance.java
@@ -16,7 +16,6 @@
 package org.jbpm.process.instance;
 
 import java.util.Date;
-import java.util.Map;
 
 import org.drools.core.common.InternalKnowledgeRuntime;
 import org.jbpm.workflow.instance.NodeInstance;
@@ -62,10 +61,6 @@ public interface ProcessInstance extends KogitoProcessInstance,
     void setRootProcessInstanceId(String parentId);
 
     void setRootProcessId(String processId);
-
-    Map<String, Object> getMetaData();
-
-    void setMetaData(String name, Object data);
 
     Object getFaultData();
 

--- a/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcessInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcessInstance.java
@@ -305,6 +305,16 @@ public abstract class AbstractProcessInstance<T extends Model> implements Proces
     }
 
     @Override
+    public Object getContextAttr(String name) {
+        return this.processInstance.getMetaData().get(name);
+    }
+
+    @Override
+    public void setContextAttr(String name, Object value) {
+        this.processInstance.setMetaData(name, value);
+    }
+
+    @Override
     public Optional<ProcessError> error() {
         if (this.status == STATE_ERROR) {
             return Optional.of(this.processError != null ? this.processError : buildProcessError());

--- a/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/ProcessServiceImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/ProcessServiceImpl.java
@@ -17,7 +17,6 @@ package org.kie.kogito.process.impl;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;

--- a/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/ProcessServiceImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/ProcessServiceImpl.java
@@ -17,6 +17,7 @@ package org.kie.kogito.process.impl;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -42,6 +43,7 @@ import org.kie.kogito.process.workitem.Comment;
 import org.kie.kogito.process.workitem.HumanTaskWorkItem;
 import org.kie.kogito.process.workitem.Policies;
 import org.kie.kogito.services.uow.UnitOfWorkExecutor;
+import org.kie.kogito.transport.TransportConfig;
 
 public class ProcessServiceImpl implements ProcessService {
 
@@ -54,9 +56,13 @@ public class ProcessServiceImpl implements ProcessService {
     @Override
     public <T extends Model> ProcessInstance<T> createProcessInstance(Process<T> process, String businessKey,
             T model,
-            String startFromNodeId) {
+            String startFromNodeId,
+            Map<String, String> transportContext) {
         return UnitOfWorkExecutor.executeInUnitOfWork(application.unitOfWorkManager(), () -> {
             ProcessInstance<T> pi = process.createInstance(businessKey, model);
+            if (transportContext != null) {
+                pi.setContextAttr(TransportConfig.TRANSPORT_CONTEXT, transportContext);
+            }
             if (startFromNodeId != null) {
                 pi.startFrom(startFromNodeId);
             } else {
@@ -64,6 +70,13 @@ public class ProcessServiceImpl implements ProcessService {
             }
             return pi;
         });
+    }
+
+    @Override
+    public <T extends Model> ProcessInstance<T> createProcessInstance(Process<T> process, String businessKey,
+            T model,
+            String startFromNodeId) {
+        return createProcessInstance(process, businessKey, model, startFromNodeId, null);
     }
 
     @Override

--- a/jbpm/process-serialization-protobuf/src/main/java/org/kie/kogito/serialization/process/impl/ProtobufProcessInstanceReader.java
+++ b/jbpm/process-serialization-protobuf/src/main/java/org/kie/kogito/serialization/process/impl/ProtobufProcessInstanceReader.java
@@ -189,9 +189,11 @@ public class ProtobufProcessInstanceReader {
             processInstance.getIterationLevels().putAll(buildIterationLevels(workflowContext.getIterationLevelsList()));
         }
 
-        if (workflowContext.getTransportContextCount() > 0) {
+        if (processInstanceProtobuf.getTransportContextCount() > 0) {
             Map<String, Object> transportContext = new HashMap<>();
-            varReader.buildVariables(workflowContext.getTransportContextList()).forEach(v -> transportContext.put(v.getName(), v.getValue()));
+            varReader.buildVariables(processInstanceProtobuf.getTransportContextList())
+                    .stream()
+                    .forEach(v -> transportContext.put(v.getName(), v.getValue()));
             processInstance.setMetaData(TransportConfig.TRANSPORT_CONTEXT, transportContext);
         }
 
@@ -493,11 +495,6 @@ public class ProtobufProcessInstanceReader {
         }
         if (workflowContext.getIterationLevelsCount() > 0) {
             container.getIterationLevels().putAll(buildIterationLevels(workflowContext.getIterationLevelsList()));
-        }
-        if (workflowContext.getTransportContextCount() > 0) {
-            Map<String, Object> transportContext = new HashMap<>();
-            varReader.buildVariables(workflowContext.getTransportContextList()).forEach(v -> transportContext.put(v.getName(), v.getValue()));
-            container.setMetaData(TransportConfig.TRANSPORT_CONTEXT, transportContext);
         }
     }
 

--- a/jbpm/process-serialization-protobuf/src/main/java/org/kie/kogito/serialization/process/impl/ProtobufProcessInstanceReader.java
+++ b/jbpm/process-serialization-protobuf/src/main/java/org/kie/kogito/serialization/process/impl/ProtobufProcessInstanceReader.java
@@ -79,6 +79,7 @@ import org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.SLACont
 import org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.WorkflowContext;
 import org.kie.kogito.serialization.process.protobuf.KogitoWorkItemsProtobuf;
 import org.kie.kogito.serialization.process.protobuf.KogitoWorkItemsProtobuf.HumanTaskWorkItemData;
+import org.kie.kogito.transport.TransportConfig;
 
 import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -186,6 +187,12 @@ public class ProtobufProcessInstanceReader {
 
         if (workflowContext.getIterationLevelsCount() > 0) {
             processInstance.getIterationLevels().putAll(buildIterationLevels(workflowContext.getIterationLevelsList()));
+        }
+
+        if (workflowContext.getTransportContextCount() > 0) {
+            Map<String, Object> transportContext = new HashMap<>();
+            varReader.buildVariables(workflowContext.getTransportContextList()).forEach(v -> transportContext.put(v.getName(), v.getValue()));
+            processInstance.setMetaData(TransportConfig.TRANSPORT_CONTEXT, transportContext);
         }
 
         return processInstance;
@@ -486,6 +493,11 @@ public class ProtobufProcessInstanceReader {
         }
         if (workflowContext.getIterationLevelsCount() > 0) {
             container.getIterationLevels().putAll(buildIterationLevels(workflowContext.getIterationLevelsList()));
+        }
+        if (workflowContext.getTransportContextCount() > 0) {
+            Map<String, Object> transportContext = new HashMap<>();
+            varReader.buildVariables(workflowContext.getTransportContextList()).forEach(v -> transportContext.put(v.getName(), v.getValue()));
+            container.setMetaData(TransportConfig.TRANSPORT_CONTEXT, transportContext);
         }
     }
 

--- a/jbpm/process-serialization-protobuf/src/main/java/org/kie/kogito/serialization/process/impl/ProtobufProcessInstanceWriter.java
+++ b/jbpm/process-serialization-protobuf/src/main/java/org/kie/kogito/serialization/process/impl/ProtobufProcessInstanceWriter.java
@@ -144,8 +144,11 @@ public class ProtobufProcessInstanceWriter {
         VariableScopeInstance variableScopeInstance = (VariableScopeInstance) workFlow.getContextInstance(VariableScope.VARIABLE_SCOPE);
         List<Map.Entry<String, Object>> variables = new ArrayList<>(variableScopeInstance.getVariables().entrySet());
         List<Map.Entry<String, Integer>> iterationlevels = new ArrayList<>(workFlow.getIterationLevels().entrySet());
-        List<Map.Entry<String, Object>> transportContext = (List<Entry<String, Object>>) workFlow.getMetaData().get(TransportConfig.TRANSPORT_CONTEXT);
-        instance.setContext(buildWorkflowContext(nodeInstances, exclusiveGroupInstances, variables, iterationlevels, transportContext));
+        instance.setContext(buildWorkflowContext(nodeInstances, exclusiveGroupInstances, variables, iterationlevels));
+        if (workFlow.getMetaData().containsKey(TransportConfig.TRANSPORT_CONTEXT)) {
+            Map<String, Object> transportContext = (Map<String, Object>) workFlow.getMetaData().get(TransportConfig.TRANSPORT_CONTEXT);
+            instance.addAllTransportContext(varWriter.buildVariables(new ArrayList<>(transportContext.entrySet())));
+        }
 
         KogitoProcessInstanceProtobuf.ProcessInstance piProtobuf = instance.build();
 
@@ -189,15 +192,13 @@ public class ProtobufProcessInstanceWriter {
     private KogitoTypesProtobuf.WorkflowContext buildWorkflowContext(List<NodeInstance> nodeInstances,
             List<ContextInstance> exclusiveGroupInstances,
             List<Entry<String, Object>> variables,
-            List<Entry<String, Integer>> iterationlevels,
-            List<Entry<String, Object>> transportContext) {
+            List<Entry<String, Integer>> iterationlevels) {
 
         KogitoTypesProtobuf.WorkflowContext.Builder workflowContextBuilder = KogitoTypesProtobuf.WorkflowContext.newBuilder();
         workflowContextBuilder.addAllNodeInstance(buildNodeInstances(nodeInstances));
         workflowContextBuilder.addAllExclusiveGroup(buildGroups(exclusiveGroupInstances));
         workflowContextBuilder.addAllVariable(varWriter.buildVariables(variables));
         workflowContextBuilder.addAllIterationLevels(buildIterationLevels(iterationlevels));
-        workflowContextBuilder.addAllTransportContext(varWriter.buildVariables(transportContext));
         return workflowContextBuilder.build();
 
     }
@@ -279,8 +280,7 @@ public class ProtobufProcessInstanceWriter {
         VariableScopeInstance variableScopeInstance = (VariableScopeInstance) nodeInstance.getContextInstance(VariableScope.VARIABLE_SCOPE);
         List<Map.Entry<String, Object>> variables = new ArrayList<>(variableScopeInstance.getVariables().entrySet());
         List<Map.Entry<String, Integer>> iterationlevels = new ArrayList<>(nodeInstance.getIterationLevels().entrySet());
-        List<Map.Entry<String, Object>> transportContext = (List<Entry<String, Object>>) nodeInstance.getMetaData().get(TransportConfig.TRANSPORT_CONTEXT);
-        foreachBuilder.setContext(buildWorkflowContext(nodeInstances, exclusiveGroupInstances, variables, iterationlevels, transportContext));
+        foreachBuilder.setContext(buildWorkflowContext(nodeInstances, exclusiveGroupInstances, variables, iterationlevels));
 
         return Any.pack(foreachBuilder.build());
     }
@@ -396,8 +396,7 @@ public class ProtobufProcessInstanceWriter {
         VariableScopeInstance variableScopeInstance = (VariableScopeInstance) nodeInstance.getContextInstance(VariableScope.VARIABLE_SCOPE);
         List<Map.Entry<String, Object>> variables = new ArrayList<>(variableScopeInstance.getVariables().entrySet());
         List<Map.Entry<String, Integer>> iterationLevels = new ArrayList<>(nodeInstance.getIterationLevels().entrySet());
-        List<Map.Entry<String, Object>> transportContext = (List<Entry<String, Object>>) nodeInstance.getMetaData().get(TransportConfig.TRANSPORT_CONTEXT);
-        return buildWorkflowContext(nodeInstances, exclusiveGroupInstances, variables, iterationLevels, transportContext);
+        return buildWorkflowContext(nodeInstances, exclusiveGroupInstances, variables, iterationLevels);
     }
 
     private Any buildWorkItemNodeInstance(WorkItemNodeInstance nodeInstance) {

--- a/jbpm/process-serialization-protobuf/src/main/java/org/kie/kogito/serialization/process/impl/ProtobufVariableWriter.java
+++ b/jbpm/process-serialization-protobuf/src/main/java/org/kie/kogito/serialization/process/impl/ProtobufVariableWriter.java
@@ -39,10 +39,13 @@ public class ProtobufVariableWriter {
     }
 
     public List<KogitoTypesProtobuf.Variable> buildVariables(List<Map.Entry<String, Object>> variables) {
-        Comparator<Map.Entry<String, Object>> comparator = (o1, o2) -> o1.getKey().compareTo(o2.getKey());
+        List<KogitoTypesProtobuf.Variable> variablesProtobuf = new ArrayList<>();
+        if (variables == null) {
+            return variablesProtobuf;
+        }
+        Comparator<Map.Entry<String, Object>> comparator = Comparator.comparing(Map.Entry::getKey);
         Collections.sort(variables, comparator);
 
-        List<KogitoTypesProtobuf.Variable> variablesProtobuf = new ArrayList<>();
         for (Map.Entry<String, Object> entry : variables) {
             KogitoTypesProtobuf.Variable.Builder variableBuilder = KogitoTypesProtobuf.Variable.newBuilder();
             variableBuilder.setName(entry.getKey());

--- a/jbpm/process-serialization-protobuf/src/main/java/org/kie/kogito/serialization/process/protobuf/KogitoProcessInstanceProtobuf.java
+++ b/jbpm/process-serialization-protobuf/src/main/java/org/kie/kogito/serialization/process/protobuf/KogitoProcessInstanceProtobuf.java
@@ -309,6 +309,30 @@ public final class KogitoProcessInstanceProtobuf {
         int index);
 
     /**
+     * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 21;</code>
+     */
+    java.util.List<org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable> 
+        getTransportContextList();
+    /**
+     * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 21;</code>
+     */
+    org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable getTransportContext(int index);
+    /**
+     * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 21;</code>
+     */
+    int getTransportContextCount();
+    /**
+     * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 21;</code>
+     */
+    java.util.List<? extends org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.VariableOrBuilder> 
+        getTransportContextOrBuilderList();
+    /**
+     * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 21;</code>
+     */
+    org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.VariableOrBuilder getTransportContextOrBuilder(
+        int index);
+
+    /**
      * <code>repeated string completedNodeIds = 20;</code>
      * @return A list containing the completedNodeIds.
      */
@@ -359,6 +383,7 @@ public final class KogitoProcessInstanceProtobuf {
       errorMessage_ = "";
       referenceId_ = "";
       swimlaneContext_ = java.util.Collections.emptyList();
+      transportContext_ = java.util.Collections.emptyList();
       completedNodeIds_ = com.google.protobuf.LazyStringArrayList.EMPTY;
     }
 
@@ -522,11 +547,20 @@ public final class KogitoProcessInstanceProtobuf {
             }
             case 162: {
               java.lang.String s = input.readStringRequireUtf8();
-              if (!((mutable_bitField0_ & 0x00004000) != 0)) {
+              if (!((mutable_bitField0_ & 0x00008000) != 0)) {
                 completedNodeIds_ = new com.google.protobuf.LazyStringArrayList();
-                mutable_bitField0_ |= 0x00004000;
+                mutable_bitField0_ |= 0x00008000;
               }
               completedNodeIds_.add(s);
+              break;
+            }
+            case 170: {
+              if (!((mutable_bitField0_ & 0x00004000) != 0)) {
+                transportContext_ = new java.util.ArrayList<org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable>();
+                mutable_bitField0_ |= 0x00004000;
+              }
+              transportContext_.add(
+                  input.readMessage(org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable.parser(), extensionRegistry));
               break;
             }
             default: {
@@ -547,8 +581,11 @@ public final class KogitoProcessInstanceProtobuf {
         if (((mutable_bitField0_ & 0x00002000) != 0)) {
           swimlaneContext_ = java.util.Collections.unmodifiableList(swimlaneContext_);
         }
-        if (((mutable_bitField0_ & 0x00004000) != 0)) {
+        if (((mutable_bitField0_ & 0x00008000) != 0)) {
           completedNodeIds_ = completedNodeIds_.getUnmodifiableView();
+        }
+        if (((mutable_bitField0_ & 0x00004000) != 0)) {
+          transportContext_ = java.util.Collections.unmodifiableList(transportContext_);
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -1248,6 +1285,46 @@ public final class KogitoProcessInstanceProtobuf {
       return swimlaneContext_.get(index);
     }
 
+    public static final int TRANSPORT_CONTEXT_FIELD_NUMBER = 21;
+    private java.util.List<org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable> transportContext_;
+    /**
+     * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 21;</code>
+     */
+    @java.lang.Override
+    public java.util.List<org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable> getTransportContextList() {
+      return transportContext_;
+    }
+    /**
+     * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 21;</code>
+     */
+    @java.lang.Override
+    public java.util.List<? extends org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.VariableOrBuilder> 
+        getTransportContextOrBuilderList() {
+      return transportContext_;
+    }
+    /**
+     * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 21;</code>
+     */
+    @java.lang.Override
+    public int getTransportContextCount() {
+      return transportContext_.size();
+    }
+    /**
+     * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 21;</code>
+     */
+    @java.lang.Override
+    public org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable getTransportContext(int index) {
+      return transportContext_.get(index);
+    }
+    /**
+     * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 21;</code>
+     */
+    @java.lang.Override
+    public org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.VariableOrBuilder getTransportContextOrBuilder(
+        int index) {
+      return transportContext_.get(index);
+    }
+
     public static final int COMPLETEDNODEIDS_FIELD_NUMBER = 20;
     private com.google.protobuf.LazyStringList completedNodeIds_;
     /**
@@ -1357,6 +1434,9 @@ public final class KogitoProcessInstanceProtobuf {
       for (int i = 0; i < completedNodeIds_.size(); i++) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 20, completedNodeIds_.getRaw(i));
       }
+      for (int i = 0; i < transportContext_.size(); i++) {
+        output.writeMessage(21, transportContext_.get(i));
+      }
       unknownFields.writeTo(output);
     }
 
@@ -1437,6 +1517,10 @@ public final class KogitoProcessInstanceProtobuf {
         }
         size += dataSize;
         size += 2 * getCompletedNodeIdsList().size();
+      }
+      for (int i = 0; i < transportContext_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(21, transportContext_.get(i));
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -1530,6 +1614,8 @@ public final class KogitoProcessInstanceProtobuf {
       }
       if (!getSwimlaneContextList()
           .equals(other.getSwimlaneContextList())) return false;
+      if (!getTransportContextList()
+          .equals(other.getTransportContextList())) return false;
       if (!getCompletedNodeIdsList()
           .equals(other.getCompletedNodeIdsList())) return false;
       if (!unknownFields.equals(other.unknownFields)) return false;
@@ -1611,6 +1697,10 @@ public final class KogitoProcessInstanceProtobuf {
       if (getSwimlaneContextCount() > 0) {
         hash = (37 * hash) + SWIMLANE_CONTEXT_FIELD_NUMBER;
         hash = (53 * hash) + getSwimlaneContextList().hashCode();
+      }
+      if (getTransportContextCount() > 0) {
+        hash = (37 * hash) + TRANSPORT_CONTEXT_FIELD_NUMBER;
+        hash = (53 * hash) + getTransportContextList().hashCode();
       }
       if (getCompletedNodeIdsCount() > 0) {
         hash = (37 * hash) + COMPLETEDNODEIDS_FIELD_NUMBER;
@@ -1747,6 +1837,7 @@ public final class KogitoProcessInstanceProtobuf {
           getSlaFieldBuilder();
           getContextFieldBuilder();
           getSwimlaneContextFieldBuilder();
+          getTransportContextFieldBuilder();
         }
       }
       @java.lang.Override
@@ -1802,8 +1893,14 @@ public final class KogitoProcessInstanceProtobuf {
         } else {
           swimlaneContextBuilder_.clear();
         }
+        if (transportContextBuilder_ == null) {
+          transportContext_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00004000);
+        } else {
+          transportContextBuilder_.clear();
+        }
         completedNodeIds_ = com.google.protobuf.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00004000);
+        bitField0_ = (bitField0_ & ~0x00008000);
         return this;
       }
 
@@ -1906,9 +2003,18 @@ public final class KogitoProcessInstanceProtobuf {
         } else {
           result.swimlaneContext_ = swimlaneContextBuilder_.build();
         }
-        if (((bitField0_ & 0x00004000) != 0)) {
+        if (transportContextBuilder_ == null) {
+          if (((bitField0_ & 0x00004000) != 0)) {
+            transportContext_ = java.util.Collections.unmodifiableList(transportContext_);
+            bitField0_ = (bitField0_ & ~0x00004000);
+          }
+          result.transportContext_ = transportContext_;
+        } else {
+          result.transportContext_ = transportContextBuilder_.build();
+        }
+        if (((bitField0_ & 0x00008000) != 0)) {
           completedNodeIds_ = completedNodeIds_.getUnmodifiableView();
-          bitField0_ = (bitField0_ & ~0x00004000);
+          bitField0_ = (bitField0_ & ~0x00008000);
         }
         result.completedNodeIds_ = completedNodeIds_;
         result.bitField0_ = to_bitField0_;
@@ -2061,10 +2167,36 @@ public final class KogitoProcessInstanceProtobuf {
             }
           }
         }
+        if (transportContextBuilder_ == null) {
+          if (!other.transportContext_.isEmpty()) {
+            if (transportContext_.isEmpty()) {
+              transportContext_ = other.transportContext_;
+              bitField0_ = (bitField0_ & ~0x00004000);
+            } else {
+              ensureTransportContextIsMutable();
+              transportContext_.addAll(other.transportContext_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.transportContext_.isEmpty()) {
+            if (transportContextBuilder_.isEmpty()) {
+              transportContextBuilder_.dispose();
+              transportContextBuilder_ = null;
+              transportContext_ = other.transportContext_;
+              bitField0_ = (bitField0_ & ~0x00004000);
+              transportContextBuilder_ = 
+                com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
+                   getTransportContextFieldBuilder() : null;
+            } else {
+              transportContextBuilder_.addAllMessages(other.transportContext_);
+            }
+          }
+        }
         if (!other.completedNodeIds_.isEmpty()) {
           if (completedNodeIds_.isEmpty()) {
             completedNodeIds_ = other.completedNodeIds_;
-            bitField0_ = (bitField0_ & ~0x00004000);
+            bitField0_ = (bitField0_ & ~0x00008000);
           } else {
             ensureCompletedNodeIdsIsMutable();
             completedNodeIds_.addAll(other.completedNodeIds_);
@@ -3696,11 +3828,251 @@ public final class KogitoProcessInstanceProtobuf {
         return swimlaneContextBuilder_;
       }
 
+      private java.util.List<org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable> transportContext_ =
+        java.util.Collections.emptyList();
+      private void ensureTransportContextIsMutable() {
+        if (!((bitField0_ & 0x00004000) != 0)) {
+          transportContext_ = new java.util.ArrayList<org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable>(transportContext_);
+          bitField0_ |= 0x00004000;
+         }
+      }
+
+      private com.google.protobuf.RepeatedFieldBuilderV3<
+          org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable, org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable.Builder, org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.VariableOrBuilder> transportContextBuilder_;
+
+      /**
+       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 21;</code>
+       */
+      public java.util.List<org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable> getTransportContextList() {
+        if (transportContextBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(transportContext_);
+        } else {
+          return transportContextBuilder_.getMessageList();
+        }
+      }
+      /**
+       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 21;</code>
+       */
+      public int getTransportContextCount() {
+        if (transportContextBuilder_ == null) {
+          return transportContext_.size();
+        } else {
+          return transportContextBuilder_.getCount();
+        }
+      }
+      /**
+       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 21;</code>
+       */
+      public org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable getTransportContext(int index) {
+        if (transportContextBuilder_ == null) {
+          return transportContext_.get(index);
+        } else {
+          return transportContextBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 21;</code>
+       */
+      public Builder setTransportContext(
+          int index, org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable value) {
+        if (transportContextBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureTransportContextIsMutable();
+          transportContext_.set(index, value);
+          onChanged();
+        } else {
+          transportContextBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 21;</code>
+       */
+      public Builder setTransportContext(
+          int index, org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable.Builder builderForValue) {
+        if (transportContextBuilder_ == null) {
+          ensureTransportContextIsMutable();
+          transportContext_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          transportContextBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 21;</code>
+       */
+      public Builder addTransportContext(org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable value) {
+        if (transportContextBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureTransportContextIsMutable();
+          transportContext_.add(value);
+          onChanged();
+        } else {
+          transportContextBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 21;</code>
+       */
+      public Builder addTransportContext(
+          int index, org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable value) {
+        if (transportContextBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureTransportContextIsMutable();
+          transportContext_.add(index, value);
+          onChanged();
+        } else {
+          transportContextBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 21;</code>
+       */
+      public Builder addTransportContext(
+          org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable.Builder builderForValue) {
+        if (transportContextBuilder_ == null) {
+          ensureTransportContextIsMutable();
+          transportContext_.add(builderForValue.build());
+          onChanged();
+        } else {
+          transportContextBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 21;</code>
+       */
+      public Builder addTransportContext(
+          int index, org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable.Builder builderForValue) {
+        if (transportContextBuilder_ == null) {
+          ensureTransportContextIsMutable();
+          transportContext_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          transportContextBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 21;</code>
+       */
+      public Builder addAllTransportContext(
+          java.lang.Iterable<? extends org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable> values) {
+        if (transportContextBuilder_ == null) {
+          ensureTransportContextIsMutable();
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, transportContext_);
+          onChanged();
+        } else {
+          transportContextBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 21;</code>
+       */
+      public Builder clearTransportContext() {
+        if (transportContextBuilder_ == null) {
+          transportContext_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00004000);
+          onChanged();
+        } else {
+          transportContextBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 21;</code>
+       */
+      public Builder removeTransportContext(int index) {
+        if (transportContextBuilder_ == null) {
+          ensureTransportContextIsMutable();
+          transportContext_.remove(index);
+          onChanged();
+        } else {
+          transportContextBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 21;</code>
+       */
+      public org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable.Builder getTransportContextBuilder(
+          int index) {
+        return getTransportContextFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 21;</code>
+       */
+      public org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.VariableOrBuilder getTransportContextOrBuilder(
+          int index) {
+        if (transportContextBuilder_ == null) {
+          return transportContext_.get(index);  } else {
+          return transportContextBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      /**
+       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 21;</code>
+       */
+      public java.util.List<? extends org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.VariableOrBuilder> 
+           getTransportContextOrBuilderList() {
+        if (transportContextBuilder_ != null) {
+          return transportContextBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(transportContext_);
+        }
+      }
+      /**
+       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 21;</code>
+       */
+      public org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable.Builder addTransportContextBuilder() {
+        return getTransportContextFieldBuilder().addBuilder(
+            org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 21;</code>
+       */
+      public org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable.Builder addTransportContextBuilder(
+          int index) {
+        return getTransportContextFieldBuilder().addBuilder(
+            index, org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 21;</code>
+       */
+      public java.util.List<org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable.Builder> 
+           getTransportContextBuilderList() {
+        return getTransportContextFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilderV3<
+          org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable, org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable.Builder, org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.VariableOrBuilder> 
+          getTransportContextFieldBuilder() {
+        if (transportContextBuilder_ == null) {
+          transportContextBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
+              org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable, org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable.Builder, org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.VariableOrBuilder>(
+                  transportContext_,
+                  ((bitField0_ & 0x00004000) != 0),
+                  getParentForChildren(),
+                  isClean());
+          transportContext_ = null;
+        }
+        return transportContextBuilder_;
+      }
+
       private com.google.protobuf.LazyStringList completedNodeIds_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       private void ensureCompletedNodeIdsIsMutable() {
-        if (!((bitField0_ & 0x00004000) != 0)) {
+        if (!((bitField0_ & 0x00008000) != 0)) {
           completedNodeIds_ = new com.google.protobuf.LazyStringArrayList(completedNodeIds_);
-          bitField0_ |= 0x00004000;
+          bitField0_ |= 0x00008000;
          }
       }
       /**
@@ -3785,7 +4157,7 @@ public final class KogitoProcessInstanceProtobuf {
        */
       public Builder clearCompletedNodeIds() {
         completedNodeIds_ = com.google.protobuf.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00004000);
+        bitField0_ = (bitField0_ & ~0x00008000);
         onChanged();
         return this;
       }
@@ -3876,7 +4248,7 @@ public final class KogitoProcessInstanceProtobuf {
       "rotobuf/kogito_process_instance.proto\022-o" +
       "rg.kie.kogito.serialization.process.prot" +
       "obuf\032@org/kie/kogito/serialization/proce" +
-      "ss/protobuf/kogito_types.proto\"\312\007\n\017Proce" +
+      "ss/protobuf/kogito_types.proto\"\236\010\n\017Proce" +
       "ssInstance\022\024\n\014process_type\030\001 \001(\t\022\022\n\nproc" +
       "ess_id\030\002 \001(\t\022\n\n\002id\030\003 \001(\t\022\'\n\032parent_proce" +
       "ss_instance_id\030\004 \001(\tH\000\210\001\001\022\031\n\014business_ke" +
@@ -3894,15 +4266,17 @@ public final class KogitoProcessInstanceProtobuf {
       "ation.process.protobuf.WorkflowContextH\014" +
       "\210\001\001\022X\n\020swimlane_context\030\023 \003(\0132>.org.kie." +
       "kogito.serialization.process.protobuf.Sw" +
-      "imlaneContext\022\030\n\020completedNodeIds\030\024 \003(\tB" +
-      "\035\n\033_parent_process_instance_idB\017\n\r_busin" +
-      "ess_keyB\017\n\r_deploymentIdB\016\n\014_description" +
-      "B\r\n\013_start_dateB\030\n\026_node_instance_counte" +
-      "rB\033\n\031_root_process_instance_idB\022\n\020_root_" +
-      "process_idB\020\n\016_error_node_idB\020\n\016_error_m" +
-      "essageB\017\n\r_reference_idB\006\n\004_slaB\n\n\010_cont" +
-      "extB\037B\035KogitoProcessInstanceProtobufb\006pr" +
-      "oto3"
+      "imlaneContext\022R\n\021transport_context\030\025 \003(\013" +
+      "27.org.kie.kogito.serialization.process." +
+      "protobuf.Variable\022\030\n\020completedNodeIds\030\024 " +
+      "\003(\tB\035\n\033_parent_process_instance_idB\017\n\r_b" +
+      "usiness_keyB\017\n\r_deploymentIdB\016\n\014_descrip" +
+      "tionB\r\n\013_start_dateB\030\n\026_node_instance_co" +
+      "unterB\033\n\031_root_process_instance_idB\022\n\020_r" +
+      "oot_process_idB\020\n\016_error_node_idB\020\n\016_err" +
+      "or_messageB\017\n\r_reference_idB\006\n\004_slaB\n\n\010_" +
+      "contextB\037B\035KogitoProcessInstanceProtobuf" +
+      "b\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -3914,7 +4288,7 @@ public final class KogitoProcessInstanceProtobuf {
     internal_static_org_kie_kogito_serialization_process_protobuf_ProcessInstance_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_org_kie_kogito_serialization_process_protobuf_ProcessInstance_descriptor,
-        new java.lang.String[] { "ProcessType", "ProcessId", "Id", "ParentProcessInstanceId", "BusinessKey", "DeploymentId", "Description", "State", "StartDate", "NodeInstanceCounter", "SignalCompletion", "RootProcessInstanceId", "RootProcessId", "ErrorNodeId", "ErrorMessage", "ReferenceId", "Sla", "Context", "SwimlaneContext", "CompletedNodeIds", "ParentProcessInstanceId", "BusinessKey", "DeploymentId", "Description", "StartDate", "NodeInstanceCounter", "RootProcessInstanceId", "RootProcessId", "ErrorNodeId", "ErrorMessage", "ReferenceId", "Sla", "Context", });
+        new java.lang.String[] { "ProcessType", "ProcessId", "Id", "ParentProcessInstanceId", "BusinessKey", "DeploymentId", "Description", "State", "StartDate", "NodeInstanceCounter", "SignalCompletion", "RootProcessInstanceId", "RootProcessId", "ErrorNodeId", "ErrorMessage", "ReferenceId", "Sla", "Context", "SwimlaneContext", "TransportContext", "CompletedNodeIds", "ParentProcessInstanceId", "BusinessKey", "DeploymentId", "Description", "StartDate", "NodeInstanceCounter", "RootProcessInstanceId", "RootProcessId", "ErrorNodeId", "ErrorMessage", "ReferenceId", "Sla", "Context", });
     org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.getDescriptor();
   }
 

--- a/jbpm/process-serialization-protobuf/src/main/java/org/kie/kogito/serialization/process/protobuf/KogitoTypesProtobuf.java
+++ b/jbpm/process-serialization-protobuf/src/main/java/org/kie/kogito/serialization/process/protobuf/KogitoTypesProtobuf.java
@@ -2313,6 +2313,30 @@ public final class KogitoTypesProtobuf {
      */
     org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.IterationLevelOrBuilder getIterationLevelsOrBuilder(
         int index);
+
+    /**
+     * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
+     */
+    java.util.List<org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable> 
+        getTransportContextList();
+    /**
+     * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
+     */
+    org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable getTransportContext(int index);
+    /**
+     * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
+     */
+    int getTransportContextCount();
+    /**
+     * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
+     */
+    java.util.List<? extends org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.VariableOrBuilder> 
+        getTransportContextOrBuilderList();
+    /**
+     * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
+     */
+    org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.VariableOrBuilder getTransportContextOrBuilder(
+        int index);
   }
   /**
    * Protobuf type {@code org.kie.kogito.serialization.process.protobuf.WorkflowContext}
@@ -2331,6 +2355,7 @@ public final class KogitoTypesProtobuf {
       nodeInstance_ = java.util.Collections.emptyList();
       exclusiveGroup_ = java.util.Collections.emptyList();
       iterationLevels_ = java.util.Collections.emptyList();
+      transportContext_ = java.util.Collections.emptyList();
     }
 
     @java.lang.Override
@@ -2400,6 +2425,15 @@ public final class KogitoTypesProtobuf {
                   input.readMessage(org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.IterationLevel.parser(), extensionRegistry));
               break;
             }
+            case 42: {
+              if (!((mutable_bitField0_ & 0x00000010) != 0)) {
+                transportContext_ = new java.util.ArrayList<org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable>();
+                mutable_bitField0_ |= 0x00000010;
+              }
+              transportContext_.add(
+                  input.readMessage(org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable.parser(), extensionRegistry));
+              break;
+            }
             default: {
               if (!parseUnknownField(
                   input, unknownFields, extensionRegistry, tag)) {
@@ -2426,6 +2460,9 @@ public final class KogitoTypesProtobuf {
         }
         if (((mutable_bitField0_ & 0x00000008) != 0)) {
           iterationLevels_ = java.util.Collections.unmodifiableList(iterationLevels_);
+        }
+        if (((mutable_bitField0_ & 0x00000010) != 0)) {
+          transportContext_ = java.util.Collections.unmodifiableList(transportContext_);
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -2604,6 +2641,46 @@ public final class KogitoTypesProtobuf {
       return iterationLevels_.get(index);
     }
 
+    public static final int TRANSPORT_CONTEXT_FIELD_NUMBER = 5;
+    private java.util.List<org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable> transportContext_;
+    /**
+     * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
+     */
+    @java.lang.Override
+    public java.util.List<org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable> getTransportContextList() {
+      return transportContext_;
+    }
+    /**
+     * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
+     */
+    @java.lang.Override
+    public java.util.List<? extends org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.VariableOrBuilder> 
+        getTransportContextOrBuilderList() {
+      return transportContext_;
+    }
+    /**
+     * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
+     */
+    @java.lang.Override
+    public int getTransportContextCount() {
+      return transportContext_.size();
+    }
+    /**
+     * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
+     */
+    @java.lang.Override
+    public org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable getTransportContext(int index) {
+      return transportContext_.get(index);
+    }
+    /**
+     * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
+     */
+    @java.lang.Override
+    public org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.VariableOrBuilder getTransportContextOrBuilder(
+        int index) {
+      return transportContext_.get(index);
+    }
+
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -2630,6 +2707,9 @@ public final class KogitoTypesProtobuf {
       for (int i = 0; i < iterationLevels_.size(); i++) {
         output.writeMessage(4, iterationLevels_.get(i));
       }
+      for (int i = 0; i < transportContext_.size(); i++) {
+        output.writeMessage(5, transportContext_.get(i));
+      }
       unknownFields.writeTo(output);
     }
 
@@ -2655,6 +2735,10 @@ public final class KogitoTypesProtobuf {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(4, iterationLevels_.get(i));
       }
+      for (int i = 0; i < transportContext_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(5, transportContext_.get(i));
+      }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
       return size;
@@ -2678,6 +2762,8 @@ public final class KogitoTypesProtobuf {
           .equals(other.getExclusiveGroupList())) return false;
       if (!getIterationLevelsList()
           .equals(other.getIterationLevelsList())) return false;
+      if (!getTransportContextList()
+          .equals(other.getTransportContextList())) return false;
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
     }
@@ -2704,6 +2790,10 @@ public final class KogitoTypesProtobuf {
       if (getIterationLevelsCount() > 0) {
         hash = (37 * hash) + ITERATIONLEVELS_FIELD_NUMBER;
         hash = (53 * hash) + getIterationLevelsList().hashCode();
+      }
+      if (getTransportContextCount() > 0) {
+        hash = (37 * hash) + TRANSPORT_CONTEXT_FIELD_NUMBER;
+        hash = (53 * hash) + getTransportContextList().hashCode();
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -2837,6 +2927,7 @@ public final class KogitoTypesProtobuf {
           getNodeInstanceFieldBuilder();
           getExclusiveGroupFieldBuilder();
           getIterationLevelsFieldBuilder();
+          getTransportContextFieldBuilder();
         }
       }
       @java.lang.Override
@@ -2865,6 +2956,12 @@ public final class KogitoTypesProtobuf {
           bitField0_ = (bitField0_ & ~0x00000008);
         } else {
           iterationLevelsBuilder_.clear();
+        }
+        if (transportContextBuilder_ == null) {
+          transportContext_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000010);
+        } else {
+          transportContextBuilder_.clear();
         }
         return this;
       }
@@ -2928,6 +3025,15 @@ public final class KogitoTypesProtobuf {
           result.iterationLevels_ = iterationLevels_;
         } else {
           result.iterationLevels_ = iterationLevelsBuilder_.build();
+        }
+        if (transportContextBuilder_ == null) {
+          if (((bitField0_ & 0x00000010) != 0)) {
+            transportContext_ = java.util.Collections.unmodifiableList(transportContext_);
+            bitField0_ = (bitField0_ & ~0x00000010);
+          }
+          result.transportContext_ = transportContext_;
+        } else {
+          result.transportContext_ = transportContextBuilder_.build();
         }
         onBuilt();
         return result;
@@ -3078,6 +3184,32 @@ public final class KogitoTypesProtobuf {
                    getIterationLevelsFieldBuilder() : null;
             } else {
               iterationLevelsBuilder_.addAllMessages(other.iterationLevels_);
+            }
+          }
+        }
+        if (transportContextBuilder_ == null) {
+          if (!other.transportContext_.isEmpty()) {
+            if (transportContext_.isEmpty()) {
+              transportContext_ = other.transportContext_;
+              bitField0_ = (bitField0_ & ~0x00000010);
+            } else {
+              ensureTransportContextIsMutable();
+              transportContext_.addAll(other.transportContext_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.transportContext_.isEmpty()) {
+            if (transportContextBuilder_.isEmpty()) {
+              transportContextBuilder_.dispose();
+              transportContextBuilder_ = null;
+              transportContext_ = other.transportContext_;
+              bitField0_ = (bitField0_ & ~0x00000010);
+              transportContextBuilder_ = 
+                com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
+                   getTransportContextFieldBuilder() : null;
+            } else {
+              transportContextBuilder_.addAllMessages(other.transportContext_);
             }
           }
         }
@@ -4069,6 +4201,246 @@ public final class KogitoTypesProtobuf {
           iterationLevels_ = null;
         }
         return iterationLevelsBuilder_;
+      }
+
+      private java.util.List<org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable> transportContext_ =
+        java.util.Collections.emptyList();
+      private void ensureTransportContextIsMutable() {
+        if (!((bitField0_ & 0x00000010) != 0)) {
+          transportContext_ = new java.util.ArrayList<org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable>(transportContext_);
+          bitField0_ |= 0x00000010;
+         }
+      }
+
+      private com.google.protobuf.RepeatedFieldBuilderV3<
+          org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable, org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable.Builder, org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.VariableOrBuilder> transportContextBuilder_;
+
+      /**
+       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
+       */
+      public java.util.List<org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable> getTransportContextList() {
+        if (transportContextBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(transportContext_);
+        } else {
+          return transportContextBuilder_.getMessageList();
+        }
+      }
+      /**
+       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
+       */
+      public int getTransportContextCount() {
+        if (transportContextBuilder_ == null) {
+          return transportContext_.size();
+        } else {
+          return transportContextBuilder_.getCount();
+        }
+      }
+      /**
+       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
+       */
+      public org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable getTransportContext(int index) {
+        if (transportContextBuilder_ == null) {
+          return transportContext_.get(index);
+        } else {
+          return transportContextBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
+       */
+      public Builder setTransportContext(
+          int index, org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable value) {
+        if (transportContextBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureTransportContextIsMutable();
+          transportContext_.set(index, value);
+          onChanged();
+        } else {
+          transportContextBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
+       */
+      public Builder setTransportContext(
+          int index, org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable.Builder builderForValue) {
+        if (transportContextBuilder_ == null) {
+          ensureTransportContextIsMutable();
+          transportContext_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          transportContextBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
+       */
+      public Builder addTransportContext(org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable value) {
+        if (transportContextBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureTransportContextIsMutable();
+          transportContext_.add(value);
+          onChanged();
+        } else {
+          transportContextBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
+       */
+      public Builder addTransportContext(
+          int index, org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable value) {
+        if (transportContextBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureTransportContextIsMutable();
+          transportContext_.add(index, value);
+          onChanged();
+        } else {
+          transportContextBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
+       */
+      public Builder addTransportContext(
+          org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable.Builder builderForValue) {
+        if (transportContextBuilder_ == null) {
+          ensureTransportContextIsMutable();
+          transportContext_.add(builderForValue.build());
+          onChanged();
+        } else {
+          transportContextBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
+       */
+      public Builder addTransportContext(
+          int index, org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable.Builder builderForValue) {
+        if (transportContextBuilder_ == null) {
+          ensureTransportContextIsMutable();
+          transportContext_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          transportContextBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
+       */
+      public Builder addAllTransportContext(
+          java.lang.Iterable<? extends org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable> values) {
+        if (transportContextBuilder_ == null) {
+          ensureTransportContextIsMutable();
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, transportContext_);
+          onChanged();
+        } else {
+          transportContextBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
+       */
+      public Builder clearTransportContext() {
+        if (transportContextBuilder_ == null) {
+          transportContext_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000010);
+          onChanged();
+        } else {
+          transportContextBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
+       */
+      public Builder removeTransportContext(int index) {
+        if (transportContextBuilder_ == null) {
+          ensureTransportContextIsMutable();
+          transportContext_.remove(index);
+          onChanged();
+        } else {
+          transportContextBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
+       */
+      public org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable.Builder getTransportContextBuilder(
+          int index) {
+        return getTransportContextFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
+       */
+      public org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.VariableOrBuilder getTransportContextOrBuilder(
+          int index) {
+        if (transportContextBuilder_ == null) {
+          return transportContext_.get(index);  } else {
+          return transportContextBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      /**
+       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
+       */
+      public java.util.List<? extends org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.VariableOrBuilder> 
+           getTransportContextOrBuilderList() {
+        if (transportContextBuilder_ != null) {
+          return transportContextBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(transportContext_);
+        }
+      }
+      /**
+       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
+       */
+      public org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable.Builder addTransportContextBuilder() {
+        return getTransportContextFieldBuilder().addBuilder(
+            org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
+       */
+      public org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable.Builder addTransportContextBuilder(
+          int index) {
+        return getTransportContextFieldBuilder().addBuilder(
+            index, org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
+       */
+      public java.util.List<org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable.Builder> 
+           getTransportContextBuilderList() {
+        return getTransportContextFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilderV3<
+          org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable, org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable.Builder, org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.VariableOrBuilder> 
+          getTransportContextFieldBuilder() {
+        if (transportContextBuilder_ == null) {
+          transportContextBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
+              org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable, org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable.Builder, org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.VariableOrBuilder>(
+                  transportContext_,
+                  ((bitField0_ & 0x00000010) != 0),
+                  getParentForChildren(),
+                  isClean());
+          transportContext_ = null;
+        }
+        return transportContextBuilder_;
       }
       @java.lang.Override
       public final Builder setUnknownFields(
@@ -7103,7 +7475,7 @@ public final class KogitoTypesProtobuf {
       " \001(\003H\001\210\001\001\022K\n\003sla\030\006 \001(\01329.org.kie.kogito." +
       "serialization.process.protobuf.SLAContex" +
       "tH\002\210\001\001B\010\n\006_levelB\017\n\r_trigger_dateB\006\n\004_sl" +
-      "a\"\343\002\n\017WorkflowContext\022I\n\010variable\030\001 \003(\0132" +
+      "a\"\267\003\n\017WorkflowContext\022I\n\010variable\030\001 \003(\0132" +
       "7.org.kie.kogito.serialization.process.p" +
       "rotobuf.Variable\022R\n\rnode_instance\030\002 \003(\0132" +
       ";.org.kie.kogito.serialization.process.p" +
@@ -7111,17 +7483,20 @@ public final class KogitoTypesProtobuf {
       "\003 \003(\0132@.org.kie.kogito.serialization.pro" +
       "cess.protobuf.NodeInstanceGroup\022V\n\017itera" +
       "tionLevels\030\004 \003(\0132=.org.kie.kogito.serial" +
-      "ization.process.protobuf.IterationLevel\"" +
-      "Y\n\017SwimlaneContext\022\025\n\010swimlane\030\001 \001(\tH\000\210\001" +
-      "\001\022\025\n\010actor_id\030\002 \001(\tH\001\210\001\001B\013\n\t_swimlaneB\013\n" +
-      "\t_actor_id\"\224\001\n\nSLAContext\022\031\n\014sla_timer_i" +
-      "d\030\001 \001(\tH\000\210\001\001\022\031\n\014sla_due_date\030\002 \001(\003H\001\210\001\001\022" +
-      "\033\n\016sla_compliance\030\003 \001(\005H\002\210\001\001B\017\n\r_sla_tim" +
-      "er_idB\017\n\r_sla_due_dateB\021\n\017_sla_complianc" +
-      "e\"F\n\016IterationLevel\022\017\n\002id\030\001 \001(\tH\000\210\001\001\022\022\n\005" +
-      "level\030\002 \001(\005H\001\210\001\001B\005\n\003_idB\010\n\006_level\"3\n\021Nod" +
-      "eInstanceGroup\022\036\n\026group_node_instance_id" +
-      "\030\001 \003(\tB\025B\023KogitoTypesProtobufb\006proto3"
+      "ization.process.protobuf.IterationLevel\022" +
+      "R\n\021transport_context\030\005 \003(\01327.org.kie.kog" +
+      "ito.serialization.process.protobuf.Varia" +
+      "ble\"Y\n\017SwimlaneContext\022\025\n\010swimlane\030\001 \001(\t" +
+      "H\000\210\001\001\022\025\n\010actor_id\030\002 \001(\tH\001\210\001\001B\013\n\t_swimlan" +
+      "eB\013\n\t_actor_id\"\224\001\n\nSLAContext\022\031\n\014sla_tim" +
+      "er_id\030\001 \001(\tH\000\210\001\001\022\031\n\014sla_due_date\030\002 \001(\003H\001" +
+      "\210\001\001\022\033\n\016sla_compliance\030\003 \001(\005H\002\210\001\001B\017\n\r_sla" +
+      "_timer_idB\017\n\r_sla_due_dateB\021\n\017_sla_compl" +
+      "iance\"F\n\016IterationLevel\022\017\n\002id\030\001 \001(\tH\000\210\001\001" +
+      "\022\022\n\005level\030\002 \001(\005H\001\210\001\001B\005\n\003_idB\010\n\006_level\"3\n" +
+      "\021NodeInstanceGroup\022\036\n\026group_node_instanc" +
+      "e_id\030\001 \003(\tB\025B\023KogitoTypesProtobufb\006proto" +
+      "3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -7145,7 +7520,7 @@ public final class KogitoTypesProtobuf {
     internal_static_org_kie_kogito_serialization_process_protobuf_WorkflowContext_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_org_kie_kogito_serialization_process_protobuf_WorkflowContext_descriptor,
-        new java.lang.String[] { "Variable", "NodeInstance", "ExclusiveGroup", "IterationLevels", });
+        new java.lang.String[] { "Variable", "NodeInstance", "ExclusiveGroup", "IterationLevels", "TransportContext", });
     internal_static_org_kie_kogito_serialization_process_protobuf_SwimlaneContext_descriptor =
       getDescriptor().getMessageTypes().get(3);
     internal_static_org_kie_kogito_serialization_process_protobuf_SwimlaneContext_fieldAccessorTable = new

--- a/jbpm/process-serialization-protobuf/src/main/java/org/kie/kogito/serialization/process/protobuf/KogitoTypesProtobuf.java
+++ b/jbpm/process-serialization-protobuf/src/main/java/org/kie/kogito/serialization/process/protobuf/KogitoTypesProtobuf.java
@@ -2313,30 +2313,6 @@ public final class KogitoTypesProtobuf {
      */
     org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.IterationLevelOrBuilder getIterationLevelsOrBuilder(
         int index);
-
-    /**
-     * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
-     */
-    java.util.List<org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable> 
-        getTransportContextList();
-    /**
-     * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
-     */
-    org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable getTransportContext(int index);
-    /**
-     * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
-     */
-    int getTransportContextCount();
-    /**
-     * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
-     */
-    java.util.List<? extends org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.VariableOrBuilder> 
-        getTransportContextOrBuilderList();
-    /**
-     * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
-     */
-    org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.VariableOrBuilder getTransportContextOrBuilder(
-        int index);
   }
   /**
    * Protobuf type {@code org.kie.kogito.serialization.process.protobuf.WorkflowContext}
@@ -2355,7 +2331,6 @@ public final class KogitoTypesProtobuf {
       nodeInstance_ = java.util.Collections.emptyList();
       exclusiveGroup_ = java.util.Collections.emptyList();
       iterationLevels_ = java.util.Collections.emptyList();
-      transportContext_ = java.util.Collections.emptyList();
     }
 
     @java.lang.Override
@@ -2425,15 +2400,6 @@ public final class KogitoTypesProtobuf {
                   input.readMessage(org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.IterationLevel.parser(), extensionRegistry));
               break;
             }
-            case 42: {
-              if (!((mutable_bitField0_ & 0x00000010) != 0)) {
-                transportContext_ = new java.util.ArrayList<org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable>();
-                mutable_bitField0_ |= 0x00000010;
-              }
-              transportContext_.add(
-                  input.readMessage(org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable.parser(), extensionRegistry));
-              break;
-            }
             default: {
               if (!parseUnknownField(
                   input, unknownFields, extensionRegistry, tag)) {
@@ -2460,9 +2426,6 @@ public final class KogitoTypesProtobuf {
         }
         if (((mutable_bitField0_ & 0x00000008) != 0)) {
           iterationLevels_ = java.util.Collections.unmodifiableList(iterationLevels_);
-        }
-        if (((mutable_bitField0_ & 0x00000010) != 0)) {
-          transportContext_ = java.util.Collections.unmodifiableList(transportContext_);
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -2641,46 +2604,6 @@ public final class KogitoTypesProtobuf {
       return iterationLevels_.get(index);
     }
 
-    public static final int TRANSPORT_CONTEXT_FIELD_NUMBER = 5;
-    private java.util.List<org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable> transportContext_;
-    /**
-     * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
-     */
-    @java.lang.Override
-    public java.util.List<org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable> getTransportContextList() {
-      return transportContext_;
-    }
-    /**
-     * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
-     */
-    @java.lang.Override
-    public java.util.List<? extends org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.VariableOrBuilder> 
-        getTransportContextOrBuilderList() {
-      return transportContext_;
-    }
-    /**
-     * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
-     */
-    @java.lang.Override
-    public int getTransportContextCount() {
-      return transportContext_.size();
-    }
-    /**
-     * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
-     */
-    @java.lang.Override
-    public org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable getTransportContext(int index) {
-      return transportContext_.get(index);
-    }
-    /**
-     * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
-     */
-    @java.lang.Override
-    public org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.VariableOrBuilder getTransportContextOrBuilder(
-        int index) {
-      return transportContext_.get(index);
-    }
-
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -2707,9 +2630,6 @@ public final class KogitoTypesProtobuf {
       for (int i = 0; i < iterationLevels_.size(); i++) {
         output.writeMessage(4, iterationLevels_.get(i));
       }
-      for (int i = 0; i < transportContext_.size(); i++) {
-        output.writeMessage(5, transportContext_.get(i));
-      }
       unknownFields.writeTo(output);
     }
 
@@ -2735,10 +2655,6 @@ public final class KogitoTypesProtobuf {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(4, iterationLevels_.get(i));
       }
-      for (int i = 0; i < transportContext_.size(); i++) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(5, transportContext_.get(i));
-      }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
       return size;
@@ -2762,8 +2678,6 @@ public final class KogitoTypesProtobuf {
           .equals(other.getExclusiveGroupList())) return false;
       if (!getIterationLevelsList()
           .equals(other.getIterationLevelsList())) return false;
-      if (!getTransportContextList()
-          .equals(other.getTransportContextList())) return false;
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
     }
@@ -2790,10 +2704,6 @@ public final class KogitoTypesProtobuf {
       if (getIterationLevelsCount() > 0) {
         hash = (37 * hash) + ITERATIONLEVELS_FIELD_NUMBER;
         hash = (53 * hash) + getIterationLevelsList().hashCode();
-      }
-      if (getTransportContextCount() > 0) {
-        hash = (37 * hash) + TRANSPORT_CONTEXT_FIELD_NUMBER;
-        hash = (53 * hash) + getTransportContextList().hashCode();
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -2927,7 +2837,6 @@ public final class KogitoTypesProtobuf {
           getNodeInstanceFieldBuilder();
           getExclusiveGroupFieldBuilder();
           getIterationLevelsFieldBuilder();
-          getTransportContextFieldBuilder();
         }
       }
       @java.lang.Override
@@ -2956,12 +2865,6 @@ public final class KogitoTypesProtobuf {
           bitField0_ = (bitField0_ & ~0x00000008);
         } else {
           iterationLevelsBuilder_.clear();
-        }
-        if (transportContextBuilder_ == null) {
-          transportContext_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000010);
-        } else {
-          transportContextBuilder_.clear();
         }
         return this;
       }
@@ -3025,15 +2928,6 @@ public final class KogitoTypesProtobuf {
           result.iterationLevels_ = iterationLevels_;
         } else {
           result.iterationLevels_ = iterationLevelsBuilder_.build();
-        }
-        if (transportContextBuilder_ == null) {
-          if (((bitField0_ & 0x00000010) != 0)) {
-            transportContext_ = java.util.Collections.unmodifiableList(transportContext_);
-            bitField0_ = (bitField0_ & ~0x00000010);
-          }
-          result.transportContext_ = transportContext_;
-        } else {
-          result.transportContext_ = transportContextBuilder_.build();
         }
         onBuilt();
         return result;
@@ -3184,32 +3078,6 @@ public final class KogitoTypesProtobuf {
                    getIterationLevelsFieldBuilder() : null;
             } else {
               iterationLevelsBuilder_.addAllMessages(other.iterationLevels_);
-            }
-          }
-        }
-        if (transportContextBuilder_ == null) {
-          if (!other.transportContext_.isEmpty()) {
-            if (transportContext_.isEmpty()) {
-              transportContext_ = other.transportContext_;
-              bitField0_ = (bitField0_ & ~0x00000010);
-            } else {
-              ensureTransportContextIsMutable();
-              transportContext_.addAll(other.transportContext_);
-            }
-            onChanged();
-          }
-        } else {
-          if (!other.transportContext_.isEmpty()) {
-            if (transportContextBuilder_.isEmpty()) {
-              transportContextBuilder_.dispose();
-              transportContextBuilder_ = null;
-              transportContext_ = other.transportContext_;
-              bitField0_ = (bitField0_ & ~0x00000010);
-              transportContextBuilder_ = 
-                com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
-                   getTransportContextFieldBuilder() : null;
-            } else {
-              transportContextBuilder_.addAllMessages(other.transportContext_);
             }
           }
         }
@@ -4201,246 +4069,6 @@ public final class KogitoTypesProtobuf {
           iterationLevels_ = null;
         }
         return iterationLevelsBuilder_;
-      }
-
-      private java.util.List<org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable> transportContext_ =
-        java.util.Collections.emptyList();
-      private void ensureTransportContextIsMutable() {
-        if (!((bitField0_ & 0x00000010) != 0)) {
-          transportContext_ = new java.util.ArrayList<org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable>(transportContext_);
-          bitField0_ |= 0x00000010;
-         }
-      }
-
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable, org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable.Builder, org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.VariableOrBuilder> transportContextBuilder_;
-
-      /**
-       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
-       */
-      public java.util.List<org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable> getTransportContextList() {
-        if (transportContextBuilder_ == null) {
-          return java.util.Collections.unmodifiableList(transportContext_);
-        } else {
-          return transportContextBuilder_.getMessageList();
-        }
-      }
-      /**
-       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
-       */
-      public int getTransportContextCount() {
-        if (transportContextBuilder_ == null) {
-          return transportContext_.size();
-        } else {
-          return transportContextBuilder_.getCount();
-        }
-      }
-      /**
-       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
-       */
-      public org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable getTransportContext(int index) {
-        if (transportContextBuilder_ == null) {
-          return transportContext_.get(index);
-        } else {
-          return transportContextBuilder_.getMessage(index);
-        }
-      }
-      /**
-       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
-       */
-      public Builder setTransportContext(
-          int index, org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable value) {
-        if (transportContextBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureTransportContextIsMutable();
-          transportContext_.set(index, value);
-          onChanged();
-        } else {
-          transportContextBuilder_.setMessage(index, value);
-        }
-        return this;
-      }
-      /**
-       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
-       */
-      public Builder setTransportContext(
-          int index, org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable.Builder builderForValue) {
-        if (transportContextBuilder_ == null) {
-          ensureTransportContextIsMutable();
-          transportContext_.set(index, builderForValue.build());
-          onChanged();
-        } else {
-          transportContextBuilder_.setMessage(index, builderForValue.build());
-        }
-        return this;
-      }
-      /**
-       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
-       */
-      public Builder addTransportContext(org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable value) {
-        if (transportContextBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureTransportContextIsMutable();
-          transportContext_.add(value);
-          onChanged();
-        } else {
-          transportContextBuilder_.addMessage(value);
-        }
-        return this;
-      }
-      /**
-       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
-       */
-      public Builder addTransportContext(
-          int index, org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable value) {
-        if (transportContextBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureTransportContextIsMutable();
-          transportContext_.add(index, value);
-          onChanged();
-        } else {
-          transportContextBuilder_.addMessage(index, value);
-        }
-        return this;
-      }
-      /**
-       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
-       */
-      public Builder addTransportContext(
-          org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable.Builder builderForValue) {
-        if (transportContextBuilder_ == null) {
-          ensureTransportContextIsMutable();
-          transportContext_.add(builderForValue.build());
-          onChanged();
-        } else {
-          transportContextBuilder_.addMessage(builderForValue.build());
-        }
-        return this;
-      }
-      /**
-       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
-       */
-      public Builder addTransportContext(
-          int index, org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable.Builder builderForValue) {
-        if (transportContextBuilder_ == null) {
-          ensureTransportContextIsMutable();
-          transportContext_.add(index, builderForValue.build());
-          onChanged();
-        } else {
-          transportContextBuilder_.addMessage(index, builderForValue.build());
-        }
-        return this;
-      }
-      /**
-       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
-       */
-      public Builder addAllTransportContext(
-          java.lang.Iterable<? extends org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable> values) {
-        if (transportContextBuilder_ == null) {
-          ensureTransportContextIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, transportContext_);
-          onChanged();
-        } else {
-          transportContextBuilder_.addAllMessages(values);
-        }
-        return this;
-      }
-      /**
-       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
-       */
-      public Builder clearTransportContext() {
-        if (transportContextBuilder_ == null) {
-          transportContext_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000010);
-          onChanged();
-        } else {
-          transportContextBuilder_.clear();
-        }
-        return this;
-      }
-      /**
-       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
-       */
-      public Builder removeTransportContext(int index) {
-        if (transportContextBuilder_ == null) {
-          ensureTransportContextIsMutable();
-          transportContext_.remove(index);
-          onChanged();
-        } else {
-          transportContextBuilder_.remove(index);
-        }
-        return this;
-      }
-      /**
-       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
-       */
-      public org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable.Builder getTransportContextBuilder(
-          int index) {
-        return getTransportContextFieldBuilder().getBuilder(index);
-      }
-      /**
-       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
-       */
-      public org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.VariableOrBuilder getTransportContextOrBuilder(
-          int index) {
-        if (transportContextBuilder_ == null) {
-          return transportContext_.get(index);  } else {
-          return transportContextBuilder_.getMessageOrBuilder(index);
-        }
-      }
-      /**
-       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
-       */
-      public java.util.List<? extends org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.VariableOrBuilder> 
-           getTransportContextOrBuilderList() {
-        if (transportContextBuilder_ != null) {
-          return transportContextBuilder_.getMessageOrBuilderList();
-        } else {
-          return java.util.Collections.unmodifiableList(transportContext_);
-        }
-      }
-      /**
-       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
-       */
-      public org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable.Builder addTransportContextBuilder() {
-        return getTransportContextFieldBuilder().addBuilder(
-            org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable.getDefaultInstance());
-      }
-      /**
-       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
-       */
-      public org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable.Builder addTransportContextBuilder(
-          int index) {
-        return getTransportContextFieldBuilder().addBuilder(
-            index, org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable.getDefaultInstance());
-      }
-      /**
-       * <code>repeated .org.kie.kogito.serialization.process.protobuf.Variable transport_context = 5;</code>
-       */
-      public java.util.List<org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable.Builder> 
-           getTransportContextBuilderList() {
-        return getTransportContextFieldBuilder().getBuilderList();
-      }
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable, org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable.Builder, org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.VariableOrBuilder> 
-          getTransportContextFieldBuilder() {
-        if (transportContextBuilder_ == null) {
-          transportContextBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable, org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.Variable.Builder, org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf.VariableOrBuilder>(
-                  transportContext_,
-                  ((bitField0_ & 0x00000010) != 0),
-                  getParentForChildren(),
-                  isClean());
-          transportContext_ = null;
-        }
-        return transportContextBuilder_;
       }
       @java.lang.Override
       public final Builder setUnknownFields(
@@ -7475,7 +7103,7 @@ public final class KogitoTypesProtobuf {
       " \001(\003H\001\210\001\001\022K\n\003sla\030\006 \001(\01329.org.kie.kogito." +
       "serialization.process.protobuf.SLAContex" +
       "tH\002\210\001\001B\010\n\006_levelB\017\n\r_trigger_dateB\006\n\004_sl" +
-      "a\"\267\003\n\017WorkflowContext\022I\n\010variable\030\001 \003(\0132" +
+      "a\"\343\002\n\017WorkflowContext\022I\n\010variable\030\001 \003(\0132" +
       "7.org.kie.kogito.serialization.process.p" +
       "rotobuf.Variable\022R\n\rnode_instance\030\002 \003(\0132" +
       ";.org.kie.kogito.serialization.process.p" +
@@ -7483,20 +7111,17 @@ public final class KogitoTypesProtobuf {
       "\003 \003(\0132@.org.kie.kogito.serialization.pro" +
       "cess.protobuf.NodeInstanceGroup\022V\n\017itera" +
       "tionLevels\030\004 \003(\0132=.org.kie.kogito.serial" +
-      "ization.process.protobuf.IterationLevel\022" +
-      "R\n\021transport_context\030\005 \003(\01327.org.kie.kog" +
-      "ito.serialization.process.protobuf.Varia" +
-      "ble\"Y\n\017SwimlaneContext\022\025\n\010swimlane\030\001 \001(\t" +
-      "H\000\210\001\001\022\025\n\010actor_id\030\002 \001(\tH\001\210\001\001B\013\n\t_swimlan" +
-      "eB\013\n\t_actor_id\"\224\001\n\nSLAContext\022\031\n\014sla_tim" +
-      "er_id\030\001 \001(\tH\000\210\001\001\022\031\n\014sla_due_date\030\002 \001(\003H\001" +
-      "\210\001\001\022\033\n\016sla_compliance\030\003 \001(\005H\002\210\001\001B\017\n\r_sla" +
-      "_timer_idB\017\n\r_sla_due_dateB\021\n\017_sla_compl" +
-      "iance\"F\n\016IterationLevel\022\017\n\002id\030\001 \001(\tH\000\210\001\001" +
-      "\022\022\n\005level\030\002 \001(\005H\001\210\001\001B\005\n\003_idB\010\n\006_level\"3\n" +
-      "\021NodeInstanceGroup\022\036\n\026group_node_instanc" +
-      "e_id\030\001 \003(\tB\025B\023KogitoTypesProtobufb\006proto" +
-      "3"
+      "ization.process.protobuf.IterationLevel\"" +
+      "Y\n\017SwimlaneContext\022\025\n\010swimlane\030\001 \001(\tH\000\210\001" +
+      "\001\022\025\n\010actor_id\030\002 \001(\tH\001\210\001\001B\013\n\t_swimlaneB\013\n" +
+      "\t_actor_id\"\224\001\n\nSLAContext\022\031\n\014sla_timer_i" +
+      "d\030\001 \001(\tH\000\210\001\001\022\031\n\014sla_due_date\030\002 \001(\003H\001\210\001\001\022" +
+      "\033\n\016sla_compliance\030\003 \001(\005H\002\210\001\001B\017\n\r_sla_tim" +
+      "er_idB\017\n\r_sla_due_dateB\021\n\017_sla_complianc" +
+      "e\"F\n\016IterationLevel\022\017\n\002id\030\001 \001(\tH\000\210\001\001\022\022\n\005" +
+      "level\030\002 \001(\005H\001\210\001\001B\005\n\003_idB\010\n\006_level\"3\n\021Nod" +
+      "eInstanceGroup\022\036\n\026group_node_instance_id" +
+      "\030\001 \003(\tB\025B\023KogitoTypesProtobufb\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -7520,7 +7145,7 @@ public final class KogitoTypesProtobuf {
     internal_static_org_kie_kogito_serialization_process_protobuf_WorkflowContext_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_org_kie_kogito_serialization_process_protobuf_WorkflowContext_descriptor,
-        new java.lang.String[] { "Variable", "NodeInstance", "ExclusiveGroup", "IterationLevels", "TransportContext", });
+        new java.lang.String[] { "Variable", "NodeInstance", "ExclusiveGroup", "IterationLevels", });
     internal_static_org_kie_kogito_serialization_process_protobuf_SwimlaneContext_descriptor =
       getDescriptor().getMessageTypes().get(3);
     internal_static_org_kie_kogito_serialization_process_protobuf_SwimlaneContext_fieldAccessorTable = new

--- a/jbpm/process-serialization-protobuf/src/main/resources/org/kie/kogito/serialization/process/protobuf/kogito_process_instance.proto
+++ b/jbpm/process-serialization-protobuf/src/main/resources/org/kie/kogito/serialization/process/protobuf/kogito_process_instance.proto
@@ -34,6 +34,7 @@ message ProcessInstance {
 
     optional WorkflowContext context = 18;
     repeated SwimlaneContext swimlane_context = 19;
+    repeated Variable transport_context = 21;
 
     repeated string completedNodeIds = 20;
 

--- a/jbpm/process-serialization-protobuf/src/main/resources/org/kie/kogito/serialization/process/protobuf/kogito_types.proto
+++ b/jbpm/process-serialization-protobuf/src/main/resources/org/kie/kogito/serialization/process/protobuf/kogito_types.proto
@@ -28,6 +28,7 @@ message WorkflowContext {
     repeated NodeInstance node_instance = 2;
     repeated NodeInstanceGroup exclusive_group = 3;
     repeated IterationLevel iterationLevels = 4;
+    repeated Variable transport_context = 5;
 }
 
 message SwimlaneContext {

--- a/jbpm/process-serialization-protobuf/src/main/resources/org/kie/kogito/serialization/process/protobuf/kogito_types.proto
+++ b/jbpm/process-serialization-protobuf/src/main/resources/org/kie/kogito/serialization/process/protobuf/kogito_types.proto
@@ -28,7 +28,6 @@ message WorkflowContext {
     repeated NodeInstance node_instance = 2;
     repeated NodeInstanceGroup exclusive_group = 3;
     repeated IterationLevel iterationLevels = 4;
-    repeated Variable transport_context = 5;
 }
 
 message SwimlaneContext {

--- a/kogito-codegen-modules/kogito-codegen-core/src/main/java/org/kie/kogito/codegen/core/CodegenUtils.java
+++ b/kogito-codegen-modules/kogito-codegen-core/src/main/java/org/kie/kogito/codegen/core/CodegenUtils.java
@@ -137,6 +137,10 @@ public class CodegenUtils {
         return fd.getElementType().isClassOrInterfaceType() && fd.getElementType().asClassOrInterfaceType().getNameAsString().equals("Application");
     }
 
+    public static boolean isConfigBean(FieldDeclaration fd) {
+        return fd.getElementType().asClassOrInterfaceType().getNameAsString().equals("ConfigBean");
+    }
+
     public static boolean isObjectMapperField(FieldDeclaration fd) {
         return fd.getElementType().isClassOrInterfaceType() && fd.getElementType().asClassOrInterfaceType().getNameAsString().equals("ObjectMapper");
     }

--- a/kogito-codegen-modules/kogito-codegen-core/src/main/resources/class-templates/config/ConfigBeanQuarkusTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-core/src/main/resources/class-templates/config/ConfigBeanQuarkusTemplate.java
@@ -25,10 +25,14 @@ public class ConfigBean extends org.kie.kogito.conf.StaticConfigBean {
     @org.eclipse.microprofile.config.inject.ConfigProperty(name = "kogito.messaging.as-cloudevents", defaultValue="true")
     boolean useCloudEvents;
 
+    @javax.inject.Inject
+    javax.enterprise.inject.Instance<org.kie.kogito.transport.TransportFilter> transportFilters;
+
     @javax.annotation.PostConstruct
     protected void init() {
         setServiceUrl(kogitoService.orElse(""));
         setCloudEvents(useCloudEvents);
         setGav($gav$);
+        setTransportConfig(new org.kie.kogito.transport.TransportConfig(transportFilters));
     }
 }

--- a/kogito-codegen-modules/kogito-codegen-core/src/main/resources/class-templates/config/ConfigBeanSpringTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-core/src/main/resources/class-templates/config/ConfigBeanSpringTemplate.java
@@ -24,10 +24,14 @@ public class ConfigBean extends org.kie.kogito.conf.StaticConfigBean {
     @org.springframework.beans.factory.annotation.Value("${kogito.messaging.as-cloudevents:#{true}}")
     boolean useCloudEvents;
 
+    @org.springframework.beans.factory.annotation.Autowired(required = false)
+    java.util.List<org.kie.kogito.transport.TransportFilter> transportFilters;
+
     @javax.annotation.PostConstruct
     protected void init() {
         setServiceUrl(kogitoService.orElse(""));
         setCloudEvents(useCloudEvents);
         setGav($gav$);
+        setTransportConfig(new org.kie.kogito.transport.TransportConfig(transportFilters));
     }
 }

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/ProcessInstanceGenerator.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/ProcessInstanceGenerator.java
@@ -49,7 +49,6 @@ public class ProcessInstanceGenerator {
     private final ModelMetaData model;
     private final String canonicalName;
     private final String targetTypeName;
-    private final String targetCanonicalName;
     private final String generatedFilePath;
     private final String completePath;
 
@@ -63,7 +62,7 @@ public class ProcessInstanceGenerator {
         this.model = model;
         this.canonicalName = packageName + "." + typeName;
         this.targetTypeName = typeName + "ProcessInstance";
-        this.targetCanonicalName = packageName + "." + targetTypeName;
+        String targetCanonicalName = packageName + "." + targetTypeName;
         this.generatedFilePath = targetCanonicalName.replace('.', '/') + ".java";
         this.completePath = "src/main/java/" + generatedFilePath;
     }

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/RestResourceQuarkusTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/RestResourceQuarkusTemplate.java
@@ -43,17 +43,20 @@ import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 import javax.ws.rs.core.Response.Status;
 
+
 import org.jbpm.util.JsonSchemaUtil;
+import org.kie.kogito.conf.ConfigBean;
 import org.kie.kogito.process.Process;
 import org.kie.kogito.process.ProcessInstance;
-import org.kie.kogito.process.WorkItem;
 import org.kie.kogito.process.ProcessService;
+import org.kie.kogito.process.WorkItem;
 import org.kie.kogito.process.workitem.Attachment;
 import org.kie.kogito.process.workitem.AttachmentInfo;
 import org.kie.kogito.process.workitem.Comment;
 import org.kie.kogito.process.workitem.Policies;
 import org.kie.kogito.process.workitem.TaskModel;
 import org.kie.kogito.auth.IdentityProvider;
+import org.kie.kogito.transport.TransportConfig;
 
 @Path("/$name$")
 public class $Type$Resource {
@@ -62,6 +65,9 @@ public class $Type$Resource {
 
     @Inject
     ProcessService processService;
+
+    @Inject
+    ConfigBean configBean;
 
     @POST
     @Produces(MediaType.APPLICATION_JSON)
@@ -74,6 +80,7 @@ public class $Type$Resource {
                                                                           businessKey,
                                                                           Optional.ofNullable(resource).orElse(new $Type$Input()).toModel(),
                                                                           httpHeaders.getHeaderString("X-KOGITO-StartFromNode"));
+        addTransportHeaders(pi, httpHeaders);
         return Response.created(uriInfo.getAbsolutePathBuilder().path(pi.id()).build())
                 .entity(pi.checkError().variables().toModel())
                 .build();
@@ -118,5 +125,11 @@ public class $Type$Resource {
                 .stream()
                 .map($TaskModelFactory$::from)
                 .collect(Collectors.toList());
+    }
+
+    private void addTransportHeaders(ProcessInstance<$Type$> instance, HttpHeaders httpHeaders) {
+        Map<String, String> transportContext = configBean.transportConfig()
+                .buildContext(httpHeaders.getRequestHeaders());
+        instance.setContextAttr(TransportConfig.TRANSPORT_CONTEXT, transportContext);
     }
 }

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/RestResourceQuarkusTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/RestResourceQuarkusTemplate.java
@@ -43,7 +43,6 @@ import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 import javax.ws.rs.core.Response.Status;
 
-
 import org.jbpm.util.JsonSchemaUtil;
 import org.kie.kogito.conf.ConfigBean;
 import org.kie.kogito.process.Process;
@@ -79,8 +78,8 @@ public class $Type$Resource {
         ProcessInstance<$Type$> pi = processService.createProcessInstance(process,
                                                                           businessKey,
                                                                           Optional.ofNullable(resource).orElse(new $Type$Input()).toModel(),
-                                                                          httpHeaders.getHeaderString("X-KOGITO-StartFromNode"));
-        addTransportHeaders(pi, httpHeaders);
+                                                                          httpHeaders.getHeaderString("X-KOGITO-StartFromNode"),
+                                                                          configBean.transportConfig().buildContext(httpHeaders.getRequestHeaders()));
         return Response.created(uriInfo.getAbsolutePathBuilder().path(pi.id()).build())
                 .entity(pi.checkError().variables().toModel())
                 .build();
@@ -125,11 +124,5 @@ public class $Type$Resource {
                 .stream()
                 .map($TaskModelFactory$::from)
                 .collect(Collectors.toList());
-    }
-
-    private void addTransportHeaders(ProcessInstance<$Type$> instance, HttpHeaders httpHeaders) {
-        Map<String, String> transportContext = configBean.transportConfig()
-                .buildContext(httpHeaders.getRequestHeaders());
-        instance.setContextAttr(TransportConfig.TRANSPORT_CONTEXT, transportContext);
     }
 }

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/RestResourceSpringTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/RestResourceSpringTemplate.java
@@ -23,21 +23,24 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.jbpm.util.JsonSchemaUtil;
+import org.kie.kogito.auth.IdentityProvider;
+import org.kie.kogito.conf.ConfigBean;
 import org.kie.kogito.process.Process;
 import org.kie.kogito.process.ProcessInstance;
-import org.kie.kogito.process.WorkItem;
 import org.kie.kogito.process.ProcessService;
+import org.kie.kogito.process.WorkItem;
 import org.kie.kogito.process.workitem.Attachment;
 import org.kie.kogito.process.workitem.AttachmentInfo;
 import org.kie.kogito.process.workitem.Comment;
 import org.kie.kogito.process.workitem.Policies;
 import org.kie.kogito.process.workitem.TaskModel;
-import org.kie.kogito.auth.IdentityProvider;
+import org.kie.kogito.transport.TransportConfig;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -50,7 +53,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
-import org.springframework.http.ResponseEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -64,6 +66,9 @@ public class $Type$Resource {
     @Autowired
     ProcessService processService;
 
+    @Autowired
+    ConfigBean configBean;
+
     @PostMapping(produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<$Type$Output> createResource_$name$(@RequestHeader HttpHeaders httpHeaders,
                                                               @RequestParam(value = "businessKey", required = false) String businessKey,
@@ -73,6 +78,7 @@ public class $Type$Resource {
                                                                           businessKey,
                                                                           Optional.ofNullable(resource).orElse(new $Type$Input()).toModel(),
                                                                           httpHeaders.getOrEmpty("X-KOGITO-StartFromNode").stream().findFirst().orElse(null));
+        addTransportHeaders(pi, httpHeaders);
         return ResponseEntity.created(uriComponentsBuilder.path("/$name$/{id}").buildAndExpand(pi.id()).toUri())
                 .body(pi.checkError().variables().toModel());
     }
@@ -107,5 +113,10 @@ public class $Type$Resource {
                 .stream()
                 .map($TaskModelFactory$::from)
                 .collect(Collectors.toList());
+    }
+
+    private void addTransportHeaders(ProcessInstance<$Type$> instance, HttpHeaders httpHeaders) {
+        Map<String, String> transportContext = configBean.transportConfig().buildContext(httpHeaders);
+        instance.setContextAttr(TransportConfig.TRANSPORT_CONTEXT, transportContext);
     }
 }

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/RestResourceSpringTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/RestResourceSpringTemplate.java
@@ -77,8 +77,8 @@ public class $Type$Resource {
         ProcessInstance<$Type$> pi = processService.createProcessInstance(process,
                                                                           businessKey,
                                                                           Optional.ofNullable(resource).orElse(new $Type$Input()).toModel(),
-                                                                          httpHeaders.getOrEmpty("X-KOGITO-StartFromNode").stream().findFirst().orElse(null));
-        addTransportHeaders(pi, httpHeaders);
+                                                                          httpHeaders.getOrEmpty("X-KOGITO-StartFromNode").stream().findFirst().orElse(null),
+                                                                          configBean.transportConfig().buildContext(httpHeaders));
         return ResponseEntity.created(uriComponentsBuilder.path("/$name$/{id}").buildAndExpand(pi.id()).toUri())
                 .body(pi.checkError().variables().toModel());
     }
@@ -113,10 +113,5 @@ public class $Type$Resource {
                 .stream()
                 .map($TaskModelFactory$::from)
                 .collect(Collectors.toList());
-    }
-
-    private void addTransportHeaders(ProcessInstance<$Type$> instance, HttpHeaders httpHeaders) {
-        Map<String, String> transportContext = configBean.transportConfig().buildContext(httpHeaders);
-        instance.setContextAttr(TransportConfig.TRANSPORT_CONTEXT, transportContext);
     }
 }


### PR DESCRIPTION
Fix https://issues.redhat.com/browse/KOGITO-3840

Adds the concept of `TransportContext` to be handled individually by each transport (HTTP, Kafka, etc.). The transport context will include key value attributes that will be used by the TaskHandlers that also interact with transports.
The purpose is to provide the possibility to propagate such properties to external services. This is very useful for distributed tracing and transactions such as LRA.

An example is an HTTP Request that contains an LRA_HTTP_CONTEXT_HEADER HttpHeader that has to be propagated to the external services invoked by the RestTaskHandler.

The way to decide which headers to propagate will be through defining TransportFilter classes that will specify which parameters are allowed to be filtered.