### PR TITLE
KOGITO-3964 Add RequestHandler Generation for RuleUnits

### DIFF
--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/AddonsConfig.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/AddonsConfig.java
@@ -23,7 +23,8 @@ public class AddonsConfig {
             .withMonitoring(false)
             .withPrometheusMonitoring(false)
             .withKnativeEventing(false)
-            .withCloudEvents(false);
+            .withCloudEvents(false)
+            .withRequestHandlers(false);
 
     private boolean usePersistence;
     private boolean useTracing;
@@ -31,6 +32,7 @@ public class AddonsConfig {
     private boolean usePrometheusMonitoring;
     private boolean useKnativeEventing;
     private boolean useCloudEvents;
+    private boolean useRequestHandlers;
 
     public AddonsConfig withPersistence(boolean usePersistence) {
         this.usePersistence = usePersistence;
@@ -61,6 +63,11 @@ public class AddonsConfig {
         this.useCloudEvents = useCloudEvents;
         return this;
     }
+    
+    public AddonsConfig withRequestHandlers(boolean useRequestHandlers) {
+        this.useRequestHandlers = useRequestHandlers;
+        return this;
+    }
 
     public boolean usePersistence() {
         return usePersistence;
@@ -84,5 +91,9 @@ public class AddonsConfig {
 
     public boolean useCloudEvents() {
         return useCloudEvents;
+    }
+    
+    public boolean useRequestHandlers() {
+        return useRequestHandlers;
     }
 }

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
@@ -323,6 +323,7 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
             List<String> queryClasses = useRestServices ? generateQueriesEndpoint(errors, generatedFiles, ruleUnitHelper, ruleUnit) : Collections.emptyList();
 
             List<String> handlerClasses = useRequestHandlers ? generateHandlers(errors, generatedFiles, ruleUnitHelper, ruleUnit) : Collections.emptyList();
+            List<String> handlerClasses = addonsConfig.useRequestHandlers() ? generateHandlers(errors, generatedFiles, ruleUnitHelper, ruleUnit) : Collections.emptyList();
 
             List<String> allClasses = new ArrayList<>(queryClasses);
 

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
@@ -318,10 +318,14 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
             // add the label id of the rule unit with value set to `rules` as resource type
             this.addLabel(ruleUnit.label(), "rules");
             ruleUnit.setApplicationPackageName(packageName);
+            
+            if (annotator == null) {
+                generatedFiles.add(new RuleUnitDTOSourceClass(ruleUnit.getRuleUnitDescription(), ruleUnitHelper).generateFile(org.kie.kogito.codegen.GeneratedFile.Type.DTO));
+            }
+            
+            List<String> queryClasses = useRestServices ? generateQueriesEndpoint(errors, generatedFiles, ruleUnit) : Collections.emptyList();
 
-            List<String> queryClasses = useRestServices ? generateQueriesEndpoint(errors, generatedFiles, ruleUnitHelper, ruleUnit) : Collections.emptyList();
-
-            List<String> handlerClasses = useRequestHandlers ? generateHandlers(errors, generatedFiles, ruleUnitHelper, ruleUnit) : Collections.emptyList();
+            List<String> handlerClasses = useRequestHandlers ? generateHandlers(errors, generatedFiles, ruleUnit) : Collections.emptyList();
 
             List<String> allClasses = queryClasses;
             allClasses.addAll(handlerClasses);
@@ -335,29 +339,20 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
         }
     }
 
-    private List<String> generateQueriesEndpoint(List<DroolsError> errors, List<org.kie.kogito.codegen.GeneratedFile> generatedFiles, RuleUnitHelper ruleUnitHelper, RuleUnitGenerator ruleUnit) {
+    private List<String> generateQueriesEndpoint(List<DroolsError> errors, List<org.kie.kogito.codegen.GeneratedFile> generatedFiles, RuleUnitGenerator ruleUnit) {
         List<QueryEndpointGenerator> queries = ruleUnit.queries();
         if (queries.isEmpty()) {
             return Collections.emptyList();
-        }
-
-        if (annotator == null) {
-            generatedFiles.add(new RuleUnitDTOSourceClass(ruleUnit.getRuleUnitDescription(), ruleUnitHelper).generateFile(org.kie.kogito.codegen.GeneratedFile.Type.DTO));
         }
 
         return queries.stream().map(q -> generateQueryEndpoint(errors, generatedFiles, q))
                 .flatMap(o -> o.isPresent() ? Stream.of(o.get()) : Stream.empty()).collect(toList());
     }
 
-    private List<String> generateHandlers(List<DroolsError> errors, List<org.kie.kogito.codegen.GeneratedFile> generatedFiles,
-                                          RuleUnitHelper ruleUnitHelper, RuleUnitGenerator ruleUnit) {
+    private List<String> generateHandlers(List<DroolsError> errors, List<org.kie.kogito.codegen.GeneratedFile> generatedFiles, RuleUnitGenerator ruleUnit) {
         List<QueryRequestHandlerGenerator> queries = ruleUnit.queriesAsRequests();
         if (queries.isEmpty()) {
             return Collections.emptyList();
-        }
-
-        if (annotator == null) {
-            generatedFiles.add(new RuleUnitDTOSourceClass(ruleUnit.getRuleUnitDescription(), ruleUnitHelper).generateFile(org.kie.kogito.codegen.GeneratedFile.Type.DTO));
         }
 
         return queries.stream().map(q -> generateQueryRequestHandlers(errors, generatedFiles, q))

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
@@ -346,7 +346,7 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
         }
 
         return queries.stream().map(q -> generateQueryEndpoint(errors, generatedFiles, q))
-                .flatMap(o -> o.isPresent() ? Stream.of(o.get()) : Stream.empty()).collect(toList());
+                .flatMap(o -> o.map(Stream::of).orElseGet(Stream::empty)).collect(toList());
     }
 
     private List<String> generateHandlers(List<DroolsError> errors, List<org.kie.kogito.codegen.GeneratedFile> generatedFiles, RuleUnitGenerator ruleUnit) {
@@ -356,7 +356,7 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
         }
 
         return queries.stream().map(q -> generateQueryRequestHandlers(errors, generatedFiles, q))
-                .flatMap(o -> o.isPresent() ? Stream.of(o.get()) : Stream.empty()).collect(toList());
+                .flatMap(o -> o.map(Stream::of).orElseGet(Stream::empty)).collect(toList());
     }
 
     private void initRuleUnitHelper(RuleUnitHelper ruleUnitHelper, RuleUnitDescription ruleUnitDesc) {

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
@@ -327,7 +327,8 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
 
             List<String> handlerClasses = useRequestHandlers ? generateHandlers(errors, generatedFiles, ruleUnit) : Collections.emptyList();
 
-            List<String> allClasses = queryClasses;
+            List<String> allClasses = new ArrayList<>(queryClasses);
+            
             allClasses.addAll(handlerClasses);
 
             generatedFiles.add(ruleUnit.generateFile(org.kie.kogito.codegen.GeneratedFile.Type.RULE));

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/QueryRequestHandlerGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/QueryRequestHandlerGenerator.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.codegen.rules;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.ImportDeclaration;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.body.*;
+import com.github.javaparser.ast.expr.*;
+import com.github.javaparser.ast.stmt.*;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import com.github.javaparser.ast.type.Type;
+import org.drools.compiler.compiler.DroolsError;
+import org.drools.modelcompiler.builder.QueryModel;
+import org.kie.internal.ruleunit.RuleUnitDescription;
+import org.kie.kogito.codegen.AddonsConfig;
+import org.kie.kogito.codegen.BodyDeclarationComparator;
+import org.kie.kogito.codegen.FileGenerator;
+import org.kie.kogito.codegen.di.DependencyInjectionAnnotator;
+
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.github.javaparser.StaticJavaParser.*;
+import static org.drools.modelcompiler.builder.generator.DrlxParseUtil.classNameToReferenceType;
+
+public class QueryRequestHandlerGenerator implements FileGenerator {
+
+    private final RuleUnitDescription ruleUnit;
+    private final QueryModel query;
+    private final DependencyInjectionAnnotator annotator;
+
+    private final String name;
+    private final String requestHandler;
+    private final String queryClassName;
+    private final String targetCanonicalName;
+    private final String generatedFilePath;
+    private final AddonsConfig addonsConfig;
+
+    public QueryRequestHandlerGenerator(RuleUnitDescription ruleUnit, QueryModel query, DependencyInjectionAnnotator annotator, AddonsConfig addonsConfig) {
+        this.ruleUnit = ruleUnit;
+        this.query = query;
+        this.name = toCamelCase(query.getName());
+        this.requestHandler = toKebabCase(name);
+        this.annotator = annotator;
+
+        this.queryClassName = ruleUnit.getSimpleName() + "Query" + name;
+        this.targetCanonicalName = queryClassName + "RequestHandler";
+        this.generatedFilePath = (query.getNamespace() + "." + targetCanonicalName).replace('.', '/') + ".java";
+        this.addonsConfig = addonsConfig;
+    }
+
+    public QueryGenerator getQueryGenerator() {
+        return new QueryGenerator(ruleUnit, query, name);
+    }
+
+    @Override
+    public String generatedFilePath() {
+        return generatedFilePath;
+    }
+
+    @Override
+    public boolean validate() {
+        return !query.getBindings().isEmpty();
+    }
+
+    @Override
+    public DroolsError getError() {
+        if (query.getBindings().isEmpty()) {
+            return new NoBindingQuery( query );
+        }
+        return null;
+    }
+
+    public static class NoBindingQuery extends DroolsError {
+        private static final int[] ERROR_LINES = new int[0];
+
+        private final QueryModel query;
+
+        public NoBindingQuery( QueryModel query ) {
+            this.query = query;
+        }
+
+        @Override
+        public String getMessage() {
+            return "Query " + query.getName() + " has no bound variable. At least one binding is required to determine the value returned by this query";
+        }
+
+        @Override
+        public int[] getLines() {
+            return ERROR_LINES;
+        }
+    }
+
+    @Override
+    public String generate() {
+        CompilationUnit cu = parse(
+                this.getClass().getResourceAsStream("/class-templates/rules/RequestHandlerQueryTemplate.java"));
+        cu.setPackageDeclaration(query.getNamespace());
+
+        ClassOrInterfaceDeclaration clazz = cu
+                .findFirst(ClassOrInterfaceDeclaration.class)
+                .orElseThrow(() -> new NoSuchElementException("Compilation unit doesn't contain a class or interface declaration!"));
+        clazz.setName(targetCanonicalName);
+
+        cu.findAll(StringLiteralExpr.class).forEach(this::interpolateStrings);
+
+        FieldDeclaration ruleUnitDeclaration = clazz
+                .getFieldByName("ruleUnit")
+                .orElseThrow(() -> new NoSuchElementException("ClassOrInterfaceDeclaration doesn't contain a field named ruleUnit!"));
+        setUnitGeneric(ruleUnitDeclaration.getElementType());
+        if (annotator != null) {
+            annotator.withInjection(ruleUnitDeclaration);
+        }
+
+        String returnType = getReturnType(clazz);
+        generateConstructors(clazz);
+        generateInterfaces(clazz, returnType);
+        generateHandleRequestMethods(cu, clazz, returnType);
+        clazz.getMembers().sort(new BodyDeclarationComparator());
+        return cu.toString();
+    }
+
+    public String getRequestHandlerName() {
+        return requestHandler;
+    }
+
+    private void generateConstructors(ClassOrInterfaceDeclaration clazz) {
+        for (ConstructorDeclaration c : clazz.getConstructors()) {
+            c.setName(targetCanonicalName);
+            if (!c.getParameters().isEmpty()) {
+                setUnitGeneric(c.getParameter(0).getType());
+            }
+        }
+    }
+
+    private void generateInterfaces(ClassOrInterfaceDeclaration clazz, String returnType) {
+        ClassOrInterfaceType implementedTypes = clazz.getImplementedTypes(0);
+        implementedTypes.asClassOrInterfaceType().setTypeArguments(classNameToReferenceType(ruleUnit.getCanonicalName()),
+                classNameToReferenceType(returnType));
+    }
+
+    private void generateHandleRequestMethods(CompilationUnit cu, ClassOrInterfaceDeclaration clazz, String returnType) {
+        boolean hasDI = annotator != null;
+
+        MethodDeclaration handleRequestMethod = clazz.getMethodsByName("handleRequest").get(0);
+        handleRequestMethod.getParameter(0).setType(ruleUnit.getCanonicalName() + (hasDI ? "" : "DTO"));
+        handleRequestMethod.setType(toNonPrimitiveType(returnType));
+
+        Statement statement = handleRequestMethod
+                .getBody()
+                .orElseThrow(() -> new NoSuchElementException("A method declaration doesn't contain a body!"))
+                .getStatement(0);
+        statement.findAll(VariableDeclarator.class).forEach(decl -> setUnitGeneric(decl.getType()));
+        statement.findAll( MethodCallExpr.class ).forEach(m -> m.addArgument( hasDI ? "unitDTO" : "unitDTO.get()" ) );
+
+        Statement secondStatementListResults = handleRequestMethod
+                .getBody()
+                .orElseThrow(() -> new NoSuchElementException("A method declaration doesn't contain a body!"))
+                .getStatement(1);
+        secondStatementListResults.findAll(VariableDeclarator.class).forEach(decl -> setGeneric(decl.getType(), returnType));
+        secondStatementListResults.findAll(ClassExpr.class).forEach(expr -> expr.setType( queryClassName ) );
+
+        Statement returnMethodSingle = handleRequestMethod
+                .getBody()
+                .orElseThrow(() -> new NoSuchElementException("A method declaration doesn't contain a body!"))
+                .getStatement(2);
+        returnMethodSingle.findAll(VariableDeclarator.class).forEach(decl -> decl.setType(toNonPrimitiveType(returnType)));
+
+        if (addonsConfig.useMonitoring()) {
+            addMonitoringToResource(cu, new MethodDeclaration[]{handleRequestMethod}, requestHandler);
+        }
+    }
+
+    private void addMonitoringToResource(CompilationUnit cu, MethodDeclaration[] methods, String nameURL) {
+        cu.addImport(new ImportDeclaration(new Name("org.kie.kogito.monitoring.core.system.metrics.SystemMetricsCollector"), false, false));
+
+        for (MethodDeclaration md : methods) {
+            BlockStmt body = md.getBody().orElseThrow(() -> new NoSuchElementException("A method declaration doesn't contain a body!"));
+            NodeList<Statement> statements = body.getStatements();
+            ReturnStmt returnStmt = body.findFirst(ReturnStmt.class).orElseThrow(() -> new NoSuchElementException("A method declaration doesn't contain a return statement!"));
+            statements.addFirst(parseStatement("long startTime = System.nanoTime();"));
+            statements.addBefore(parseStatement("long endTime = System.nanoTime();"), returnStmt);
+            statements.addBefore(parseStatement("SystemMetricsCollector.registerElapsedTimeSampleMetrics(\"" + nameURL + "\", endTime - startTime);"), returnStmt);
+            md.setBody(wrapBodyAddingExceptionLogging(body, nameURL));
+        }
+    }
+
+    private BlockStmt wrapBodyAddingExceptionLogging(BlockStmt body, String nameURL) {
+        TryStmt ts = new TryStmt();
+        ts.setTryBlock(body);
+        CatchClause cc = new CatchClause();
+        String exceptionName = "e";
+        cc.setParameter(new Parameter().setName(exceptionName).setType(Exception.class));
+        BlockStmt cb = new BlockStmt();
+        cb.addStatement(parseStatement(
+                String.format(
+                        "SystemMetricsCollector.registerException(\"%s\", %s.getStackTrace()[0].toString());",
+                        nameURL,
+                        exceptionName)
+        ));
+        cb.addStatement(new ThrowStmt(new NameExpr(exceptionName)));
+        cc.setBody(cb);
+        ts.setCatchClauses(new NodeList<>(cc));
+        return new BlockStmt(new NodeList<>(ts));
+    }
+
+    private String getReturnType(ClassOrInterfaceDeclaration clazz) {
+        if (query.getBindings().size() == 1) {
+            Map.Entry<String, Class<?>> binding = query.getBindings().entrySet().iterator().next();
+            return binding.getValue().getCanonicalName();
+        }
+        return queryClassName + ".Result";
+    }
+
+    private void interpolateStrings(StringLiteralExpr vv) {
+        String interpolated = vv.getValue()
+                .replace("$name$", name)
+                .replace("$endpointName$", requestHandler)
+                .replace("$queryName$", query.getName())
+                .replace("$prometheusName$", requestHandler);
+        vv.setString(interpolated);
+    }
+
+    private void setUnitGeneric(Type type) {
+        setGeneric(type, ruleUnit);
+    }
+
+    static void setGeneric(Type type, RuleUnitDescription ruleUnit) {
+        type.asClassOrInterfaceType().setTypeArguments(classNameToReferenceType(ruleUnit.getCanonicalName()));
+    }
+
+    static void setGeneric(Type type, String typeArgument) {
+        type.asClassOrInterfaceType().setTypeArguments(parseClassOrInterfaceType(toNonPrimitiveType(typeArgument)));
+    }
+
+    private static String toNonPrimitiveType(String type) {
+        switch (type) {
+            case "int":
+                return "Integer";
+            case "long":
+                return "Long";
+            case "double":
+                return "Double";
+            case "float":
+                return "Float";
+            case "short":
+                return "Short";
+            case "byte":
+                return "Byte";
+            case "char":
+                return "Character";
+            case "boolean":
+                return "Boolean";
+        }
+        return type;
+    }
+
+    private static String toCamelCase(String inputString) {
+        return Stream.of(inputString.split(" "))
+                .map(s -> s.length() > 1 ? s.substring(0, 1).toUpperCase() + s.substring(1) : s.substring(0, 1).toUpperCase())
+                .collect(Collectors.joining());
+    }
+
+    private static String toKebabCase(String inputString) {
+        return inputString.replaceAll("(.)(\\p{Upper})", "$1-$2").toLowerCase();
+    }
+}

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/RuleUnitGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/RuleUnitGenerator.java
@@ -15,23 +15,17 @@
 
 package org.kie.kogito.codegen.rules;
 
+import static com.github.javaparser.StaticJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parseExpression;
+import static com.github.javaparser.ast.NodeList.nodeList;
+import static java.util.stream.Collectors.toList;
+import static org.kie.kogito.codegen.metadata.ImageMetaData.LABEL_PREFIX;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
-import com.github.javaparser.ast.CompilationUnit;
-import com.github.javaparser.ast.Modifier;
-import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
-import com.github.javaparser.ast.body.ConstructorDeclaration;
-import com.github.javaparser.ast.body.MethodDeclaration;
-import com.github.javaparser.ast.expr.ClassExpr;
-import com.github.javaparser.ast.expr.Expression;
-import com.github.javaparser.ast.expr.IntegerLiteralExpr;
-import com.github.javaparser.ast.expr.NameExpr;
-import com.github.javaparser.ast.expr.ObjectCreationExpr;
-import com.github.javaparser.ast.type.ClassOrInterfaceType;
-import com.github.javaparser.ast.type.TypeParameter;
 import org.drools.modelcompiler.builder.QueryModel;
 import org.kie.internal.ruleunit.RuleUnitDescription;
 import org.kie.kogito.codegen.AddonsConfig;
@@ -45,11 +39,18 @@ import org.kie.kogito.rules.RuleUnitConfig;
 import org.kie.kogito.rules.units.GeneratedRuleUnitDescription;
 import org.kie.kogito.rules.units.impl.AbstractRuleUnit;
 
-import static com.github.javaparser.StaticJavaParser.parse;
-import static com.github.javaparser.StaticJavaParser.parseExpression;
-import static com.github.javaparser.ast.NodeList.nodeList;
-import static java.util.stream.Collectors.toList;
-import static org.kie.kogito.codegen.metadata.ImageMetaData.LABEL_PREFIX;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.ConstructorDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.ClassExpr;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.IntegerLiteralExpr;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import com.github.javaparser.ast.type.TypeParameter;
 
 public class RuleUnitGenerator implements FileGenerator {
 
@@ -96,6 +97,13 @@ public class RuleUnitGenerator implements FileGenerator {
         return queries.stream()
                 .filter(query -> !query.hasParameters())
                 .map(query -> new QueryEndpointGenerator(ruleUnit, query, annotator, addonsConfig))
+                .collect(toList());
+    }
+
+    public List<QueryRequestHandlerGenerator> queriesAsRequests() {
+        return queries.stream()
+                .filter(query -> !query.hasParameters())
+                .map(query -> new QueryRequestHandlerGenerator(ruleUnit, query, annotator, addonsConfig))
                 .collect(toList());
     }
 

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/RuleUnitGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/rules/RuleUnitGenerator.java
@@ -15,29 +15,10 @@
 
 package org.kie.kogito.codegen.rules;
 
-import static com.github.javaparser.StaticJavaParser.parse;
-import static com.github.javaparser.StaticJavaParser.parseExpression;
-import static com.github.javaparser.ast.NodeList.nodeList;
-import static java.util.stream.Collectors.toList;
-import static org.kie.kogito.codegen.metadata.ImageMetaData.LABEL_PREFIX;
-
 import java.util.Collection;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
-
-import org.drools.modelcompiler.builder.QueryModel;
-import org.kie.internal.ruleunit.RuleUnitDescription;
-import org.kie.kogito.codegen.AddonsConfig;
-import org.kie.kogito.codegen.ApplicationGenerator;
-import org.kie.kogito.codegen.FileGenerator;
-import org.kie.kogito.codegen.di.DependencyInjectionAnnotator;
-import org.kie.kogito.conf.ClockType;
-import org.kie.kogito.conf.EventProcessingType;
-import org.kie.kogito.rules.RuleUnit;
-import org.kie.kogito.rules.RuleUnitConfig;
-import org.kie.kogito.rules.units.GeneratedRuleUnitDescription;
-import org.kie.kogito.rules.units.impl.AbstractRuleUnit;
 
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Modifier;
@@ -51,6 +32,24 @@ import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.TypeParameter;
+import org.drools.modelcompiler.builder.QueryModel;
+import org.kie.internal.ruleunit.RuleUnitDescription;
+import org.kie.kogito.codegen.AddonsConfig;
+import org.kie.kogito.codegen.ApplicationGenerator;
+import org.kie.kogito.codegen.FileGenerator;
+import org.kie.kogito.codegen.di.DependencyInjectionAnnotator;
+import org.kie.kogito.conf.ClockType;
+import org.kie.kogito.conf.EventProcessingType;
+import org.kie.kogito.rules.RuleUnit;
+import org.kie.kogito.rules.RuleUnitConfig;
+import org.kie.kogito.rules.units.GeneratedRuleUnitDescription;
+import org.kie.kogito.rules.units.impl.AbstractRuleUnit;
+
+import static com.github.javaparser.StaticJavaParser.parse;
+import static com.github.javaparser.StaticJavaParser.parseExpression;
+import static com.github.javaparser.ast.NodeList.nodeList;
+import static java.util.stream.Collectors.toList;
+import static org.kie.kogito.codegen.metadata.ImageMetaData.LABEL_PREFIX;
 
 public class RuleUnitGenerator implements FileGenerator {
 

--- a/kogito-codegen/src/main/resources/class-templates/rules/RequestHandlerQueryTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/rules/RequestHandlerQueryTemplate.java
@@ -1,0 +1,44 @@
+package com.myspace.demo;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Named;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+
+import org.kie.kogito.rules.RuleUnit;
+import org.kie.kogito.rules.RuleUnitInstance;
+
+import static java.util.stream.Collectors.toList;
+
+@Named("$endpointName$")
+public class $unit$Query$name$RequestHandler implements RequestHandler<$UnitType$, $ReturnType$> {
+
+    RuleUnit<$UnitType$> ruleUnit;
+
+    public $unit$Query$name$RequestHandler() { }
+
+    public $unit$Query$name$RequestHandler(RuleUnit<$UnitType$> ruleUnit) {
+        this.ruleUnit = ruleUnit;
+    }
+
+    /**
+     * Returns same thing as /first
+     * @param unitDTO
+     * @return
+     */
+    @Override
+    public $ReturnType$ handleRequest($UnitTypeDTO$ unitDTO, Context context) {
+        RuleUnitInstance<$UnitType$> instance = ruleUnit.createInstance();
+        List<$ReturnType$> results = instance.executeQuery($unit$Query$name$.class);
+        $ReturnType$ response = results.isEmpty() ? null : results.get(0);
+        return response;
+    }
+}

--- a/kogito-codegen/src/main/resources/class-templates/rules/RequestHandlerQueryTemplate.java
+++ b/kogito-codegen/src/main/resources/class-templates/rules/RequestHandlerQueryTemplate.java
@@ -1,29 +1,21 @@
 package com.myspace.demo;
 
 import java.util.List;
-import java.util.Map;
 
 import javax.inject.Named;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
-
 import org.kie.kogito.rules.RuleUnit;
 import org.kie.kogito.rules.RuleUnitInstance;
-
-import static java.util.stream.Collectors.toList;
 
 @Named("$endpointName$")
 public class $unit$Query$name$RequestHandler implements RequestHandler<$UnitType$, $ReturnType$> {
 
     RuleUnit<$UnitType$> ruleUnit;
 
-    public $unit$Query$name$RequestHandler() { }
+    public $unit$Query$name$RequestHandler() {
+    }
 
     public $unit$Query$name$RequestHandler(RuleUnit<$UnitType$> ruleUnit) {
         this.ruleUnit = ruleUnit;
@@ -31,6 +23,7 @@ public class $unit$Query$name$RequestHandler implements RequestHandler<$UnitType
 
     /**
      * Returns same thing as /first
+     *
      * @param unitDTO
      * @return
      */

--- a/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
+++ b/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
@@ -16,6 +16,23 @@
 
 package org.kie.kogito.maven.plugin;
 
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -26,22 +43,18 @@ import org.apache.maven.project.MavenProject;
 import org.drools.compiler.builder.impl.KogitoKieModuleModelImpl;
 import org.drools.compiler.kproject.models.KieModuleModelImpl;
 import org.kie.api.builder.model.KieModuleModel;
-import org.kie.kogito.codegen.*;
+import org.kie.kogito.codegen.AddonsConfig;
+import org.kie.kogito.codegen.ApplicationGenerator;
+import org.kie.kogito.codegen.DashboardGeneratedFileUtils;
+import org.kie.kogito.codegen.GeneratedFile;
 import org.kie.kogito.codegen.GeneratedFile.Type;
+import org.kie.kogito.codegen.GeneratorContext;
 import org.kie.kogito.codegen.decision.DecisionCodegen;
 import org.kie.kogito.codegen.io.CollectedResource;
 import org.kie.kogito.codegen.prediction.PredictionCodegen;
 import org.kie.kogito.codegen.process.ProcessCodegen;
 import org.kie.kogito.codegen.rules.IncrementalRuleCodegen;
 import org.kie.kogito.maven.plugin.util.MojoUtil;
-
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.*;
-import java.util.*;
-import java.util.stream.Stream;
 
 @Mojo(name = "generateModel",
         requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME,

--- a/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
+++ b/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/GenerateModelMojo.java
@@ -16,23 +16,6 @@
 
 package org.kie.kogito.maven.plugin;
 
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
-import java.nio.file.NoSuchFileException;
-import java.nio.file.Path;
-import java.nio.file.PathMatcher;
-import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Stream;
-
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -43,18 +26,22 @@ import org.apache.maven.project.MavenProject;
 import org.drools.compiler.builder.impl.KogitoKieModuleModelImpl;
 import org.drools.compiler.kproject.models.KieModuleModelImpl;
 import org.kie.api.builder.model.KieModuleModel;
-import org.kie.kogito.codegen.AddonsConfig;
-import org.kie.kogito.codegen.ApplicationGenerator;
-import org.kie.kogito.codegen.GeneratedFile;
+import org.kie.kogito.codegen.*;
 import org.kie.kogito.codegen.GeneratedFile.Type;
-import org.kie.kogito.codegen.GeneratorContext;
-import org.kie.kogito.codegen.DashboardGeneratedFileUtils;
 import org.kie.kogito.codegen.decision.DecisionCodegen;
 import org.kie.kogito.codegen.io.CollectedResource;
 import org.kie.kogito.codegen.prediction.PredictionCodegen;
 import org.kie.kogito.codegen.process.ProcessCodegen;
 import org.kie.kogito.codegen.rules.IncrementalRuleCodegen;
 import org.kie.kogito.maven.plugin.util.MojoUtil;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.*;
+import java.util.*;
+import java.util.stream.Stream;
 
 @Mojo(name = "generateModel",
         requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME,
@@ -277,11 +264,13 @@ public class GenerateModelMojo extends AbstractKieMojo {
         if (generateRules()) {
             boolean useRestServices = hasClassOnClasspath(project, "javax.ws.rs.Path")
                     || hasClassOnClasspath(project, "org.springframework.web.bind.annotation.RestController");
+            boolean useRequestHandlers = hasClassOnClasspath(project, "com.amazonaws.services.lambda.runtime.RequestHandler");
             appGen.setupGenerator(IncrementalRuleCodegen.ofCollectedResources(CollectedResource.fromDirectory(kieSourcesDirectory.toPath())))
                     .withKModule(getKModuleModel())
                     .withClassLoader(projectClassLoader)
                     .withAddons(addonsConfig)
-                    .withRestServices(useRestServices);
+                    .withRestServices(useRestServices)
+                    .withRequestHandlers(useRequestHandlers);
         }
 
         boolean isJPMMLAvailable = hasClassOnClasspath(project, "org.kie.dmn.jpmml.DMNjPMMLInvocationEvaluator");

--- a/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/KogitoAssetsProcessor.java
+++ b/kogito-quarkus-extension/deployment/src/main/java/org/kie/kogito/quarkus/deployment/KogitoAssetsProcessor.java
@@ -117,6 +117,7 @@ public class KogitoAssetsProcessor {
     private static final DotName dmnJpmmlClass = DotName.createSimple( "org.kie.dmn.jpmml.DMNjPMMLInvocationEvaluator");
     private static final DotName quarkusCloudEvents = DotName.createSimple("org.kie.kogito.addon.cloudevents.quarkus.QuarkusCloudEventEmitter");
     private static final DotName quarkusSVGService = DotName.createSimple("org.kie.kogito.svg.service.QuarkusProcessSvgService");
+    private static final DotName awsRequestHandler = DotName.createSimple("com.amazonaws.services.lambda.runtime.RequestHandler");
 
     private static final PathMatcher svgFileMatcher = FileSystems.getDefault().getPathMatcher("glob:**.svg");
 
@@ -167,6 +168,9 @@ public class KogitoAssetsProcessor {
         boolean isJPMMLAvailable = combinedIndexBuildItem.getIndex().getClassByName(dmnJpmmlClass) != null;
         boolean useCloudEvents = combinedIndexBuildItem.getIndex().getClassByName(quarkusCloudEvents) != null;
         boolean useProcessSVG = combinedIndexBuildItem.getIndex().getClassByName(quarkusSVGService) != null;
+        boolean useRequestHandlers = combinedIndexBuildItem.getIndex().getAllKnownImplementors(awsRequestHandler) != null;
+        DotName requestHandler = DotName.createSimple("com.amazonaws.services.lambda.runtime.RequestHandler");
+        Collection<ClassInfo> allKnownImplementors = combinedIndexBuildItem.getIndex().getAllKnownImplementors(requestHandler);
 
         AddonsConfig addonsConfig = new AddonsConfig()
                 .withPersistence(usePersistence)
@@ -175,6 +179,8 @@ public class KogitoAssetsProcessor {
                 .withTracing(useTracing)
                 .withKnativeEventing(useKnativeEventing)
                 .withCloudEvents(useCloudEvents);
+                .withCloudEvents(useCloudEvents)
+                .withRequestHandlers(useRequestHandlers);
 
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         GeneratorContext context = buildContext(appPaths, combinedIndexBuildItem.getIndex());


### PR DESCRIPTION
In order to call kogito code in AWS, you must use a REST API, therefore
you cannot call directly from lambda to lambda, but must instead go out
through API Gateway, necessitating setting up large amounts of
infrastructure for a simple call from one lambda to another.

Instead, generate RequestHandlers that can create lambda functions that
can be called directly. Copy the interface of the existing Query
Endpoints, but instead implement the RequestHandler interface and
provide a handleRequest method that AWS can use to generate the lambda
functions.

https://issues.redhat.com/browse/KOGITO-3964
https://kie.zulipchat.com/#narrow/stream/232676-kogito/topic/kogito.20handler.20which.20implements.20RequestHandler

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket