### PR TITLE
KOGITO-3659 Process codegen won't generate duplicate classes

### DIFF
--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/GeneratedFile.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/GeneratedFile.java
@@ -16,6 +16,7 @@
 package org.kie.kogito.codegen;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 
 public class GeneratedFile {
 
@@ -86,5 +87,22 @@ public class GeneratedFile {
                 "type=" + type +
                 ", relativePath='" + relativePath + '\'' +
                 '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        GeneratedFile that = (GeneratedFile) o;
+        return Objects.equals(relativePath, that.relativePath) && type == that.type;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(relativePath, type);
     }
 }

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/GeneratedFile.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/GeneratedFile.java
@@ -99,13 +99,11 @@ public class GeneratedFile {
             return false;
         }
         GeneratedFile that = (GeneratedFile) o;
-        return Objects.equals(relativePath, that.relativePath) && Arrays.equals(contents, that.contents) && type == that.type;
+        return Objects.equals(relativePath, that.relativePath);
     }
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(relativePath, type);
-        result = 31 * result + Arrays.hashCode(contents);
-        return result;
+        return Objects.hash(relativePath);
     }
 }

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/GeneratedFile.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/GeneratedFile.java
@@ -16,6 +16,7 @@
 package org.kie.kogito.codegen;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Objects;
 
 public class GeneratedFile {
@@ -98,11 +99,13 @@ public class GeneratedFile {
             return false;
         }
         GeneratedFile that = (GeneratedFile) o;
-        return Objects.equals(relativePath, that.relativePath) && type == that.type;
+        return Objects.equals(relativePath, that.relativePath) && Arrays.equals(contents, that.contents) && type == that.type;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(relativePath, type);
+        int result = Objects.hash(relativePath, type);
+        result = 31 * result + Arrays.hashCode(contents);
+        return result;
     }
 }

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ProcessCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ProcessCodegen.java
@@ -480,7 +480,11 @@ public class ProcessCodegen extends AbstractGenerator {
     }
 
     private void storeFile(Type type, String path, String source) {
-        generatedFiles.add(new GeneratedFile(type, path, log(source).getBytes(StandardCharsets.UTF_8)));
+        if (generatedFiles.stream().anyMatch(f -> path.equals(f.relativePath()))) {
+            LOGGER.warn("There's already a generated file named {} to be compiled. Ignoring.", path);
+        } else {
+            generatedFiles.add(new GeneratedFile(type, path, log(source).getBytes(StandardCharsets.UTF_8)));
+        }
     }
 
     public Set<GeneratedFile> getGeneratedFiles() {

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ProcessCodegen.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/ProcessCodegen.java
@@ -174,7 +174,7 @@ public class ProcessCodegen extends AbstractGenerator {
     private ProcessContainerGenerator moduleGenerator;
 
     private final Map<String, WorkflowProcess> processes;
-    private final List<GeneratedFile> generatedFiles = new ArrayList<>();
+    private final Set<GeneratedFile> generatedFiles = new HashSet<>();
 
     private AddonsConfig addonsConfig = AddonsConfig.DEFAULT;
 
@@ -227,9 +227,9 @@ public class ProcessCodegen extends AbstractGenerator {
         return this;
     }
 
-    public List<GeneratedFile> generate() {
+    public Set<GeneratedFile> generate() {
         if (processes.isEmpty()) {
-            return Collections.emptyList();
+            return Collections.emptySet();
         }
 
         List<ProcessGenerator> ps = new ArrayList<>();
@@ -483,7 +483,7 @@ public class ProcessCodegen extends AbstractGenerator {
         generatedFiles.add(new GeneratedFile(type, path, log(source).getBytes(StandardCharsets.UTF_8)));
     }
 
-    public List<GeneratedFile> getGeneratedFiles() {
+    public Set<GeneratedFile> getGeneratedFiles() {
         return generatedFiles;
     }
 


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

See: https://issues.redhat.com/browse/KOGITO-3659

On Serverless Workflows, sometimes we want to reuse a given set of functions on subprocesses. In such scenarios, the codegen was duplicating the `WorkItemHandlers` responsible for handling these functions.

An example of such a case can be viewed in: <PR to be sent>

Instead of using a `List`, we use a `Set` to not have duplicates in the final generated code. This can be re-think in the future. For example: would make sense to generate all the handlers beforehand on a specific package instead? Today each process take care of their handlers, we don't have "global" scope for such thing. Wouldn't that make sense? For a handler to be reused on subprocesses/flows?

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket