### PR TITLE
[KOGITO-4057] Missing triggerTime in BoundaryEventNodes

### DIFF
--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/BoundaryEventNodeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/BoundaryEventNodeInstance.java
@@ -16,6 +16,7 @@
 package org.jbpm.workflow.instance.node;
 
 import java.util.Collection;
+import java.util.Date;
 
 import org.jbpm.ruleflow.core.Metadata;
 import org.jbpm.workflow.core.node.BoundaryEventNode;
@@ -30,6 +31,9 @@ public class BoundaryEventNodeInstance extends EventNodeInstance {
 
     @Override
     public void signalEvent(String type, Object event) {
+        if(triggerTime == null) {
+            triggerTime = new Date();
+        }
         BoundaryEventNode boundaryNode = (BoundaryEventNode) getEventNode();
 
         String attachedTo = boundaryNode.getAttachedToNodeId();


### PR DESCRIPTION
Fix https://issues.redhat.com/browse/KOGITO-4057

Signed-off-by: ruromero <rromerom@redhat.com>

BoundaryEventNodes didn't have a triggerTime initialized. This field is mapped to the graphql.schema as the `NodeInstance:enter` required field.