### PR TITLE
KOGITO-4125 - Mongodb persistence generates proto files during codegen

### DIFF
--- a/addons/tracing/tracing-decision-quarkus-addon/src/main/resources/META-INF/microprofile-config.properties
+++ b/addons/tracing/tracing-decision-quarkus-addon/src/main/resources/META-INF/microprofile-config.properties
@@ -1,0 +1,11 @@
+# Kafka Tracing
+mp.messaging.outgoing.kogito-tracing-decision.group.id=kogito-runtimes
+mp.messaging.outgoing.kogito-tracing-decision.connector=smallrye-kafka
+mp.messaging.outgoing.kogito-tracing-decision.topic=kogito-tracing-decision
+mp.messaging.outgoing.kogito-tracing-decision.value.serializer=org.apache.kafka.common.serialization.StringSerializer
+
+# Kafka Tracing Model
+mp.messaging.outgoing.kogito-tracing-model.group.id=kogito-runtimes
+mp.messaging.outgoing.kogito-tracing-model.connector=smallrye-kafka
+mp.messaging.outgoing.kogito-tracing-model.topic=kogito-tracing-model
+mp.messaging.outgoing.kogito-tracing-model.value.serializer=org.apache.kafka.common.serialization.StringSerializer

--- a/addons/tracing/tracing-decision-springboot-addon/src/main/java/org/kie/kogito/tracing/decision/SpringBootModelEventEmitter.java
+++ b/addons/tracing/tracing-decision-springboot-addon/src/main/java/org/kie/kogito/tracing/decision/SpringBootModelEventEmitter.java
@@ -33,7 +33,7 @@ public class SpringBootModelEventEmitter extends BaseModelEventEmitter {
     @Autowired
     public SpringBootModelEventEmitter(final DecisionModelResourcesProvider decisionModelResourcesProvider,
                                        final KafkaTemplate<String, String> template,
-                                       final @Value(value = "${kogito.addon.tracing.decision.kafka.topic.name:kogito-tracing-model}") String kafkaTopicName) {
+                                       final @Value(value = "${kogito.addon.tracing.model.kafka.topic.name:kogito-tracing-model}") String kafkaTopicName) {
         super(decisionModelResourcesProvider);
         this.template = template;
         this.kafkaTopicName = kafkaTopicName;

--- a/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/persistence/PersistenceGenerator.java
+++ b/kogito-codegen/src/main/java/org/kie/kogito/codegen/process/persistence/PersistenceGenerator.java
@@ -45,9 +45,9 @@ import com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt;
 import com.github.javaparser.ast.stmt.ReturnStmt;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import org.kie.kogito.codegen.AbstractGenerator;
+import org.kie.kogito.codegen.ApplicationConfigGenerator;
 import org.kie.kogito.codegen.ApplicationSection;
 import org.kie.kogito.codegen.BodyDeclarationComparator;
-import org.kie.kogito.codegen.ApplicationConfigGenerator;
 import org.kie.kogito.codegen.GeneratedFile;
 import org.kie.kogito.codegen.context.KogitoBuildContext;
 import org.kie.kogito.codegen.context.QuarkusKogitoBuildContext;
@@ -55,7 +55,6 @@ import org.kie.kogito.codegen.context.SpringBootKogitoBuildContext;
 import org.kie.kogito.codegen.process.persistence.proto.Proto;
 import org.kie.kogito.codegen.process.persistence.proto.ProtoDataClassesResult;
 import org.kie.kogito.codegen.process.persistence.proto.ProtoGenerator;
-
 
 public class PersistenceGenerator extends AbstractGenerator {
 
@@ -272,8 +271,12 @@ public class PersistenceGenerator extends AbstractGenerator {
         return generatedFiles;
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     private Collection<GeneratedFile> mongodbBasedPersistence() {
-        Collection<GeneratedFile> generatedFiles = new ArrayList<>();
+
+        ProtoDataClassesResult protoDataClassesResult = protoGenerator.extractDataClasses((Collection) modelClasses);
+        Collection<GeneratedFile> generatedFiles = new ArrayList<>(protoDataClassesResult.getGeneratedFiles());
+
         ClassOrInterfaceDeclaration persistenceProviderClazz = new ClassOrInterfaceDeclaration()
                                                                                                 .setName(KOGITO_PROCESS_INSTANCE_FACTORY_IMPL).setModifiers(Modifier.Keyword.PUBLIC)
                                                                                                 .addExtendedType(KOGITO_PROCESS_INSTANCE_FACTORY_PACKAGE);

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/data/AnswerWithAnnotations.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/data/AnswerWithAnnotations.java
@@ -3,9 +3,8 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,25 +15,13 @@
 
 package org.kie.kogito.codegen.data;
 
-public class QuestionWithAnnotatedEnum {
+import org.infinispan.protostream.annotations.ProtoEnumValue;
 
-    private String question;
-    private AnswerWithAnnotations answer;
-
-    public String getQuestion() {
-        return question;
-    }
-
-    public void setQuestion(String question) {
-        this.question = question;
-    }
-
-    public AnswerWithAnnotations getAnswer() {
-        return answer;
-    }
-
-    public void setAnswer(AnswerWithAnnotations answer) {
-        this.answer = answer;
-    }
-
+public enum AnswerWithAnnotations {
+    @ProtoEnumValue(number = 1)
+    YES,
+    @ProtoEnumValue(number = 2)
+    MAYBE,
+    @ProtoEnumValue(number = 3)
+    NO
 }

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/data/GeneratedPOJO.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/data/GeneratedPOJO.java
@@ -12,16 +12,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.kie.kogito.codegen.data;
 
-import org.infinispan.protostream.annotations.ProtoEnumValue;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.kie.internal.kogito.codegen.Generated;
+import org.kie.internal.kogito.codegen.VariableInfo;
 
-public enum AnswerWitAnnotations {
-    @ProtoEnumValue(number = 1)
-    YES,
-    @ProtoEnumValue(number = 2)
-    MAYBE,
-    @ProtoEnumValue(number = 3)
-    NO
+@Generated(value = {"kogito-codegen"}, reference = "generatedPerson", name = "GeneratedPerson")
+public class GeneratedPOJO {
+    @VariableInfo(tags = "test")
+    @JsonProperty("generatedProperty")
+    private String generatedProperty;
 }

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/process/persistence/MongoDBPersistenceGeneratorTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/process/persistence/MongoDBPersistenceGeneratorTest.java
@@ -17,13 +17,13 @@ package org.kie.kogito.codegen.process.persistence;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
@@ -62,6 +62,9 @@ class MongoDBPersistenceGeneratorTest {
                 Arrays.asList("com.mongodb.client.MongoClient"),
                 "mongodb");
         Collection<GeneratedFile> generatedFiles = persistenceGenerator.generate();
+
+        List<GeneratedFile> protoFiles = generatedFiles.stream().filter(gf -> gf.relativePath().contains(".proto")).collect(Collectors.toList());
+        assertEquals(1, protoFiles.size());
 
         Optional<GeneratedFile> generatedCLASSFile = generatedFiles.stream().filter(gf -> gf.getType() == GeneratedFile.Type.CLASS).findFirst();
         assertTrue(generatedCLASSFile.isPresent());

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/process/persistence/MongoDBPersistenceGeneratorTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/process/persistence/MongoDBPersistenceGeneratorTest.java
@@ -35,7 +35,8 @@ import org.kie.kogito.codegen.AddonsConfig;
 import org.kie.kogito.codegen.GeneratedFile;
 import org.kie.kogito.codegen.context.KogitoBuildContext;
 import org.kie.kogito.codegen.context.QuarkusKogitoBuildContext;
-import org.kie.kogito.codegen.data.Person;
+import org.kie.kogito.codegen.data.GeneratedPOJO;
+import org.kie.kogito.codegen.process.persistence.proto.ReflectionProtoGenerator;
 
 import static com.github.javaparser.StaticJavaParser.parse;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -56,8 +57,8 @@ class MongoDBPersistenceGeneratorTest {
     void test() {
         PersistenceGenerator persistenceGenerator = new PersistenceGenerator(
                 context,
-                Collections.singleton(Person.class),
-                null,
+                Collections.singleton(GeneratedPOJO.class),
+                new ReflectionProtoGenerator(),
                 null,
                 Arrays.asList("com.mongodb.client.MongoClient"),
                 "mongodb");

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/process/persistence/proto/MarshallerGeneratorTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/process/persistence/proto/MarshallerGeneratorTest.java
@@ -16,7 +16,6 @@
 package org.kie.kogito.codegen.process.persistence.proto;
 
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -24,10 +23,9 @@ import java.util.stream.Stream;
 
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
-import org.infinispan.protostream.EnumMarshaller;
 import org.junit.jupiter.api.Test;
 import org.kie.kogito.codegen.data.Answer;
-import org.kie.kogito.codegen.data.AnswerWitAnnotations;
+import org.kie.kogito.codegen.data.AnswerWithAnnotations;
 import org.kie.kogito.codegen.data.Person;
 import org.kie.kogito.codegen.data.PersonWithAddress;
 import org.kie.kogito.codegen.data.PersonWithAddresses;
@@ -153,7 +151,7 @@ class MarshallerGeneratorTest {
 
     @Test
     void testEnumMarshallers() {
-        Stream.of(Answer.class, AnswerWitAnnotations.class).forEach(e -> {
+        Stream.of(Answer.class, AnswerWithAnnotations.class).forEach(e -> {
             Proto proto = generator.generate("org.kie.kogito.test", Collections.singleton(e));
             assertThat(proto).isNotNull();
             assertThat(proto.getEnums()).hasSize(1);

--- a/kogito-codegen/src/test/java/org/kie/kogito/codegen/process/persistence/proto/ReflectionProtoGeneratorTest.java
+++ b/kogito-codegen/src/test/java/org/kie/kogito/codegen/process/persistence/proto/ReflectionProtoGeneratorTest.java
@@ -20,7 +20,7 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.kie.kogito.codegen.data.Answer;
-import org.kie.kogito.codegen.data.AnswerWitAnnotations;
+import org.kie.kogito.codegen.data.AnswerWithAnnotations;
 import org.kie.kogito.codegen.data.Person;
 import org.kie.kogito.codegen.data.PersonVarInfo;
 import org.kie.kogito.codegen.data.PersonWithAddress;
@@ -375,7 +375,7 @@ class ReflectionProtoGeneratorTest {
     @Test
     void testAnswerWithAnnotationsProtoFile() {
 
-        Proto proto = generator.generate("org.kie.kogito.test.persons", Collections.singleton(AnswerWitAnnotations.class));
+        Proto proto = generator.generate("org.kie.kogito.test.persons", Collections.singleton(AnswerWithAnnotations.class));
         assertThat(proto).isNotNull();
 
         assertThat(proto.getPackageName()).isEqualTo("org.kie.kogito.test.persons");
@@ -384,7 +384,7 @@ class ReflectionProtoGeneratorTest {
 
         ProtoEnum answer = proto.getEnums().get(0);
         assertThat(answer).isNotNull();
-        assertThat(answer.getName()).isEqualTo("AnswerWitAnnotations");
+        assertThat(answer.getName()).isEqualTo("AnswerWithAnnotations");
         assertThat(answer.getJavaPackageOption()).isEqualTo("org.kie.kogito.codegen.data");
         assertThat(answer.getFields()).hasSize(3);
 
@@ -467,7 +467,7 @@ class ReflectionProtoGeneratorTest {
         ProtoField field = question.getFields().get(0);
         assertThat(field).isNotNull();
         assertThat(field.getName()).isEqualTo("answer");
-        assertThat(field.getType()).isEqualTo("AnswerWitAnnotations");
+        assertThat(field.getType()).isEqualTo("AnswerWithAnnotations");
         assertThat(field.getApplicability()).isEqualTo("optional");
 
         field = question.getFields().get(1);


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/KOGITO-4125

I was surfing around the codebase and I found out that the data index needs the protobuf files, but they are generated only if a persistence module is added as dependency and if `kogito.persistence.type==infinispan`. By consequence, if the user selects `kogito.persistence.type=mongodb` no proto files are generated/exposed and the data-index is not going to work. 


Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket