### PR TITLE
[master][cherry-pick] fix for optaplanner checkout in PR release branch (#966)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,10 +29,10 @@ pipeline {
                     checkoutRepo("kogito-runtimes")
                     checkoutRepo("kogito-runtimes", "integration-tests")
                     checkoutRepo("kogito-apps")
+                    checkoutOptaplannerRepo()
                     checkoutRepo("kogito-examples")
                     checkoutRepo("kogito-examples", "kogito-examples-persistence")
                     checkoutRepo("kogito-examples", "kogito-examples-events")
-                    checkoutRepo("optaplanner")
                 }
             }
         }
@@ -104,6 +104,22 @@ pipeline {
 void checkoutRepo(String repo, String dirName=repo) {
     dir(dirName) {
         githubscm.checkoutIfExists(repo, changeAuthor, changeBranch, 'kiegroup', changeTarget, true)
+    }
+}
+
+void checkoutOptaplannerRepo() {
+    String targetBranch = changeTarget
+    String [] versionSplit = targetBranch.split("\\.")
+    if(versionSplit.length == 3 
+        && versionSplit[0].isNumber()
+        && versionSplit[1].isNumber()
+       && versionSplit[2] == 'x') {
+        targetBranch = "${Integer.parseInt(versionSplit[0]) + 7}.${versionSplit[1]}.x"
+    } else {
+        echo "Cannot parse changeTarget as release branch so going further with current value: ${changeTarget}"
+    }
+    dir('optaplanner') {
+        githubscm.checkoutIfExists('optaplanner', changeAuthor, changeBranch, 'kiegroup', targetBranch, true)
     }
 }
 


### PR DESCRIPTION
To allow to select correct target branch on optaplanner.

Cherry-pick: https://github.com/kiegroup/kogito-runtimes/pull/966

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket