### PR TITLE
KOGITO-4224 Kogito Quarkus archetype disaligned static serv. Swagger/OAS

### DIFF
--- a/archetypes/kogito-quarkus-archetype/src/main/resources/archetype-resources/README.md
+++ b/archetypes/kogito-quarkus-archetype/src/main/resources/archetype-resources/README.md
@@ -38,8 +38,8 @@ Then just build the project and run.
 # Swagger documentation
 
 The exposed service [OpenAPI specification](https://swagger.io/docs/specification) is generated at 
-[/docs/openapi.json](http://localhost:8080/docs/openapi.json).
+[/q/openapi](http://localhost:8080/q/openapi).
 
-You can visualize and interact with the generated specification using the embbeded [Swagger UI](http://localhost:8080/swagger-ui) or importing the generated specification file on [Swagger Editor](https://editor.swagger.io).
+You can visualize and interact with the generated specification using the embbeded [Swagger UI](http://localhost:8080/q/swagger-ui) or importing the generated specification file on [Swagger Editor](https://editor.swagger.io).
 
 In addition client application can be easily generated from the swagger definition to interact with this service.

--- a/archetypes/kogito-quarkus-archetype/src/main/resources/archetype-resources/src/main/resources/application.properties
+++ b/archetypes/kogito-quarkus-archetype/src/main/resources/archetype-resources/src/main/resources/application.properties
@@ -15,7 +15,6 @@
 #
 
 #https://quarkus.io/guides/openapi-swaggerui
-quarkus.smallrye-openapi.path=/docs/openapi.json
 quarkus.swagger-ui.always-include=true
 
 kogito.service.url=http://localhost:8080

--- a/integration-tests/integration-tests-quarkus-decisions/src/main/resources/application.properties
+++ b/integration-tests/integration-tests-quarkus-decisions/src/main/resources/application.properties
@@ -1,2 +1,7 @@
 # for these tests, we do NOT want stronglytyped to be enabled, leave it as default disabled.
 # kogito.decisions.stronglytyped=false
+
+quarkus.log.level=DEBUG
+quarkus.log.min-level=DEBUG
+quarkus.log.category."io.quarkus.deployment.index".min-level=DEBUG
+quarkus.log.category."io.quarkus.deployment.index".level=DEBUG

--- a/integration-tests/integration-tests-quarkus-decisions/src/main/resources/application.properties
+++ b/integration-tests/integration-tests-quarkus-decisions/src/main/resources/application.properties
@@ -1,7 +1,2 @@
 # for these tests, we do NOT want stronglytyped to be enabled, leave it as default disabled.
 # kogito.decisions.stronglytyped=false
-
-quarkus.log.level=DEBUG
-quarkus.log.min-level=DEBUG
-quarkus.log.category."io.quarkus.deployment.index".min-level=DEBUG
-quarkus.log.category."io.quarkus.deployment.index".level=DEBUG


### PR DESCRIPTION
As described in JIRA https://issues.redhat.com/browse/KOGITO-4224

Moreover since Quarkus v1.11 I would just embrace the (Quarkus) platform conventions: https://quarkus.io/blog/quarkus-1-11-0-final-released/#non-application-endpoints-moved-to-q

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket