### PR TITLE
Proposal: enforce code-style format check in pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,7 @@ Many thanks for submitting your Pull Request :heart:!
 Please make sure that your PR meets the following requirements:
 
 - [ ] You have read the [contributors guide](CONTRIBUTING.md)
+- [ ] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/droolsjbpm-build-bootstrap/tree/master/ide-configuration)
 - [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
 - [ ] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
 - [ ] Pull Request contains link to the JIRA issue


### PR DESCRIPTION
This is a proposal to enforce that we have an IDE configuration file that the contributors should use. 
Chatting with people, It turned out that not everybody is using it. 
This is mainly for new joiners/contributors that are not aware of it (even if it's in the contributors guide - first line of the template). 

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket