### PR TITLE
DROOLS-5910 Enable range index for JoinNode

### DIFF
--- a/api/kogito-api/src/build/revapi-config.json
+++ b/api/kogito-api/src/build/revapi-config.json
@@ -231,7 +231,7 @@
           "annotation": "@com.thoughtworks.xstream.annotations.XStreamAlias(\"PMML4Result\")",
           "package": "org.kie.api.pmml",
           "classSimpleName": "PMML4Result",
-          "elementKind": "class",
+          "elementKind": "class"
         },
         {
           "code": "java.method.addedToInterface",
@@ -250,6 +250,24 @@
           "methodName": "setMutability",
           "elementKind": "method",
           "justification": "Allow to define that a KieBase is immutable for performance reasons"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method org.kie.api.conf.BetaRangeIndexOption org.kie.api.builder.model.KieBaseModel::getBetaRangeIndexOption()",
+          "package": "org.kie.api.builder.model",
+          "classSimpleName": "KieBaseModel",
+          "methodName": "getBetaRangeIndexOption",
+          "elementKind": "method",
+          "justification": "Allow to use range index for JoinNode"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method org.kie.api.builder.model.KieBaseModel org.kie.api.builder.model.KieBaseModel::setBetaRangeIndexOption(org.kie.api.conf.BetaRangeIndexOption)",
+          "package": "org.kie.api.builder.model",
+          "classSimpleName": "KieBaseModel",
+          "methodName": "setBetaRangeIndexOption",
+          "elementKind": "method",
+          "justification": "Allow to use range index for JoinNode"
         }
       ]
     }

--- a/api/kogito-api/src/main/java/org/kie/api/builder/model/KieBaseModel.java
+++ b/api/kogito-api/src/main/java/org/kie/api/builder/model/KieBaseModel.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.kie.api.conf.BetaRangeIndexOption;
 import org.kie.api.conf.DeclarativeAgendaOption;
 import org.kie.api.conf.EqualityBehaviorOption;
 import org.kie.api.conf.EventProcessingOption;
@@ -150,6 +151,17 @@ public interface KieBaseModel {
      * Default is DeclarativeAgendaOption.DISABLED
      */
     KieBaseModel setDeclarativeAgenda(DeclarativeAgendaOption declarativeAgenda);
+
+    /**
+     * Returns the BetaRangeIndexOption of this KieBaseModel
+     */
+    BetaRangeIndexOption getBetaRangeIndexOption();
+
+    /**
+     * Sets the BetaRangeIndexOption for this KieBaseModel
+     * Default is BetaRangeIndexOption.DISABLED
+     */
+    KieBaseModel setBetaRangeIndexOption(BetaRangeIndexOption betaRangeIndexOption);
 
     /**
      * Returns the SequentialOption of this KieBaseModel

--- a/api/kogito-api/src/main/java/org/kie/api/conf/BetaRangeIndexOption.java
+++ b/api/kogito-api/src/main/java/org/kie/api/conf/BetaRangeIndexOption.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.api.conf;
+
+/**
+ * <p>
+ * An enum to enable beta node range index option.
+ * </p>
+ *
+ * <pre>
+ * drools.betaNodeRangeIndexEnabled = &lt;true|false&gt;
+ * </pre>
+ *
+ * <b>DEFAULT = false</b>
+ *
+ */
+public enum BetaRangeIndexOption implements SingleValueKieBaseOption {
+
+    ENABLED(true),
+    DISABLED(false);
+
+    /**
+     * The property name for beta node range index option
+     */
+    public static final String PROPERTY_NAME = "drools.betaNodeRangeIndexEnabled";
+
+    private boolean value;
+
+    BetaRangeIndexOption(final boolean value) {
+        this.value = value;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public String getPropertyName() {
+        return PROPERTY_NAME;
+    }
+
+    public boolean isBetaRangeIndexEnabled() {
+        return this.value;
+    }
+
+    public static BetaRangeIndexOption determineBetaRangeIndex(String option) {
+        if (ENABLED.name().equalsIgnoreCase(option) || "true".equalsIgnoreCase(option)) {
+            return ENABLED;
+        } else if (DISABLED.name().equalsIgnoreCase(option) || "false".equalsIgnoreCase(option)) {
+            return DISABLED;
+        }
+        throw new IllegalArgumentException("Illegal enum value '" + option + "' for BetaRangeIndexOption");
+    }
+
+}

--- a/api/kogito-api/src/main/resources/org/kie/api/kmodule.xsd
+++ b/api/kogito-api/src/main/resources/org/kie/api/kmodule.xsd
@@ -67,6 +67,7 @@
       <xsd:attribute name="eventProcessingMode" type="eventModeEnum"/>
       <xsd:attribute name="declarativeAgenda" type="declarativeAgendaEnum"/>
       <xsd:attribute name="sessionsPool" type="xsd:int"/>
+      <xsd:attribute name="betaRangeIndex" type="betaRangeIndexEnum"/>
     </xsd:complexType>
   </xsd:element>
 
@@ -237,6 +238,15 @@
       <xsd:enumeration value="simple"/>
       <xsd:enumeration value="jtms"/>
       <xsd:enumeration value="defeasible"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="betaRangeIndexEnum">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="enabled"/>
+      <xsd:enumeration value="disabled"/>
+      <xsd:enumeration value="true"/>
+      <xsd:enumeration value="false"/>
     </xsd:restriction>
   </xsd:simpleType>
 


### PR DESCRIPTION
- forward port for kogito-api

https://issues.redhat.com/browse/DROOLS-5910

This PR is a forward port of https://github.com/kiegroup/droolsjbpm-knowledge/commit/5cafa765f32074193dc7d8e8820b641fc50eb677

This PR is required when you update to the drools version which contains https://github.com/kiegroup/drools/commit/d0ecb0a55a454eeec45658f2ebe58a878dd0dc87
(currently drools 7.50.0-SNAPSHOT)

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket