### PR TITLE
KOGITO-4435 Fix path resolution error on macOS

### DIFF
--- a/kogito-codegen-modules/kogito-codegen-api/src/main/java/org/kie/kogito/codegen/api/io/CollectedResource.java
+++ b/kogito-codegen-modules/kogito-codegen-api/src/main/java/org/kie/kogito/codegen/api/io/CollectedResource.java
@@ -18,6 +18,7 @@ package org.kie.kogito.codegen.api.io;
 
 import org.kie.api.io.Resource;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -32,11 +33,18 @@ public class CollectedResource {
     public CollectedResource(Path basePath, Resource resource) {
         // basePath must be a prefix of sourcePath
         // unless it is a jar file, then the check is ignored
-        if (! basePath.toString().endsWith(".jar") &&
-                ! Paths.get(resource.getSourcePath()).toAbsolutePath().startsWith(basePath.toAbsolutePath())) {
+        try {
+            if (! basePath.toString().endsWith(".jar") &&
+                    ! Paths.get(resource.getSourcePath()).toAbsolutePath().toRealPath()
+                            .startsWith(basePath.toAbsolutePath().toRealPath())) {
+                throw new IllegalArgumentException(
+                        String.format("basePath %s is not a prefix to the resource sourcePath %s",
+                                      basePath, resource.getSourcePath()));
+            }
+        } catch (IOException e) {
             throw new IllegalArgumentException(
-                    String.format("basePath %s is not a prefix to the resource sourcePath %s",
-                                  basePath, resource.getSourcePath()));
+                    String.format("Could not determine if basePath %s is a prefix to the resource sourcePath %s",
+                            basePath, resource.getSourcePath()), e);
         }
         this.basePath = basePath;
         this.resource = resource;


### PR DESCRIPTION
resolve symlinks -- on macOS `/var` is symlinked to `/private/var`

https://issues.redhat.com/browse/KOGITO-4435

