### PR TITLE
[KOGITO-4356] Remove/minimize KieSession usages in jbpm-bpmn2 tests

### DIFF
--- a/api/kogito-api/src/main/java/org/kie/kogito/internal/process/runtime/KogitoProcessRuntime.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/internal/process/runtime/KogitoProcessRuntime.java
@@ -20,7 +20,9 @@ import java.util.Collection;
 import java.util.Map;
 
 import org.kie.api.KieBase;
+import org.kie.api.event.process.ProcessEventManager;
 import org.kie.api.runtime.KieRuntime;
+import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.process.ProcessRuntime;
 import org.kie.api.runtime.rule.AgendaFilter;
 import org.kie.kogito.jobs.JobsService;
@@ -207,9 +209,14 @@ public interface KogitoProcessRuntime {
 
     KogitoProcessEventSupport getProcessEventSupport();
 
+    ProcessEventManager getProcessEventManager();
+
     @Deprecated
     KieRuntime getKieRuntime();
 
     @Deprecated
     KieBase getKieBase();
+
+    @Deprecated
+    KieSession getKieSession();
 }

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/handler/ReceiveTaskHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/handler/ReceiveTaskHandler.java
@@ -19,7 +19,6 @@ package org.jbpm.bpmn2.handler;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.kie.api.runtime.KieSession;
 import org.kie.kogito.internal.process.runtime.KogitoProcessRuntime;
 import org.kie.kogito.internal.process.runtime.KogitoWorkItem;
 import org.kie.kogito.internal.process.runtime.KogitoWorkItemHandler;
@@ -28,15 +27,15 @@ import org.kie.kogito.internal.process.runtime.KogitoWorkItemManager;
 public class ReceiveTaskHandler implements KogitoWorkItemHandler {
     
     // TODO: use correlation instead of message id
-    private Map<String, String> waiting = new HashMap<String, String>();
+    private Map<String, String> waiting = new HashMap<>();
     private KogitoProcessRuntime kruntime;
     
-    public ReceiveTaskHandler(KieSession ksession) {
-        this.kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+    public ReceiveTaskHandler(KogitoProcessRuntime kruntime) {
+        this.kruntime = kruntime;
     }
     
-    public void setKnowledgeRuntime(KieSession ksession) {
-    	this.kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+    public void setKnowledgeRuntime(KogitoProcessRuntime kruntime) {
+    	this.kruntime = kruntime;
     }
 
     public void executeWorkItem( KogitoWorkItem workItem, KogitoWorkItemManager manager) {
@@ -49,7 +48,7 @@ public class ReceiveTaskHandler implements KogitoWorkItemHandler {
         if (workItemId == null) {
             return;
         }
-        Map<String, Object> results = new HashMap<String, Object>();
+        Map<String, Object> results = new HashMap<>();
         results.put("Message", message);
         kruntime.getWorkItemManager().completeWorkItem(workItemId, results);
     }

--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/ActivityTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/ActivityTest.java
@@ -63,12 +63,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.kie.api.KieBase;
 import org.kie.api.command.ExecutableCommand;
 import org.kie.api.definition.process.Node;
 import org.kie.api.definition.process.NodeContainer;
 import org.kie.api.definition.process.Process;
-import org.kie.api.event.process.DefaultProcessEventListener;
 import org.kie.api.event.process.ProcessNodeTriggeredEvent;
 import org.kie.api.event.process.ProcessStartedEvent;
 import org.kie.api.event.process.ProcessVariableChangedEvent;
@@ -77,21 +75,18 @@ import org.kie.api.event.rule.AgendaEventListener;
 import org.kie.api.event.rule.BeforeMatchFiredEvent;
 import org.kie.api.event.rule.MatchCancelledEvent;
 import org.kie.api.event.rule.MatchCreatedEvent;
-import org.kie.api.runtime.Context;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.process.DataTransformer;
 import org.kie.api.runtime.process.NodeInstance;
-import org.kie.api.runtime.process.ProcessContext;
-import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.api.runtime.process.WorkItem;
 import org.kie.api.runtime.process.WorkItemManager;
-import org.kie.api.runtime.process.WorkflowProcessInstance;
 import org.kie.internal.command.RegistryContext;
-import org.kie.internal.runtime.StatefulKnowledgeSession;
+import org.kie.kogito.internal.process.event.DefaultKogitoProcessEventListener;
 import org.kie.kogito.internal.process.runtime.KogitoNodeInstanceContainer;
 import org.kie.kogito.internal.process.runtime.KogitoProcessInstance;
 import org.kie.kogito.internal.process.runtime.KogitoProcessRuntime;
 import org.kie.kogito.internal.process.runtime.KogitoWorkItemManager;
+import org.kie.kogito.internal.process.runtime.KogitoWorkflowProcessInstance;
 import org.kie.kogito.process.workitems.KogitoWorkItem;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -104,65 +99,57 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ActivityTest extends JbpmBpmn2TestCase {
 
-    private KieSession ksession2;
+    private KogitoProcessRuntime kruntime2;
 
     @AfterEach
     @Override
-    public void disposeSession() {
-        super.disposeSession();
-        if (ksession2 != null) {
-            ksession2.dispose();
-            ksession2 = null;
+    public void disposeKogitoProcessRuntime() {
+        super.disposeKogitoProcessRuntime();
+        if (kruntime2 != null && kruntime2.getKieSession() != null) {
+            kruntime2.getKieSession().dispose();
+            kruntime2 = null;
         }
     }
 
     @Test
     public void testMinimalProcess() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-MinimalProcess.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-MinimalProcess.bpmn2");
         KogitoProcessInstance processInstance = kruntime.startProcess("Minimal");
         assertProcessInstanceCompleted(processInstance);
     }
 
     @Test
     public void testMinimalProcessImplicit() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-MinimalProcessImplicit.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-MinimalProcessImplicit.bpmn2");
         KogitoProcessInstance processInstance = kruntime.startProcess("Minimal");
         assertProcessInstanceCompleted(processInstance);
     }
 
     @Test
     public void testMinimalProcessWithGraphical() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-MinimalProcessWithGraphical.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-MinimalProcessWithGraphical.bpmn2");
         KogitoProcessInstance processInstance = kruntime.startProcess("Minimal");
         assertProcessInstanceCompleted(processInstance);
     }
 
     @Test
     public void testMinimalProcessWithDIGraphical() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-MinimalProcessWithDIGraphical.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-MinimalProcessWithDIGraphical.bpmn2");
         KogitoProcessInstance processInstance = kruntime.startProcess("Minimal");
         assertProcessInstanceCompleted(processInstance);
     }
 
     @Test
     public void testMinimalProcessMetaData() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-MinimalProcessMetaData.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-MinimalProcessMetaData.bpmn2");
 
-        final List<String> list1 = new ArrayList<String>();
-        final List<String> list2 = new ArrayList<String>();
-        final List<String> list3 = new ArrayList<String>();
-        final List<String> list4 = new ArrayList<String>();
-        ksession.addEventListener(new DefaultProcessEventListener() {
+        final List<String> list1 = new ArrayList<>();
+        final List<String> list2 = new ArrayList<>();
+        final List<String> list3 = new ArrayList<>();
+        final List<String> list4 = new ArrayList<>();
+        kruntime.getProcessEventManager().addEventListener(new DefaultKogitoProcessEventListener() {
+
+            @Override
 			public void beforeNodeTriggered(ProcessNodeTriggeredEvent event) {
 				logger.debug("before node");
 				Map<String, Object> metaData = event.getNodeInstance().getNode().getMetaData();
@@ -178,7 +165,9 @@ public class ActivityTest extends JbpmBpmn2TestCase {
 					list2.add(customTag2);
 				}
 			}
-			public void afterVariableChanged(ProcessVariableChangedEvent event) {
+
+            @Override
+            public void afterVariableChanged(ProcessVariableChangedEvent event) {
 				logger.debug("after variable");
 				VariableScope variableScope = (VariableScope)
 					((org.jbpm.process.core.impl.ProcessImpl) event.getProcessInstance().getProcess())
@@ -195,7 +184,9 @@ public class ActivityTest extends JbpmBpmn2TestCase {
 					list3.add(customTag);
 				}
 			}
-			public void afterProcessStarted(ProcessStartedEvent event) {
+
+            @Override
+            public void afterProcessStarted(ProcessStartedEvent event) {
 				logger.debug("after process");
 	        	Map<String, Object> metaData = event.getProcessInstance().getProcess().getMetaData();
 	        	for (Map.Entry<String, Object> entry: metaData.entrySet()) {
@@ -207,7 +198,7 @@ public class ActivityTest extends JbpmBpmn2TestCase {
 				}
 			}
 		});
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", "krisv");
         KogitoProcessInstance processInstance = kruntime.startProcess("Minimal", params);
         assertProcessInstanceCompleted(processInstance);
@@ -219,18 +210,14 @@ public class ActivityTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testCompositeProcessWithDIGraphical() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-CompositeProcessWithDIGraphical.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-CompositeProcessWithDIGraphical.bpmn2");
         KogitoProcessInstance processInstance = kruntime.startProcess("Composite");
         assertProcessInstanceCompleted(processInstance);
     }
 
     @Test
     public void testScriptTask() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-ScriptTask.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-ScriptTask.bpmn2");
         KogitoProcessInstance processInstance = kruntime.startProcess("ScriptTask");
         assertProcessInstanceCompleted(processInstance);
     }
@@ -243,19 +230,17 @@ public class ActivityTest extends JbpmBpmn2TestCase {
                 .describedAs("GraalJS is not supported.")
                 .isNotEqualTo("GraalJSScriptEngine");
 
-        KieBase kbase = createKnowledgeBase("BPMN2-ScriptTaskJS.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-ScriptTaskJS.bpmn2");
 
         TestWorkItemHandler handler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", handler);
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("name", "krisv");
         Person person = new Person();
         person.setName("krisv");
         params.put("person", person);
 
-        WorkflowProcessInstance processInstance = (WorkflowProcessInstance) ksession.startProcess("ScriptTask", params);
+        KogitoWorkflowProcessInstance processInstance = (KogitoWorkflowProcessInstance) kruntime.startProcess("ScriptTask", params);
         assertEquals("Entry", processInstance.getVariable("x"));
         assertNull(processInstance.getVariable("y"));
 
@@ -263,18 +248,16 @@ public class ActivityTest extends JbpmBpmn2TestCase {
         assertEquals("Exit", getProcessVarValue(processInstance, "y"));
         assertEquals("tester", processInstance.getVariable("surname"));
     }
-    
+
     @Test
     public void testScriptTaskWithIO() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-ScriptTaskWithIO.bpmn2");
+        kruntime = createKogitoProcessRuntime("BPMN2-ScriptTaskWithIO.bpmn2");
 
-        Process scriptProcess = kbase.getProcess("ScriptTask");
+        Process scriptProcess = kruntime.getKieBase().getProcess("ScriptTask");
         assertThat(scriptProcess).isNotNull();
         Node[] nodes = ((NodeContainer) scriptProcess).getNodes();
         assertThat(nodes).hasSize(3);
         assertThat(nodes).filteredOn(n -> n instanceof ActionNode).allMatch(n -> ((ActionNode) n).getInAssociations().size() == 1 && ((ActionNode) n).getOutAssociations().size() == 1);
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
 
         Map<String, Object> params = new HashMap<>();
         params.put("name", "John");
@@ -285,65 +268,54 @@ public class ActivityTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testRuleTask() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-RuleTask.bpmn2",
+        kruntime = createKogitoProcessRuntime("BPMN2-RuleTask.bpmn2",
                 "BPMN2-RuleTask.drl");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
 
-        List<String> list = new ArrayList<String>();
-        ksession.setGlobal("list", list);
-        KogitoProcessInstance processInstance = kruntime.startProcess("RuleTask");        
-        ksession.setGlobal("list", list);
-        assertTrue(list.size() == 1);
-        assertProcessInstanceFinished(processInstance, ksession);
+        List<String> list = new ArrayList<>();
+        kruntime.getKieSession().setGlobal("list", list);
+        KogitoProcessInstance processInstance = kruntime.startProcess("RuleTask");
+        kruntime.getKieSession().setGlobal("list", list);
+        assertEquals(1, list.size());
+        assertProcessInstanceFinished(processInstance, kruntime);
     }
 
     @Test
     public void testRuleTask2() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-RuleTask2.bpmn2",
-                "BPMN2-RuleTask2.drl");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-RuleTask2.bpmn2", "BPMN2-RuleTask2.drl");
 
-        List<String> list = new ArrayList<String>();
-        ksession.setGlobal("list", list);
-        Map<String, Object> params = new HashMap<String, Object>();
+        List<String> list = new ArrayList<>();
+        kruntime.getKieSession().setGlobal("list", list);
+        Map<String, Object> params = new HashMap<>();
         params.put("x", "SomeString");
         KogitoProcessInstance processInstance = kruntime.startProcess("RuleTask",
                 params);
-        assertTrue(list.size() == 0);
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertTrue(list.isEmpty());
+        assertProcessInstanceFinished(processInstance, kruntime);
     }
 
     @Test
     public void testRuleTaskSetVariableWithReconnect() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-RuleTask2.bpmn2",
-                "BPMN2-RuleTaskSetVariableReconnect.drl");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-RuleTask2.bpmn2", "BPMN2-RuleTaskSetVariableReconnect.drl");
 
-        List<String> list = new ArrayList<String>();
-        ksession.setGlobal("list", list);
-        Map<String, Object> params = new HashMap<String, Object>();
+        List<String> list = new ArrayList<>();
+        kruntime.getKieSession().setGlobal("list", list);
+        Map<String, Object> params = new HashMap<>();
         params.put("x", "SomeString");
 
         KogitoProcessInstance processInstance = kruntime.startProcess("RuleTask",
-                params);       
-        assertTrue(list.size() == 1);
+                params);
+        assertEquals(1, list.size());
 
         assertProcessVarValue(processInstance, "x", "AnotherString");
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
     }
 
     @Test
     @RequirePersistence(false)
     public void testRuleTaskWithFacts() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-RuleTaskWithFact.bpmn2",
-                "BPMN2-RuleTask3.drl");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-RuleTaskWithFact.bpmn2", "BPMN2-RuleTask3.drl");
 
-        ksession.addEventListener(new AgendaEventListener() {
+        kruntime.getKieSession().addEventListener(new AgendaEventListener() {
             public void matchCreated(MatchCreatedEvent event) {
             }
 
@@ -375,7 +347,7 @@ public class ActivityTest extends JbpmBpmn2TestCase {
 
             public void afterRuleFlowGroupActivated(
                     org.kie.api.event.rule.RuleFlowGroupActivatedEvent event) {
-                ksession.fireAllRules();
+                kruntime.getKieSession().fireAllRules();
             }
 
             public void afterMatchFired(AfterMatchFiredEvent event) {
@@ -383,130 +355,113 @@ public class ActivityTest extends JbpmBpmn2TestCase {
 
         });
 
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", "SomeString");
         KogitoProcessInstance processInstance = kruntime.startProcess("RuleTask",
                 params);
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
-        params = new HashMap<String, Object>();
-        
+        params = new HashMap<>();
+
         processInstance = kruntime.startProcess("RuleTask", params);
-        
+
         assertEquals(KogitoProcessInstance.STATE_ERROR, processInstance.getState());
 
-        params = new HashMap<String, Object>();
+        params = new HashMap<>();
         params.put("x", "SomeString");
         processInstance = kruntime.startProcess("RuleTask", params);
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
     }
 
     @Test
     public void testRuleTaskAcrossSessions() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-RuleTask.bpmn2",
-                "BPMN2-RuleTask.drl");
-        ksession = createKnowledgeSession(kbase);
-        ksession2 = createKnowledgeSession(kbase);
-        List<String> list1 = new ArrayList<String>();
-        ksession.setGlobal("list", list1);
-        List<String> list2 = new ArrayList<String>();
-        ksession2.setGlobal("list", list2);
-        ProcessInstance processInstance1 = ksession.startProcess("RuleTask");
-        ProcessInstance processInstance2 = ksession2.startProcess("RuleTask");       
-        assertProcessInstanceFinished(processInstance1, ksession);
-        assertProcessInstanceFinished(processInstance2, ksession2);
+        kruntime = createKogitoProcessRuntime("BPMN2-RuleTask.bpmn2", "BPMN2-RuleTask.drl");
+        kruntime2 = createKogitoProcessRuntime("BPMN2-RuleTask.bpmn2", "BPMN2-RuleTask.drl");
+
+        List<String> list1 = new ArrayList<>();
+        kruntime.getKieSession().setGlobal("list", list1);
+        List<String> list2 = new ArrayList<>();
+        kruntime2.getKieSession().setGlobal("list", list2);
+        KogitoProcessInstance processInstance1 = kruntime.startProcess("RuleTask");
+        KogitoProcessInstance processInstance2 = kruntime2.startProcess("RuleTask");
+        assertProcessInstanceFinished(processInstance1, kruntime);
+        assertProcessInstanceFinished(processInstance2, kruntime2);
     }
 
     @Test
     public void testUserTaskWithDataStoreScenario() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-UserTaskWithDataStore.bpmn2");
-        StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-UserTaskWithDataStore.bpmn2");
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 new DoNothingWorkItemHandler());
-        ksession.startProcess("UserProcess");
+        kruntime.startProcess("UserProcess");
         // we can't test further as user tasks are asynchronous.
     }
 
     @Test
     public void testUserTask() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-UserTask.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-UserTask.bpmn2");
 
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 workItemHandler);
         KogitoProcessInstance processInstance = kruntime.startProcess("UserTask");
-        assertTrue(processInstance.getState() == ProcessInstance.STATE_ACTIVE);
-        ksession = restoreSession(ksession, true);
+        assertEquals(KogitoProcessInstance.STATE_ACTIVE, processInstance.getState());
         org.kie.kogito.internal.process.runtime.KogitoWorkItem workItem = workItemHandler.getWorkItem();
         assertNotNull(workItem);
         assertEquals("john", workItem.getParameter("ActorId"));
         kruntime.getWorkItemManager().completeWorkItem(workItem.getStringId(), null);
-        assertProcessInstanceFinished(processInstance, ksession);
-        ksession.dispose();
+        assertProcessInstanceFinished(processInstance, kruntime);
     }
 
     @Test
     public void testUserTaskVerifyParameters() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-UserTask.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        ksession.getEnvironment().set("deploymentId", "test-deployment-id");
+        kruntime = createKogitoProcessRuntime("BPMN2-UserTask.bpmn2");
+
+        kruntime.getKieSession().getEnvironment().set("deploymentId", "test-deployment-id");
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
         KogitoProcessInstance processInstance = kruntime.startProcess("UserTask");
-        assertTrue(processInstance.getState() == ProcessInstance.STATE_ACTIVE);
-        ksession = restoreSession(ksession, true);
+        assertEquals(KogitoProcessInstance.STATE_ACTIVE, processInstance.getState());
         org.kie.kogito.internal.process.runtime.KogitoWorkItem workItem = workItemHandler.getWorkItem();
         assertNotNull(workItem);
         assertEquals("john", workItem.getParameter("ActorId"));
         final String pId = processInstance.getStringId();
 
-        ksession.execute(new ExecutableCommand<Void>() {
+        kruntime.getKieSession().execute((ExecutableCommand<Void>) context -> {
 
-            @Override
-            public Void execute(Context context) {
+            KogitoProcessRuntime kruntimeLocal = KogitoProcessRuntime.asKogitoProcessRuntime(((RegistryContext) context).lookup( KieSession.class ));
+            KogitoProcessInstance processInstance1 = kruntimeLocal.getProcessInstance(pId);
+            assertNotNull(processInstance1);
+            NodeInstance nodeInstance = (( KogitoNodeInstanceContainer ) processInstance1)
+                    .getNodeInstance((( KogitoWorkItem ) workItem).getNodeInstanceStringId());
 
-                KieSession ksession = ((RegistryContext) context).lookup( KieSession.class );
-                KogitoProcessInstance processInstance = kruntime.getProcessInstance(pId);
-                assertNotNull(processInstance);
-                NodeInstance nodeInstance = (( KogitoNodeInstanceContainer ) processInstance)
-                        .getNodeInstance((( KogitoWorkItem ) workItem).getNodeInstanceStringId());
+            assertNotNull(nodeInstance);
+            assertTrue(nodeInstance instanceof WorkItemNodeInstance);
+            String deploymentId = ((WorkItemNodeInstance) nodeInstance).getWorkItem().getDeploymentId();
+            String nodeInstanceId = ((WorkItemNodeInstance) nodeInstance).getWorkItem().getNodeInstanceStringId();
+            long nodeId = ((WorkItemNodeInstance) nodeInstance).getWorkItem().getNodeId();
 
-                assertNotNull(nodeInstance);
-                assertTrue(nodeInstance instanceof WorkItemNodeInstance);
-                String deploymentId = ((WorkItemNodeInstance) nodeInstance).getWorkItem().getDeploymentId();
-                String nodeInstanceId = ((WorkItemNodeInstance) nodeInstance).getWorkItem().getNodeInstanceStringId();
-                long nodeId = ((WorkItemNodeInstance) nodeInstance).getWorkItem().getNodeId();
+            assertEquals((( KogitoWorkItem ) workItem).getDeploymentId(), deploymentId);
+            assertEquals((( KogitoWorkItem ) workItem).getNodeId(), nodeId);
+            assertEquals((( KogitoWorkItem ) workItem).getNodeInstanceStringId(), nodeInstanceId);
 
-                assertEquals((( KogitoWorkItem ) workItem).getDeploymentId(), deploymentId);
-                assertEquals((( KogitoWorkItem ) workItem).getNodeId(), nodeId);
-                assertEquals((( KogitoWorkItem ) workItem).getNodeInstanceStringId(), nodeInstanceId);
-
-                return null;
-            }
+            return null;
         });
 
 
 
         kruntime.getWorkItemManager().completeWorkItem(workItem.getStringId(), null);
-        assertProcessInstanceFinished(processInstance, ksession);
-        ksession.dispose();
+        assertProcessInstanceFinished(processInstance, kruntime);
     }
-    
+
 
     @Test
     public void testCallActivityWithContantsAssignment() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("subprocess/SingleTaskWithVarDef.bpmn2",
-                "subprocess/InputMappingUsingValue.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("subprocess/SingleTaskWithVarDef.bpmn2", "subprocess/InputMappingUsingValue.bpmn2");
 
         TestWorkItemHandler handler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("CustomTask", handler);
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         KogitoProcessInstance processInstance = kruntime.startProcess("defaultPackage.InputMappingUsingValue", params);
 
         org.kie.kogito.internal.process.runtime.KogitoWorkItem workItem = handler.getWorkItem();
@@ -523,9 +478,7 @@ public class ActivityTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testSubProcessWithEntryExitScripts() throws Exception {
-        KieBase kbase = createKnowledgeBase("subprocess/BPMN2-SubProcessWithEntryExitScripts.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("subprocess/BPMN2-SubProcessWithEntryExitScripts.bpmn2");
         TestWorkItemHandler handler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", handler);
 
@@ -566,29 +519,23 @@ public class ActivityTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testCallActivity() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-CallActivity.bpmn2",
-                "BPMN2-CallActivitySubProcess.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-CallActivity.bpmn2", "BPMN2-CallActivitySubProcess.bpmn2");
 
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", "oldValue");
         KogitoProcessInstance processInstance = kruntime.startProcess(
                 "ParentProcess", params);
         assertProcessInstanceCompleted(processInstance);
         assertEquals("new value",
-                ((WorkflowProcessInstance) processInstance).getVariable("y"));
+                ((KogitoWorkflowProcessInstance) processInstance).getVariable("y"));
     }
 
     @Test
     public void testCallActivityMI() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-CallActivityMI.bpmn2",
-                "BPMN2-CallActivitySubProcess.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-CallActivityMI.bpmn2", "BPMN2-CallActivitySubProcess.bpmn2");
 
         final List<String> subprocessStarted = new ArrayList<>();
-        ksession.addEventListener(new DefaultProcessEventListener() {
+        kruntime.getProcessEventManager().addEventListener(new DefaultKogitoProcessEventListener() {
 
             @Override
             public void beforeProcessStarted(ProcessStartedEvent event) {
@@ -599,12 +546,12 @@ public class ActivityTest extends JbpmBpmn2TestCase {
 
         });
 
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         list.add("first");
         list.add("second");
-        List<String> listOut = new ArrayList<String>();
+        List<String> listOut = new ArrayList<>();
 
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", "oldValue");
         params.put("list", list);
         params.put("listOut", listOut);
@@ -613,7 +560,7 @@ public class ActivityTest extends JbpmBpmn2TestCase {
         assertProcessInstanceCompleted(processInstance);
 
         assertEquals(2, subprocessStarted.size());
-        listOut = (List)((WorkflowProcessInstance) processInstance).getVariable("listOut");
+        listOut = (List)((KogitoWorkflowProcessInstance) processInstance).getVariable("listOut");
         assertNotNull(listOut);
         assertEquals(2, listOut.size());
 
@@ -623,63 +570,59 @@ public class ActivityTest extends JbpmBpmn2TestCase {
 
 	@Test
 	public void testCallActivity2() throws Exception {
-		KieBase kbase = createKnowledgeBase("BPMN2-CallActivity2.bpmn2",
-				"BPMN2-CallActivitySubProcess.bpmn2");
-		ksession = createKnowledgeSession(kbase);
+        kruntime = createKogitoProcessRuntime("BPMN2-CallActivity2.bpmn2", "BPMN2-CallActivitySubProcess.bpmn2");
 		TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
 
 		kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 workItemHandler);
-		Map<String, Object> params = new HashMap<String, Object>();
+		Map<String, Object> params = new HashMap<>();
 		params.put("x", "oldValue");
 		KogitoProcessInstance processInstance = kruntime.startProcess(
 				"ParentProcess", params);
 		assertProcessInstanceActive(processInstance);
 		assertEquals("new value",
-				((WorkflowProcessInstance) processInstance).getVariable("y"));
+				((KogitoWorkflowProcessInstance) processInstance).getVariable("y"));
 
-		ksession = restoreSession(ksession, true);
 		org.kie.kogito.internal.process.runtime.KogitoWorkItem workItem = workItemHandler.getWorkItem();
 		assertNotNull(workItem);
 		assertEquals("krisv", workItem.getParameter("ActorId"));
 		kruntime.getWorkItemManager().completeWorkItem(workItem.getStringId(), null);
 
-		assertProcessInstanceFinished(processInstance, ksession);
+		assertProcessInstanceFinished(processInstance, kruntime);
 	}
 
     @Test
     public void testCallActivityByName() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-CallActivityByName.bpmn2",
+        kruntime = createKogitoProcessRuntime("BPMN2-CallActivityByName.bpmn2",
                 "BPMN2-CallActivitySubProcess.bpmn2",
                 "BPMN2-CallActivitySubProcessV2.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
 
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", "oldValue");
         KogitoProcessInstance processInstance = kruntime.startProcess(
                 "ParentProcess", params);
         assertProcessInstanceCompleted(processInstance);
         assertEquals("new value V2",
-                ((WorkflowProcessInstance) processInstance).getVariable("y"));
+                ((KogitoWorkflowProcessInstance) processInstance).getVariable("y"));
     }
-  
+
     @Test
     public void testSubProcess() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-SubProcess.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-SubProcess.bpmn2");
 
-        ksession.addEventListener(new DefaultProcessEventListener() {
+        kruntime.getProcessEventManager().addEventListener(new DefaultKogitoProcessEventListener() {
+
+            @Override
             public void afterProcessStarted(ProcessStartedEvent event) {
                 logger.debug(event.toString());
             }
 
+            @Override
             public void beforeVariableChanged(ProcessVariableChangedEvent event) {
                 logger.debug(event.toString());
             }
 
+            @Override
             public void afterVariableChanged(ProcessVariableChangedEvent event) {
                 logger.debug(event.toString());
             }
@@ -691,41 +634,37 @@ public class ActivityTest extends JbpmBpmn2TestCase {
     @Test
     public void testInvalidSubProcess() throws Exception {
     	try {
-    		KieBase kbase = createKnowledgeBase("BPMN2-SubProcessInvalid.bpmn2");
-    		ksession = createKnowledgeSession(kbase);
+    	    kruntime = createKogitoProcessRuntime("BPMN2-SubProcessInvalid.bpmn2");
     		fail("Process should be invalid, there should be build errors");
     	} catch (RuntimeException e) {
     		// there should be build errors
     	}
     }
-    
+
     @Test
     public void testSubProcessWrongStartEvent() throws Exception {
         try {
-            KieBase kbase = createKnowledgeBase("BPMN2-SubProcessWrongStartEvent.bpmn2");
-            ksession = createKnowledgeSession(kbase);
+            kruntime = createKogitoProcessRuntime("BPMN2-SubProcessWrongStartEvent.bpmn2");
             fail("Process should be invalid, there should be build errors");
         } catch (RuntimeException e) {
             assertThat(e.getMessage()).contains("Embedded subprocess can only have none start event.");
         }
     }
-    
+
     @Test
     public void testSubProcessWrongStartEventTimer() throws Exception {
         try {
-            KieBase kbase = createKnowledgeBase("SubprocessWithTimer.bpmn2");
-            ksession = createKnowledgeSession(kbase);
+            kruntime = createKogitoProcessRuntime("SubprocessWithTimer.bpmn2");
             fail("Process should be invalid, there should be build errors");
         } catch (RuntimeException e) {
             assertThat(e.getMessage()).contains("Embedded subprocess can only have none start event.");
         }
     }
-    
+
     @Test
     public void testMultiinstanceSubProcessWrongStartEvent() throws Exception {
         try {
-            KieBase kbase = createKnowledgeBase("MultipleSubprocessWithSignalStartEvent.bpmn2");
-            ksession = createKnowledgeSession(kbase);
+            kruntime = createKogitoProcessRuntime("MultipleSubprocessWithSignalStartEvent.bpmn2");
             fail("Process should be invalid, there should be build errors");
         } catch (RuntimeException e) {
             assertThat(e.getMessage()).contains("MultiInstance subprocess can only have none start event.");
@@ -734,17 +673,16 @@ public class ActivityTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testSubProcessWithTerminateEndEvent() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-SubProcessWithTerminateEndEvent.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        final List<String> list = new ArrayList<String>();
-        ksession.addEventListener(new DefaultProcessEventListener() {
+        kruntime = createKogitoProcessRuntime("BPMN2-SubProcessWithTerminateEndEvent.bpmn2");
+        final List<String> list = new ArrayList<>();
+        kruntime.getProcessEventManager().addEventListener(new DefaultKogitoProcessEventListener() {
 
+            @Override
             public void afterNodeTriggered(ProcessNodeTriggeredEvent event) {
                 list.add(event.getNodeInstance().getNodeName());
             }
         });
-        ProcessInstance processInstance = ksession
-                .startProcess("SubProcessTerminate");
+        KogitoProcessInstance processInstance = kruntime.startProcess("SubProcessTerminate");
         assertProcessInstanceCompleted(processInstance);
         assertEquals(7, list.size());
     }
@@ -752,30 +690,26 @@ public class ActivityTest extends JbpmBpmn2TestCase {
     @Test
     public void testSubProcessWithTerminateEndEventProcessScope()
             throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-SubProcessWithTerminateEndEventProcessScope.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        final List<String> list = new ArrayList<String>();
-        ksession.addEventListener(new DefaultProcessEventListener() {
+        kruntime = createKogitoProcessRuntime("BPMN2-SubProcessWithTerminateEndEventProcessScope.bpmn2");
+        final List<String> list = new ArrayList<>();
+        kruntime.getProcessEventManager().addEventListener(new DefaultKogitoProcessEventListener() {
 
+            @Override
             public void afterNodeTriggered(ProcessNodeTriggeredEvent event) {
                 list.add(event.getNodeInstance().getNodeName());
             }
         });
-        ProcessInstance processInstance = ksession
-                .startProcess("SubProcessTerminate");
+        KogitoProcessInstance processInstance = kruntime.startProcess("SubProcessTerminate");
         assertProcessInstanceCompleted(processInstance);
         assertEquals(5, list.size());
     }
 
     @Test
     public void testAdHocProcess() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-AdHocProcess.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-AdHocProcess.bpmn2");
 
         KogitoProcessInstance processInstance = kruntime.startProcess("AdHocProcess");
-        assertTrue(processInstance.getState() == ProcessInstance.STATE_ACTIVE);
-        ksession = restoreSession(ksession, true);
+        assertEquals(KogitoProcessInstance.STATE_ACTIVE, processInstance.getState());
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 new DoNothingWorkItemHandler());
         logger.debug("Triggering node");
@@ -783,20 +717,17 @@ public class ActivityTest extends JbpmBpmn2TestCase {
         assertProcessInstanceActive(processInstance);
         kruntime.signalEvent("User1", null, processInstance.getStringId());
         assertProcessInstanceActive(processInstance);
-        ksession.insert(new Person());
+        kruntime.getKieSession().insert(new Person());
         kruntime.signalEvent("Task3", null, processInstance.getStringId());
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
     }
 
     @Test
     public void testAdHocProcessDynamicTask() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-AdHocProcess.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-AdHocProcess.bpmn2");
 
         KogitoProcessInstance processInstance = kruntime.startProcess("AdHocProcess");
-        assertTrue(processInstance.getState() == ProcessInstance.STATE_ACTIVE);
-        ksession = restoreSession(ksession, true);
+        assertEquals(KogitoProcessInstance.STATE_ACTIVE, processInstance.getState());
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 new DoNothingWorkItemHandler());
         logger.debug("Triggering node");
@@ -805,29 +736,24 @@ public class ActivityTest extends JbpmBpmn2TestCase {
         TestWorkItemHandler workItemHandler2 = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("OtherTask",
                 workItemHandler2);
-        DynamicUtils.addDynamicWorkItem(processInstance, ksession, "OtherTask",
-                new HashMap<String, Object>());
+        DynamicUtils.addDynamicWorkItem(processInstance, kruntime.getKieSession(), "OtherTask",
+                new HashMap<>());
         org.kie.kogito.internal.process.runtime.KogitoWorkItem workItem = workItemHandler2.getWorkItem();
         assertNotNull(workItem);
-        ksession = restoreSession(ksession, true);
         kruntime.getWorkItemManager().completeWorkItem(workItem.getStringId(), null);
         kruntime.signalEvent("User1", null, processInstance.getStringId());
         assertProcessInstanceActive(processInstance);
-        ksession.insert(new Person());
+        kruntime.getKieSession().insert(new Person());
         kruntime.signalEvent("Task3", null, processInstance.getStringId());
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
     }
 
     @Test
     public void testAdHocProcessDynamicSubProcess() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-AdHocProcess.bpmn2",
-                "BPMN2-MinimalProcess.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-AdHocProcess.bpmn2", "BPMN2-MinimalProcess.bpmn2");
 
         KogitoProcessInstance processInstance = kruntime.startProcess("AdHocProcess");
-        assertTrue(processInstance.getState() == ProcessInstance.STATE_ACTIVE);
-        ksession = restoreSession(ksession, true);
+        assertEquals(KogitoProcessInstance.STATE_ACTIVE, processInstance.getState());
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 new DoNothingWorkItemHandler());
         logger.debug("Triggering node");
@@ -836,37 +762,32 @@ public class ActivityTest extends JbpmBpmn2TestCase {
         TestWorkItemHandler workItemHandler2 = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("OtherTask",
                 workItemHandler2);
-        DynamicUtils.addDynamicSubProcess(processInstance, ksession, "Minimal",
-                new HashMap<String, Object>());
-        ksession = restoreSession(ksession, true);
+        DynamicUtils.addDynamicSubProcess(processInstance, kruntime.getKieSession(), "Minimal",
+                new HashMap<>());
         kruntime.signalEvent("User1", null, processInstance.getStringId());
         assertProcessInstanceActive(processInstance);
-        ksession.insert(new Person());
+        kruntime.getKieSession().insert(new Person());
         kruntime.signalEvent("Task3", null, processInstance.getStringId());
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
     }
 
     @Test
     public void testServiceTask() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-ServiceProcess.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-ServiceProcess.bpmn2");
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Service Task",
                 new ServiceTaskHandler());
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("s", "john");
-        WorkflowProcessInstance processInstance = (WorkflowProcessInstance) ksession
+        KogitoWorkflowProcessInstance processInstance = (KogitoWorkflowProcessInstance) kruntime
                 .startProcess("ServiceProcess", params);
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
         assertEquals("Hello john!", processInstance.getVariable("s"));
     }
 
     @Test
     public void testServiceTaskWithAccessToWorkItemInfo() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-ServiceProcess.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-ServiceProcess.bpmn2");
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Service Task",
                                                               new ServiceTaskHandler() {
@@ -879,44 +800,38 @@ public class ActivityTest extends JbpmBpmn2TestCase {
                                                                   }
 
                                                               });
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("s", "john");
-        WorkflowProcessInstance processInstance = (WorkflowProcessInstance) ksession
-                                                                                    .startProcess("ServiceProcess", params);
-        assertProcessInstanceFinished(processInstance, ksession);
+        KogitoWorkflowProcessInstance processInstance = (KogitoWorkflowProcessInstance) kruntime.startProcess("ServiceProcess", params);
+        assertProcessInstanceFinished(processInstance, kruntime);
         assertEquals("Hello john!", processInstance.getVariable("s"));
     }
 
     @Test
     @Disabled("Transfomer has been disabled")
     public void testServiceTaskWithTransformation() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-ServiceProcessWithTransformation.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-ServiceProcessWithTransformation.bpmn2");
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Service Task",
                 new ServiceTaskHandler());
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("s", "JoHn");
-        WorkflowProcessInstance processInstance = (WorkflowProcessInstance) ksession
-                .startProcess("ServiceProcess", params);
-        assertProcessInstanceFinished(processInstance, ksession);
+        KogitoWorkflowProcessInstance processInstance = (KogitoWorkflowProcessInstance) kruntime.startProcess("ServiceProcess", params);
+        assertProcessInstanceFinished(processInstance, kruntime);
         assertEquals("hello john!", processInstance.getVariable("s"));
     }
 
     @Test
     public void testServiceTaskWithMvelTransformation() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-ServiceProcessWithMvelTransformation.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-ServiceProcessWithMvelTransformation.bpmn2");
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Service Task",
                 new ServiceTaskHandler());
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("s", "JoHn");
-        WorkflowProcessInstance processInstance = (WorkflowProcessInstance) ksession
+        KogitoWorkflowProcessInstance processInstance = (KogitoWorkflowProcessInstance) kruntime
                 .startProcess("ServiceProcess", params);
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
         assertEquals("hello john!", processInstance.getVariable("s"));
     }
 
@@ -951,26 +866,22 @@ public class ActivityTest extends JbpmBpmn2TestCase {
 				return expression;
 			}
 		});
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-ServiceProcessWithCustomTransformation.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+    	kruntime = createKogitoProcessRuntime("BPMN2-ServiceProcessWithCustomTransformation.bpmn2");
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Service Task",
                 new ServiceTaskHandler());
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("s", "john doe");
 
-        WorkflowProcessInstance processInstance = (WorkflowProcessInstance) ksession
+        KogitoWorkflowProcessInstance processInstance = (KogitoWorkflowProcessInstance) kruntime
                 .startProcess("ServiceProcess", params);
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
         assertEquals("John doE", processInstance.getVariable("s"));
     }
 
     @Test
     public void testServiceTaskNoInterfaceName() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-ServiceTask-web-service.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-ServiceTask-web-service.bpmn2");
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Service Task",
                 new SystemOutWorkItemHandler() {
@@ -987,152 +898,128 @@ public class ActivityTest extends JbpmBpmn2TestCase {
                     }
 
                 });
-        Map<String, Object> params = new HashMap<String, Object>();
-        WorkflowProcessInstance processInstance = (WorkflowProcessInstance) ksession
+        Map<String, Object> params = new HashMap<>();
+        KogitoWorkflowProcessInstance processInstance = (KogitoWorkflowProcessInstance) kruntime
                 .startProcess("org.jboss.qa.jbpm.CallWS", params);
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
     }
 
     @Test
     public void testSendTask() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-SendTask.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-SendTask.bpmn2");
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Send Task",
                 new SendTaskHandler());
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("s", "john");
-        WorkflowProcessInstance processInstance = (WorkflowProcessInstance) ksession
+        KogitoWorkflowProcessInstance processInstance = (KogitoWorkflowProcessInstance) kruntime
                 .startProcess("SendTask", params);
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
     }
 
     @Test
     public void testReceiveTask() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-ReceiveTask.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        ReceiveTaskHandler receiveTaskHandler = new ReceiveTaskHandler(ksession);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-ReceiveTask.bpmn2");
+        ReceiveTaskHandler receiveTaskHandler = new ReceiveTaskHandler(kruntime);
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Receive Task",
                 receiveTaskHandler);
-        WorkflowProcessInstance processInstance = (WorkflowProcessInstance) ksession
+        KogitoWorkflowProcessInstance processInstance = (KogitoWorkflowProcessInstance) kruntime
                 .startProcess("ReceiveTask");
         assertProcessInstanceActive(processInstance);
-        ksession = restoreSession(ksession, true);
-        receiveTaskHandler.setKnowledgeRuntime(ksession);
+        receiveTaskHandler.setKnowledgeRuntime(kruntime);
         receiveTaskHandler.messageReceived("HelloMessage", "Hello john!");
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
     }
 
     @Test
     @RequirePersistence(false)
     public void testBusinessRuleTask() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-BusinessRuleTask.bpmn2",
-                "BPMN2-BusinessRuleTask.drl");
-        ksession = createKnowledgeSession(kbase);
-        ksession.addEventListener(new RuleAwareProcessEventListener());
-        ProcessInstance processInstance = ksession
-                .startProcess("BPMN2-BusinessRuleTask");
-        assertProcessInstanceFinished(processInstance, ksession);
+        kruntime = createKogitoProcessRuntime("BPMN2-BusinessRuleTask.bpmn2", "BPMN2-BusinessRuleTask.drl");
+        kruntime.getProcessEventManager().addEventListener(new RuleAwareProcessEventListener());
+        KogitoProcessInstance processInstance = kruntime.startProcess("BPMN2-BusinessRuleTask");
+        assertProcessInstanceFinished(processInstance, kruntime);
     }
 
     @Test
     @RequirePersistence(true)
     public void testBusinessRuleTaskWithPersistence() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-BusinessRuleTask.bpmn2",
-                "BPMN2-BusinessRuleTask.drl");
-        ksession = createKnowledgeSession(kbase);
-        ksession.addEventListener(new RuleAwareProcessEventListener());
-        ProcessInstance processInstance = ksession
+        kruntime = createKogitoProcessRuntime("BPMN2-BusinessRuleTask.bpmn2", "BPMN2-BusinessRuleTask.drl");
+        kruntime.getProcessEventManager().addEventListener(new RuleAwareProcessEventListener());
+        KogitoProcessInstance processInstance = kruntime
                 .startProcess("BPMN2-BusinessRuleTask");
 
-        ksession = restoreSession(ksession, true);
-        ksession.addEventListener(new RuleAwareProcessEventListener());
+        kruntime.getProcessEventManager().addEventListener(new RuleAwareProcessEventListener());
 
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
     }
 
     @Test
     public void testBusinessRuleTaskDynamic() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper(
-                "BPMN2-BusinessRuleTaskDynamic.bpmn2",
+        kruntime = createKogitoProcessRuntime("BPMN2-BusinessRuleTaskDynamic.bpmn2",
                 "BPMN2-BusinessRuleTask.drl");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
 
-        ksession.addEventListener(new RuleAwareProcessEventListener());
+        kruntime.getProcessEventManager().addEventListener(new RuleAwareProcessEventListener());
 
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("dynamicrule", "MyRuleFlow");
         KogitoProcessInstance processInstance = kruntime.startProcess(
                 "BPMN2-BusinessRuleTask", params);
 
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
     }
 
     @Test
     public void testBusinessRuleTaskWithDataInputsWithPersistence()
             throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper(
-                "BPMN2-BusinessRuleTaskWithDataInputs.bpmn2",
+        kruntime = createKogitoProcessRuntime("BPMN2-BusinessRuleTaskWithDataInputs.bpmn2",
                 "BPMN2-BusinessRuleTaskWithDataInput.drl");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
 
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("person", new Person());
         KogitoProcessInstance processInstance = kruntime.startProcess(
                 "BPMN2-BusinessRuleTask", params);
-       
-        assertProcessInstanceFinished(processInstance, ksession);
+
+        assertProcessInstanceFinished(processInstance, kruntime);
     }
 
     @Test
     public void testBusinessRuleTaskWithDataInputs2WithPersistence()
             throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper(
-                "BPMN2-BusinessRuleTaskWithDataInput.bpmn2",
+        kruntime = createKogitoProcessRuntime("BPMN2-BusinessRuleTaskWithDataInput.bpmn2",
                 "BPMN2-BusinessRuleTaskWithDataInput.drl");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
 
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("person", new Person());
         KogitoProcessInstance processInstance = kruntime.startProcess(
                 "BPMN2-BusinessRuleTask", params);
 
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
     }
 
     @Test
     public void testBusinessRuleTaskWithContionalEvent() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-ConditionalEventRuleTask.bpmn2",
+        kruntime = createKogitoProcessRuntime("BPMN2-ConditionalEventRuleTask.bpmn2",
                 "BPMN2-ConditionalEventRuleTask.drl");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        List<String> list = new ArrayList<String>();
-        ksession.setGlobal("list", list);
+        List<String> list = new ArrayList<>();
+        kruntime.getKieSession().setGlobal("list", list);
         KogitoProcessInstance processInstance = kruntime.startProcess("TestFlow");
-        assertTrue(processInstance.getState() == ProcessInstance.STATE_ACTIVE);
+        assertEquals(KogitoProcessInstance.STATE_ACTIVE, processInstance.getState());
         Person person = new Person();
         person.setName("john");
-        ksession.insert(person);
+        kruntime.getKieSession().insert(person);
         
 
-        assertProcessInstanceCompleted(processInstance.getStringId(), ksession);
-        assertTrue(list.size() == 1);
+        assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
+        assertEquals(1, list.size());
     }
 
     @Test
     public void testScriptTaskWithVariableByName() throws Exception {
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("myVar", "test");
-        KieBase kbase = createKnowledgeBase("BPMN2-ProcessWithVariableName.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-ProcessWithVariableName.bpmn2");
 
         KogitoProcessInstance processInstance = kruntime.startProcess(
                 "BPMN2-ProcessWithVariableName", params);
@@ -1142,23 +1029,21 @@ public class ActivityTest extends JbpmBpmn2TestCase {
     @Test
     public void testCallActivityWithBoundaryEvent() throws Exception {
         NodeLeftCountDownProcessEventListener countDownListener = new NodeLeftCountDownProcessEventListener("Boundary event", 1);
-        KieBase kbase = createKnowledgeBase(
+        kruntime = createKogitoProcessRuntime(
                 "BPMN2-CallActivityWithBoundaryEvent.bpmn2",
                 "BPMN2-CallActivitySubProcessWithBoundaryEvent.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        ksession.addEventListener(countDownListener);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime.getProcessEventManager().addEventListener(countDownListener);
 
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 workItemHandler);
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", "oldValue");
         KogitoProcessInstance processInstance = kruntime.startProcess("ParentProcess", params);
 
         countDownListener.waitTillCompleted();
 
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
         // assertEquals("new timer value",
         // ((WorkflowProcessInstance) processInstance).getVariable("y"));
         // first check the parent process executed nodes
@@ -1171,25 +1056,23 @@ public class ActivityTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testCallActivityWithSubProcessWaitState() throws Exception {
-        KieBase kbase = createKnowledgeBase(
+        kruntime = createKogitoProcessRuntime(
                 "BPMN2-CallActivity.bpmn2",
                 "BPMN2-CallActivitySubProcessWithBoundaryEvent.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
 
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 workItemHandler);
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         KogitoProcessInstance processInstance = kruntime.startProcess("ParentProcess", params);
-        assertProcessInstanceActive(processInstance.getStringId(), ksession);
+        assertProcessInstanceActive(processInstance.getStringId(), kruntime);
 
         org.kie.kogito.internal.process.runtime.KogitoWorkItem wi = workItemHandler.getWorkItem();
         assertNotNull(wi);
 
         kruntime.getWorkItemManager().completeWorkItem(wi.getStringId(), null);
 
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
         // first check the parent process executed nodes
         assertNodeTriggered(processInstance.getStringId(), "StartProcess", "CallActivity", "EndProcess");
         // then check child process executed nodes - is there better way to get child process id than simply increment?
@@ -1198,59 +1081,50 @@ public class ActivityTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testUserTaskWithBooleanOutput() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-UserTaskWithBooleanOutput.bpmn2");
-        ksession = createKnowledgeSession(kbase);
+        kruntime = createKogitoProcessRuntime("BPMN2-UserTaskWithBooleanOutput.bpmn2");
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 workItemHandler);
         KogitoProcessInstance processInstance = kruntime
                 .startProcess("com.sample.boolean");
         assertProcessInstanceActive(processInstance);
-        ksession = restoreSession(ksession, true);
         org.kie.kogito.internal.process.runtime.KogitoWorkItem workItem = workItemHandler.getWorkItem();
         assertNotNull(workItem);
         assertEquals("john", workItem.getParameter("ActorId"));
-        HashMap<String, Object> output = new HashMap<String, Object>();
+        HashMap<String, Object> output = new HashMap<>();
         output.put("isCheckedCheckbox", "true");
         kruntime.getWorkItemManager()
                 .completeWorkItem(workItem.getStringId(), output);
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
     }
 
     @Test
     public void testUserTaskWithSimData() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-UserTaskWithSimulationMetaData.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-UserTaskWithSimulationMetaData.bpmn2");
 
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 workItemHandler);
         KogitoProcessInstance processInstance = kruntime.startProcess("UserTask");
-        assertTrue(processInstance.getState() == ProcessInstance.STATE_ACTIVE);
-        ksession = restoreSession(ksession, true);
+        assertEquals(KogitoProcessInstance.STATE_ACTIVE, processInstance.getState());
         org.kie.kogito.internal.process.runtime.KogitoWorkItem workItem = workItemHandler.getWorkItem();
         assertNotNull(workItem);
         assertEquals("john", workItem.getParameter("ActorId"));
         kruntime.getWorkItemManager().completeWorkItem(workItem.getStringId(), null);
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
     }
 
     @Test
     public void testCallActivityWithBoundaryErrorEvent() throws Exception {
-        KieBase kbase = createKnowledgeBase(
-                "BPMN2-CallActivityProcessBoundaryError.bpmn2",
+        kruntime = createKogitoProcessRuntime("BPMN2-CallActivityProcessBoundaryError.bpmn2",
                 "BPMN2-CallActivitySubProcessBoundaryError.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
 
         kruntime.getWorkItemManager().registerWorkItemHandler("task1",
                 new SystemOutWorkItemHandler());
         KogitoProcessInstance processInstance = kruntime.startProcess("ParentProcess");
 
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
         assertNodeTriggered(processInstance.getStringId(), "StartProcess",
                 "Call Activity 1", "Boundary event", "Task Parent", "End2");
         // then check child process executed nodes - is there better way to get child process id than simply increment?
@@ -1259,11 +1133,9 @@ public class ActivityTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testCallActivityWithBoundaryErrorEventWithWaitState() throws Exception {
-        KieBase kbase = createKnowledgeBase(
+        kruntime = createKogitoProcessRuntime(
                 "BPMN2-CallActivityProcessBoundaryError.bpmn2",
                 "BPMN2-CallActivitySubProcessBoundaryError.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
 
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("task1", workItemHandler);
@@ -1277,7 +1149,7 @@ public class ActivityTest extends JbpmBpmn2TestCase {
         assertNotNull(workItem);
         kruntime.getWorkItemManager().completeWorkItem(workItem.getStringId(), null);
 
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
         assertNodeTriggered(processInstance.getStringId(), "StartProcess",
                 "Call Activity 1", "Boundary event", "Task Parent", "End2");
         // then check child process executed nodes - is there better way to get child process id than simply increment?
@@ -1287,20 +1159,19 @@ public class ActivityTest extends JbpmBpmn2TestCase {
     @Test
     @Timeout(10)
     public void testInvalidServiceTask() {
-        assertThrows(RuntimeException.class, () -> createKnowledgeBase("BPMN2-InvalidServiceProcess.bpmn2"));
+        assertThrows(RuntimeException.class, () -> createKogitoProcessRuntime("BPMN2-InvalidServiceProcess.bpmn2"));
     }
 
     @Test // JBPM-3951
     public void testServiceTaskInterface() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-ServiceTask.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-ServiceTask.bpmn2");
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Service Task", new SystemOutWorkItemHandler());
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
 
-        WorkflowProcessInstance processInstance = (WorkflowProcessInstance) ksession.startProcess("EAID_DP000000_23D3_4e7e_80FE_6D8C0AF83CAA", params);
-        assertProcessInstanceFinished(processInstance, ksession);
+        KogitoWorkflowProcessInstance processInstance = (KogitoWorkflowProcessInstance) kruntime
+                .startProcess("EAID_DP000000_23D3_4e7e_80FE_6D8C0AF83CAA", params);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
     }
 
@@ -1308,22 +1179,20 @@ public class ActivityTest extends JbpmBpmn2TestCase {
 	@Test
     @Disabled("Transfomer has been disabled")
     public void testBusinessRuleTaskWithTransformation() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-RuleTaskWithTransformation.bpmn2",
+        kruntime = createKogitoProcessRuntime("BPMN2-RuleTaskWithTransformation.bpmn2",
                 "BPMN2-RuleTaskWithTransformation.drl");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
 
-        List<String> data = new ArrayList<String>();
+        List<String> data = new ArrayList<>();
 
-        ksession.setGlobal("data", data);
+        kruntime.getKieSession().setGlobal("data", data);
 
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("name", "JoHn");
         KogitoProcessInstance processInstance = kruntime.startProcess("BPMN2-RuleTaskWithTransformation", params);
 
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
-        data = (List<String>) ksession.getGlobal("data");
+        data = (List<String>) kruntime.getKieSession().getGlobal("data");
         assertNotNull(data);
         assertEquals(1, data.size());
         assertEquals("JOHN", data.get(0));
@@ -1337,48 +1206,44 @@ public class ActivityTest extends JbpmBpmn2TestCase {
     @Test
     @Disabled("Transfomer has been disabled")
     public void testCallActivityWithTransformation() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-CallActivityWithTransformation.bpmn2", "BPMN2-CallActivitySubProcess.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-CallActivityWithTransformation.bpmn2", "BPMN2-CallActivitySubProcess.bpmn2");
 
-        final List<ProcessInstance> instances = new ArrayList<ProcessInstance>();
-        ksession.addEventListener(new DefaultProcessEventListener() {
+        final List<KogitoProcessInstance> instances = new ArrayList<>();
+        kruntime.getProcessEventManager().addEventListener(new DefaultKogitoProcessEventListener() {
 
             @Override
             public void beforeProcessStarted(ProcessStartedEvent event) {
-                instances.add(event.getProcessInstance());
+                instances.add((KogitoProcessInstance) event.getProcessInstance());
             }
 
         });
 
 
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", "oldValue");
         KogitoProcessInstance processInstance = kruntime.startProcess("ParentProcess", params);
         assertProcessInstanceCompleted(processInstance);
 
         assertEquals(2, instances.size());
         // assert variables of parent process, first in start (input transformation, then on end output transformation)
-        assertEquals("oldValue",((WorkflowProcessInstance) instances.get(0)).getVariable("x"));
-        assertEquals("NEW VALUE",((WorkflowProcessInstance) instances.get(0)).getVariable("y"));
+        assertEquals("oldValue",((KogitoWorkflowProcessInstance) instances.get(0)).getVariable("x"));
+        assertEquals("NEW VALUE",((KogitoWorkflowProcessInstance) instances.get(0)).getVariable("y"));
         // assert variables of subprocess, first in start (input transformation, then on end output transformation)
-        assertEquals("OLDVALUE", ((WorkflowProcessInstance) instances.get(1)).getVariable("subX"));
-        assertEquals("new value",((WorkflowProcessInstance) instances.get(1)).getVariable("subY"));
+        assertEquals("OLDVALUE", ((KogitoWorkflowProcessInstance) instances.get(1)).getVariable("subX"));
+        assertEquals("new value",((KogitoWorkflowProcessInstance) instances.get(1)).getVariable("subY"));
     }
 
     @Test
     public void testServiceTaskWithMvelCollectionTransformation() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-ServiceProcessWithMvelCollectionTransformation.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-ServiceProcessWithMvelCollectionTransformation.bpmn2");
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Service Task",
                 new ServiceTaskHandler());
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("s", "john,poul,mary");
-        WorkflowProcessInstance processInstance = (WorkflowProcessInstance) ksession
+        KogitoWorkflowProcessInstance processInstance = (KogitoWorkflowProcessInstance) kruntime
                 .startProcess("ServiceProcess", params);
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
         @SuppressWarnings("unchecked")
 		List<String> result = (List<String>)processInstance.getVariable("list");
         assertEquals(3, result.size());
@@ -1386,13 +1251,11 @@ public class ActivityTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testServiceTaskWithMvelJaxbTransformation() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-ServiceProcessWithMvelJaxbTransformation.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-ServiceProcessWithMvelJaxbTransformation.bpmn2");
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Service Task",
                 new ServiceTaskHandler());
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         Person person = new Person();
         person.setId(123);
         person.setName("john");
@@ -1400,59 +1263,53 @@ public class ActivityTest extends JbpmBpmn2TestCase {
 
         HelloService.VALIDATE_STRING = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><person><id>123</id><name>john</name></person>";
 
-        WorkflowProcessInstance processInstance = (WorkflowProcessInstance) ksession
+        KogitoWorkflowProcessInstance processInstance = (KogitoWorkflowProcessInstance) kruntime
                 .startProcess("ServiceProcess", params);
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
     }
 
     @Test
     public void testErrorBetweenProcessesProcess() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("subprocess/ErrorsBetweenProcess-Process.bpmn2",
+        kruntime = createKogitoProcessRuntime("subprocess/ErrorsBetweenProcess-Process.bpmn2",
         		"subprocess/ErrorsBetweenProcess-SubProcess.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
 
-        Map<String, Object> variables = new HashMap<String, Object>();
+        Map<String, Object> variables = new HashMap<>();
 
         variables.put("tipoEvento", "error");
         variables.put("pasoVariable", 3);
         KogitoProcessInstance processInstance = kruntime.startProcess("Principal", variables);
 
-        assertProcessInstanceCompleted(processInstance.getStringId(), ksession);
-        assertProcessInstanceAborted(processInstance.getStringId()+1, ksession);
+        assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
+        assertProcessInstanceAborted(processInstance.getStringId()+1, kruntime);
 
         assertProcessVarValue(processInstance, "event", "error desde Subproceso");
     }
 
     @Test
     public void testProcessCustomDescriptionMetaData() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-ProcessCustomDescriptionMetaData.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-ProcessCustomDescriptionMetaData.bpmn2");
 
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
 
         KogitoProcessInstance processInstance = kruntime.startProcess("Minimal", params);
         assertProcessInstanceCompleted(processInstance);
 
-        String description = ((org.jbpm.process.instance.impl.ProcessInstanceImpl)processInstance).getDescription();
+        String description = processInstance.getDescription();
         assertNotNull(description);
         assertEquals("my process with description", description);
     }
 
     @Test
     public void testProcessVariableCustomDescriptionMetaData() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-ProcessVariableCustomDescriptionMetaData.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-ProcessVariableCustomDescriptionMetaData.bpmn2");
 
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", "variable name for process");
         KogitoProcessInstance processInstance = kruntime.startProcess("Minimal", params);
         assertProcessInstanceCompleted(processInstance);
 
-        String description = ((org.jbpm.process.instance.impl.ProcessInstanceImpl)processInstance).getDescription();
+        String description = processInstance.getDescription();
         assertNotNull(description);
         assertEquals("variable name for process", description);
     }
@@ -1460,8 +1317,7 @@ public class ActivityTest extends JbpmBpmn2TestCase {
     @Test
     public void testInvalidSubProcessNoOutgoingSF() throws Exception {
     	try {
-    		KieBase kbase = createKnowledgeBase("subprocess/BPMN2-InvalidEmdeddedSubProcess.bpmn2");
-    		ksession = createKnowledgeSession(kbase);
+    	    createKogitoProcessRuntime("subprocess/BPMN2-InvalidEmdeddedSubProcess.bpmn2");
     		fail("Process should be invalid, there should be build errors");
     	} catch (RuntimeException e) {
     		// there should be build errors
@@ -1471,7 +1327,7 @@ public class ActivityTest extends JbpmBpmn2TestCase {
     @Test
     public void testAdHocSubProcessEmptyCompleteExpression() throws Exception {
         try {
-        	createKnowledgeBaseWithoutDumper("BPMN2-AdHocSubProcessEmptyCompleteExpression.bpmn2");
+        	createKogitoProcessRuntime("BPMN2-AdHocSubProcessEmptyCompleteExpression.bpmn2");
         	fail("Process should be invalid, there should be build errors");
     	} catch (RuntimeException e) {
     		// there should be build errors
@@ -1480,12 +1336,10 @@ public class ActivityTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testSubProcessWithTypeVariable() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("subprocess/BPMN2-SubProcessWithTypeVariable.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("subprocess/BPMN2-SubProcessWithTypeVariable.bpmn2");
 
-        final List<String> list = new ArrayList<String>();
-        ksession.addEventListener(new DefaultProcessEventListener() {
+        final List<String> list = new ArrayList<>();
+        kruntime.getProcessEventManager().addEventListener(new DefaultKogitoProcessEventListener() {
 
             public void afterNodeTriggered(ProcessNodeTriggeredEvent event) {
                 if (event.getNodeInstance().getNodeName().equals("Read Map")) {
@@ -1500,40 +1354,34 @@ public class ActivityTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testUserTaskParametrizedInput() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-UserTaskWithParametrizedInput.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
+        kruntime = createKogitoProcessRuntime("BPMN2-UserTaskWithParametrizedInput.bpmn2");
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
         KogitoProcessInstance processInstance = kruntime.startProcess("UserTask");
-        assertTrue(processInstance.getState() == ProcessInstance.STATE_ACTIVE);
-        ksession = restoreSession(ksession, true);
+        assertEquals(KogitoProcessInstance.STATE_ACTIVE, processInstance.getState());
         org.kie.kogito.internal.process.runtime.KogitoWorkItem workItem = workItemHandler.getWorkItem();
         assertNotNull(workItem);
         assertEquals("Executing task of process instance " + processInstance.getStringId() + " as work item with Hello",
                 workItem.getParameter("Description").toString().trim());
         kruntime.getWorkItemManager().completeWorkItem(workItem.getStringId(), null);
-        assertProcessInstanceFinished(processInstance, ksession);
-        ksession.dispose();
+        assertProcessInstanceFinished(processInstance, kruntime);
     }
 
     @Test
     public void testMultipleBusinessRuleTaskWithDataInputsWithPersistence()
             throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper(
+        kruntime = createKogitoProcessRuntime(
                 "BPMN2-MultipleRuleTasksWithDataInput.bpmn2",
                 "BPMN2-MultipleRuleTasks.drl");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
 
-        ksession.addEventListener(new TriggerRulesEventListener(ksession));
+        kruntime.getKieSession().addEventListener(new TriggerRulesEventListener(kruntime));
 
-        List<String> listPerson = new ArrayList<String>();
-        List<String> listAddress = new ArrayList<String>();
+        List<String> listPerson = new ArrayList<>();
+        List<String> listAddress = new ArrayList<>();
 
-        ksession.setGlobal("listPerson", listPerson);
-        ksession.setGlobal("listAddress", listAddress);
+        kruntime.getKieSession().setGlobal("listPerson", listPerson);
+        kruntime.getKieSession().setGlobal("listAddress", listAddress);
 
         Person person = new Person();
         person.setName("john");
@@ -1541,142 +1389,130 @@ public class ActivityTest extends JbpmBpmn2TestCase {
         Address address = new Address();
         address.setStreet("5th avenue");
 
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("person", person);
         params.put("address", address);
         KogitoProcessInstance processInstance = kruntime.startProcess("multiple-rule-tasks", params);
 
         assertEquals(1, listPerson.size());
         assertEquals(1, listAddress.size());
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
     }
 
     @Test
     public void testSubProcessInAdHocProcess() throws Exception {
         // JBPM-5374
-        KieBase kbase = createKnowledgeBaseWithoutDumper(
+        kruntime = createKogitoProcessRuntime(
                 "BPMN2-SubProcessInAdHocProcess.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
 
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
 
-        Map<String, Object> parameters = new HashMap<String, Object>();
+        Map<String, Object> parameters = new HashMap<>();
         KogitoProcessInstance processInstance = kruntime.startProcess("SubProcessInAdHocProcess", parameters);
         assertProcessInstanceActive(processInstance);
 
-        ksession = restoreSession(ksession, true);
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
 
         org.kie.kogito.internal.process.runtime.KogitoWorkItem workItem = workItemHandler.getWorkItem();
         assertNotNull(workItem);
         kruntime.getWorkItemManager().completeWorkItem(workItem.getStringId(), null);
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
     }
     
     @Test
     public void testCallActivityWithDataAssignment() throws Exception {
-        KieBase kbase = createKnowledgeBase("subprocess/AssignmentProcess.bpmn2", "subprocess/AssignmentSubProcess.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("subprocess/AssignmentProcess.bpmn2", "subprocess/AssignmentSubProcess.bpmn2");
 
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("name", "oldValue");
         KogitoProcessInstance processInstance = kruntime.startProcess("assignmentProcess", params);
         assertProcessInstanceCompleted(processInstance);
-        assertEquals("Hello Genworth welcome to jBPMS!", ((WorkflowProcessInstance) processInstance).getVariable("message"));
+        assertEquals("Hello Genworth welcome to jBPMS!", ((KogitoWorkflowProcessInstance) processInstance).getVariable("message"));
     }
     
     @Test
     public void testDMNBusinessRuleTask()throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper(
+        kruntime = createKogitoProcessRuntime(
                 "dmn/BPMN2-BusinessRuleTaskDMN.bpmn2", "dmn/0020-vacation-days.dmn");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
 
         // first run 16, 1 and expected days is 27
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("age", 16);
         params.put("yearsOfService", 1);
         KogitoProcessInstance processInstance = kruntime.startProcess("BPMN2-BusinessRuleTask", params);
 
-        assertProcessInstanceFinished(processInstance, ksession);
-        BigDecimal vacationDays = (BigDecimal) ((WorkflowProcessInstance) processInstance).getVariable("vacationDays");
+        assertProcessInstanceFinished(processInstance, kruntime);
+        BigDecimal vacationDays = (BigDecimal) ((KogitoWorkflowProcessInstance) processInstance).getVariable("vacationDays");
         assertEquals(BigDecimal.valueOf(27), vacationDays);
         
         // second run 44, 20 and expected days is 24
-        params = new HashMap<String, Object>();
+        params = new HashMap<>();
         params.put("age", 44);
         params.put("yearsOfService", 20);
         processInstance = kruntime.startProcess("BPMN2-BusinessRuleTask", params);
 
-        assertProcessInstanceFinished(processInstance, ksession);
-        vacationDays = (BigDecimal) ((WorkflowProcessInstance) processInstance).getVariable("vacationDays");
+        assertProcessInstanceFinished(processInstance, kruntime);
+        vacationDays = (BigDecimal) ((KogitoWorkflowProcessInstance) processInstance).getVariable("vacationDays");
         assertEquals(BigDecimal.valueOf(24), vacationDays);
         
         // second run 50, 30 and expected days is 30
-        params = new HashMap<String, Object>();
+        params = new HashMap<>();
         params.put("age", 50);
         params.put("yearsOfService", 30);
         processInstance = kruntime.startProcess("BPMN2-BusinessRuleTask", params);
 
-        assertProcessInstanceFinished(processInstance, ksession);
-        vacationDays = (BigDecimal) ((WorkflowProcessInstance) processInstance).getVariable("vacationDays");
+        assertProcessInstanceFinished(processInstance, kruntime);
+        vacationDays = (BigDecimal) ((KogitoWorkflowProcessInstance) processInstance).getVariable("vacationDays");
         assertEquals(BigDecimal.valueOf(30), vacationDays);
     }
 
     @Disabled
     @Test
     public void testDMNBusinessRuleTaskByDecisionName()throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper(
+        kruntime = createKogitoProcessRuntime(
                 "dmn/BPMN2-BusinessRuleTaskDMNByDecisionName.bpmn2", "dmn/0020-vacation-days.dmn");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
 
         // first run 16, 1 and expected days is 5
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("age", 16);
         params.put("yearsOfService", 1);
         KogitoProcessInstance processInstance = kruntime.startProcess("BPMN2-BusinessRuleTask", params);
 
-        assertProcessInstanceFinished(processInstance, ksession);
-        BigDecimal vacationDays = (BigDecimal) ((WorkflowProcessInstance) processInstance).getVariable("vacationDays");
+        assertProcessInstanceFinished(processInstance, kruntime);
+        BigDecimal vacationDays = (BigDecimal) ((KogitoWorkflowProcessInstance) processInstance).getVariable("vacationDays");
         assertEquals(BigDecimal.valueOf(5), vacationDays);
     }
 
     @Disabled
     @Test
     public void testDMNBusinessRuleTaskMultipleDecisionsOutput()throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper(
+        kruntime = createKogitoProcessRuntime(
                 "dmn/BPMN2-BusinessRuleTaskDMNMultipleDecisionsOutput.bpmn2", "dmn/0020-vacation-days.dmn");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
 
         // first run 16, 1 and expected days is 5
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("age", 16);
         params.put("yearsOfService", 1);
         KogitoProcessInstance processInstance = kruntime.startProcess("BPMN2-BusinessRuleTask", params);
 
-        assertProcessInstanceFinished(processInstance, ksession);
-        BigDecimal vacationDays = (BigDecimal) ((WorkflowProcessInstance) processInstance).getVariable("vacationDays");
+        assertProcessInstanceFinished(processInstance, kruntime);
+        BigDecimal vacationDays = (BigDecimal) ((KogitoWorkflowProcessInstance) processInstance).getVariable("vacationDays");
         assertEquals(BigDecimal.valueOf(27), vacationDays);
-        BigDecimal extraDays = (BigDecimal) ((WorkflowProcessInstance) processInstance).getVariable("extraDays");
+        BigDecimal extraDays = (BigDecimal) ((KogitoWorkflowProcessInstance) processInstance).getVariable("extraDays");
         assertEquals(BigDecimal.valueOf(5), extraDays);
     }
 
     @Disabled
     @Test
     public void testDMNBusinessRuleTaskInvalidExecution()throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper(
+        kruntime = createKogitoProcessRuntime(
                 "dmn/BPMN2-BusinessRuleTaskDMNByDecisionName.bpmn2", "dmn/0020-vacation-days.dmn");
-        ksession = createKnowledgeSession(kbase);
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("age", 16);        
         
         try {
-            ksession.startProcess("BPMN2-BusinessRuleTask", params);
+            kruntime.startProcess("BPMN2-BusinessRuleTask", params);
         } catch (Exception e) {
             assertTrue(e instanceof WorkflowRuntimeException);
             assertTrue(e.getCause() instanceof RuntimeException);
@@ -1687,50 +1523,46 @@ public class ActivityTest extends JbpmBpmn2TestCase {
     @Disabled
     @Test
     public void testDMNBusinessRuleTaskModelById()throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper(
+        kruntime = createKogitoProcessRuntime(
                 "dmn/BPMN2-BusinessRuleTaskDMNModelById.bpmn2", "dmn/0020-vacation-days.dmn");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
 
         // first run 16, 1 and expected days is 27
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("age", 16);
         params.put("yearsOfService", 1);
         KogitoProcessInstance processInstance = kruntime.startProcess("BPMN2-BusinessRuleTask", params);
 
-        assertProcessInstanceFinished(processInstance, ksession);
-        BigDecimal vacationDays = (BigDecimal) ((WorkflowProcessInstance) processInstance).getVariable("vacationDays");
+        assertProcessInstanceFinished(processInstance, kruntime);
+        BigDecimal vacationDays = (BigDecimal) ((KogitoWorkflowProcessInstance) processInstance).getVariable("vacationDays");
         assertEquals(BigDecimal.valueOf(27), vacationDays);
         
         // second run 44, 20 and expected days is 24
-        params = new HashMap<String, Object>();
+        params = new HashMap<>();
         params.put("age", 44);
         params.put("yearsOfService", 20);
         processInstance = kruntime.startProcess("BPMN2-BusinessRuleTask", params);
 
-        assertProcessInstanceFinished(processInstance, ksession);
-        vacationDays = (BigDecimal) ((WorkflowProcessInstance) processInstance).getVariable("vacationDays");
+        assertProcessInstanceFinished(processInstance, kruntime);
+        vacationDays = (BigDecimal) ((KogitoWorkflowProcessInstance) processInstance).getVariable("vacationDays");
         assertEquals(BigDecimal.valueOf(24), vacationDays);
         
         // second run 50, 30 and expected days is 30
-        params = new HashMap<String, Object>();
+        params = new HashMap<>();
         params.put("age", 50);
         params.put("yearsOfService", 30);
         processInstance = kruntime.startProcess("BPMN2-BusinessRuleTask", params);
 
-        assertProcessInstanceFinished(processInstance, ksession);
-        vacationDays = (BigDecimal) ((WorkflowProcessInstance) processInstance).getVariable("vacationDays");
+        assertProcessInstanceFinished(processInstance, kruntime);
+        vacationDays = (BigDecimal) ((KogitoWorkflowProcessInstance) processInstance).getVariable("vacationDays");
         assertEquals(BigDecimal.valueOf(30), vacationDays);
     }
     
     @Test
     public void testBusinessRuleTaskFireLimit() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-BusinessRuleTaskLoop.bpmn2",
+        kruntime = createKogitoProcessRuntime("BPMN2-BusinessRuleTaskLoop.bpmn2",
                 "BPMN2-BusinessRuleTaskInfiniteLoop.drl");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
 
-        ksession.insert(new Person());
+        kruntime.getKieSession().insert(new Person());
         KogitoProcessInstance processInstance = kruntime.startProcess("BPMN2-BusinessRuleTask");
         
         assertEquals(KogitoProcessInstance.STATE_ERROR, processInstance.getState());
@@ -1739,12 +1571,10 @@ public class ActivityTest extends JbpmBpmn2TestCase {
     
     @Test
     public void testBusinessRuleTaskFireLimitAsParameter() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-BusinessRuleTaskWithDataInputLoop.bpmn2",
+        kruntime = createKogitoProcessRuntime("BPMN2-BusinessRuleTaskWithDataInputLoop.bpmn2",
                 "BPMN2-BusinessRuleTaskInfiniteLoop.drl");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
 
-        ksession.insert(new Person());
+        kruntime.getKieSession().insert(new Person());
         
         Map<String, Object> parameters = Collections.singletonMap("limit", 5);
         
@@ -1756,14 +1586,12 @@ public class ActivityTest extends JbpmBpmn2TestCase {
     @Disabled
     @Test
     public void testScriptTaskFEEL() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-ScriptTaskFEEL.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-ScriptTaskFEEL.bpmn2");
 
         TestWorkItemHandler handler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", handler);
 
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("name", "krisv");
         Person person = new Person();
         person.setName("krisv");
@@ -1782,12 +1610,10 @@ public class ActivityTest extends JbpmBpmn2TestCase {
     
     @Test
     public void testBusinessRuleTaskException() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-BusinessRuleTask.bpmn2",
+        kruntime = createKogitoProcessRuntime("BPMN2-BusinessRuleTask.bpmn2",
                 "BPMN2-BusinessRuleTaskWithException.drl");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
 
-        ksession.insert(new Person());
+        kruntime.getKieSession().insert(new Person());
         KogitoProcessInstance processInstance = kruntime.startProcess("BPMN2-BusinessRuleTask");
                
         assertEquals(KogitoProcessInstance.STATE_ERROR, processInstance.getState());
@@ -1797,9 +1623,7 @@ public class ActivityTest extends JbpmBpmn2TestCase {
     
     @Test
     public void testXORWithSameTargetProcess() throws Exception {
-        KieBase kbase = createKnowledgeBase("build/XORSameTarget.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("build/XORSameTarget.bpmn2");
 
         Map<String, Object> params = new HashMap<>();
         params.put("choice", 1);
@@ -1814,9 +1638,7 @@ public class ActivityTest extends JbpmBpmn2TestCase {
     
     @Test
     public void testUserTaskWithExpressionsForIO() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-UserTaskWithIOexpression.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-UserTaskWithIOexpression.bpmn2");
 
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
@@ -1825,8 +1647,7 @@ public class ActivityTest extends JbpmBpmn2TestCase {
         parameters.put("person", new Person("john"));
         
         KogitoProcessInstance processInstance = kruntime.startProcess("UserTask", parameters);
-        assertTrue(processInstance.getState() == ProcessInstance.STATE_ACTIVE);
-        ksession = restoreSession(ksession, true);
+        assertEquals(KogitoProcessInstance.STATE_ACTIVE, processInstance.getState());
         org.kie.kogito.internal.process.runtime.KogitoWorkItem workItem = workItemHandler.getWorkItem();
         assertNotNull(workItem);
         assertEquals("john", workItem.getParameter("ActorId"));
@@ -1834,55 +1655,50 @@ public class ActivityTest extends JbpmBpmn2TestCase {
         
         kruntime.getWorkItemManager().completeWorkItem(workItem.getStringId(), Collections.singletonMap("personAge", 50));
         
-        Person person = (Person) (( org.jbpm.workflow.instance.WorkflowProcessInstance ) processInstance).getVariables().get("person");
+        Person person = (Person) processInstance.getVariables().get("person");
         assertEquals(50, person.getAge());
-        assertProcessInstanceFinished(processInstance, ksession);
-        ksession.dispose();
+        assertProcessInstanceFinished(processInstance, kruntime);
     }
     
     @Test
     public void testCallActivitykWithExpressionsForIO() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-CallActivityWithIOexpression.bpmn2", "BPMN2-CallActivitySubProcess.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-CallActivityWithIOexpression.bpmn2", "BPMN2-CallActivitySubProcess.bpmn2");
 
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("person", new Person("john"));
         KogitoProcessInstance processInstance = kruntime.startProcess("ParentProcess", params);
         assertProcessInstanceActive(processInstance);
         
-        Person person = (Person) (( org.jbpm.workflow.instance.WorkflowProcessInstance ) processInstance).getVariables().get("person");
+        Person person = (Person) processInstance.getVariables().get("person");
         assertEquals("new value", person.getName());
 
-        ksession = restoreSession(ksession, true);
         org.kie.kogito.internal.process.runtime.KogitoWorkItem workItem = workItemHandler.getWorkItem();
         assertNotNull(workItem);
         assertEquals("krisv", workItem.getParameter("ActorId"));
         kruntime.getWorkItemManager().completeWorkItem(workItem.getStringId(), null);
 
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
     }
     
     @Test
     @RequirePersistence(false)
     public void testBusinessRuleTaskWithExpressionsForIO() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-BusinessRuleTaskWithDataInputIOExpression.bpmn2",
+        kruntime = createKogitoProcessRuntime("BPMN2-BusinessRuleTaskWithDataInputIOExpression.bpmn2",
                 "BPMN2-BusinessRuleTaskWithDataInput.drl");
-        ksession = createKnowledgeSession(kbase);
-        ksession.addEventListener(new RuleAwareProcessEventListener());
+        kruntime.getProcessEventManager().addEventListener(new RuleAwareProcessEventListener());
         
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("person", new Person(null));
         params.put("account", new Account());
-        ProcessInstance processInstance = ksession
+        KogitoProcessInstance processInstance = kruntime
                 .startProcess("BPMN2-BusinessRuleTask", params);
-        assertProcessInstanceFinished(processInstance, ksession);
-        Person person = (Person) (( org.jbpm.workflow.instance.WorkflowProcessInstance ) processInstance).getVariables().get("person");
+        assertProcessInstanceFinished(processInstance, kruntime);
+        Person person = (Person) processInstance.getVariables().get("person");
         assertEquals("john", person.getName());
         
-        Account account = (Account) (( org.jbpm.workflow.instance.WorkflowProcessInstance ) processInstance).getVariables().get("account");
+        Account account = (Account) processInstance.getVariables().get("account");
         assertNotNull(account.getPerson());
     }
     
@@ -1903,21 +1719,10 @@ public class ActivityTest extends JbpmBpmn2TestCase {
 
             @Override
             public AssignmentBuilder getAssignmentBuilder() {
-                return new AssignmentBuilder() {
-
-                    @Override
-                    public void build(PackageBuildContext context, Assignment assignment, String sourceExpr, String targetExpr, ContextResolver contextResolver, boolean isInput) {
-                        assignment.setMetaData("Action", new AssignmentAction() {
-
-                            @Override
-                            public void execute( KogitoWorkItem workItem, ProcessContext context) throws Exception {
-                                assertEquals("from_expression", assignment.getFrom());
-                                assertEquals("to_expression", assignment.getTo());
-                            }
-                        });
-
-                    }
-                };
+                return (context, assignment, sourceExpr, targetExpr, contextResolver, isInput) -> assignment.setMetaData("Action", (AssignmentAction) (workItem, context1) -> {
+                    assertEquals("from_expression", assignment.getFrom());
+                    assertEquals("to_expression", assignment.getTo());
+                });
             }
 
             @Override
@@ -1930,15 +1735,13 @@ public class ActivityTest extends JbpmBpmn2TestCase {
 
             }
         });
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-DataOutputAssignmentCustomExpressionLang.bpmn2");
+        kruntime = createKogitoProcessRuntime("BPMN2-DataOutputAssignmentCustomExpressionLang.bpmn2");
 
-        Process scriptProcess = kbase.getProcess("process");
+        Process scriptProcess = kruntime.getKieBase().getProcess("process");
         assertThat(scriptProcess).isNotNull();
         Node[] nodes = ((NodeContainer) scriptProcess).getNodes();
         assertThat(nodes).hasSize(3);
-        assertThat(nodes).filteredOn(n -> n instanceof WorkItemNode).allMatch(n -> matchExpectedAssociationSetup(n));
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        assertThat(nodes).filteredOn(n -> n instanceof WorkItemNode).allMatch(this::matchExpectedAssociationSetup);
 
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);

--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/AgendaFilterTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/AgendaFilterTest.java
@@ -18,8 +18,6 @@ package org.jbpm.bpmn2;
 
 import org.jbpm.bpmn2.objects.Order;
 import org.junit.jupiter.api.Test;
-import org.kie.api.KieBase;
-import org.kie.api.runtime.KieSession;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -28,28 +26,26 @@ public class AgendaFilterTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testNoFilter() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-AgendaFilter.bpmn2", "BPMN2-AgendaFilter.drl");
-        KieSession ksession = createKnowledgeSession(kbase);
+        kruntime = createKogitoProcessRuntime("BPMN2-AgendaFilter.bpmn2", "BPMN2-AgendaFilter.drl");
 
         Order order = new Order();
         order.setId("ORDER-1");
-        ksession.insert(order);
+        kruntime.getKieSession().insert(order);
 
-        ksession.startProcess("Ruleflow");
+        kruntime.startProcess("Ruleflow");
 
         assertTrue(order.isValid());
     }
 
     @Test
     public void testWithFilter() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-AgendaFilter.bpmn2", "BPMN2-AgendaFilter.drl");
-        KieSession ksession = createKnowledgeSession(kbase);
+        kruntime = createKogitoProcessRuntime("BPMN2-AgendaFilter.bpmn2", "BPMN2-AgendaFilter.drl");
 
         Order order = new Order();
         order.setId("ORDER-1");
-        ksession.insert(order);
+        kruntime.getKieSession().insert(order);
 
-        ksession.startProcess("Ruleflow", match -> false);
+        kruntime.startProcess("Ruleflow", match -> false);
 
         assertFalse(order.isValid());
     }

--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/CompensationTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/CompensationTest.java
@@ -28,19 +28,16 @@ import org.jbpm.process.instance.impl.demo.SystemOutWorkItemHandler;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.kie.api.event.process.DefaultProcessEventListener;
-import org.kie.api.event.process.ProcessEventListener;
 import org.kie.api.event.process.ProcessNodeLeftEvent;
 import org.kie.api.event.process.ProcessNodeTriggeredEvent;
-import org.kie.api.runtime.KieSession;
-import org.kie.api.runtime.process.ProcessInstance;
+import org.kie.kogito.internal.process.event.DefaultKogitoProcessEventListener;
+import org.kie.kogito.internal.process.event.KogitoProcessEventListener;
 import org.kie.kogito.internal.process.runtime.KogitoProcessInstance;
-import org.kie.kogito.internal.process.runtime.KogitoProcessRuntime;
 import org.kie.kogito.internal.process.runtime.KogitoWorkItem;
 
 public class CompensationTest extends JbpmBpmn2TestCase {
 
-    private ProcessEventListener LOGGING_EVENT_LISTENER = new DefaultProcessEventListener() {
+    private KogitoProcessEventListener LOGGING_EVENT_LISTENER = new DefaultKogitoProcessEventListener() {
 
         @Override
         public void afterNodeLeft(ProcessNodeLeftEvent event) {
@@ -75,30 +72,28 @@ public class CompensationTest extends JbpmBpmn2TestCase {
 
     @Test
     public void compensationViaIntermediateThrowEventProcess() throws Exception {
-        KieSession ksession = createKnowledgeSession("compensation/BPMN2-Compensation-IntermediateThrowEvent.bpmn2");
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("compensation/BPMN2-Compensation-IntermediateThrowEvent.bpmn2");
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
         
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", "0");
         KogitoProcessInstance processInstance = kruntime.startProcess("CompensateIntermediateThrowEvent", params);
 
         kruntime.getWorkItemManager().completeWorkItem(workItemHandler.getWorkItem().getStringId(), null);
 
         // compensation activity (assoc. with script task) signaled *after* script task
-        assertProcessInstanceCompleted(processInstance.getStringId(), ksession);
+        assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
         assertProcessVarValue(processInstance, "x", "1" );
     }
     
     @Test
     public void compensationTwiceViaSignal() throws Exception {
-        KieSession ksession = createKnowledgeSession("compensation/BPMN2-Compensation-IntermediateThrowEvent.bpmn2");
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("compensation/BPMN2-Compensation-IntermediateThrowEvent.bpmn2");
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
         
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", "0");
         String processId = "CompensateIntermediateThrowEvent";
         KogitoProcessInstance processInstance = kruntime.startProcess(processId, params);
@@ -108,22 +103,21 @@ public class CompensationTest extends JbpmBpmn2TestCase {
         kruntime.getWorkItemManager().completeWorkItem(workItemHandler.getWorkItem().getStringId(), null);
 
         // compensation activity (assoc. with script task) signaled *after* script task
-        assertProcessInstanceCompleted(processInstance.getStringId(), ksession);
+        assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
         assertProcessVarValue(processInstance, "x", "2");
     }
     
     @Test
     public void compensationViaEventSubProcess() throws Exception {
-        KieSession ksession = createKnowledgeSession("compensation/BPMN2-Compensation-EventSubProcess.bpmn2");
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("compensation/BPMN2-Compensation-EventSubProcess.bpmn2");
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
  
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", "0");
         KogitoProcessInstance processInstance = kruntime.startProcess("CompensationEventSubProcess", params);
 
-        assertProcessInstanceActive(processInstance.getStringId(), ksession);
+        assertProcessInstanceActive(processInstance.getStringId(), kruntime);
         kruntime.getWorkItemManager().completeWorkItem(workItemHandler.getWorkItem().getStringId(), null);
         
         assertProcessVarValue(processInstance, "x", "1");
@@ -131,13 +125,12 @@ public class CompensationTest extends JbpmBpmn2TestCase {
     
     @Test
     public void compensationOnlyAfterAssociatedActivityHasCompleted() throws Exception {
-        KieSession ksession = createKnowledgeSession("compensation/BPMN2-Compensation-UserTaskBeforeAssociatedActivity.bpmn2");
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        ksession.addEventListener(LOGGING_EVENT_LISTENER);
+        kruntime = createKogitoProcessRuntime("compensation/BPMN2-Compensation-UserTaskBeforeAssociatedActivity.bpmn2");
+        kruntime.getProcessEventManager().addEventListener(LOGGING_EVENT_LISTENER);
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
         
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", "0");
         KogitoProcessInstance processInstance = kruntime.startProcess("CompensateIntermediateThrowEvent", params);
         
@@ -148,20 +141,19 @@ public class CompensationTest extends JbpmBpmn2TestCase {
         kruntime.getWorkItemManager().completeWorkItem(workItemHandler.getWorkItem().getStringId(), null);
         
         // compensation activity (assoc. with script task) signaled *after* to-compensate script task
-        assertProcessInstanceCompleted(processInstance.getStringId(), ksession);
+        assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
         assertProcessVarValue(processInstance, "x", "1");
     }
     
     @Test
-    public void orderedCompensation() throws Exception { 
-        KieSession ksession = createKnowledgeSession("compensation/BPMN2-Compensation-ParallelOrderedCompensation-IntermediateThrowEvent.bpmn2");
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+    public void orderedCompensation() throws Exception {
+        kruntime = createKogitoProcessRuntime("compensation/BPMN2-Compensation-ParallelOrderedCompensation-IntermediateThrowEvent.bpmn2");
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
         
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", "");
-        ProcessInstance processInstance = ksession.startProcess("CompensateParallelOrdered", params);
+        KogitoProcessInstance processInstance = kruntime.startProcess("CompensateParallelOrdered", params);
         List<KogitoWorkItem> workItems = workItemHandler.getWorkItems();
         List<String> workItemIds = new ArrayList<>();
         for( KogitoWorkItem workItem : workItems ) {
@@ -193,12 +185,11 @@ public class CompensationTest extends JbpmBpmn2TestCase {
     
     @Test
     public void compensationInSubSubProcesses() throws Exception {
-        KieSession ksession = createKnowledgeSession("compensation/BPMN2-Compensation-InSubSubProcess.bpmn2");
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("compensation/BPMN2-Compensation-InSubSubProcess.bpmn2");
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
         
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", "0");
         KogitoProcessInstance processInstance = kruntime.startProcess("CompensateSubSubSub", params);
 
@@ -209,23 +200,22 @@ public class CompensationTest extends JbpmBpmn2TestCase {
         kruntime.getWorkItemManager().completeWorkItem(workItemHandler.getWorkItem().getStringId(), null);
 
         // compensation activity (assoc. with script task) signaled *after* script task
-        assertProcessInstanceCompleted(processInstance.getStringId(), ksession);
+        assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
         assertProcessVarValue(processInstance, "x", "2");
     }
     
     @Test
     public void specificCompensationOfASubProcess() throws Exception {
-        KieSession ksession = createKnowledgeSession("compensation/BPMN2-Compensation-ThrowSpecificForSubProcess.bpmn2");
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("compensation/BPMN2-Compensation-ThrowSpecificForSubProcess.bpmn2");
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
         
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", 1);
         KogitoProcessInstance processInstance = kruntime.startProcess("CompensationSpecificSubProcess", params);
         
         // compensation activity (assoc. with script task) signaled *after* to-compensate script task
-        assertProcessInstanceCompleted(processInstance.getStringId(), ksession);
+        assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
         
         assertProcessVarValue(processInstance, "x", null);
     }
@@ -233,12 +223,11 @@ public class CompensationTest extends JbpmBpmn2TestCase {
     @Test
     @Disabled
     public void compensationViaCancellation() throws Exception {
-        KieSession ksession = createKnowledgeSession("compensation/BPMN2-Compensation-IntermediateThrowEvent.bpmn2");
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("compensation/BPMN2-Compensation-IntermediateThrowEvent.bpmn2");
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
         
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", "0");
         KogitoProcessInstance processInstance = kruntime.startProcess("CompensateIntermediateThrowEvent", params);
 
@@ -246,21 +235,20 @@ public class CompensationTest extends JbpmBpmn2TestCase {
         kruntime.getWorkItemManager().completeWorkItem(workItemHandler.getWorkItem().getStringId(), null);
 
         // compensation activity (assoc. with script task) signaled *after* script task
-        assertProcessInstanceCompleted(processInstance.getStringId(), ksession);
+        assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
         assertProcessVarValue(processInstance, "x", "1");
     }
     
     @Test
     public void compensationInvokingSubProcess() throws Exception {
-    	KieSession ksession = createKnowledgeSession("compensation/BPMN2-UserTaskCompensation.bpmn2");
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("compensation/BPMN2-UserTaskCompensation.bpmn2");
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", new SystemOutWorkItemHandler());
         
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("compensation", "True");
         KogitoProcessInstance processInstance = kruntime.startProcess("UserTaskCompensation", params);
         
-        assertProcessInstanceCompleted(processInstance.getStringId(), ksession);
+        assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
         assertProcessVarValue(processInstance, "compensation", "compensation");
     }
     
@@ -272,10 +260,10 @@ public class CompensationTest extends JbpmBpmn2TestCase {
 	 */
 	@Test
 	public void compensationWithReusableSubprocess() throws Exception {
-		KieSession ksession = createKnowledgeSession("compensation/BPMN2-Booking.bpmn2",
+	    kruntime = createKogitoProcessRuntime("compensation/BPMN2-Booking.bpmn2",
 				"compensation/BPMN2-BookResource.bpmn2", "compensation/BPMN2-CancelResource.bpmn2");
-		ProcessInstance processInstance = ksession.startProcess("Booking");
-		assertProcessInstanceCompleted( (( KogitoProcessInstance ) processInstance).getStringId(), ksession);
+		KogitoProcessInstance processInstance = kruntime.startProcess("Booking");
+		assertProcessInstanceCompleted( processInstance.getStringId(), kruntime);
 	}
     
 }

--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/CompilationTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/CompilationTest.java
@@ -34,9 +34,6 @@ import org.jbpm.process.core.ContextResolver;
 import org.jbpm.process.instance.impl.ReturnValueConstraintEvaluator;
 import org.jbpm.workflow.core.DroolsAction;
 import org.junit.jupiter.api.Test;
-import org.kie.api.KieBase;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -49,7 +46,7 @@ public class CompilationTest extends JbpmBpmn2TestCase {
         ProcessDialectRegistry.setDialect("java", javaProcessDialect);
 
         String filename = "BPMN2-GatewaySplit-SequenceConditions.bpmn2";
-        KieBase kbase = createKnowledgeBase(filename);
+        kruntime = createKogitoProcessRuntime(filename);
 
         assertFalse(javaProcessDialect.getActionDescrs().isEmpty(),
                     "No " + ActionDescr.class.getSimpleName() + " instances caught for testing!");

--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/DataTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/DataTest.java
@@ -32,36 +32,32 @@ import org.jbpm.process.core.datatype.impl.type.ObjectDataType;
 import org.jbpm.process.instance.impl.demo.SystemOutWorkItemHandler;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.kie.api.KieBase;
-import org.kie.api.runtime.process.ProcessInstance;
-import org.kie.api.runtime.process.WorkItem;
-import org.kie.api.runtime.process.WorkItemHandler;
-import org.kie.api.runtime.process.WorkItemManager;
+import org.kie.kogito.internal.process.runtime.KogitoProcessInstance;
+import org.kie.kogito.internal.process.runtime.KogitoWorkItem;
+import org.kie.kogito.internal.process.runtime.KogitoWorkItemHandler;
+import org.kie.kogito.internal.process.runtime.KogitoWorkItemManager;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DataTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testImport() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-Import.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        ProcessInstance processInstance = ksession.startProcess("Import");
+        kruntime = createKogitoProcessRuntime("BPMN2-Import.bpmn2");
+        KogitoProcessInstance processInstance = kruntime.startProcess("Import");
         assertProcessInstanceCompleted(processInstance);
         
     }
 
     @Test
     public void testDataObject() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-DataObject.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        Map<String, Object> params = new HashMap<String, Object>();
+        kruntime = createKogitoProcessRuntime("BPMN2-DataObject.bpmn2");
+        Map<String, Object> params = new HashMap<>();
         params.put("employee", "UserId-12345");
-        ProcessInstance processInstance = ksession.startProcess("Evaluation",
+        KogitoProcessInstance processInstance = kruntime.startProcess("Evaluation",
                 params);
         assertProcessInstanceCompleted(processInstance);
         
@@ -69,13 +65,12 @@ public class DataTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testDataStore() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-DataStore.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        ProcessInstance processInstance = ksession.startProcess("Evaluation");
+        kruntime = createKogitoProcessRuntime("BPMN2-DataStore.bpmn2");
+        KogitoProcessInstance processInstance = kruntime.startProcess("Evaluation");
         Definitions def = (Definitions) processInstance.getProcess()
                 .getMetaData().get("Definitions");
         assertNotNull(def.getDataStores());
-        assertTrue(def.getDataStores().size() == 1);
+        assertEquals(1, def.getDataStores().size());
         DataStore dataStore = def.getDataStores().get(0);
         assertEquals("employee", dataStore.getId());
         assertEquals("employeeStore", dataStore.getName());
@@ -86,12 +81,11 @@ public class DataTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testAssociation() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-Association.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        ProcessInstance processInstance = ksession.startProcess("Evaluation");
+        kruntime = createKogitoProcessRuntime("BPMN2-Association.bpmn2");
+        KogitoProcessInstance processInstance = kruntime.startProcess("Evaluation");
         List<Association> associations = (List<Association>) processInstance.getProcess().getMetaData().get(ProcessHandler.ASSOCIATIONS);
         assertNotNull(associations);
-        assertTrue(associations.size() == 1);
+        assertEquals(1, associations.size());
         Association assoc = associations.get(0);
         assertEquals("_1234", assoc.getId());
         assertEquals("_1", assoc.getSourceRef());
@@ -101,15 +95,14 @@ public class DataTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testEvaluationProcess() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-EvaluationProcess.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
+        kruntime = createKogitoProcessRuntime("BPMN2-EvaluationProcess.bpmn2");
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 new SystemOutWorkItemHandler());
-        ksession.getWorkItemManager().registerWorkItemHandler(
+        kruntime.getWorkItemManager().registerWorkItemHandler(
                 "RegisterRequest", new SystemOutWorkItemHandler());
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("employee", "UserId-12345");
-        ProcessInstance processInstance = ksession.startProcess("Evaluation",
+        KogitoProcessInstance processInstance = kruntime.startProcess("Evaluation",
                 params);
         assertProcessInstanceCompleted(processInstance);
         
@@ -117,13 +110,12 @@ public class DataTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testEvaluationProcess2() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-EvaluationProcess2.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
+        kruntime = createKogitoProcessRuntime("BPMN2-EvaluationProcess2.bpmn2");
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 new SystemOutWorkItemHandler());
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("employee", "UserId-12345");
-        ProcessInstance processInstance = ksession.startProcess(
+        KogitoProcessInstance processInstance = kruntime.startProcess(
                 "com.sample.evaluation", params);
         assertProcessInstanceCompleted(processInstance);
         
@@ -131,15 +123,14 @@ public class DataTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testEvaluationProcess3() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-EvaluationProcess3.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
+        kruntime = createKogitoProcessRuntime("BPMN2-EvaluationProcess3.bpmn2");
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 new SystemOutWorkItemHandler());
-        ksession.getWorkItemManager().registerWorkItemHandler(
+        kruntime.getWorkItemManager().registerWorkItemHandler(
                 "RegisterRequest", new SystemOutWorkItemHandler());
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("employee", "john2");
-        ProcessInstance processInstance = ksession.startProcess("Evaluation",
+        KogitoProcessInstance processInstance = kruntime.startProcess("Evaluation",
                 params);
         assertProcessInstanceCompleted(processInstance);
         
@@ -147,17 +138,16 @@ public class DataTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testXpathExpression() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-XpathExpression.bpmn2");
-        ksession = createKnowledgeSession(kbase);
+        kruntime = createKogitoProcessRuntime("BPMN2-XpathExpression.bpmn2");
         Document document = DocumentBuilderFactory
                 .newInstance()
                 .newDocumentBuilder()
                 .parse(new ByteArrayInputStream(
                         "<instanceMetadata><user approved=\"false\" /></instanceMetadata>"
                                 .getBytes()));
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("instanceMetadata", document);
-        ProcessInstance processInstance = ksession.startProcess("XPathProcess",
+        KogitoProcessInstance processInstance = kruntime.startProcess("XPathProcess",
                 params);
         assertProcessInstanceCompleted(processInstance);
         
@@ -165,17 +155,18 @@ public class DataTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testDataInputAssociations() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-DataInputAssociations.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
-                new WorkItemHandler() {
-                    public void abortWorkItem(WorkItem manager,
-                            WorkItemManager mgr) {
+        kruntime = createKogitoProcessRuntime("BPMN2-DataInputAssociations.bpmn2");
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
+                new KogitoWorkItemHandler() {
+                    @Override
+                    public void abortWorkItem(KogitoWorkItem manager,
+                                              KogitoWorkItemManager mgr) {
 
                     }
 
-                    public void executeWorkItem(WorkItem workItem,
-                            WorkItemManager mgr) {
+                    @Override
+                    public void executeWorkItem(KogitoWorkItem workItem,
+                                                KogitoWorkItemManager mgr) {
                         assertEquals("hello world",
                                 workItem.getParameter("coId"));
                     }
@@ -185,34 +176,35 @@ public class DataTest extends JbpmBpmn2TestCase {
                 .newDocumentBuilder()
                 .parse(new ByteArrayInputStream("<user hello='hello world' />"
                         .getBytes()));
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("instanceMetadata", document.getFirstChild());
-        ProcessInstance processInstance = ksession.startProcess("process",
+        KogitoProcessInstance processInstance = kruntime.startProcess("process",
                 params);
         
     }
 
     @Test
     public void testDataInputAssociationsWithStringObject() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-DataInputAssociations-string-object.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
-                new WorkItemHandler() {
+        kruntime = createKogitoProcessRuntime("BPMN2-DataInputAssociations-string-object.bpmn2");
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
+                new KogitoWorkItemHandler() {
 
-                    public void abortWorkItem(WorkItem manager,
-                            WorkItemManager mgr) {
+                    @Override
+                    public void abortWorkItem(KogitoWorkItem manager,
+                                              KogitoWorkItemManager mgr) {
 
                     }
 
-                    public void executeWorkItem(WorkItem workItem,
-                            WorkItemManager mgr) {
+                    @Override
+                    public void executeWorkItem(KogitoWorkItem workItem, 
+                                                KogitoWorkItemManager mgr) {
                         assertEquals("hello", workItem.getParameter("coId"));
                     }
 
                 });
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("instanceMetadata", "hello");
-        ProcessInstance processInstance = ksession.startProcess("process",
+        KogitoProcessInstance processInstance = kruntime.startProcess("process",
                 params);
         
     }
@@ -224,18 +216,17 @@ public class DataTest extends JbpmBpmn2TestCase {
     @Disabled
     public void testDataInputAssociationsWithLazyLoading()
             throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-DataInputAssociations-lazy-creating.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
-                new WorkItemHandler() {
+        kruntime = createKogitoProcessRuntime("BPMN2-DataInputAssociations-lazy-creating.bpmn2");
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
+                new KogitoWorkItemHandler() {
 
-                    public void abortWorkItem(WorkItem manager,
-                            WorkItemManager mgr) {
+                    public void abortWorkItem(KogitoWorkItem manager,
+                            KogitoWorkItemManager mgr) {
 
                     }
 
-                    public void executeWorkItem(WorkItem workItem,
-                            WorkItemManager mgr) {
+                    public void executeWorkItem(KogitoWorkItem workItem,
+                            KogitoWorkItemManager mgr) {
                         Object coIdParamObj = workItem.getParameter("coId");
                         assertEquals("mydoc", ((Element) coIdParamObj).getNodeName());
                         assertEquals("mynode", ((Element) workItem.getParameter("coId")).getFirstChild().getNodeName());
@@ -256,32 +247,31 @@ public class DataTest extends JbpmBpmn2TestCase {
                 .newDocumentBuilder()
                 .parse(new ByteArrayInputStream("<user hello='hello world' />"
                         .getBytes()));
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("instanceMetadata", document.getFirstChild());
-        ProcessInstance processInstance = ksession.startProcess("process",
+        KogitoProcessInstance processInstance = kruntime.startProcess("process",
                 params);
         
     }
 
     @Test
     public void testDataInputAssociationsWithString() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-DataInputAssociations-string.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
-                new WorkItemHandler() {
+        kruntime = createKogitoProcessRuntime("BPMN2-DataInputAssociations-string.bpmn2");
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
+                new KogitoWorkItemHandler() {
 
-                    public void abortWorkItem(WorkItem manager,
-                            WorkItemManager mgr) {
+                    public void abortWorkItem(KogitoWorkItem manager,
+                            KogitoWorkItemManager mgr) {
 
                     }
 
-                    public void executeWorkItem(WorkItem workItem,
-                            WorkItemManager mgr) {
+                    public void executeWorkItem(KogitoWorkItem workItem,
+                            KogitoWorkItemManager mgr) {
                         assertEquals("hello", workItem.getParameter("coId"));
                     }
 
                 });
-        ProcessInstance processInstance = ksession
+        KogitoProcessInstance processInstance = kruntime
                 .startProcess("process");
         
     }
@@ -289,41 +279,39 @@ public class DataTest extends JbpmBpmn2TestCase {
     @Test
     public void testDataInputAssociationsWithStringWithoutQuotes()
             throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-DataInputAssociations-string-no-quotes.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
-                new WorkItemHandler() {
+        kruntime = createKogitoProcessRuntime("BPMN2-DataInputAssociations-string-no-quotes.bpmn2");
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
+                new KogitoWorkItemHandler() {
 
-                    public void abortWorkItem(WorkItem manager,
-                            WorkItemManager mgr) {
+                    public void abortWorkItem(KogitoWorkItem manager,
+                            KogitoWorkItemManager mgr) {
 
                     }
 
-                    public void executeWorkItem(WorkItem workItem,
-                            WorkItemManager mgr) {
+                    public void executeWorkItem(KogitoWorkItem workItem,
+                            KogitoWorkItemManager mgr) {
                         assertEquals("hello", workItem.getParameter("coId"));
                     }
 
                 });
-        ProcessInstance processInstance = ksession
+        KogitoProcessInstance processInstance = kruntime
                 .startProcess("process");
         
     }
 
     @Test
     public void testDataInputAssociationsWithXMLLiteral() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-DataInputAssociations-xml-literal.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
-                new WorkItemHandler() {
+        kruntime = createKogitoProcessRuntime("BPMN2-DataInputAssociations-xml-literal.bpmn2");
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
+                new KogitoWorkItemHandler() {
 
-                    public void abortWorkItem(WorkItem manager,
-                            WorkItemManager mgr) {
+                    public void abortWorkItem(KogitoWorkItem manager,
+                            KogitoWorkItemManager mgr) {
 
                     }
 
-                    public void executeWorkItem(WorkItem workItem,
-                            WorkItemManager mgr) {
+                    public void executeWorkItem(KogitoWorkItem workItem,
+                            KogitoWorkItemManager mgr) {
                         assertEquals("id", ((org.w3c.dom.Node) workItem
                                 .getParameter("coId")).getNodeName());
                         assertEquals("some text", ((org.w3c.dom.Node) workItem
@@ -332,7 +320,7 @@ public class DataTest extends JbpmBpmn2TestCase {
                     }
 
                 });
-        ProcessInstance processInstance = ksession
+        KogitoProcessInstance processInstance = kruntime
                 .startProcess("process");
         
     }
@@ -343,18 +331,17 @@ public class DataTest extends JbpmBpmn2TestCase {
     @Test
     @Disabled
     public void testDataInputAssociationsWithTwoAssigns() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-DataInputAssociations-two-assigns.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
-                new WorkItemHandler() {
+        kruntime = createKogitoProcessRuntime("BPMN2-DataInputAssociations-two-assigns.bpmn2");
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
+                new KogitoWorkItemHandler() {
 
-                    public void abortWorkItem(WorkItem manager,
-                            WorkItemManager mgr) {
+                    public void abortWorkItem(KogitoWorkItem manager,
+                            KogitoWorkItemManager mgr) {
 
                     }
 
-                    public void executeWorkItem(WorkItem workItem,
-                            WorkItemManager mgr) {
+                    public void executeWorkItem(KogitoWorkItem workItem,
+                            KogitoWorkItemManager mgr) {
                         assertEquals("foo", ((Element) workItem
                                 .getParameter("Comment")).getNodeName());
                         // assertEquals("mynode", ((Element)
@@ -371,27 +358,26 @@ public class DataTest extends JbpmBpmn2TestCase {
                 .newDocumentBuilder()
                 .parse(new ByteArrayInputStream("<user hello='hello world' />"
                         .getBytes()));
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("instanceMetadata", document.getFirstChild());
-        ProcessInstance processInstance = ksession.startProcess("process",
+        KogitoProcessInstance processInstance = kruntime.startProcess("process",
                 params);
         
     }
 
     @Test
     public void testDataOutputAssociationsforHumanTask() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-DataOutputAssociations-HumanTask.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
-                new WorkItemHandler() {
+        kruntime = createKogitoProcessRuntime("BPMN2-DataOutputAssociations-HumanTask.bpmn2");
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
+                new KogitoWorkItemHandler() {
 
-                    public void abortWorkItem(WorkItem manager,
-                            WorkItemManager mgr) {
+                    public void abortWorkItem(KogitoWorkItem manager,
+                            KogitoWorkItemManager mgr) {
 
                     }
 
-                    public void executeWorkItem(WorkItem workItem,
-                            WorkItemManager mgr) {
+                    public void executeWorkItem(KogitoWorkItem workItem,
+                            KogitoWorkItemManager mgr) {
                         DocumentBuilderFactory factory = DocumentBuilderFactory
                                 .newInstance();
                         DocumentBuilder builder;
@@ -400,7 +386,7 @@ public class DataTest extends JbpmBpmn2TestCase {
                         } catch (ParserConfigurationException e) {
                             throw new RuntimeException(e);
                         }
-                        final Map<String, Object> results = new HashMap<String, Object>();
+                        final Map<String, Object> results = new HashMap<>();
 
                         // process metadata
                         org.w3c.dom.Document processMetadaDoc = builder
@@ -419,26 +405,25 @@ public class DataTest extends JbpmBpmn2TestCase {
                     }
 
                 });
-        Map<String, Object> params = new HashMap<String, Object>();
-        ProcessInstance processInstance = ksession.startProcess("process",
+        Map<String, Object> params = new HashMap<>();
+        KogitoProcessInstance processInstance = kruntime.startProcess("process",
                 params);
         
     }
 
     @Test
     public void testDataOutputAssociations() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-DataOutputAssociations.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
-                new WorkItemHandler() {
+        kruntime = createKogitoProcessRuntime("BPMN2-DataOutputAssociations.bpmn2");
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
+                new KogitoWorkItemHandler() {
 
-                    public void abortWorkItem(WorkItem manager,
-                            WorkItemManager mgr) {
+                    public void abortWorkItem(KogitoWorkItem manager,
+                            KogitoWorkItemManager mgr) {
 
                     }
 
-                    public void executeWorkItem(WorkItem workItem,
-                            WorkItemManager mgr) {
+                    public void executeWorkItem(KogitoWorkItem workItem,
+                            KogitoWorkItemManager mgr) {
                         try {
                             Document document = DocumentBuilderFactory
                                     .newInstance()
@@ -446,7 +431,7 @@ public class DataTest extends JbpmBpmn2TestCase {
                                     .parse(new ByteArrayInputStream(
                                             "<user hello='hello world' />"
                                                     .getBytes()));
-                            Map<String, Object> params = new HashMap<String, Object>();
+                            Map<String, Object> params = new HashMap<>();
                             params.put("output", document.getFirstChild());
                             mgr.completeWorkItem(workItem.getId(), params);
                         } catch (Throwable e) {
@@ -456,25 +441,24 @@ public class DataTest extends JbpmBpmn2TestCase {
                     }
 
                 });
-        ProcessInstance processInstance = ksession
+        KogitoProcessInstance processInstance = kruntime
                 .startProcess("process");
         
     }
 
     @Test
     public void testDataOutputAssociationsXmlNode() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-DataOutputAssociations-xml-node.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
-                new WorkItemHandler() {
+        kruntime = createKogitoProcessRuntime("BPMN2-DataOutputAssociations-xml-node.bpmn2");
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
+                new KogitoWorkItemHandler() {
 
-                    public void abortWorkItem(WorkItem manager,
-                            WorkItemManager mgr) {
+                    public void abortWorkItem(KogitoWorkItem manager,
+                            KogitoWorkItemManager mgr) {
 
                     }
 
-                    public void executeWorkItem(WorkItem workItem,
-                            WorkItemManager mgr) {
+                    public void executeWorkItem(KogitoWorkItem workItem,
+                            KogitoWorkItemManager mgr) {
                         try {
                             Document document = DocumentBuilderFactory
                                     .newInstance()
@@ -482,7 +466,7 @@ public class DataTest extends JbpmBpmn2TestCase {
                                     .parse(new ByteArrayInputStream(
                                             "<user hello='hello world' />"
                                                     .getBytes()));
-                            Map<String, Object> params = new HashMap<String, Object>();
+                            Map<String, Object> params = new HashMap<>();
                             params.put("output", document.getFirstChild());
                             mgr.completeWorkItem(workItem.getId(), params);
                         } catch (Throwable e) {
@@ -492,7 +476,7 @@ public class DataTest extends JbpmBpmn2TestCase {
                     }
 
                 });
-        ProcessInstance processInstance = ksession
+        KogitoProcessInstance processInstance = kruntime
                 .startProcess("process");
         
     }

--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/EndEventTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/EndEventTest.java
@@ -25,12 +25,7 @@ import org.jbpm.bpmn2.handler.SendTaskHandler;
 import org.jbpm.bpmn2.objects.TestWorkItemHandler;
 import org.jbpm.process.instance.impl.demo.SystemOutWorkItemHandler;
 import org.junit.jupiter.api.Test;
-import org.kie.api.KieBase;
-import org.kie.api.runtime.process.ProcessInstance;
-import org.kie.api.runtime.process.WorkItem;
-import org.kie.internal.runtime.StatefulKnowledgeSession;
 import org.kie.kogito.internal.process.runtime.KogitoProcessInstance;
-import org.kie.kogito.internal.process.runtime.KogitoProcessRuntime;
 import org.kie.kogito.process.workitems.KogitoWorkItem;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -42,18 +37,16 @@ public class EndEventTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testImplicitEndParallel() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-ParallelSplit.bpmn2");
-        StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
-        ProcessInstance processInstance = ksession.startProcess("com.sample.test");
+        kruntime = createKogitoProcessRuntime("BPMN2-ParallelSplit.bpmn2");
+        KogitoProcessInstance processInstance = kruntime.startProcess("com.sample.test");
         assertProcessInstanceCompleted(processInstance);
         
     }
 
     @Test
     public void testErrorEndEventProcess() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-ErrorEndEvent.bpmn2");
-        StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
-        ProcessInstance processInstance = ksession
+        kruntime = createKogitoProcessRuntime("BPMN2-ErrorEndEvent.bpmn2");
+        KogitoProcessInstance processInstance = kruntime
                 .startProcess("ErrorEndEvent");
         assertProcessInstanceAborted(processInstance);
         assertEquals("error", ((org.jbpm.process.instance.ProcessInstance)processInstance).getOutcome());
@@ -62,9 +55,8 @@ public class EndEventTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testEscalationEndEventProcess() throws Exception {
-        KieBase kbase = createKnowledgeBase("escalation/BPMN2-EscalationEndEvent.bpmn2");
-        StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
-        ProcessInstance processInstance = ksession
+        kruntime = createKogitoProcessRuntime("escalation/BPMN2-EscalationEndEvent.bpmn2");
+        KogitoProcessInstance processInstance = kruntime
                 .startProcess("EscalationEndEvent");
         assertProcessInstanceAborted(processInstance);
         
@@ -72,23 +64,21 @@ public class EndEventTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testSignalEnd() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-SignalEndEvent.bpmn2");
-        StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
-        Map<String, Object> params = new HashMap<String, Object>();
+        kruntime = createKogitoProcessRuntime("BPMN2-SignalEndEvent.bpmn2");
+        Map<String, Object> params = new HashMap<>();
         params.put("x", "MyValue");
-        ksession.startProcess("SignalEndEvent", params);
+        kruntime.startProcess("SignalEndEvent", params);
         
     }
 
     @Test
     public void testMessageEnd() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-MessageEndEvent.bpmn2");
-        StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
-        ksession.getWorkItemManager().registerWorkItemHandler("Send Task",
+        kruntime = createKogitoProcessRuntime("BPMN2-MessageEndEvent.bpmn2");
+        kruntime.getWorkItemManager().registerWorkItemHandler("Send Task",
                 new SendTaskHandler());
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", "MyValue");
-        ProcessInstance processInstance = ksession.startProcess(
+        KogitoProcessInstance processInstance = kruntime.startProcess(
                 "MessageEndEvent", params);
         assertProcessInstanceCompleted(processInstance);
         
@@ -96,42 +86,39 @@ public class EndEventTest extends JbpmBpmn2TestCase {
     
     @Test
     public void testMessageEndVerifyDeploymentId() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-MessageEndEvent.bpmn2");
+        kruntime = createKogitoProcessRuntime("BPMN2-MessageEndEvent.bpmn2");
         
         TestWorkItemHandler handler = new TestWorkItemHandler();
         
-        StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
-        ksession.getWorkItemManager().registerWorkItemHandler("Send Task", handler);
-        Map<String, Object> params = new HashMap<String, Object>();
+        kruntime.getWorkItemManager().registerWorkItemHandler("Send Task", handler);
+        Map<String, Object> params = new HashMap<>();
         params.put("x", "MyValue");
-        ProcessInstance processInstance = ksession.startProcess("MessageEndEvent", params);
+        KogitoProcessInstance processInstance = kruntime.startProcess("MessageEndEvent", params);
         assertProcessInstanceCompleted(processInstance);
         
-        WorkItem workItem = handler.getWorkItem();
+        KogitoWorkItem workItem = (KogitoWorkItem) handler.getWorkItem();
         assertNotNull(workItem);
-        assertTrue(workItem instanceof KogitoWorkItem );
         
-        String nodeInstanceId = (( KogitoWorkItem ) workItem).getNodeInstanceStringId();
-        long nodeId = (( KogitoWorkItem ) workItem).getNodeId();
-        String deploymentId = (( KogitoWorkItem ) workItem).getDeploymentId();
+        String nodeInstanceId = workItem.getNodeInstanceStringId();
+        long nodeId = workItem.getNodeId();
+        String deploymentId = workItem.getDeploymentId();
         
         assertNotNull(nodeId);
         assertTrue(nodeId > 0);
         assertNotNull(nodeInstanceId);
         assertNull(deploymentId);
         
-        // now set deployment id as part of ksession's env
-        ksession.getEnvironment().set("deploymentId", "testDeploymentId");
+        // now set deployment id as part of kruntime's env
+        kruntime.getKieRuntime().getEnvironment().set("deploymentId", "testDeploymentId");
         
-        processInstance = ksession.startProcess("MessageEndEvent", params);
+        processInstance = kruntime.startProcess("MessageEndEvent", params);
         assertProcessInstanceCompleted(processInstance);
         
-        workItem = handler.getWorkItem();
+        workItem = (KogitoWorkItem) handler.getWorkItem();
         assertNotNull(workItem);
-        assertTrue(workItem instanceof KogitoWorkItem );
-        
-        nodeInstanceId = (( KogitoWorkItem ) workItem).getNodeInstanceStringId();
-        nodeId = (( KogitoWorkItem ) workItem).getNodeId();
+
+        nodeInstanceId = workItem.getNodeInstanceStringId();
+        nodeId = workItem.getNodeId();
         
         assertNotNull(nodeId);
         assertTrue(nodeId > 0);
@@ -140,13 +127,12 @@ public class EndEventTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testOnEntryExitScript() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-OnEntryExitScriptProcess.bpmn2");
-        StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
-        ksession.getWorkItemManager().registerWorkItemHandler("MyTask",
+        kruntime = createKogitoProcessRuntime("BPMN2-OnEntryExitScriptProcess.bpmn2");
+        kruntime.getWorkItemManager().registerWorkItemHandler("MyTask",
                 new SystemOutWorkItemHandler());
-        List<String> myList = new ArrayList<String>();
-        ksession.setGlobal("list", myList);
-        ProcessInstance processInstance = ksession
+        List<String> myList = new ArrayList<>();
+        kruntime.getKieSession().setGlobal("list", myList);
+        KogitoProcessInstance processInstance = kruntime
                 .startProcess("OnEntryExitScriptProcess");
         assertProcessInstanceCompleted(processInstance);
         assertEquals(4, myList.size());
@@ -155,13 +141,12 @@ public class EndEventTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testOnEntryExitNamespacedScript() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-OnEntryExitNamespacedScriptProcess.bpmn2");
-        StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
-        ksession.getWorkItemManager().registerWorkItemHandler("MyTask",
+        kruntime = createKogitoProcessRuntime("BPMN2-OnEntryExitNamespacedScriptProcess.bpmn2");
+        kruntime.getWorkItemManager().registerWorkItemHandler("MyTask",
                 new SystemOutWorkItemHandler());
-        List<String> myList = new ArrayList<String>();
-        ksession.setGlobal("list", myList);
-        ProcessInstance processInstance = ksession
+        List<String> myList = new ArrayList<>();
+        kruntime.getKieSession().setGlobal("list", myList);
+        KogitoProcessInstance processInstance = kruntime
                 .startProcess("OnEntryExitScriptProcess");
         assertProcessInstanceCompleted(processInstance);
         assertEquals(4, myList.size());
@@ -170,13 +155,12 @@ public class EndEventTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testOnEntryExitMixedNamespacedScript() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-OnEntryExitMixedNamespacedScriptProcess.bpmn2");
-        StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
-        ksession.getWorkItemManager().registerWorkItemHandler("MyTask",
+        kruntime = createKogitoProcessRuntime("BPMN2-OnEntryExitMixedNamespacedScriptProcess.bpmn2");
+        kruntime.getWorkItemManager().registerWorkItemHandler("MyTask",
                 new SystemOutWorkItemHandler());
-        List<String> myList = new ArrayList<String>();
-        ksession.setGlobal("list", myList);
-        ProcessInstance processInstance = ksession
+        List<String> myList = new ArrayList<>();
+        kruntime.getKieSession().setGlobal("list", myList);
+        KogitoProcessInstance processInstance = kruntime
                 .startProcess("OnEntryExitScriptProcess");
         assertProcessInstanceCompleted(processInstance);
         assertEquals(4, myList.size());
@@ -185,13 +169,12 @@ public class EndEventTest extends JbpmBpmn2TestCase {
     
     @Test
     public void testOnEntryExitScriptDesigner() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-OnEntryExitDesignerScriptProcess.bpmn2");
-        StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
-        ksession.getWorkItemManager().registerWorkItemHandler("MyTask",
+        kruntime = createKogitoProcessRuntime("BPMN2-OnEntryExitDesignerScriptProcess.bpmn2");
+        kruntime.getWorkItemManager().registerWorkItemHandler("MyTask",
                 new SystemOutWorkItemHandler());
-        List<String> myList = new ArrayList<String>();
-        ksession.setGlobal("list", myList);
-        ProcessInstance processInstance = ksession
+        List<String> myList = new ArrayList<>();
+        kruntime.getKieSession().setGlobal("list", myList);
+        KogitoProcessInstance processInstance = kruntime
                 .startProcess("OnEntryExitScriptProcess");
         assertProcessInstanceCompleted(processInstance);
         assertEquals(4, myList.size());
@@ -200,9 +183,7 @@ public class EndEventTest extends JbpmBpmn2TestCase {
     
     @Test
     public void testTerminateWithinSubprocessEnd() throws Exception {
-        KieBase kbase = createKnowledgeBase("subprocess/BPMN2-SubprocessWithParallelSpitTerminate.bpmn2");
-        StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("subprocess/BPMN2-SubprocessWithParallelSpitTerminate.bpmn2");
         KogitoProcessInstance processInstance = kruntime.startProcess("BPMN2-SubprocessWithParallelSpitTerminate");
 
         kruntime.signalEvent("signal1", null, processInstance.getStringId());
@@ -213,9 +194,7 @@ public class EndEventTest extends JbpmBpmn2TestCase {
     
     @Test
     public void testTerminateEnd() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-ParallelSpitTerminate.bpmn2");
-        StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-ParallelSpitTerminate.bpmn2");
         KogitoProcessInstance processInstance = kruntime.startProcess("BPMN2-ParallelSpitTerminate");
 
         kruntime.signalEvent("Signal 1", null, processInstance.getStringId());
@@ -226,10 +205,9 @@ public class EndEventTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testSignalEndWithData() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-EndEventSignalWithData.bpmn2");
-        StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
-        Map<String, Object> params = new HashMap<String, Object>();
-        ProcessInstance processInstance = ksession.startProcess("src.simpleEndSignal", params);
+        kruntime = createKogitoProcessRuntime("BPMN2-EndEventSignalWithData.bpmn2");
+        Map<String, Object> params = new HashMap<>();
+        KogitoProcessInstance processInstance = kruntime.startProcess("src.simpleEndSignal", params);
         
         assertProcessInstanceCompleted(processInstance);
         

--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/FlowTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/FlowTest.java
@@ -40,16 +40,14 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.kie.api.KieBase;
 import org.kie.api.command.ExecutableCommand;
-import org.kie.api.event.process.DefaultProcessEventListener;
 import org.kie.api.event.process.ProcessNodeTriggeredEvent;
 import org.kie.api.event.process.ProcessStartedEvent;
 import org.kie.api.runtime.Context;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.process.NodeInstance;
-import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.internal.command.RegistryContext;
+import org.kie.kogito.internal.process.event.DefaultKogitoProcessEventListener;
 import org.kie.kogito.internal.process.runtime.KogitoProcessInstance;
 import org.kie.kogito.internal.process.runtime.KogitoProcessRuntime;
 import org.kie.kogito.internal.process.runtime.KogitoWorkItem;
@@ -80,24 +78,23 @@ public class FlowTest extends JbpmBpmn2TestCase {
     @Test
     public void testExclusiveSplitWithNoConditions() throws Exception {
         try {
-            createKnowledgeBaseWithoutDumper("BPMN2-ExclusiveGatewayWithNoConditionsDefined.bpmn2");
+            createKogitoProcessRuntime("BPMN2-ExclusiveGatewayWithNoConditionsDefined.bpmn2");
             fail("Should fail as XOR gateway does not have conditions defined");
         } catch (RuntimeException e) {
-            assertTrue(e.getMessage().indexOf("does not have a constraint for Connection") != -1);
+            assertTrue(e.getMessage().contains("does not have a constraint for Connection"));
         }
 
     }
     
     @Test
     public void testExclusiveSplit() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-ExclusiveSplit.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        ksession.getWorkItemManager().registerWorkItemHandler("Email",
+        kruntime = createKogitoProcessRuntime("BPMN2-ExclusiveSplit.bpmn2");
+        kruntime.getWorkItemManager().registerWorkItemHandler("Email",
                 new SystemOutWorkItemHandler());
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", "First");
         params.put("y", "Second");
-        ProcessInstance processInstance = ksession.startProcess(
+        KogitoProcessInstance processInstance = kruntime.startProcess(
                 "com.sample.test", params);
         assertProcessInstanceCompleted(processInstance);
 
@@ -105,11 +102,10 @@ public class FlowTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testExclusiveSplitXPathAdvanced() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-ExclusiveSplitXPath-advanced.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        ksession.getWorkItemManager().registerWorkItemHandler("Email",
+        kruntime = createKogitoProcessRuntime("BPMN2-ExclusiveSplitXPath-advanced.bpmn2");
+        kruntime.getWorkItemManager().registerWorkItemHandler("Email",
                 new SystemOutWorkItemHandler());
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         Document doc = DocumentBuilderFactory.newInstance()
                 .newDocumentBuilder().newDocument();
         Element hi = doc.createElement("hi");
@@ -120,7 +116,7 @@ public class FlowTest extends JbpmBpmn2TestCase {
         attr.setValue("a");
         params.put("x", hi);
         params.put("y", "Second");
-        ProcessInstance processInstance = ksession.startProcess(
+        KogitoProcessInstance processInstance = kruntime.startProcess(
                 "com.sample.test", params);
         assertProcessInstanceCompleted(processInstance);
 
@@ -128,11 +124,10 @@ public class FlowTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testExclusiveSplitXPathAdvanced2() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-ExclusiveSplitXPath-advanced-vars-not-signaled.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        ksession.getWorkItemManager().registerWorkItemHandler("Email",
+        kruntime = createKogitoProcessRuntime("BPMN2-ExclusiveSplitXPath-advanced-vars-not-signaled.bpmn2");
+        kruntime.getWorkItemManager().registerWorkItemHandler("Email",
                 new SystemOutWorkItemHandler());
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         Document doc = DocumentBuilderFactory.newInstance()
                 .newDocumentBuilder().newDocument();
         Element hi = doc.createElement("hi");
@@ -143,7 +138,7 @@ public class FlowTest extends JbpmBpmn2TestCase {
         attr.setValue("a");
         params.put("x", hi);
         params.put("y", "Second");
-        ProcessInstance processInstance = ksession.startProcess(
+        KogitoProcessInstance processInstance = kruntime.startProcess(
                 "com.sample.test", params);
         assertProcessInstanceCompleted(processInstance);
 
@@ -151,11 +146,10 @@ public class FlowTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testExclusiveSplitXPathAdvancedWithVars() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-ExclusiveSplitXPath-advanced-with-vars.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        ksession.getWorkItemManager().registerWorkItemHandler("Email",
+        kruntime = createKogitoProcessRuntime("BPMN2-ExclusiveSplitXPath-advanced-with-vars.bpmn2");
+        kruntime.getWorkItemManager().registerWorkItemHandler("Email",
                 new SystemOutWorkItemHandler());
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         Document doc = DocumentBuilderFactory.newInstance()
                 .newDocumentBuilder().newDocument();
         Element hi = doc.createElement("hi");
@@ -166,7 +160,7 @@ public class FlowTest extends JbpmBpmn2TestCase {
         attr.setValue("a");
         params.put("x", hi);
         params.put("y", "Second");
-        ProcessInstance processInstance = ksession.startProcess(
+        KogitoProcessInstance processInstance = kruntime.startProcess(
                 "com.sample.test", params);
         assertProcessInstanceCompleted(processInstance);
 
@@ -174,14 +168,13 @@ public class FlowTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testExclusiveSplitPriority() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-ExclusiveSplitPriority.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        ksession.getWorkItemManager().registerWorkItemHandler("Email",
+        kruntime = createKogitoProcessRuntime("BPMN2-ExclusiveSplitPriority.bpmn2");
+        kruntime.getWorkItemManager().registerWorkItemHandler("Email",
                 new SystemOutWorkItemHandler());
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", "First");
         params.put("y", "Second");
-        ProcessInstance processInstance = ksession.startProcess(
+        KogitoProcessInstance processInstance = kruntime.startProcess(
                 "com.sample.test", params);
         assertProcessInstanceCompleted(processInstance);
 
@@ -189,14 +182,13 @@ public class FlowTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testExclusiveSplitDefault() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-ExclusiveSplitDefault.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        ksession.getWorkItemManager().registerWorkItemHandler("Email",
+        kruntime = createKogitoProcessRuntime("BPMN2-ExclusiveSplitDefault.bpmn2");
+        kruntime.getWorkItemManager().registerWorkItemHandler("Email",
                 new SystemOutWorkItemHandler());
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", "NotFirst");
         params.put("y", "Second");
-        ProcessInstance processInstance = ksession.startProcess(
+        KogitoProcessInstance processInstance = kruntime.startProcess(
                 "com.sample.test", params);
         assertProcessInstanceCompleted(processInstance);
 
@@ -204,15 +196,14 @@ public class FlowTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testExclusiveXORGateway() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-gatewayTest.bpmn2");
-        ksession = createKnowledgeSession(kbase);
+        kruntime = createKogitoProcessRuntime("BPMN2-gatewayTest.bpmn2");
         Document document = DocumentBuilderFactory
                 .newInstance()
                 .newDocumentBuilder()
                 .parse(new ByteArrayInputStream(
                         "<instanceMetadata><user approved=\"false\" /></instanceMetadata>"
                                 .getBytes()));
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("instanceMetadata", document);
         params.put(
                 "startMessage",
@@ -222,7 +213,7 @@ public class FlowTest extends JbpmBpmn2TestCase {
                         .parse(new ByteArrayInputStream(
                                 "<task subject='foobar2'/>".getBytes()))
                         .getFirstChild());
-        ProcessInstance processInstance = ksession.startProcess("process",
+        KogitoProcessInstance processInstance = kruntime.startProcess("process",
                 params);
         assertProcessInstanceCompleted(processInstance);
 
@@ -230,11 +221,10 @@ public class FlowTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testInclusiveSplit() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-InclusiveSplit.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        Map<String, Object> params = new HashMap<String, Object>();
+        kruntime = createKogitoProcessRuntime("BPMN2-InclusiveSplit.bpmn2");
+        Map<String, Object> params = new HashMap<>();
         params.put("x", 15);
-        ProcessInstance processInstance = ksession.startProcess(
+        KogitoProcessInstance processInstance = kruntime.startProcess(
                 "com.sample.test", params);
         assertProcessInstanceCompleted(processInstance);
 
@@ -242,110 +232,97 @@ public class FlowTest extends JbpmBpmn2TestCase {
     
     @Test
     public void testInclusiveSplitDefaultConnection() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-InclusiveGatewayWithDefault.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        Map<String, Object> params = new HashMap<String, Object>();
+        kruntime = createKogitoProcessRuntime("BPMN2-InclusiveGatewayWithDefault.bpmn2");
+        Map<String, Object> params = new HashMap<>();
         params.put("test", "c");
-        ProcessInstance processInstance = ksession.startProcess("InclusiveGatewayWithDefault", params);
+        KogitoProcessInstance processInstance = kruntime.startProcess("InclusiveGatewayWithDefault", params);
         assertProcessInstanceCompleted(processInstance);
 
     }
 
     @Test
     public void testInclusiveSplitAndJoin() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-InclusiveSplitAndJoin.bpmn2");
-        ksession = createKnowledgeSession(kbase);
+        kruntime = createKogitoProcessRuntime("BPMN2-InclusiveSplitAndJoin.bpmn2");
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
 
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", 15);
-        ProcessInstance processInstance = kruntime.startProcess(
+        KogitoProcessInstance processInstance = kruntime.startProcess(
                 "com.sample.test", params);
 
         List<KogitoWorkItem> activeWorkItems = workItemHandler.getWorkItems();
 
         assertEquals(2, activeWorkItems.size());
-        ksession = restoreSession(ksession, true);
 
         for (KogitoWorkItem wi : activeWorkItems) {
             kruntime.getWorkItemManager().completeWorkItem(wi.getStringId(), null);
         }
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
     }
 
     @Test
     public void testInclusiveSplitAndJoinLoop() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-InclusiveSplitAndJoinLoop.bpmn2");
-        ksession = createKnowledgeSession(kbase);
+        kruntime = createKogitoProcessRuntime("BPMN2-InclusiveSplitAndJoinLoop.bpmn2");
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
 
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", 21);
-        ProcessInstance processInstance = kruntime.startProcess(
+        KogitoProcessInstance processInstance = kruntime.startProcess(
                 "com.sample.test", params);
 
         List<KogitoWorkItem> activeWorkItems = workItemHandler.getWorkItems();
 
         assertEquals(3, activeWorkItems.size());
-        ksession = restoreSession(ksession, true);
 
         for (KogitoWorkItem wi : activeWorkItems) {
             kruntime.getWorkItemManager().completeWorkItem(wi.getStringId(), null);
         }
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
     }
 
     @Test
     public void testInclusiveSplitAndJoinLoop2() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-InclusiveSplitAndJoinLoop2.bpmn2");
-        ksession = createKnowledgeSession(kbase);
+        kruntime = createKogitoProcessRuntime("BPMN2-InclusiveSplitAndJoinLoop2.bpmn2");
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 workItemHandler);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
 
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", 21);
-        ProcessInstance processInstance = ksession.startProcess(
+        KogitoProcessInstance processInstance = kruntime.startProcess(
                 "com.sample.test", params);
 
         List<KogitoWorkItem> activeWorkItems = workItemHandler.getWorkItems();
 
         assertEquals(3, activeWorkItems.size());
-        ksession = restoreSession(ksession, true);
 
         for (KogitoWorkItem wi : activeWorkItems) {
             kruntime.getWorkItemManager().completeWorkItem(wi.getStringId(), null);
         }
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
     }
 
     @Test
     public void testInclusiveSplitAndJoinNested() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-InclusiveSplitAndJoinNested.bpmn2");
-        ksession = createKnowledgeSession(kbase);
+        kruntime = createKogitoProcessRuntime("BPMN2-InclusiveSplitAndJoinNested.bpmn2");
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 workItemHandler);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
 
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", 15);
-        ProcessInstance processInstance = ksession.startProcess(
+        KogitoProcessInstance processInstance = kruntime.startProcess(
                 "com.sample.test", params);
 
         List<KogitoWorkItem> activeWorkItems = workItemHandler.getWorkItems();
 
         assertEquals(2, activeWorkItems.size());
-        ksession = restoreSession(ksession, true);
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 workItemHandler);
 
         for (KogitoWorkItem wi : activeWorkItems) {
@@ -354,87 +331,77 @@ public class FlowTest extends JbpmBpmn2TestCase {
 
         activeWorkItems = workItemHandler.getWorkItems();
         assertEquals(2, activeWorkItems.size());
-        ksession = restoreSession(ksession, true);
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 workItemHandler);
 
         for (KogitoWorkItem wi : activeWorkItems) {
             kruntime.getWorkItemManager().completeWorkItem(wi.getStringId(), null);
         }
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
     }
 
     @Test
     public void testInclusiveSplitAndJoinEmbedded() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-InclusiveSplitAndJoinEmbedded.bpmn2");
-        ksession = createKnowledgeSession(kbase);
+        kruntime = createKogitoProcessRuntime("BPMN2-InclusiveSplitAndJoinEmbedded.bpmn2");
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 workItemHandler);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
 
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", 15);
-        ProcessInstance processInstance = ksession.startProcess(
+        KogitoProcessInstance processInstance = kruntime.startProcess(
                 "com.sample.test", params);
 
         List<KogitoWorkItem> activeWorkItems = workItemHandler.getWorkItems();
 
         assertEquals(2, activeWorkItems.size());
-        ksession = restoreSession(ksession, true);
 
         for (KogitoWorkItem wi : activeWorkItems) {
             kruntime.getWorkItemManager().completeWorkItem(wi.getStringId(), null);
         }
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
     }
 
     @Test
     public void testInclusiveSplitAndJoinWithParallel() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-InclusiveSplitAndJoinWithParallel.bpmn2");
-        ksession = createKnowledgeSession(kbase);
+        kruntime = createKogitoProcessRuntime("BPMN2-InclusiveSplitAndJoinWithParallel.bpmn2");
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 workItemHandler);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
 
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", 25);
-        ProcessInstance processInstance = ksession.startProcess(
+        KogitoProcessInstance processInstance = kruntime.startProcess(
                 "com.sample.test", params);
 
         List<KogitoWorkItem> activeWorkItems = workItemHandler.getWorkItems();
 
         assertEquals(4, activeWorkItems.size());
-        ksession = restoreSession(ksession, true);
 
         for (KogitoWorkItem wi : activeWorkItems) {
             kruntime.getWorkItemManager().completeWorkItem(wi.getStringId(), null);
         }
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
     }
 
     @Test
     public void testInclusiveSplitAndJoinWithEnd() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-InclusiveSplitAndJoinWithEnd.bpmn2");
-        ksession = createKnowledgeSession(kbase);
+        kruntime = createKogitoProcessRuntime("BPMN2-InclusiveSplitAndJoinWithEnd.bpmn2");
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 workItemHandler);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
 
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", 25);
-        ProcessInstance processInstance = ksession.startProcess(
+        KogitoProcessInstance processInstance = kruntime.startProcess(
                 "com.sample.test", params);
 
         List<KogitoWorkItem> activeWorkItems = workItemHandler.getWorkItems();
 
         assertEquals(3, activeWorkItems.size());
-        ksession = restoreSession(ksession, true);
 
         for (int i = 0; i < 2; i++) {
             kruntime.getWorkItemManager().completeWorkItem(
@@ -444,7 +411,7 @@ public class FlowTest extends JbpmBpmn2TestCase {
 
         kruntime.getWorkItemManager().completeWorkItem(
                 activeWorkItems.get(2).getStringId(), null);
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
     }
 
@@ -452,17 +419,15 @@ public class FlowTest extends JbpmBpmn2TestCase {
     @Timeout(10000)
     public void testInclusiveSplitAndJoinWithTimer() throws Exception {
         NodeLeftCountDownProcessEventListener countDownListener = new NodeLeftCountDownProcessEventListener("timer", 2);
-        KieBase kbase = createKnowledgeBase("BPMN2-InclusiveSplitAndJoinWithTimer.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        ksession.addEventListener(countDownListener);
+        kruntime = createKogitoProcessRuntime("BPMN2-InclusiveSplitAndJoinWithTimer.bpmn2");
+        kruntime.getProcessEventManager().addEventListener(countDownListener);
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 workItemHandler);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
 
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", 15);
-        ProcessInstance processInstance = ksession.startProcess(
+        KogitoProcessInstance processInstance = kruntime.startProcess(
                 "com.sample.test", params);
 
         List<KogitoWorkItem> activeWorkItems = workItemHandler.getWorkItems();
@@ -482,30 +447,27 @@ public class FlowTest extends JbpmBpmn2TestCase {
 
         kruntime.getWorkItemManager().completeWorkItem(
                 activeWorkItems.get(1).getStringId(), null);
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
     }
 
     @Test
     public void testInclusiveSplitAndJoinExtraPath() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-InclusiveSplitAndJoinExtraPath.bpmn2");
-        ksession = createKnowledgeSession(kbase);
+        kruntime = createKogitoProcessRuntime("BPMN2-InclusiveSplitAndJoinExtraPath.bpmn2");
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 workItemHandler);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
 
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", 25);
-        ProcessInstance processInstance = ksession.startProcess(
+        KogitoProcessInstance processInstance = kruntime.startProcess(
                 "com.sample.test", params);
 
-        ksession.signalEvent("signal", null);
+        kruntime.signalEvent("signal", null);
 
         List<KogitoWorkItem> activeWorkItems = workItemHandler.getWorkItems();
 
         assertEquals(4, activeWorkItems.size());
-        ksession = restoreSession(ksession, true);
 
         for (int i = 0; i < 3; i++) {
             kruntime.getWorkItemManager().completeWorkItem(
@@ -515,17 +477,16 @@ public class FlowTest extends JbpmBpmn2TestCase {
 
         kruntime.getWorkItemManager().completeWorkItem(
                 activeWorkItems.get(3).getStringId(), null);
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
     }
 
     @Test
     public void testInclusiveSplitDefault() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-InclusiveSplitDefault.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        Map<String, Object> params = new HashMap<String, Object>();
+        kruntime = createKogitoProcessRuntime("BPMN2-InclusiveSplitDefault.bpmn2");
+        Map<String, Object> params = new HashMap<>();
         params.put("x", -5);
-        ProcessInstance processInstance = ksession.startProcess(
+        KogitoProcessInstance processInstance = kruntime.startProcess(
                 "com.sample.test", params);
         assertProcessInstanceCompleted(processInstance);
 
@@ -533,32 +494,30 @@ public class FlowTest extends JbpmBpmn2TestCase {
     
     @Test
     public void testInclusiveParallelExclusiveSplitNoLoop() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-InclusiveNestedInParallelNestedInExclusive.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-InclusiveNestedInParallelNestedInExclusive.bpmn2");
 
-        ksession.getWorkItemManager().registerWorkItemHandler("testWI", new SystemOutWorkItemHandler());
-        ksession.getWorkItemManager().registerWorkItemHandler("testWI2", new SystemOutWorkItemHandler() {
+        kruntime.getWorkItemManager().registerWorkItemHandler("testWI", new SystemOutWorkItemHandler());
+        kruntime.getWorkItemManager().registerWorkItemHandler("testWI2", new SystemOutWorkItemHandler() {
 
             @Override
             public void executeWorkItem(KogitoWorkItem workItem, KogitoWorkItemManager manager) {
                 Integer x = (Integer) workItem.getParameter("input1");
                 x++;
-                Map<String, Object> results = new HashMap<String, Object>();
+                Map<String, Object> results = new HashMap<>();
                 results.put("output1", x);
                 manager.completeWorkItem(workItem.getStringId(), results);
             }
             
         });
-        final Map<String, Integer> nodeInstanceExecutionCounter = new HashMap<String, Integer>(); 
-        ksession.addEventListener(new DefaultProcessEventListener(){
+        final Map<String, Integer> nodeInstanceExecutionCounter = new HashMap<>(); 
+        kruntime.getProcessEventManager().addEventListener(new DefaultKogitoProcessEventListener(){
 
             @Override
             public void beforeNodeTriggered(ProcessNodeTriggeredEvent event) {   
                 logger.info(event.getNodeInstance().getNodeName());
                 Integer value = nodeInstanceExecutionCounter.get(event.getNodeInstance().getNodeName());
                 if (value == null) {
-                    value = new Integer(0);
+                    value = 0;
                 }
                 
                 value++;
@@ -567,9 +526,9 @@ public class FlowTest extends JbpmBpmn2TestCase {
 
             
         });
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", 0);
-        ProcessInstance processInstance = ksession.startProcess("Process_1", params);
+        KogitoProcessInstance processInstance = kruntime.startProcess("Process_1", params);
         assertProcessInstanceCompleted(processInstance);
         
         assertEquals(12, nodeInstanceExecutionCounter.size());
@@ -589,29 +548,28 @@ public class FlowTest extends JbpmBpmn2TestCase {
     
     @Test
     public void testInclusiveParallelExclusiveSplitLoop() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-InclusiveNestedInParallelNestedInExclusive.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        ksession.getWorkItemManager().registerWorkItemHandler("testWI", new SystemOutWorkItemHandler());
-        ksession.getWorkItemManager().registerWorkItemHandler("testWI2", new SystemOutWorkItemHandler() {
+        kruntime = createKogitoProcessRuntime("BPMN2-InclusiveNestedInParallelNestedInExclusive.bpmn2");
+        kruntime.getWorkItemManager().registerWorkItemHandler("testWI", new SystemOutWorkItemHandler());
+        kruntime.getWorkItemManager().registerWorkItemHandler("testWI2", new SystemOutWorkItemHandler() {
 
             @Override
             public void executeWorkItem(KogitoWorkItem workItem,  KogitoWorkItemManager manager) {
                 Integer x = (Integer) workItem.getParameter("input1");
                 x++;
-                Map<String, Object> results = new HashMap<String, Object>();
+                Map<String, Object> results = new HashMap<>();
                 results.put("output1", x);
                 manager.completeWorkItem(workItem.getStringId(), results);
             }
             
         });
-        final Map<String, Integer> nodeInstanceExecutionCounter = new HashMap<String, Integer>(); 
-        ksession.addEventListener(new DefaultProcessEventListener(){
+        final Map<String, Integer> nodeInstanceExecutionCounter = new HashMap<>();
+        kruntime.getProcessEventManager().addEventListener(new DefaultKogitoProcessEventListener(){
 
             @Override
             public void beforeNodeTriggered(ProcessNodeTriggeredEvent event) {                
                 Integer value = nodeInstanceExecutionCounter.get(event.getNodeInstance().getNodeName());
                 if (value == null) {
-                    value = new Integer(0);
+                    value = 0;
                 }
                 
                 value++;
@@ -619,9 +577,9 @@ public class FlowTest extends JbpmBpmn2TestCase {
             }
             
         });
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", -1);
-        ProcessInstance processInstance = ksession.startProcess("Process_1", params);
+        KogitoProcessInstance processInstance = kruntime.startProcess("Process_1", params);
         assertProcessInstanceCompleted(processInstance);
         
         assertEquals(12, nodeInstanceExecutionCounter.size());
@@ -641,26 +599,24 @@ public class FlowTest extends JbpmBpmn2TestCase {
     
     @Test
     public void testInclusiveParallelExclusiveSplitNoLoopAsync() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-InclusiveNestedInParallelNestedInExclusive.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-InclusiveNestedInParallelNestedInExclusive.bpmn2");
 
         TestWorkItemHandler handler = new TestWorkItemHandler();
-        ksession.getWorkItemManager().registerWorkItemHandler("testWI", handler);
-        ksession.getWorkItemManager().registerWorkItemHandler("testWI2", new SystemOutWorkItemHandler() {
+        kruntime.getWorkItemManager().registerWorkItemHandler("testWI", handler);
+        kruntime.getWorkItemManager().registerWorkItemHandler("testWI2", new SystemOutWorkItemHandler() {
 
             @Override
             public void executeWorkItem(KogitoWorkItem workItem,  KogitoWorkItemManager manager) {
                 Integer x = (Integer) workItem.getParameter("input1");
                 x++;
-                Map<String, Object> results = new HashMap<String, Object>();
+                Map<String, Object> results = new HashMap<>();
                 results.put("output1", x);
                 manager.completeWorkItem(workItem.getStringId(), results);
             }
             
         });
-        final Map<String, Integer> nodeInstanceExecutionCounter = new HashMap<String, Integer>(); 
-        ksession.addEventListener(new DefaultProcessEventListener(){
+        final Map<String, Integer> nodeInstanceExecutionCounter = new HashMap<>();
+        kruntime.getProcessEventManager().addEventListener(new DefaultKogitoProcessEventListener(){
 
             @Override
             public void beforeNodeTriggered(ProcessNodeTriggeredEvent event) {                  
@@ -675,9 +631,9 @@ public class FlowTest extends JbpmBpmn2TestCase {
 
             
         });
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", 0);
-        ProcessInstance processInstance = ksession.startProcess("Process_1", params);
+        KogitoProcessInstance processInstance = kruntime.startProcess("Process_1", params);
         assertProcessInstanceActive(processInstance);
         
         List<KogitoWorkItem> workItems = handler.getWorkItems();
@@ -715,32 +671,30 @@ public class FlowTest extends JbpmBpmn2TestCase {
     
     @Test
     public void testInclusiveParallelExclusiveSplitLoopAsync() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-InclusiveNestedInParallelNestedInExclusive.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-InclusiveNestedInParallelNestedInExclusive.bpmn2");
 
         TestWorkItemHandler handler = new TestWorkItemHandler();
-        ksession.getWorkItemManager().registerWorkItemHandler("testWI", handler);
-        ksession.getWorkItemManager().registerWorkItemHandler("testWI2", new SystemOutWorkItemHandler() {
+        kruntime.getWorkItemManager().registerWorkItemHandler("testWI", handler);
+        kruntime.getWorkItemManager().registerWorkItemHandler("testWI2", new SystemOutWorkItemHandler() {
 
             @Override
             public void executeWorkItem(KogitoWorkItem workItem,  KogitoWorkItemManager manager) {
                 Integer x = (Integer) workItem.getParameter("input1");
                 x++;
-                Map<String, Object> results = new HashMap<String, Object>();
+                Map<String, Object> results = new HashMap<>();
                 results.put("output1", x);
                 manager.completeWorkItem(workItem.getStringId(), results);
             }
             
         });
-        final Map<String, Integer> nodeInstanceExecutionCounter = new HashMap<String, Integer>(); 
-        ksession.addEventListener(new DefaultProcessEventListener(){
+        final Map<String, Integer> nodeInstanceExecutionCounter = new HashMap<>();
+        kruntime.getProcessEventManager().addEventListener(new DefaultKogitoProcessEventListener(){
 
             @Override
             public void beforeNodeTriggered(ProcessNodeTriggeredEvent event) { 
                 Integer value = nodeInstanceExecutionCounter.get(event.getNodeInstance().getNodeName());
                 if (value == null) {
-                    value = new Integer(0);
+                    value = 0;
                 }
                 
                 value++;
@@ -749,9 +703,9 @@ public class FlowTest extends JbpmBpmn2TestCase {
 
             
         });
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", -1);
-        ProcessInstance processInstance = kruntime.startProcess("Process_1", params);
+        KogitoProcessInstance processInstance = kruntime.startProcess("Process_1", params);
         assertProcessInstanceActive(processInstance);
         
         List<KogitoWorkItem> workItems = handler.getWorkItems();
@@ -798,16 +752,14 @@ public class FlowTest extends JbpmBpmn2TestCase {
     
     @Test
     public void testInclusiveSplitNested() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-InclusiveGatewayNested.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-InclusiveGatewayNested.bpmn2");
 
         TestWorkItemHandler handler = new TestWorkItemHandler();
         TestWorkItemHandler handler2 = new TestWorkItemHandler();
-        ksession.getWorkItemManager().registerWorkItemHandler("testWI", handler);
-        ksession.getWorkItemManager().registerWorkItemHandler("testWI2", handler2);
-        Map<String, Object> params = new HashMap<String, Object>();
-        ProcessInstance processInstance = ksession.startProcess("Process_1", params);
+        kruntime.getWorkItemManager().registerWorkItemHandler("testWI", handler);
+        kruntime.getWorkItemManager().registerWorkItemHandler("testWI2", handler2);
+        Map<String, Object> params = new HashMap<>();
+        KogitoProcessInstance processInstance = kruntime.startProcess("Process_1", params);
         
         assertProcessInstanceActive(processInstance);
         kruntime.getWorkItemManager().completeWorkItem(handler.getWorkItem().getStringId(), null);
@@ -831,12 +783,10 @@ public class FlowTest extends JbpmBpmn2TestCase {
     
     @Test
     public void testInclusiveSplitWithLoopInside() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-InclusiveGatewayWithLoopInside.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-InclusiveGatewayWithLoopInside.bpmn2");
 
-        final Map<String, Integer> nodeInstanceExecutionCounter = new HashMap<String, Integer>();
-        ksession.addEventListener(new DefaultProcessEventListener(){
+        final Map<String, Integer> nodeInstanceExecutionCounter = new HashMap<>();
+        kruntime.getProcessEventManager().addEventListener(new DefaultKogitoProcessEventListener(){
 
             @Override
             public void beforeNodeTriggered(ProcessNodeTriggeredEvent event) {                 
@@ -854,11 +804,11 @@ public class FlowTest extends JbpmBpmn2TestCase {
         });
         TestWorkItemHandler handler = new TestWorkItemHandler();
         TestWorkItemHandler handler2 = new TestWorkItemHandler();
-        ksession.getWorkItemManager().registerWorkItemHandler("testWI", handler);
-        ksession.getWorkItemManager().registerWorkItemHandler("testWI2", handler2);
-        Map<String, Object> params = new HashMap<String, Object>();
+        kruntime.getWorkItemManager().registerWorkItemHandler("testWI", handler);
+        kruntime.getWorkItemManager().registerWorkItemHandler("testWI2", handler2);
+        Map<String, Object> params = new HashMap<>();
         params.put("x", -1);
-        ProcessInstance processInstance = ksession.startProcess("Process_1", params);
+        KogitoProcessInstance processInstance = kruntime.startProcess("Process_1", params);
         
         assertProcessInstanceActive(processInstance);
         List<KogitoWorkItem> workItems = handler.getWorkItems();
@@ -895,19 +845,17 @@ public class FlowTest extends JbpmBpmn2TestCase {
     
     @Test
     public void testInclusiveSplitWithLoopInsideSubprocess() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-InclusiveGatewayWithLoopInsideSubprocess.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-InclusiveGatewayWithLoopInsideSubprocess.bpmn2");
 
-        final Map<String, Integer> nodeInstanceExecutionCounter = new HashMap<String, Integer>();
-        ksession.addEventListener(new DefaultProcessEventListener(){
+        final Map<String, Integer> nodeInstanceExecutionCounter = new HashMap<>();
+        kruntime.getProcessEventManager().addEventListener(new DefaultKogitoProcessEventListener(){
 
             @Override
             public void beforeNodeTriggered(ProcessNodeTriggeredEvent event) {                 
                 logger.info("{} {}", event.getNodeInstance().getNodeName(), ((NodeInstanceImpl) event.getNodeInstance()).getLevel());
                 Integer value = nodeInstanceExecutionCounter.get(event.getNodeInstance().getNodeName());
                 if (value == null) {
-                    value = new Integer(0);
+                    value = 0;
                 }
                 
                 value++;
@@ -918,11 +866,11 @@ public class FlowTest extends JbpmBpmn2TestCase {
         });
         TestWorkItemHandler handler = new TestWorkItemHandler();
         TestWorkItemHandler handler2 = new TestWorkItemHandler();
-        ksession.getWorkItemManager().registerWorkItemHandler("testWI", handler);
-        ksession.getWorkItemManager().registerWorkItemHandler("testWI2", handler2);
-        Map<String, Object> params = new HashMap<String, Object>();
+        kruntime.getWorkItemManager().registerWorkItemHandler("testWI", handler);
+        kruntime.getWorkItemManager().registerWorkItemHandler("testWI2", handler2);
+        Map<String, Object> params = new HashMap<>();
         params.put("x", -1);
-        ProcessInstance processInstance = ksession.startProcess("Process_1", params);
+        KogitoProcessInstance processInstance = kruntime.startProcess("Process_1", params);
         
         assertProcessInstanceActive(processInstance);
         List<KogitoWorkItem> workItems = handler.getWorkItems();
@@ -963,15 +911,13 @@ public class FlowTest extends JbpmBpmn2TestCase {
     @Test
     public void testMultiInstanceLoopCharacteristicsProcessWithORGateway()
             throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-MultiInstanceLoopCharacteristicsProcessWithORgateway.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-MultiInstanceLoopCharacteristicsProcessWithORgateway.bpmn2");
 
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 workItemHandler);
-        Map<String, Object> params = new HashMap<String, Object>();
-        List<Integer> myList = new ArrayList<Integer>();
+        Map<String, Object> params = new HashMap<>();
+        List<Integer> myList = new ArrayList<>();
         myList.add(12);
         myList.add(15);
         params.put("list", myList);
@@ -1024,26 +970,24 @@ public class FlowTest extends JbpmBpmn2TestCase {
         kruntime.getWorkItemManager().completeWorkItem(
                 workItems.get(3).getStringId(), null);
 
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
 
     }
     
     @Test
     public void testInclusiveJoinWithLoopAndHumanTasks() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-InclusiveGatewayWithHumanTasksProcess.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-InclusiveGatewayWithHumanTasksProcess.bpmn2");
 
-        final Map<String, Integer> nodeInstanceExecutionCounter = new HashMap<String, Integer>();
-        ksession.addEventListener(new DefaultProcessEventListener(){
+        final Map<String, Integer> nodeInstanceExecutionCounter = new HashMap<>();
+        kruntime.getProcessEventManager().addEventListener(new DefaultKogitoProcessEventListener(){
 
             @Override
             public void beforeNodeTriggered(ProcessNodeTriggeredEvent event) {                 
                 logger.info("{} {}", event.getNodeInstance().getNodeName(), ((NodeInstanceImpl) event.getNodeInstance()).getLevel());
                 Integer value = nodeInstanceExecutionCounter.get(event.getNodeInstance().getNodeName());
                 if (value == null) {
-                    value = new Integer(0);
+                    value = 0;
                 }
                 
                 value++;
@@ -1053,13 +997,13 @@ public class FlowTest extends JbpmBpmn2TestCase {
             
         });
         TestWorkItemHandler handler = new TestWorkItemHandler();
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task", handler);
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", handler);
         
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("firstXor", true);   
         params.put("secondXor", true); 
         params.put("thirdXor", true);
-        ProcessInstance processInstance = ksession.startProcess("InclusiveWithAdvancedLoop", params);
+        KogitoProcessInstance processInstance = kruntime.startProcess("InclusiveWithAdvancedLoop", params);
         // simulate completion of first task
         assertProcessInstanceActive(processInstance);
         kruntime.getWorkItemManager().completeWorkItem(handler.getWorkItem().getStringId(), null);
@@ -1105,33 +1049,30 @@ public class FlowTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testMultiInstanceLoopCharacteristicsProcess() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-MultiInstanceLoopCharacteristicsProcess.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        Map<String, Object> params = new HashMap<String, Object>();
-        List<String> myList = new ArrayList<String>();
+        kruntime = createKogitoProcessRuntime("BPMN2-MultiInstanceLoopCharacteristicsProcess.bpmn2");
+        Map<String, Object> params = new HashMap<>();
+        List<String> myList = new ArrayList<>();
         myList.add("First Item");
         myList.add("Second Item");
         params.put("list", myList);
-        ProcessInstance processInstance = ksession.startProcess(
+        KogitoProcessInstance processInstance = kruntime.startProcess(
                 "MultiInstanceLoopCharacteristicsProcess", params);
         assertProcessInstanceCompleted(processInstance);
     }
     
     @Test
     public void testMultiInstanceLoopNumberTest() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-MultiInstanceLoop-Numbering.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        Map<String, Object> params = new HashMap<String, Object>();
+        kruntime = createKogitoProcessRuntime("BPMN2-MultiInstanceLoop-Numbering.bpmn2");
+        Map<String, Object> params = new HashMap<>();
         
-        final Map<String, String> nodeIdNodeNameMap = new HashMap<String, String>();
-        ksession.addEventListener(new DefaultProcessEventListener() {
+        final Map<String, String> nodeIdNodeNameMap = new HashMap<>();
+        kruntime.getProcessEventManager().addEventListener(new DefaultKogitoProcessEventListener() {
 
             @Override
             public void beforeNodeTriggered(ProcessNodeTriggeredEvent event) {
                 NodeInstance nodeInstance = event.getNodeInstance();
                 String uniqId = ((NodeInstanceImpl) nodeInstance).getUniqueId();
-                String nodeName = ((NodeInstanceImpl) nodeInstance).getNode().getName();
+                String nodeName = nodeInstance.getNode().getName();
                 
                 String prevNodeName = nodeIdNodeNameMap.put( uniqId, nodeName );
                 if( prevNodeName != null ) { 
@@ -1142,9 +1083,9 @@ public class FlowTest extends JbpmBpmn2TestCase {
         });
         
         TestWorkItemHandler handler = new TestWorkItemHandler();
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task", handler);
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", handler);
         
-        ProcessInstance processInstance = ksession.startProcess("Test.MultipleInstancesBug", params);
+        KogitoProcessInstance processInstance = kruntime.startProcess("Test.MultipleInstancesBug", params);
        
         List<KogitoWorkItem> workItems = handler.getWorkItems();
         logger.debug( "COMPLETING TASKS.");
@@ -1157,14 +1098,12 @@ public class FlowTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testMultiInstanceLoopCharacteristicsProcess2() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-MultiInstanceProcessWithOutputOnTask.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-MultiInstanceProcessWithOutputOnTask.bpmn2");
 
         TestWorkItemHandler handler = new TestWorkItemHandler();
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task", handler);
-        Map<String, Object> params = new HashMap<String, Object>();
-        List<String> myList = new ArrayList<String>();
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", handler);
+        Map<String, Object> params = new HashMap<>();
+        List<String> myList = new ArrayList<>();
         List<String> myOutList = null;
         myList.add("John");
         myList.add("Mary");
@@ -1175,22 +1114,22 @@ public class FlowTest extends JbpmBpmn2TestCase {
         assertNotNull(workItems);
         assertEquals(2, workItems.size());
         
-        myOutList = (List<String>) ksession.execute(new GetProcessVariableCommand(processInstance.getStringId(), "mioutput"));
+        myOutList = (List<String>) kruntime.getKieSession().execute(new GetProcessVariableCommand(processInstance.getStringId(), "mioutput"));
         assertNull(myOutList);
         
         
-        Map<String, Object> results = new HashMap<String, Object>();
+        Map<String, Object> results = new HashMap<>();
         results.put("reply", "Hello John");
         kruntime.getWorkItemManager().completeWorkItem(workItems.get(0).getStringId(), results);
         
-        myOutList = (List<String>) ksession.execute(new GetProcessVariableCommand(processInstance.getStringId(), "mioutput"));
+        myOutList = (List<String>) kruntime.getKieSession().execute(new GetProcessVariableCommand(processInstance.getStringId(), "mioutput"));
         assertNull(myOutList);
         
-        results = new HashMap<String, Object>();
+        results = new HashMap<>();
         results.put("reply", "Hello Mary");
         kruntime.getWorkItemManager().completeWorkItem(workItems.get(1).getStringId(), results);
 
-        myOutList = (List<String>) ksession.execute(new GetProcessVariableCommand(processInstance.getStringId(), "mioutput"));
+        myOutList = (List<String>) kruntime.getKieSession().execute(new GetProcessVariableCommand(processInstance.getStringId(), "mioutput"));
         assertNotNull(myOutList);
         assertEquals(2, myOutList.size());
         assertTrue(myOutList.contains("Hello John"));
@@ -1198,24 +1137,23 @@ public class FlowTest extends JbpmBpmn2TestCase {
         
         kruntime.getWorkItemManager().completeWorkItem(handler.getWorkItem().getStringId(), null);
         
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
     }
 
     @Test
     public void testMultiInstanceLoopCharacteristicsProcessWithOutput()
             throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-MultiInstanceLoopCharacteristicsProcessWithOutput.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        Map<String, Object> params = new HashMap<String, Object>();
-        List<String> myList = new ArrayList<String>();
-        List<String> myListOut = new ArrayList<String>();
+        kruntime = createKogitoProcessRuntime("BPMN2-MultiInstanceLoopCharacteristicsProcessWithOutput.bpmn2");
+        Map<String, Object> params = new HashMap<>();
+        List<String> myList = new ArrayList<>();
+        List<String> myListOut = new ArrayList<>();
         myList.add("First Item");
         myList.add("Second Item");
         params.put("list", myList);
         params.put("listOut", myListOut);
         assertEquals(0, myListOut.size());
-        ProcessInstance processInstance = ksession.startProcess(
+        KogitoProcessInstance processInstance = kruntime.startProcess(
                 "MultiInstanceLoopCharacteristicsProcessWithOutput", params);
         assertProcessInstanceCompleted(processInstance);
         assertEquals(2, myListOut.size());
@@ -1225,17 +1163,16 @@ public class FlowTest extends JbpmBpmn2TestCase {
     @Test
     public void testMultiInstanceLoopCharacteristicsProcessWithOutputCompletionCondition()
             throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-MultiInstanceLoopCharacteristicsProcessWithOutputCmpCond.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        Map<String, Object> params = new HashMap<String, Object>();
-        List<String> myList = new ArrayList<String>();
-        List<String> myListOut = new ArrayList<String>();
+        kruntime = createKogitoProcessRuntime("BPMN2-MultiInstanceLoopCharacteristicsProcessWithOutputCmpCond.bpmn2");
+        Map<String, Object> params = new HashMap<>();
+        List<String> myList = new ArrayList<>();
+        List<String> myListOut = new ArrayList<>();
         myList.add("First Item");
         myList.add("Second Item");
         params.put("list", myList);
         params.put("listOut", myListOut);
         assertEquals(0, myListOut.size());
-        ProcessInstance processInstance = ksession.startProcess(
+        KogitoProcessInstance processInstance = kruntime.startProcess(
                 "MultiInstanceLoopCharacteristicsProcessWithOutput", params);
         assertProcessInstanceCompleted(processInstance);
         assertEquals(1, myListOut.size());
@@ -1245,19 +1182,18 @@ public class FlowTest extends JbpmBpmn2TestCase {
     @Test
     public void testMultiInstanceLoopCharacteristicsProcessWithOutputAndScripts()
             throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-MultiInstanceLoopCharacteristicsProcessWithOutputAndScripts.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        Map<String, Object> params = new HashMap<String, Object>();
-        List<String> myList = new ArrayList<String>();
-        List<String> myListOut = new ArrayList<String>();
-        List<String> scriptList = new ArrayList<String>();
+        kruntime = createKogitoProcessRuntime("BPMN2-MultiInstanceLoopCharacteristicsProcessWithOutputAndScripts.bpmn2");
+        Map<String, Object> params = new HashMap<>();
+        List<String> myList = new ArrayList<>();
+        List<String> myListOut = new ArrayList<>();
+        List<String> scriptList = new ArrayList<>();
         myList.add("First Item");
         myList.add("Second Item");
         params.put("list", myList);
         params.put("listOut", myListOut);
         params.put("scriptList", scriptList);
         assertEquals(0, myListOut.size());
-        ProcessInstance processInstance = ksession.startProcess("MultiInstanceLoopCharacteristicsProcessWithOutput", params);
+        KogitoProcessInstance processInstance = kruntime.startProcess("MultiInstanceLoopCharacteristicsProcessWithOutput", params);
         assertProcessInstanceCompleted(processInstance);
         assertEquals(2, myListOut.size());
         assertEquals(2, scriptList.size());
@@ -1267,19 +1203,18 @@ public class FlowTest extends JbpmBpmn2TestCase {
     @Test
     public void testMultiInstanceLoopCharacteristicsTaskWithOutput()
             throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-MultiInstanceLoopCharacteristicsTaskWithOutput.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
+        kruntime = createKogitoProcessRuntime("BPMN2-MultiInstanceLoopCharacteristicsTaskWithOutput.bpmn2");
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 new SystemOutWorkItemHandler());
-        Map<String, Object> params = new HashMap<String, Object>();
-        List<String> myList = new ArrayList<String>();
-        List<String> myListOut = new ArrayList<String>();
+        Map<String, Object> params = new HashMap<>();
+        List<String> myList = new ArrayList<>();
+        List<String> myListOut = new ArrayList<>();
         myList.add("First Item");
         myList.add("Second Item");
         params.put("list", myList);
         params.put("listOut", myListOut);
         assertEquals(0, myListOut.size());
-        ProcessInstance processInstance = ksession.startProcess(
+        KogitoProcessInstance processInstance = kruntime.startProcess(
                 "MultiInstanceLoopCharacteristicsTask", params);
         assertProcessInstanceCompleted(processInstance);
         assertEquals(2, myListOut.size());
@@ -1289,19 +1224,18 @@ public class FlowTest extends JbpmBpmn2TestCase {
     @Test
     public void testMultiInstanceLoopCharacteristicsTaskWithOutputCompletionCondition()
             throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-MultiInstanceLoopCharacteristicsTaskWithOutputCmpCond.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
+        kruntime = createKogitoProcessRuntime("BPMN2-MultiInstanceLoopCharacteristicsTaskWithOutputCmpCond.bpmn2");
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 new SystemOutWorkItemHandler());
-        Map<String, Object> params = new HashMap<String, Object>();
-        List<String> myList = new ArrayList<String>();
-        List<String> myListOut = new ArrayList<String>();
+        Map<String, Object> params = new HashMap<>();
+        List<String> myList = new ArrayList<>();
+        List<String> myListOut = new ArrayList<>();
         myList.add("First Item");
         myList.add("Second Item");
         params.put("list", myList);
         params.put("listOut", myListOut);
         assertEquals(0, myListOut.size());
-        ProcessInstance processInstance = ksession.startProcess(
+        KogitoProcessInstance processInstance = kruntime.startProcess(
                 "MultiInstanceLoopCharacteristicsTask", params);
         assertProcessInstanceCompleted(processInstance);
         assertEquals(1, myListOut.size());
@@ -1311,13 +1245,12 @@ public class FlowTest extends JbpmBpmn2TestCase {
     @Test
     public void testMultiInstanceLoopCharacteristicsTaskWithOutputCompletionCondition2()
             throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-MultiInstanceLoopCharacteristicsTaskWithOutputCmpCond2.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
+        kruntime = createKogitoProcessRuntime("BPMN2-MultiInstanceLoopCharacteristicsTaskWithOutputCmpCond2.bpmn2");
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 new SystemOutWorkItemHandler());
-        Map<String, Object> params = new HashMap<String, Object>();
-        List<String> myList = new ArrayList<String>();
-        List<String> myListOut = new ArrayList<String>();
+        Map<String, Object> params = new HashMap<>();
+        List<String> myList = new ArrayList<>();
+        List<String> myListOut = new ArrayList<>();
         myList.add("approved");
         myList.add("rejected");
         myList.add("approved");
@@ -1326,7 +1259,7 @@ public class FlowTest extends JbpmBpmn2TestCase {
         params.put("list", myList);
         params.put("listOut", myListOut);
         assertEquals(0, myListOut.size());
-        ProcessInstance processInstance = ksession.startProcess(
+        KogitoProcessInstance processInstance = kruntime.startProcess(
                 "MultiInstanceLoopCharacteristicsTask", params);
         assertProcessInstanceCompleted(processInstance);
         // only two approved outcomes are required to complete multiinstance and since there was reject in between we should have
@@ -1337,16 +1270,15 @@ public class FlowTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testMultiInstanceLoopCharacteristicsTask() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-MultiInstanceLoopCharacteristicsTask.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
+        kruntime = createKogitoProcessRuntime("BPMN2-MultiInstanceLoopCharacteristicsTask.bpmn2");
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 new SystemOutWorkItemHandler());
-        Map<String, Object> params = new HashMap<String, Object>();
-        List<String> myList = new ArrayList<String>();
+        Map<String, Object> params = new HashMap<>();
+        List<String> myList = new ArrayList<>();
         myList.add("First Item");
         myList.add("Second Item");
         params.put("list", myList);
-        ProcessInstance processInstance = ksession.startProcess(
+        KogitoProcessInstance processInstance = kruntime.startProcess(
                 "MultiInstanceLoopCharacteristicsTask", params);
         assertProcessInstanceCompleted(processInstance);
 
@@ -1356,11 +1288,10 @@ public class FlowTest extends JbpmBpmn2TestCase {
     public void testMultipleInOutgoingSequenceFlows() throws Exception {
         NodeLeftCountDownProcessEventListener countDownListener = new NodeLeftCountDownProcessEventListener("timer", 1);
         System.setProperty("jbpm.enable.multi.con", "true");
-        KieBase kbase = createKnowledgeBase("BPMN2-MultipleInOutgoingSequenceFlows.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        ksession.addEventListener(countDownListener);
+        kruntime = createKogitoProcessRuntime("BPMN2-MultipleInOutgoingSequenceFlows.bpmn2");
+        kruntime.getProcessEventManager().addEventListener(countDownListener);
         final List<String> list = new ArrayList<>();
-        ksession.addEventListener(new DefaultProcessEventListener() {
+        kruntime.getProcessEventManager().addEventListener(new DefaultKogitoProcessEventListener() {
             public void beforeProcessStarted(ProcessStartedEvent event) {
                 list.add( (( KogitoProcessInstance ) event.getProcessInstance()).getStringId());
             }
@@ -1379,10 +1310,9 @@ public class FlowTest extends JbpmBpmn2TestCase {
     public void testMultipleIncomingFlowToEndNode() throws Exception {
         System.setProperty("jbpm.enable.multi.con", "true");
 
-        KieBase kbase = createKnowledgeBase("BPMN2-MultipleFlowEndNode.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        
-        ProcessInstance processInstance = ksession.startProcess("MultipleFlowEndNode");
+        kruntime = createKogitoProcessRuntime("BPMN2-MultipleFlowEndNode.bpmn2");
+
+        KogitoProcessInstance processInstance = kruntime.startProcess("MultipleFlowEndNode");
         assertProcessInstanceCompleted(processInstance);
         System.clearProperty("jbpm.enable.multi.con");
     }
@@ -1390,12 +1320,10 @@ public class FlowTest extends JbpmBpmn2TestCase {
     @Test
     public void testMultipleEnabledOnSingleConditionalSequenceFlow() throws Exception {
         System.setProperty("jbpm.enable.multi.con", "true");
-        KieBase kbase = createKnowledgeBase("BPMN2-MultiConnEnabled.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-MultiConnEnabled.bpmn2");
 
-        final List<Long> list = new ArrayList<Long>();
-        ksession.addEventListener(new DefaultProcessEventListener() {
+        final List<Long> list = new ArrayList<>();
+        kruntime.getProcessEventManager().addEventListener(new DefaultKogitoProcessEventListener() {
             public void afterNodeTriggered(org.kie.api.event.process.ProcessNodeTriggeredEvent event) {
                 if ("Task2".equals(event.getNodeInstance().getNodeName())) {
                     list.add(event.getNodeInstance().getNodeId());
@@ -1417,7 +1345,7 @@ public class FlowTest extends JbpmBpmn2TestCase {
     @Test
     public void testMultipleInOutgoingSequenceFlowsDisable() throws Exception {
         try {
-            KieBase kbase = createKnowledgeBase("BPMN2-MultipleInOutgoingSequenceFlows.bpmn2");
+            createKogitoProcessRuntime("BPMN2-MultipleInOutgoingSequenceFlows.bpmn2");
             fail("Should fail as multiple outgoing and incoming connections are disabled by default");
         } catch (Exception e) {
             assertThat(e.getMessage()).contains("This type of node [ScriptTask_1, Script Task] cannot have more than one outgoing connection!");
@@ -1429,13 +1357,11 @@ public class FlowTest extends JbpmBpmn2TestCase {
         System.setProperty("jbpm.enable.multi.con", "true");
         String processId = "designer.conditional-flow";
 
-        KieBase kbase = createKnowledgeBase("BPMN2-ConditionalFlowWithoutGateway.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-ConditionalFlowWithoutGateway.bpmn2");
 
         KogitoProcessInstance wpi = kruntime.startProcess(processId);
 
-        assertProcessInstanceFinished(wpi, ksession);
+        assertProcessInstanceFinished(wpi, kruntime);
         assertNodeTriggered(wpi.getStringId(), "start", "script", "end1");
         System.clearProperty("jbpm.enable.multi.con");
 
@@ -1443,49 +1369,43 @@ public class FlowTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testLane() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-Lane.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-Lane.bpmn2");
 
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 workItemHandler);
-        ProcessInstance processInstance = ksession.startProcess("UserTask");
-        assertTrue(processInstance.getState() == ProcessInstance.STATE_ACTIVE);
-        ksession = restoreSession(ksession, true);
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
+        KogitoProcessInstance processInstance = kruntime.startProcess("UserTask");
+        assertEquals(KogitoProcessInstance.STATE_ACTIVE, processInstance.getState());
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 workItemHandler);
         KogitoWorkItem KogitoWorkItem = workItemHandler.getWorkItem();
         assertNotNull(KogitoWorkItem);
         assertEquals("john", KogitoWorkItem.getParameter("ActorId"));
-        Map<String, Object> results = new HashMap<String, Object>();
+        Map<String, Object> results = new HashMap<>();
         ((HumanTaskWorkItemImpl) KogitoWorkItem).setActualOwner("mary");
         kruntime.getWorkItemManager().completeWorkItem(KogitoWorkItem.getStringId(),
                 results);
-        ksession = restoreSession(ksession, true);
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 workItemHandler);
         KogitoWorkItem = workItemHandler.getWorkItem();
         assertNotNull(KogitoWorkItem);
         assertEquals("mary", KogitoWorkItem.getParameter("SwimlaneActorId"));
         kruntime.getWorkItemManager().completeWorkItem(KogitoWorkItem.getStringId(), null);
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
     }
     
     @Test
     public void testExclusiveSplitDefaultNoCondition() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-ExclusiveSplitDefaultNoCondition.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        ProcessInstance processInstance = ksession.startProcess("com.sample.test");
-        assertProcessInstanceFinished(processInstance, ksession);
+        kruntime = createKogitoProcessRuntime("BPMN2-ExclusiveSplitDefaultNoCondition.bpmn2");
+        KogitoProcessInstance processInstance = kruntime.startProcess("com.sample.test");
+        assertProcessInstanceFinished(processInstance, kruntime);
     }
     
     @Test
     public void testMultipleGatewaysProcess() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-MultipleGatewaysProcess.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        ksession.addEventListener(new DefaultProcessEventListener(){
-            ProcessInstance pi;
+        kruntime = createKogitoProcessRuntime("BPMN2-MultipleGatewaysProcess.bpmn2");
+        kruntime.getProcessEventManager().addEventListener(new DefaultKogitoProcessEventListener(){
+            KogitoProcessInstance pi;
 
             @Override
             public void afterNodeTriggered(ProcessNodeTriggeredEvent event) {                
@@ -1501,13 +1421,13 @@ public class FlowTest extends JbpmBpmn2TestCase {
 
             @Override
             public void beforeProcessStarted(ProcessStartedEvent event) {
-                pi=event.getProcessInstance();
+                pi= (KogitoProcessInstance) event.getProcessInstance();
                 
             }
         });
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("action", "CreateAgent");
-        ProcessInstance processInstance = ksession.startProcess("multiplegateways", params);
+        KogitoProcessInstance processInstance = kruntime.startProcess("multiplegateways", params);
         
         assertProcessInstanceCompleted(processInstance);
     }
@@ -1515,19 +1435,17 @@ public class FlowTest extends JbpmBpmn2TestCase {
     @Test
     public void testTimerAndGateway() throws Exception {
         NodeLeftCountDownProcessEventListener countDownListener = new NodeLeftCountDownProcessEventListener("timer", 1);
-        KieBase kbase = createKnowledgeBase("timer/BPMN2-ParallelSplitWithTimerProcess.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("timer/BPMN2-ParallelSplitWithTimerProcess.bpmn2");
 
-        ksession.addEventListener(countDownListener);
+        kruntime.getProcessEventManager().addEventListener(countDownListener);
         
         TestWorkItemHandler handler1 = new TestWorkItemHandler();
         TestWorkItemHandler handler2 = new TestWorkItemHandler();
         
-        ksession.getWorkItemManager().registerWorkItemHandler("task1", handler1);
-        ksession.getWorkItemManager().registerWorkItemHandler("task2", handler2);
+        kruntime.getWorkItemManager().registerWorkItemHandler("task1", handler1);
+        kruntime.getWorkItemManager().registerWorkItemHandler("task2", handler2);
 
-        KogitoProcessInstance instance = kruntime.createProcessInstance("timer-process", new HashMap<String, Object>());
+        KogitoProcessInstance instance = kruntime.createProcessInstance("timer-process", new HashMap<>());
         kruntime.startProcessInstance(instance.getStringId());
 
         KogitoWorkItem workItem1 = handler1.getWorkItem();
@@ -1536,10 +1454,9 @@ public class FlowTest extends JbpmBpmn2TestCase {
         //first safe state: task1 completed
         kruntime.getWorkItemManager().completeWorkItem(workItem1.getStringId(), null);        
         
-        ksession = restoreSession(ksession, true);
-        ksession.addEventListener(countDownListener);
-        ksession.getWorkItemManager().registerWorkItemHandler("task1", handler1);
-        ksession.getWorkItemManager().registerWorkItemHandler("task2", handler2);
+        kruntime.getProcessEventManager().addEventListener(countDownListener);
+        kruntime.getWorkItemManager().registerWorkItemHandler("task1", handler1);
+        kruntime.getWorkItemManager().registerWorkItemHandler("task2", handler2);
         //second safe state: timer completed, waiting on task2
         countDownListener.waitTillCompleted();
 
@@ -1568,8 +1485,7 @@ public class FlowTest extends JbpmBpmn2TestCase {
 
 
         public Object execute(Context context) {
-            KieSession ksession = ((RegistryContext) context).lookup( KieSession.class );
-            KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+            KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ((RegistryContext) context).lookup( KieSession.class ) );
 
             org.jbpm.process.instance.ProcessInstance processInstance = 
                     (org.jbpm.process.instance.ProcessInstance) kruntime.getProcessInstance(processInstanceId);

--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/ImportClassTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/ImportClassTest.java
@@ -18,14 +18,14 @@ package org.jbpm.bpmn2;
 
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class ImportClassTest extends JbpmBpmn2TestCase {
     
     @Test
     public void testResourceType() {
         assertThatExceptionOfType(RuntimeException.class)
-                .isThrownBy(() -> createKnowledgeBaseWithoutDumper("build/sample.bpmn", "build/sample2.bpmn"))
+                .isThrownBy(() -> createKogitoProcessRuntime("build/sample.bpmn", "build/sample2.bpmn"))
                 .withMessageContaining("Process Compilation error HelloService cannot be resolved to a type");
     }
 

--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/IntermediateEventTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/IntermediateEventTest.java
@@ -37,40 +37,48 @@ import org.jbpm.process.instance.event.listeners.RuleAwareProcessEventListener;
 import org.jbpm.process.instance.impl.demo.DoNothingWorkItemHandler;
 import org.jbpm.process.instance.impl.demo.SystemOutWorkItemHandler;
 import org.jbpm.test.util.NodeLeftCountDownProcessEventListener;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.kie.api.KieBase;
 import org.kie.api.command.ExecutableCommand;
-import org.kie.api.event.process.DefaultProcessEventListener;
-import org.kie.api.event.process.ProcessEventListener;
 import org.kie.api.event.process.ProcessNodeLeftEvent;
 import org.kie.api.event.process.ProcessNodeTriggeredEvent;
 import org.kie.api.event.process.ProcessStartedEvent;
-import org.kie.api.runtime.Context;
 import org.kie.api.runtime.KieSession;
-import org.kie.api.runtime.ObjectFilter;
-import org.kie.api.runtime.process.WorkItemHandler;
-import org.kie.api.runtime.process.WorkflowProcessInstance;
 import org.kie.api.runtime.rule.FactHandle;
 import org.kie.internal.command.RegistryContext;
-import org.kie.internal.runtime.StatefulKnowledgeSession;
-import org.kie.kogito.process.EventDescription;
-import org.kie.kogito.process.NamedDataType;
+import org.kie.kogito.internal.process.event.DefaultKogitoProcessEventListener;
+import org.kie.kogito.internal.process.event.KogitoProcessEventListener;
 import org.kie.kogito.internal.process.runtime.KogitoNodeInstance;
 import org.kie.kogito.internal.process.runtime.KogitoProcessInstance;
 import org.kie.kogito.internal.process.runtime.KogitoProcessRuntime;
 import org.kie.kogito.internal.process.runtime.KogitoWorkItem;
 import org.kie.kogito.internal.process.runtime.KogitoWorkItemHandler;
 import org.kie.kogito.internal.process.runtime.KogitoWorkItemManager;
+import org.kie.kogito.internal.process.runtime.KogitoWorkflowProcessInstance;
+import org.kie.kogito.process.EventDescription;
+import org.kie.kogito.process.NamedDataType;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class IntermediateEventTest extends JbpmBpmn2TestCase {
+    
+    private KogitoProcessRuntime kruntime2;
 
-    private ProcessEventListener LOGGING_EVENT_LISTENER = new DefaultProcessEventListener() {
+    @AfterEach
+    @Override
+    public void disposeKogitoProcessRuntime() {
+        super.disposeKogitoProcessRuntime();
+        if (kruntime2 != null && kruntime2.getKieSession() != null) {
+            kruntime2.getKieSession().dispose();
+            kruntime2 = null;
+        }
+    }
+    
+    private KogitoProcessEventListener LOGGING_EVENT_LISTENER = new DefaultKogitoProcessEventListener() {
 
         @Override
         public void afterNodeLeft(ProcessNodeLeftEvent event) {
@@ -100,11 +108,9 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testSignalBoundaryEvent() throws Exception {
-        KieBase kbase = createKnowledgeBase(
+        kruntime = createKogitoProcessRuntime(
                 "BPMN2-BoundarySignalEventOnTaskbpmn2.bpmn",
                 "BPMN2-IntermediateThrowEventSignal.bpmn2");
-        StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
 
         TestWorkItemHandler handler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
@@ -127,25 +133,23 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
             .anyMatch(m -> m.containsKey("AttachedToID") && m.containsKey("AttachedToName"));
                
         KogitoProcessInstance processInstance2 = kruntime.startProcess("SignalIntermediateEvent");
-        assertProcessInstanceFinished(processInstance2, ksession);
+        assertProcessInstanceFinished(processInstance2, kruntime);
 
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
     }
 
     @Test
     public void testSignalBoundaryNonEffectiveEvent() throws Exception {
         final String signal = "signalTest";
         final AtomicBoolean eventAfterNodeLeftTriggered = new AtomicBoolean(false);
-        KieBase kbase = createKnowledgeBase(
+        kruntime = createKogitoProcessRuntime(
                 "BPMN2-BoundaryEventWithNonEffectiveSignal.bpmn2");
-        StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
         
         TestWorkItemHandler handler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 handler);
 
-        ksession.addEventListener(new DefaultProcessEventListener() {
+        kruntime.getProcessEventManager().addEventListener(new DefaultKogitoProcessEventListener() {
             @Override
             public void afterNodeLeft(ProcessNodeLeftEvent event) {
                 // BoundaryEventNodeInstance
@@ -167,19 +171,17 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         kruntime.getWorkItemManager().completeWorkItem(
                 handler.getWorkItem().getStringId(), null);
 
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
         assertThat(eventAfterNodeLeftTriggered.get()).isTrue();
     }
 
     @Test
     public void testSignalBoundaryEventOnTask() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-BoundarySignalEventOnTaskbpmn2.bpmn");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-BoundarySignalEventOnTaskbpmn2.bpmn");
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 new TestWorkItemHandler());
-        ksession.addEventListener(LOGGING_EVENT_LISTENER);
+        kruntime.getProcessEventManager().addEventListener(LOGGING_EVENT_LISTENER);
         KogitoProcessInstance processInstance = kruntime
                 .startProcess("BoundarySignalOnTask");
         
@@ -209,51 +211,45 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
             .extracting("nodeInstanceId").doesNotContainNull();
        
         kruntime.signalEvent("MySignal", "value");
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
     }
 
     @Test
     public void testSignalBoundaryEventOnTaskWithSignalName() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-BoundarySignalWithNameEventOnTaskbpmn2.bpmn");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-BoundarySignalWithNameEventOnTaskbpmn2.bpmn");
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 new TestWorkItemHandler());
-        ksession.addEventListener(LOGGING_EVENT_LISTENER);
+        kruntime.getProcessEventManager().addEventListener(LOGGING_EVENT_LISTENER);
         KogitoProcessInstance processInstance = kruntime
                 .startProcess("BoundarySignalOnTask");
         kruntime.signalEvent("MySignal", "value");
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
     }
 
     @Test
     public void testSignalBoundaryEventOnTaskComplete() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-BoundarySignalEventOnTaskbpmn2.bpmn");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-BoundarySignalEventOnTaskbpmn2.bpmn");
 
         TestWorkItemHandler handler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 handler);
-        ksession.addEventListener(LOGGING_EVENT_LISTENER);
+        kruntime.getProcessEventManager().addEventListener(LOGGING_EVENT_LISTENER);
         KogitoProcessInstance processInstance = kruntime.startProcess("BoundarySignalOnTask");
         kruntime.getWorkItemManager().completeWorkItem(
                 handler.getWorkItem().getStringId(), null);
         kruntime.signalEvent("MySignal", "value");
         kruntime.getWorkItemManager().completeWorkItem(
                 handler.getWorkItem().getStringId(), null);
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
     }
 
     @Test
     public void testSignalBoundaryEventInterrupting() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-SignalBoundaryEventInterrupting.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-SignalBoundaryEventInterrupting.bpmn2");
 
         kruntime.getWorkItemManager().registerWorkItemHandler("MyTask",
                 new DoNothingWorkItemHandler());
@@ -275,19 +271,16 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
             .extracting("properties", Map.class)
             .anyMatch(m -> m.containsKey("AttachedToID") && m.containsKey("AttachedToName"));
 
-        ksession = restoreSession(ksession, true);
         kruntime.signalEvent("MyMessage", null);
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
     }
 
     @Test
     public void testSignalIntermediateThrow() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-IntermediateThrowEventSignal.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        
-        Map<String, Object> params = new HashMap<String, Object>();
+        kruntime = createKogitoProcessRuntime("BPMN2-IntermediateThrowEventSignal.bpmn2");
+
+        Map<String, Object> params = new HashMap<>();
         params.put("x", "MyValue");
         KogitoProcessInstance processInstance = kruntime.startProcess(
                 "SignalIntermediateEvent", params);
@@ -297,11 +290,9 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testSignalBetweenProcesses() throws Exception {
-        KieBase kbase = createKnowledgeBase(
+        kruntime = createKogitoProcessRuntime(
                 "BPMN2-IntermediateCatchSignalSingle.bpmn2",
                 "BPMN2-IntermediateThrowEventSignal.bpmn2");
-        StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
 
         TestWorkItemHandler handler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
@@ -312,16 +303,14 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
                 handler.getWorkItem().getStringId(), null);
 
         KogitoProcessInstance processInstance2 = kruntime.startProcess("SignalIntermediateEvent");
-        assertProcessInstanceFinished(processInstance2, ksession);
+        assertProcessInstanceFinished(processInstance2, kruntime);
 
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
     }
 
     @Test
     public void testEventBasedSplit() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-EventBasedSplit.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-EventBasedSplit.bpmn2");
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1",
                 new SystemOutWorkItemHandler());
@@ -331,7 +320,6 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         KogitoProcessInstance processInstance = kruntime
                 .startProcess("com.sample.test");
         assertProcessInstanceActive(processInstance);
-        ksession = restoreSession(ksession, true);
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1",
                 new SystemOutWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("Email2",
@@ -351,26 +339,23 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
             .extracting("nodeInstanceId").doesNotContainNull();
         
         kruntime.signalEvent("Yes", "YesValue", processInstance.getStringId());
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
         // No
         processInstance = kruntime.startProcess("com.sample.test");
         assertProcessInstanceActive(processInstance);
-        ksession = restoreSession(ksession, true);
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1",
                 new SystemOutWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("Email2",
                 new SystemOutWorkItemHandler());
         kruntime.signalEvent("No", "NoValue", processInstance.getStringId());
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
     }
 
     @Test
     public void testEventBasedSplitBefore() throws Exception {
         // signaling before the split is reached should have no effect
-        KieBase kbase = createKnowledgeBase("BPMN2-EventBasedSplit.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-EventBasedSplit.bpmn2");
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1",
                 new DoNothingWorkItemHandler());
@@ -379,7 +364,6 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         // Yes
         KogitoProcessInstance processInstance = kruntime.startProcess("com.sample.test");
         assertProcessInstanceActive(processInstance);
-        ksession = restoreSession(ksession, true);
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1",
                 new DoNothingWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("Email2",
@@ -389,7 +373,6 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         // No
         processInstance = kruntime.startProcess("com.sample.test");
         assertProcessInstanceActive(processInstance);
-        ksession = restoreSession(ksession, true);
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1",
                 new DoNothingWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("Email2",
@@ -403,9 +386,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     public void testEventBasedSplitAfter() throws Exception {
         // signaling the other alternative after one has been selected should
         // have no effect
-        KieBase kbase = createKnowledgeBase("BPMN2-EventBasedSplit.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-EventBasedSplit.bpmn2");
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1",
                 new SystemOutWorkItemHandler());
@@ -414,14 +395,12 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         // Yes
         KogitoProcessInstance processInstance = kruntime.startProcess("com.sample.test");
         assertProcessInstanceActive(processInstance);
-        ksession = restoreSession(ksession, true);
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1",
                 new SystemOutWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("Email2",
                 new DoNothingWorkItemHandler());
         kruntime.signalEvent("Yes", "YesValue", processInstance.getStringId());
         assertProcessInstanceActive(processInstance);
-        ksession = restoreSession(ksession, true);
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1",
                 new SystemOutWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("Email2",
@@ -435,15 +414,13 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     @Timeout(10)
     public void testEventBasedSplit2() throws Exception {
         NodeLeftCountDownProcessEventListener countDownListener = new NodeLeftCountDownProcessEventListener("timer", 2);
-        KieBase kbase = createKnowledgeBase("BPMN2-EventBasedSplit2.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-EventBasedSplit2.bpmn2");
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1",
                 new SystemOutWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("Email2",
                 new SystemOutWorkItemHandler());
-        ksession.addEventListener(countDownListener);
+        kruntime.getProcessEventManager().addEventListener(countDownListener);
         // Yes
         KogitoProcessInstance processInstance = kruntime
                 .startProcess("com.sample.test");
@@ -464,25 +441,22 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         .hasSize(1)
         .extracting("properties", Map.class)
         .anyMatch(m -> m.containsKey("TimerID") && m.containsKey("Delay"));
-        
-        ksession = restoreSession(ksession, true);
-        ksession.addEventListener(countDownListener);
+
+        kruntime.getProcessEventManager().addEventListener(countDownListener);
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1",
                 new SystemOutWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("Email2",
                 new SystemOutWorkItemHandler());
         kruntime.signalEvent("Yes", "YesValue", processInstance.getStringId());
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
-        ksession = restoreSession(ksession, true);
-        ksession.addEventListener(countDownListener);
+        kruntime.getProcessEventManager().addEventListener(countDownListener);
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1",
                 new SystemOutWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("Email2",
                 new SystemOutWorkItemHandler());
 
-        ksession = restoreSession(ksession, true);
-        ksession.addEventListener(countDownListener);
+        kruntime.getProcessEventManager().addEventListener(countDownListener);
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1",
                 new SystemOutWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("Email2",
@@ -493,22 +467,19 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
 
         countDownListener.waitTillCompleted();
 
-        ksession = restoreSession(ksession, true);
-        ksession.addEventListener(countDownListener);
+        kruntime.getProcessEventManager().addEventListener(countDownListener);
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1",
                 new SystemOutWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("Email2",
                 new SystemOutWorkItemHandler());
 
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
     }
 
     @Test
     public void testEventBasedSplit3() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-EventBasedSplit3.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-EventBasedSplit3.bpmn2");
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1",
                 new SystemOutWorkItemHandler());
@@ -532,32 +503,28 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         assertThat(eventDescriptions)            
             .extracting("processInstanceId").contains(processInstance.getStringId());
         
-        ksession = restoreSession(ksession, true);
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1",
                 new SystemOutWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("Email2",
                 new SystemOutWorkItemHandler());
         kruntime.signalEvent("Yes", "YesValue", processInstance.getStringId());
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
         // Condition
         processInstance = kruntime.startProcess("com.sample.test");
         assertProcessInstanceActive(processInstance);
-        ksession = restoreSession(ksession, true);
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1",
                 new SystemOutWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("Email2",
                 new SystemOutWorkItemHandler());
-        ksession.insert(jack);
+        kruntime.getKieSession().insert(jack);
 
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
     }
 
     @Test
     public void testEventBasedSplit4() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-EventBasedSplit4.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-EventBasedSplit4.bpmn2");
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1",
                 new SystemOutWorkItemHandler());
@@ -579,15 +546,13 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         assertThat(eventDescriptions)            
             .extracting("processInstanceId").contains(processInstance.getStringId());
         
-        ksession = restoreSession(ksession, true);
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1",
                 new SystemOutWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("Email2",
                 new SystemOutWorkItemHandler());
         kruntime.signalEvent("Message-YesMessage", "YesValue",
                 processInstance.getStringId());
-        assertProcessInstanceFinished(processInstance, ksession);
-        ksession = restoreSession(ksession, true);
+        assertProcessInstanceFinished(processInstance, kruntime);
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1",
                 new SystemOutWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("Email2",
@@ -596,80 +561,71 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         processInstance = kruntime.startProcess("com.sample.test");
         kruntime.signalEvent("Message-NoMessage", "NoValue",
                 processInstance.getStringId());
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
     }
 
     @Test
     public void testEventBasedSplit5() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-EventBasedSplit5.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-EventBasedSplit5.bpmn2");
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1",
                 new SystemOutWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("Email2",
                 new SystemOutWorkItemHandler());
-        ReceiveTaskHandler receiveTaskHandler = new ReceiveTaskHandler(ksession);
+        ReceiveTaskHandler receiveTaskHandler = new ReceiveTaskHandler(kruntime);
         kruntime.getWorkItemManager().registerWorkItemHandler("Receive Task",
                 receiveTaskHandler);
         // Yes
         KogitoProcessInstance processInstance = kruntime.startProcess("com.sample.test");
         assertProcessInstanceActive(processInstance);
-        ksession = restoreSession(ksession, true);
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1",
                 new SystemOutWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("Email2",
                 new SystemOutWorkItemHandler());
-        receiveTaskHandler.setKnowledgeRuntime(ksession);
+        receiveTaskHandler.setKnowledgeRuntime(kruntime);
         kruntime.getWorkItemManager().registerWorkItemHandler("Receive Task",
                 receiveTaskHandler);
         receiveTaskHandler.messageReceived("YesMessage", "YesValue");
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
         receiveTaskHandler.messageReceived("NoMessage", "NoValue");
-        ksession = restoreSession(ksession, true);
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1",
                 new SystemOutWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("Email2",
                 new SystemOutWorkItemHandler());
-        receiveTaskHandler.setKnowledgeRuntime(ksession);
+        receiveTaskHandler.setKnowledgeRuntime(kruntime);
         kruntime.getWorkItemManager().registerWorkItemHandler("Receive Task",
                 receiveTaskHandler);
         // No
         processInstance = kruntime.startProcess("com.sample.test");
         receiveTaskHandler.messageReceived("NoMessage", "NoValue");
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
         receiveTaskHandler.messageReceived("YesMessage", "YesValue");
 
     }
 
     @Test
     public void testEventBasedSplitWithSubprocess() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-ExclusiveEventBasedGatewayInSubprocess.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        
+        kruntime = createKogitoProcessRuntime("BPMN2-ExclusiveEventBasedGatewayInSubprocess.bpmn2");
+
         // Stop
         KogitoProcessInstance processInstance = kruntime.startProcess("com.sample.bpmn.testEBGInSubprocess");
         assertProcessInstanceActive(processInstance);
-        ksession = restoreSession(ksession, true);
 
         kruntime.signalEvent("StopSignal", "", processInstance.getStringId());
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
 
         // Continue and Stop
         processInstance = kruntime.startProcess("com.sample.bpmn.testEBGInSubprocess");
         assertProcessInstanceActive(processInstance);
-        ksession = restoreSession(ksession, true);
 
         kruntime.signalEvent("ContinueSignal", "", processInstance.getStringId());
 
         assertProcessInstanceActive(processInstance);
-        ksession = restoreSession(ksession, true);
 
         kruntime.signalEvent("StopSignal", "", processInstance.getStringId());
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
     }
 
     @Test
@@ -702,9 +658,9 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     }
 
     public void runTestEventSubprocessSignal(String processFile, String [] completedNodes) throws Exception {
-        KieBase kbase = createKnowledgeBase(processFile);
+        kruntime = createKogitoProcessRuntime(processFile);
         final List<String> executednodes = new ArrayList<>();
-        ProcessEventListener listener = new DefaultProcessEventListener() {
+        KogitoProcessEventListener listener = new DefaultKogitoProcessEventListener() {
 
             @Override
             public void afterNodeLeft(ProcessNodeLeftEvent event) {
@@ -715,18 +671,15 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
             }
 
         };
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
 
-        ksession.addEventListener(listener);
+        kruntime.getProcessEventManager().addEventListener(listener);
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 workItemHandler);
         KogitoProcessInstance processInstance = kruntime
                 .startProcess("BPMN2-EventSubprocessSignal");
         assertProcessInstanceActive(processInstance);
-        ksession = restoreSession(ksession, true);
-        ksession.addEventListener(listener);
+        kruntime.getProcessEventManager().addEventListener(listener);
 
         Set<EventDescription<?>> eventDescriptions = processInstance.getEventDescriptions();
         assertThat(eventDescriptions)
@@ -750,7 +703,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         assertThat(workItem).isNotNull();
 
         kruntime.getWorkItemManager().completeWorkItem(workItem.getStringId(), null);
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
         assertNodeTriggered(processInstance.getStringId(), completedNodes );
         assertThat(executednodes.size()).isEqualTo(4);
 
@@ -758,9 +711,9 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testEventSubprocessSignalWithStateNode() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-EventSubprocessSignalWithStateNode.bpmn2");
+        kruntime = createKogitoProcessRuntime("BPMN2-EventSubprocessSignalWithStateNode.bpmn2");
         final List<String> executednodes = new ArrayList<>();
-        ProcessEventListener listener = new DefaultProcessEventListener() {
+        KogitoProcessEventListener listener = new DefaultKogitoProcessEventListener() {
 
             @Override
             public void afterNodeLeft(ProcessNodeLeftEvent event) {
@@ -770,18 +723,15 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
             }
 
         };
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
 
-        ksession.addEventListener(listener);
+        kruntime.getProcessEventManager().addEventListener(listener);
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 workItemHandler);
         KogitoProcessInstance processInstance = kruntime
                 .startProcess("BPMN2-EventSubprocessSignal");
         assertProcessInstanceActive(processInstance);
-        ksession = restoreSession(ksession, true);
-        ksession.addEventListener(listener);
+        kruntime.getProcessEventManager().addEventListener(listener);
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 workItemHandler);
 
@@ -814,7 +764,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         assertThat(workItemTopProcess).isNotNull();
         kruntime.getWorkItemManager().completeWorkItem(
                 workItemTopProcess.getStringId(), null);
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
         assertNodeTriggered(processInstance.getStringId(), "start", "User Task 1",
                 "end", "Sub Process 1", "start-sub", "User Task 2", "end-sub");
         assertThat(executednodes.size()).isEqualTo(4);
@@ -823,9 +773,9 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testEventSubprocessSignalInterrupting() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-EventSubprocessSignalInterrupting.bpmn2");
+        kruntime = createKogitoProcessRuntime("BPMN2-EventSubprocessSignalInterrupting.bpmn2");
         final List<String> executednodes = new ArrayList<>();
-        ProcessEventListener listener = new DefaultProcessEventListener() {
+        KogitoProcessEventListener listener = new DefaultKogitoProcessEventListener() {
 
             @Override
             public void afterNodeLeft(ProcessNodeLeftEvent event) {
@@ -836,9 +786,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
             }
 
         };
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        ksession.addEventListener(listener);
+        kruntime.getProcessEventManager().addEventListener(listener);
 
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
@@ -846,12 +794,11 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         KogitoProcessInstance processInstance = kruntime
                 .startProcess("BPMN2-EventSubprocessSignal");
         assertProcessInstanceActive(processInstance);
-        ksession = restoreSession(ksession, true);
-        ksession.addEventListener(listener);
+        kruntime.getProcessEventManager().addEventListener(listener);
 
         kruntime.signalEvent("MySignal", null, processInstance.getStringId());
 
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
         assertNodeTriggered(processInstance.getStringId(), "start", "User Task 1",
                 "Sub Process 1", "start-sub", "Script Task 1", "end-sub");
         assertThat(executednodes.size()).isEqualTo(1);
@@ -860,9 +807,9 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testEventSubprocessMessage() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-EventSubprocessMessage.bpmn2");
+        kruntime = createKogitoProcessRuntime("BPMN2-EventSubprocessMessage.bpmn2");
         final List<String> executednodes = new ArrayList<>();
-        ProcessEventListener listener = new DefaultProcessEventListener() {
+        KogitoProcessEventListener listener = new DefaultKogitoProcessEventListener() {
 
             @Override
             public void afterNodeLeft(ProcessNodeLeftEvent event) {
@@ -872,10 +819,9 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
                 }
             }
 
-        };
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        ksession.addEventListener(listener);
+        };       
+        
+        kruntime.getProcessEventManager().addEventListener(listener);
 
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
@@ -890,8 +836,8 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
             .extracting("eventType").contains("signal", "workItem");       
         assertThat(eventDescriptions)            
             .extracting("processInstanceId").contains(processInstance.getStringId());
-        ksession = restoreSession(ksession, true);
-        ksession.addEventListener(listener);
+        
+        kruntime.getProcessEventManager().addEventListener(listener);
 
         kruntime.signalEvent("Message-HelloMessage", null, processInstance.getStringId());
         kruntime.signalEvent("Message-HelloMessage", null);
@@ -904,7 +850,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         KogitoWorkItem workItem = workItemHandler.getWorkItem();
         assertThat(workItem).isNotNull();
         kruntime.getWorkItemManager().completeWorkItem(workItem.getStringId(), null);
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
         assertNodeTriggered(processInstance.getStringId(), "start", "User Task 1",
                 "end", "Sub Process 1", "start-sub", "Script Task 1", "end-sub");
         assertThat(executednodes.size()).isEqualTo(4);
@@ -915,12 +861,9 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     @Timeout(10)
     public void testEventSubprocessTimer() throws Exception {
         NodeLeftCountDownProcessEventListener countDownListener = new NodeLeftCountDownProcessEventListener("Script Task 1", 1);
+        kruntime = createKogitoProcessRuntime("BPMN2-EventSubprocessTimer.bpmn2");
 
-        KieBase kbase = createKnowledgeBase("BPMN2-EventSubprocessTimer.bpmn2");
-
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        ksession.addEventListener(countDownListener);
+        kruntime.getProcessEventManager().addEventListener(countDownListener);
 
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
@@ -940,10 +883,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
             .filteredOn("eventType", "timer")
             .hasSize(1)
             .extracting("properties", Map.class)
-            .anyMatch(m -> m.containsKey("TimerID") && m.containsKey("Delay"));
-        
-        
-        countDownListener.waitTillCompleted();
+            .anyMatch(m -> m.containsKey("TimerID") && m.containsKey("Delay"));countDownListener.waitTillCompleted();
         
         eventDescriptions = processInstance.getEventDescriptions();
         assertThat(eventDescriptions)
@@ -957,7 +897,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         KogitoWorkItem workItem = workItemHandler.getWorkItem();
         assertThat(workItem).isNotNull();
         kruntime.getWorkItemManager().completeWorkItem(workItem.getStringId(), null);
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
         assertNodeTriggered(processInstance.getStringId(), "start", "User Task 1",
                 "end", "Sub Process 1", "start-sub", "Script Task 1", "end-sub");
 
@@ -969,11 +909,8 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     public void testEventSubprocessTimerCycle() throws Exception {
         NodeLeftCountDownProcessEventListener countDownListener = new NodeLeftCountDownProcessEventListener("Script Task 1", 4);
 
-        KieBase kbase = createKnowledgeBase("BPMN2-EventSubprocessTimerCycle.bpmn2");
-
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        ksession.addEventListener(countDownListener);
+        kruntime = createKogitoProcessRuntime("BPMN2-EventSubprocessTimerCycle.bpmn2");
+        kruntime.getProcessEventManager().addEventListener(countDownListener);
 
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
@@ -999,7 +936,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         KogitoWorkItem workItem = workItemHandler.getWorkItem();
         assertThat(workItem).isNotNull();
         kruntime.getWorkItemManager().completeWorkItem(workItem.getStringId(), null);
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
         assertNodeTriggered(processInstance.getStringId(), "start", "User Task 1",
                 "end", "start-sub", "Script Task 1", "end-sub");
 
@@ -1007,9 +944,9 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testEventSubprocessConditional() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-EventSubprocessConditional.bpmn2");
+        kruntime = createKogitoProcessRuntime("BPMN2-EventSubprocessConditional.bpmn2");
         final List<String> executednodes = new ArrayList<>();
-        ProcessEventListener listener = new DefaultProcessEventListener() {
+        KogitoProcessEventListener listener = new DefaultKogitoProcessEventListener() {
 
             @Override
             public void afterNodeLeft(ProcessNodeLeftEvent event) {
@@ -1019,10 +956,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
                 }
             }
 
-        };
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        ksession.addEventListener(listener);
+        };        kruntime.getProcessEventManager().addEventListener(listener);
 
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
@@ -1033,13 +967,13 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
 
         Person person = new Person();
         person.setName("john");
-        ksession.insert(person);
+        kruntime.getKieSession().insert(person);
 
 
         KogitoWorkItem workItem = workItemHandler.getWorkItem();
         assertThat(workItem).isNotNull();
         kruntime.getWorkItemManager().completeWorkItem(workItem.getStringId(), null);
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
         assertNodeTriggered(processInstance.getStringId(), "start", "User Task 1",
                 "end", "Sub Process 1", "start-sub", "Script Task 1", "end-sub");
         assertThat(executednodes.size()).isEqualTo(1);
@@ -1051,9 +985,9 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     public void testEventSubprocessMessageWithLocalVars() throws Exception {
         NodeLeftCountDownProcessEventListener countDownListener = new NodeLeftCountDownProcessEventListener("timer", 1);
 
-        KieBase kbase = createKnowledgeBase("subprocess/BPMN2-EventSubProcessWithLocalVariables.bpmn2");
+        kruntime = createKogitoProcessRuntime("subprocess/BPMN2-EventSubProcessWithLocalVariables.bpmn2");
         final Set<String> variablevalues = new HashSet<String>();
-        ProcessEventListener listener = new DefaultProcessEventListener() {
+        KogitoProcessEventListener listener = new DefaultKogitoProcessEventListener() {
 
             @Override
             public void afterNodeLeft(ProcessNodeLeftEvent event) {
@@ -1064,15 +998,12 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
             	}
             }
 
-        };
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        ksession.addEventListener(listener);
-        ksession.addEventListener(countDownListener);
+        };        kruntime.getProcessEventManager().addEventListener(listener);
+        kruntime.getProcessEventManager().addEventListener(countDownListener);
         KogitoProcessInstance processInstance = kruntime.startProcess("EventSPWithVars");
         assertProcessInstanceActive(processInstance);
 
-        Map<String, String> data = new HashMap<String, String>();
+        Map<String, String> data = new HashMap<>();
         kruntime.signalEvent("Message-MAIL", data, processInstance.getStringId());
         countDownListener.waitTillCompleted();
 
@@ -1085,12 +1016,9 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testMessageIntermediateThrow() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-IntermediateThrowEventMessage.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        kruntime.getWorkItemManager().registerWorkItemHandler("Send Task",
+        kruntime = createKogitoProcessRuntime("BPMN2-IntermediateThrowEventMessage.bpmn2");        kruntime.getWorkItemManager().registerWorkItemHandler("Send Task",
                 new SendTaskHandler());
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", "MyValue");
         KogitoProcessInstance processInstance = kruntime.startProcess(
                 "MessageIntermediateEvent", params);
@@ -1100,12 +1028,9 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testMessageIntermediateThrowVerifyWorkItemData() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-IntermediateThrowEventMessage.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        TestWorkItemHandler handler = new TestWorkItemHandler();
+        kruntime = createKogitoProcessRuntime("BPMN2-IntermediateThrowEventMessage.bpmn2");        TestWorkItemHandler handler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Send Task", handler);
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", "MyValue");
         KogitoProcessInstance processInstance = kruntime.startProcess("MessageIntermediateEvent", params);
         assertProcessInstanceCompleted(processInstance);
@@ -1124,12 +1049,9 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testMessageIntermediateThrowVerifyWorkItemDataDeploymentId() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-IntermediateThrowEventMessage.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        TestWorkItemHandler handler = new TestWorkItemHandler();
+        kruntime = createKogitoProcessRuntime("BPMN2-IntermediateThrowEventMessage.bpmn2");        TestWorkItemHandler handler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Send Task", handler);
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", "MyValue");
         KogitoProcessInstance processInstance = kruntime.startProcess("MessageIntermediateEvent", params);
         assertProcessInstanceCompleted(processInstance);
@@ -1150,15 +1072,12 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testMessageBoundaryEventOnTask() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-BoundaryMessageEventOnTask.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
+        kruntime = createKogitoProcessRuntime("BPMN2-BoundaryMessageEventOnTask.bpmn2");        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 new TestWorkItemHandler());
 
         KogitoProcessInstance processInstance = kruntime.startProcess("BoundaryMessageOnTask");
         kruntime.signalEvent("Message-HelloMessage", "message data");
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
         assertNodeTriggered(processInstance.getStringId(), "StartProcess",
                 "User Task", "Boundary event", "Condition met", "End2");
 
@@ -1166,10 +1085,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testMessageBoundaryEventOnTaskComplete() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-BoundaryMessageEventOnTask.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        TestWorkItemHandler handler = new TestWorkItemHandler();
+        kruntime = createKogitoProcessRuntime("BPMN2-BoundaryMessageEventOnTask.bpmn2");        TestWorkItemHandler handler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 handler);
 
@@ -1179,7 +1095,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         kruntime.signalEvent("Message-HelloMessage", "message data");
         kruntime.getWorkItemManager().completeWorkItem(
                 handler.getWorkItem().getStringId(), null);
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
         assertNodeTriggered(processInstance.getStringId(), "StartProcess",
                 "User Task", "User Task2", "End1");
 
@@ -1189,11 +1105,8 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     @Timeout(10)
     public void testTimerBoundaryEventDuration() throws Exception {
         NodeLeftCountDownProcessEventListener countDownListener = new NodeLeftCountDownProcessEventListener("TimerEvent", 1);
-        KieBase kbase = createKnowledgeBase("BPMN2-TimerBoundaryEventDuration.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        kruntime.getWorkItemManager().registerWorkItemHandler("MyTask", new DoNothingWorkItemHandler());
-        ksession.addEventListener(countDownListener);
+        kruntime = createKogitoProcessRuntime("BPMN2-TimerBoundaryEventDuration.bpmn2");        kruntime.getWorkItemManager().registerWorkItemHandler("MyTask", new DoNothingWorkItemHandler());
+        kruntime.getProcessEventManager().addEventListener(countDownListener);
         KogitoProcessInstance processInstance = kruntime.startProcess("TimerBoundaryEvent");
         assertProcessInstanceActive(processInstance);
         
@@ -1212,8 +1125,8 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
             .anyMatch(m -> m.containsKey("TimerID") && m.containsKey("Period"));
         
         countDownListener.waitTillCompleted();
-        ksession = restoreSession(ksession, true);
-        assertProcessInstanceFinished(processInstance, ksession);
+        
+        assertProcessInstanceFinished(processInstance, kruntime);
 
     }
 
@@ -1221,16 +1134,13 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     @Timeout(10)
     public void testTimerBoundaryEventDurationISO() throws Exception {
         NodeLeftCountDownProcessEventListener countDownListener = new NodeLeftCountDownProcessEventListener("TimerEvent", 1);
-        KieBase kbase = createKnowledgeBase("BPMN2-TimerBoundaryEventDurationISO.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        kruntime.getWorkItemManager().registerWorkItemHandler("MyTask", new DoNothingWorkItemHandler());
-        ksession.addEventListener(countDownListener);
+        kruntime = createKogitoProcessRuntime("BPMN2-TimerBoundaryEventDurationISO.bpmn2");        kruntime.getWorkItemManager().registerWorkItemHandler("MyTask", new DoNothingWorkItemHandler());
+        kruntime.getProcessEventManager().addEventListener(countDownListener);
         KogitoProcessInstance processInstance = kruntime.startProcess("TimerBoundaryEvent");
         assertProcessInstanceActive(processInstance);
         countDownListener.waitTillCompleted();
-        ksession = restoreSession(ksession, true);
-        assertProcessInstanceFinished(processInstance, ksession);
+        
+        assertProcessInstanceFinished(processInstance, kruntime);
 
     }
 
@@ -1239,19 +1149,16 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     public void testTimerBoundaryEventDateISO() throws Exception {
         NodeLeftCountDownProcessEventListener countDownListener = new NodeLeftCountDownProcessEventListener("TimerEvent", 1);
 
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-TimerBoundaryEventDateISO.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        ksession.addEventListener(countDownListener);
+        kruntime = createKogitoProcessRuntime("BPMN2-TimerBoundaryEventDateISO.bpmn2");        kruntime.getProcessEventManager().addEventListener(countDownListener);
         kruntime.getWorkItemManager().registerWorkItemHandler("MyTask", new DoNothingWorkItemHandler());
-        HashMap<String, Object> params = new HashMap<String, Object>();
+        HashMap<String, Object> params = new HashMap<>();
         OffsetDateTime plusTwoSeconds = OffsetDateTime.now().plusSeconds(2);
         params.put("date", plusTwoSeconds.toString());
         KogitoProcessInstance processInstance = kruntime.startProcess("TimerBoundaryEvent", params);
         assertProcessInstanceActive(processInstance);
         countDownListener.waitTillCompleted();
-        ksession = restoreSession(ksession, true);
-        assertProcessInstanceFinished(processInstance, ksession);
+        
+        assertProcessInstanceFinished(processInstance, kruntime);
 
     }
 
@@ -1260,16 +1167,13 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     public void testTimerBoundaryEventCycle1() throws Exception {
         NodeLeftCountDownProcessEventListener countDownListener = new NodeLeftCountDownProcessEventListener("TimerEvent", 1);
 
-        KieBase kbase = createKnowledgeBase("BPMN2-TimerBoundaryEventCycle1.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        kruntime.getWorkItemManager().registerWorkItemHandler("MyTask", new DoNothingWorkItemHandler());
-        ksession.addEventListener(countDownListener);
+        kruntime = createKogitoProcessRuntime("BPMN2-TimerBoundaryEventCycle1.bpmn2");        kruntime.getWorkItemManager().registerWorkItemHandler("MyTask", new DoNothingWorkItemHandler());
+        kruntime.getProcessEventManager().addEventListener(countDownListener);
         KogitoProcessInstance processInstance = kruntime.startProcess("TimerBoundaryEvent");
         assertProcessInstanceActive(processInstance);
         countDownListener.waitTillCompleted();
-        ksession = restoreSession(ksession, true);
-        assertProcessInstanceFinished(processInstance, ksession);
+        
+        assertProcessInstanceFinished(processInstance, kruntime);
 
     }
 
@@ -1278,11 +1182,8 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     public void testTimerBoundaryEventCycle2() throws Exception {
         NodeLeftCountDownProcessEventListener countDownListener = new NodeLeftCountDownProcessEventListener("TimerEvent", 3);
 
-        KieBase kbase = createKnowledgeBase("BPMN2-TimerBoundaryEventCycle2.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        kruntime.getWorkItemManager().registerWorkItemHandler("MyTask", new DoNothingWorkItemHandler());
-        ksession.addEventListener(countDownListener);
+        kruntime = createKogitoProcessRuntime("BPMN2-TimerBoundaryEventCycle2.bpmn2");        kruntime.getWorkItemManager().registerWorkItemHandler("MyTask", new DoNothingWorkItemHandler());
+        kruntime.getProcessEventManager().addEventListener(countDownListener);
         KogitoProcessInstance processInstance = kruntime.startProcess("TimerBoundaryEvent");
         assertProcessInstanceActive(processInstance);
         countDownListener.waitTillCompleted();
@@ -1297,10 +1198,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     @RequirePersistence(false)
     public void testTimerBoundaryEventCycleISO() throws Exception {
         NodeLeftCountDownProcessEventListener countDownListener = new NodeLeftCountDownProcessEventListener("TimerEvent", 2);
-        KieBase kbase = createKnowledgeBase("BPMN2-TimerBoundaryEventCycleISO.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        ksession.addEventListener(countDownListener);
+        kruntime = createKogitoProcessRuntime("BPMN2-TimerBoundaryEventCycleISO.bpmn2");        kruntime.getProcessEventManager().addEventListener(countDownListener);
         kruntime.getWorkItemManager().registerWorkItemHandler("MyTask", new DoNothingWorkItemHandler());
         KogitoProcessInstance processInstance = kruntime.startProcess("TimerBoundaryEvent");
         assertProcessInstanceActive(processInstance);
@@ -1314,19 +1212,16 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     public void testTimerBoundaryEventInterrupting() throws Exception {
         NodeLeftCountDownProcessEventListener countDownListener = new NodeLeftCountDownProcessEventListener("TimerEvent", 1);
 
-        KieBase kbase = createKnowledgeBase("BPMN2-TimerBoundaryEventInterrupting.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        kruntime.getWorkItemManager().registerWorkItemHandler("MyTask", new DoNothingWorkItemHandler());
-        ksession.addEventListener(countDownListener);
+        kruntime = createKogitoProcessRuntime("BPMN2-TimerBoundaryEventInterrupting.bpmn2");        kruntime.getWorkItemManager().registerWorkItemHandler("MyTask", new DoNothingWorkItemHandler());
+        kruntime.getProcessEventManager().addEventListener(countDownListener);
         KogitoProcessInstance processInstance = kruntime.startProcess("TimerBoundaryEvent");
         assertProcessInstanceActive(processInstance);
 
         countDownListener.waitTillCompleted();
-        ksession = restoreSession(ksession, true);
+        
         logger.debug("Firing timer");
 
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
     }
 
@@ -1335,97 +1230,79 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     public void testTimerBoundaryEventInterruptingOnTask() throws Exception {
         NodeLeftCountDownProcessEventListener countDownListener = new NodeLeftCountDownProcessEventListener("TimerEvent", 1);
 
-        KieBase kbase = createKnowledgeBase("BPMN2-TimerBoundaryEventInterruptingOnTask.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",  new TestWorkItemHandler());
-        ksession.addEventListener(countDownListener);
+        kruntime = createKogitoProcessRuntime("BPMN2-TimerBoundaryEventInterruptingOnTask.bpmn2");        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",  new TestWorkItemHandler());
+        kruntime.getProcessEventManager().addEventListener(countDownListener);
 
         KogitoProcessInstance processInstance = kruntime.startProcess("TimerBoundaryEvent");
         assertProcessInstanceActive(processInstance);
         countDownListener.waitTillCompleted();
-        ksession = restoreSession(ksession, true);
+        
         logger.debug("Firing timer");
 
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
     }
 
     @Test
     public void testTimerBoundaryEventInterruptingOnTaskCancelTimer() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-TimerBoundaryEventInterruptingOnTaskCancelTimer.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        TestWorkItemHandler handler = new TestWorkItemHandler();
+        kruntime = createKogitoProcessRuntime("BPMN2-TimerBoundaryEventInterruptingOnTaskCancelTimer.bpmn2");        TestWorkItemHandler handler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", handler);
         KogitoProcessInstance processInstance = kruntime.startProcess("TimerBoundaryEvent");
         assertProcessInstanceActive(processInstance);
 
-        ksession = restoreSession(ksession, true);
+        
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", handler);        
         kruntime.getWorkItemManager().completeWorkItem(handler.getWorkItem().getStringId(), null);
 
-        ksession = restoreSession(ksession, true);
+        
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", handler);        
         KogitoWorkItem workItem = handler.getWorkItem();
         if (workItem != null) {
             kruntime.getWorkItemManager().completeWorkItem(workItem.getStringId(), null);
         }
 
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
     }
 
     @Test
     public void testIntermediateCatchEventSignal() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-IntermediateCatchEventSignal.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
+        kruntime = createKogitoProcessRuntime("BPMN2-IntermediateCatchEventSignal.bpmn2");        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 new SystemOutWorkItemHandler());
         KogitoProcessInstance processInstance = kruntime.startProcess("IntermediateCatchEvent");
         assertProcessInstanceActive(processInstance);
    
-        ksession = restoreSession(ksession, true);
+        
         // now signal process instance
         kruntime.signalEvent("MyMessage", "SomeValue", processInstance.getStringId());
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
         assertNodeTriggered(processInstance.getStringId(), "StartProcess", "UserTask", "EndProcess", "event");
 
     }
 
     @Test
     public void testIntermediateCatchEventMessage() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-IntermediateCatchEventMessage.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
+        kruntime = createKogitoProcessRuntime("BPMN2-IntermediateCatchEventMessage.bpmn2");        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 new SystemOutWorkItemHandler());
         KogitoProcessInstance processInstance = kruntime.startProcess("IntermediateCatchEvent");
-        assertProcessInstanceActive(processInstance);
-                
-        ksession = restoreSession(ksession, true);
-        // now signal process instance
+        assertProcessInstanceActive(processInstance);        // now signal process instance
         kruntime.signalEvent("Message-HelloMessage", "SomeValue",
                 processInstance.getStringId());
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
     }
     
     @Test
     public void testIntermediateCatchEventMessageWithRef() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-IntermediateCatchEventMessageWithRef.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
+        kruntime = createKogitoProcessRuntime("BPMN2-IntermediateCatchEventMessageWithRef.bpmn2");        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 new SystemOutWorkItemHandler());
         KogitoProcessInstance processInstance = kruntime.startProcess("IntermediateCatchEvent");
         assertProcessInstanceActive(processInstance);
-        ksession = restoreSession(ksession, true);
+        
         // now signal process instance
         kruntime.signalEvent("Message-HelloMessage", "SomeValue",
                 processInstance.getStringId());
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
     }
 
@@ -1434,22 +1311,19 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     public void testIntermediateCatchEventTimerDuration() throws Exception {
         NodeLeftCountDownProcessEventListener countDownListener = new NodeLeftCountDownProcessEventListener("timer", 1);
 
-        KieBase kbase = createKnowledgeBase("BPMN2-IntermediateCatchEventTimerDuration.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", new DoNothingWorkItemHandler());
-        ksession.addEventListener(countDownListener);
+        kruntime = createKogitoProcessRuntime("BPMN2-IntermediateCatchEventTimerDuration.bpmn2");        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", new DoNothingWorkItemHandler());
+        kruntime.getProcessEventManager().addEventListener(countDownListener);
         KogitoProcessInstance processInstance = kruntime.startProcess("IntermediateCatchEvent");
         assertProcessInstanceActive(processInstance);
   
         // now wait for 1 second for timer to trigger
         countDownListener.waitTillCompleted();
 
-        ksession = restoreSession(ksession, true);
+        
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", new DoNothingWorkItemHandler());
-        ksession.addEventListener(countDownListener);
+        kruntime.getProcessEventManager().addEventListener(countDownListener);
 
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
     }
 
@@ -1458,13 +1332,10 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     public void testIntermediateCatchEventTimerDateISO() throws Exception {
         NodeLeftCountDownProcessEventListener countDownListener = new NodeLeftCountDownProcessEventListener("timer", 1);
 
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-IntermediateCatchEventTimerDateISO.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", new DoNothingWorkItemHandler());
-        ksession.addEventListener(countDownListener);
+        kruntime = createKogitoProcessRuntime("BPMN2-IntermediateCatchEventTimerDateISO.bpmn2");        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", new DoNothingWorkItemHandler());
+        kruntime.getProcessEventManager().addEventListener(countDownListener);
 
-        HashMap<String, Object> params = new HashMap<String, Object>();
+        HashMap<String, Object> params = new HashMap<>();
         OffsetDateTime plusTwoSeconds = OffsetDateTime.now().plusSeconds(2);
         params.put("date", plusTwoSeconds.toString());
         KogitoProcessInstance processInstance = kruntime.startProcess("IntermediateCatchEvent", params);
@@ -1472,7 +1343,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         // now wait for 1 second for timer to trigger
         countDownListener.waitTillCompleted();
 
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
     }
 
@@ -1481,21 +1352,18 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     public void testIntermediateCatchEventTimerDurationISO() throws Exception {
         NodeLeftCountDownProcessEventListener countDownListener = new NodeLeftCountDownProcessEventListener("timer", 1);
 
-        KieBase kbase = createKnowledgeBase("BPMN2-IntermediateCatchEventTimerDurationISO.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", new DoNothingWorkItemHandler());
-        ksession.addEventListener(countDownListener);
+        kruntime = createKogitoProcessRuntime("BPMN2-IntermediateCatchEventTimerDurationISO.bpmn2");        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", new DoNothingWorkItemHandler());
+        kruntime.getProcessEventManager().addEventListener(countDownListener);
 
         KogitoProcessInstance processInstance = kruntime.startProcess("IntermediateCatchEvent");
         assertProcessInstanceActive(processInstance);
         // now wait for 1.5 second for timer to trigger
         countDownListener.waitTillCompleted();
-        ksession = restoreSession(ksession, true);
+        
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 new DoNothingWorkItemHandler());
 
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
     }
 
@@ -1504,21 +1372,18 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     public void testIntermediateCatchEventTimerCycle1() throws Exception {
         NodeLeftCountDownProcessEventListener countDownListener = new NodeLeftCountDownProcessEventListener("timer", 1);
 
-        KieBase kbase = createKnowledgeBase("BPMN2-IntermediateCatchEventTimerCycle1.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", new DoNothingWorkItemHandler());
-        ksession.addEventListener(countDownListener);
+        kruntime = createKogitoProcessRuntime("BPMN2-IntermediateCatchEventTimerCycle1.bpmn2");        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", new DoNothingWorkItemHandler());
+        kruntime.getProcessEventManager().addEventListener(countDownListener);
 
         KogitoProcessInstance processInstance = kruntime.startProcess("IntermediateCatchEvent");
         assertProcessInstanceActive(processInstance);
         // now wait for 1 second for timer to trigger
         countDownListener.waitTillCompleted();
 
-        ksession = restoreSession(ksession, true);
+        
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", new DoNothingWorkItemHandler());
 
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
     }
 
@@ -1527,11 +1392,8 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     public void testIntermediateCatchEventTimerCycleISO() throws Exception {
         NodeLeftCountDownProcessEventListener countDownListener = new NodeLeftCountDownProcessEventListener("timer", 5);
 
-        KieBase kbase = createKnowledgeBase("BPMN2-IntermediateCatchEventTimerCycleISO.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", new DoNothingWorkItemHandler());
-        ksession.addEventListener(countDownListener);
+        kruntime = createKogitoProcessRuntime("BPMN2-IntermediateCatchEventTimerCycleISO.bpmn2");        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", new DoNothingWorkItemHandler());
+        kruntime.getProcessEventManager().addEventListener(countDownListener);
 
         KogitoProcessInstance processInstance = kruntime.startProcess("IntermediateCatchEvent");
         assertProcessInstanceActive(processInstance);
@@ -1547,11 +1409,8 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     public void testIntermediateCatchEventTimerCycle2() throws Exception {
         NodeLeftCountDownProcessEventListener countDownListener = new NodeLeftCountDownProcessEventListener("timer", 3);
 
-        KieBase kbase = createKnowledgeBase("BPMN2-IntermediateCatchEventTimerCycle2.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", new DoNothingWorkItemHandler());
-        ksession.addEventListener(countDownListener);
+        kruntime = createKogitoProcessRuntime("BPMN2-IntermediateCatchEventTimerCycle2.bpmn2");        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", new DoNothingWorkItemHandler());
+        kruntime.getProcessEventManager().addEventListener(countDownListener);
 
         KogitoProcessInstance processInstance = kruntime.startProcess("IntermediateCatchEvent");
         assertProcessInstanceActive(processInstance);
@@ -1564,28 +1423,25 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testIntermediateCatchEventCondition() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-IntermediateCatchEventCondition.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        KogitoProcessInstance processInstance = kruntime.startProcess("IntermediateCatchEvent");
+        kruntime = createKogitoProcessRuntime("BPMN2-IntermediateCatchEventCondition.bpmn2");        KogitoProcessInstance processInstance = kruntime.startProcess("IntermediateCatchEvent");
         assertProcessInstanceActive(processInstance);
-        ksession = restoreSession(ksession, true);
+        
         // now activate condition
         Person person = new Person();
         person.setName("Jack");
-        ksession.insert(person);
-        assertProcessInstanceFinished(processInstance, ksession);
+        kruntime.getKieSession().insert(person);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
     }
 
     @Test
     public void testIntermediateCatchEventConditionFilterByProcessInstance()
             throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-IntermediateCatchEventConditionFilterByProcessInstance.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-IntermediateCatchEventConditionFilterByProcessInstance.bpmn2");
+        
+        
 
-        Map<String, Object> params1 = new HashMap<String, Object>();
+        Map<String, Object> params1 = new HashMap<>();
         params1.put("personId", Long.valueOf(1L));
         Person person1 = new Person();
         person1.setId(1L);
@@ -1595,12 +1451,12 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
                         params1);
         String pi1id = pi1.getStringId();
 
-        ksession.insert(pi1);
-        FactHandle personHandle1 = ksession.insert(person1);
+        kruntime.getKieSession().insert(pi1);
+        FactHandle personHandle1 = kruntime.getKieSession().insert(person1);
 
         kruntime.startProcessInstance(pi1.getStringId());
 
-        Map<String, Object> params2 = new HashMap<String, Object>();
+        Map<String, Object> params2 = new HashMap<>();
         params2.put("personId", Long.valueOf(2L));
         Person person2 = new Person();
         person2.setId(2L);
@@ -1611,13 +1467,13 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
                         params2);
         String pi2id = pi2.getStringId();
 
-        ksession.insert(pi2);
-        FactHandle personHandle2 = ksession.insert(person2);
+        kruntime.getKieSession().insert(pi2);
+        FactHandle personHandle2 = kruntime.getKieSession().insert(person2);
 
         kruntime.startProcessInstance(pi2.getStringId());
 
         person1.setName("John");
-        ksession.update(personHandle1, person1);
+        kruntime.getKieSession().update(personHandle1, person1);
 
         // First process should be completed
         assertThat(kruntime.getProcessInstance(pi1id)).isNull();
@@ -1633,12 +1489,9 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
             throws Exception {
         NodeLeftCountDownProcessEventListener countDownListener = new NodeLeftCountDownProcessEventListener("timer", 3);
 
-        KieBase kbase = createKnowledgeBase("BPMN2-IntermediateCatchEventTimerCycleWithError.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", new DoNothingWorkItemHandler());
-        ksession.addEventListener(countDownListener);
-        Map<String, Object> params = new HashMap<String, Object>();
+        kruntime = createKogitoProcessRuntime("BPMN2-IntermediateCatchEventTimerCycleWithError.bpmn2");        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", new DoNothingWorkItemHandler());
+        kruntime.getProcessEventManager().addEventListener(countDownListener);
+        Map<String, Object> params = new HashMap<>();
         params.put("x", 0);
         KogitoProcessInstance processInstance = kruntime.startProcess("IntermediateCatchEvent", params);
         assertProcessInstanceActive(processInstance);
@@ -1647,11 +1500,11 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         assertProcessInstanceActive(processInstance);
 
         processInstance = kruntime.getProcessInstance(processInstance.getStringId());
-        Integer xValue = (Integer) ((WorkflowProcessInstance) processInstance).getVariable("x");
+        Integer xValue = (Integer) ((KogitoWorkflowProcessInstance) processInstance).getVariable("x");
         assertThat(xValue).isEqualTo(3);
 
         kruntime.abortProcessInstance(processInstance.getStringId());
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
     }
 
@@ -1661,49 +1514,39 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     public void testIntermediateCatchEventTimerCycleWithErrorWithPersistence() throws Exception {
         NodeLeftCountDownProcessEventListener countDownListener = new NodeLeftCountDownProcessEventListener("timer", 2);
 
-        KieBase kbase = createKnowledgeBase("BPMN2-IntermediateCatchEventTimerCycleWithError.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-IntermediateCatchEventTimerCycleWithError.bpmn2");
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", new DoNothingWorkItemHandler());
-        ksession.addEventListener(countDownListener);
+        kruntime.getProcessEventManager().addEventListener(countDownListener);
         KogitoProcessInstance processInstance = kruntime.startProcess("IntermediateCatchEvent");
         assertProcessInstanceActive(processInstance);
 
 
         final String piId = processInstance.getStringId();
-        ksession.execute(new ExecutableCommand<Void>() {
-
-            public Void execute(Context context) {
-                StatefulKnowledgeSession ksession = (StatefulKnowledgeSession) ((RegistryContext) context).lookup( KieSession.class );
-                WorkflowProcessInstance processInstance = (WorkflowProcessInstance) kruntime.getProcessInstance(piId);
-                processInstance.setVariable("x", 0);
-                return null;
-            }
+        kruntime.getKieSession().execute((ExecutableCommand<Void>) context -> {
+            KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime(((RegistryContext) context).lookup( KieSession.class ));
+            KogitoWorkflowProcessInstance processInstance1 = (KogitoWorkflowProcessInstance) kruntime.getProcessInstance(piId);
+            processInstance1.setVariable("x", 0);
+            return null;
         });
 
         // now wait for 1 second for timer to trigger
         countDownListener.waitTillCompleted();
         assertProcessInstanceActive(processInstance);
 
-        Integer xValue = ksession.execute(new ExecutableCommand<Integer>() {
+        Integer xValue = kruntime.getKieSession().execute((ExecutableCommand<Integer>) context -> {
+            KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime(((RegistryContext) context).lookup( KieSession.class ));
+            KogitoWorkflowProcessInstance processInstance2 = (KogitoWorkflowProcessInstance) kruntime.getProcessInstance(piId);
+            return (Integer) processInstance2.getVariable("x");
 
-            public Integer execute(Context context) {
-                StatefulKnowledgeSession ksession = (StatefulKnowledgeSession) ((RegistryContext) context).lookup( KieSession.class );
-                WorkflowProcessInstance processInstance = (WorkflowProcessInstance) kruntime.getProcessInstance(piId);
-                return (Integer) processInstance.getVariable("x");
-
-            }
         });
         assertThat(xValue).isEqualTo(2);
         kruntime.abortProcessInstance(processInstance.getStringId());
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
     }
 
     @Test
     public void testNoneIntermediateThrow() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-IntermediateThrowEventNone.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-IntermediateThrowEventNone.bpmn2");
         KogitoProcessInstance processInstance = kruntime.startProcess(
                 "NoneIntermediateEvent");
         assertProcessInstanceCompleted(processInstance);
@@ -1712,10 +1555,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testLinkIntermediateEvent() throws Exception {
-
-        KieBase kbase = createKnowledgeBase("BPMN2-IntermediateLinkEvent.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-IntermediateLinkEvent.bpmn2");
         KogitoProcessInstance processInstance = kruntime.startProcess("linkEventProcessExample");
         assertProcessInstanceCompleted(processInstance);
 
@@ -1723,9 +1563,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testLinkEventCompositeProcess() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-LinkEventCompositeProcess.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-LinkEventCompositeProcess.bpmn2");
         KogitoProcessInstance processInstance = kruntime.startProcess("Composite");
         assertProcessInstanceCompleted(processInstance);
 
@@ -1733,18 +1571,16 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testConditionalBoundaryEventOnTask() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-BoundaryConditionalEventOnTask.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-BoundaryConditionalEventOnTask.bpmn2");
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 new TestWorkItemHandler());
         KogitoProcessInstance processInstance = kruntime.startProcess("BoundarySignalOnTask");
 
         Person person = new Person();
         person.setName("john");
-        ksession.insert(person);
+        kruntime.getKieSession().insert(person);
 
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
         assertNodeTriggered(processInstance.getStringId(), "StartProcess",
                 "User Task", "Boundary event", "Condition met", "End2");
 
@@ -1752,10 +1588,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testConditionalBoundaryEventOnTaskComplete() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-BoundaryConditionalEventOnTask.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        TestWorkItemHandler handler = new TestWorkItemHandler();
+        kruntime = createKogitoProcessRuntime("BPMN2-BoundaryConditionalEventOnTask.bpmn2");        TestWorkItemHandler handler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 handler);
         KogitoProcessInstance processInstance = kruntime.startProcess("BoundarySignalOnTask");
@@ -1765,10 +1598,10 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         Person person = new Person();
         person.setName("john");
         // as the node that boundary event is attached to has been completed insert will not have any effect
-        ksession.insert(person);
+        kruntime.getKieSession().insert(person);
         kruntime.getWorkItemManager().completeWorkItem(
                 handler.getWorkItem().getStringId(), null);
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
         assertNodeTriggered(processInstance.getStringId(), "StartProcess",
                 "User Task", "User Task2", "End1");
 
@@ -1777,16 +1610,13 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     @Test
     public void testConditionalBoundaryEventOnTaskActiveOnStartup()
             throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-BoundaryConditionalEventOnTask.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
+        kruntime = createKogitoProcessRuntime("BPMN2-BoundaryConditionalEventOnTask.bpmn2");        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 new TestWorkItemHandler());
 
         KogitoProcessInstance processInstance = kruntime.startProcess("BoundarySignalOnTask");
         Person person = new Person();
         person.setName("john");
-        ksession.insert(person);
+        kruntime.getKieSession().insert(person);
 
 
         assertProcessInstanceCompleted(processInstance);
@@ -1797,21 +1627,18 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testConditionalBoundaryEventInterrupting() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-ConditionalBoundaryEventInterrupting.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        kruntime.getWorkItemManager().registerWorkItemHandler("MyTask",
+        kruntime = createKogitoProcessRuntime("BPMN2-ConditionalBoundaryEventInterrupting.bpmn2");        kruntime.getWorkItemManager().registerWorkItemHandler("MyTask",
                 new DoNothingWorkItemHandler());
         KogitoProcessInstance processInstance = kruntime.startProcess("ConditionalBoundaryEvent");
         assertProcessInstanceActive(processInstance);
 
-        ksession = restoreSession(ksession, true);
+        
         Person person = new Person();
         person.setName("john");
-        ksession.insert(person);
+        kruntime.getKieSession().insert(person);
 
 
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
         assertNodeTriggered(processInstance.getStringId(), "StartProcess", "Hello",
                 "StartSubProcess", "Task", "BoundaryEvent", "Goodbye",
                 "EndProcess");
@@ -1820,75 +1647,57 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testSignallingExceptionServiceTask() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-ExceptionServiceProcess-Signalling.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-
-        StandaloneBPMNProcessTest.runTestSignallingExceptionServiceTask(ksession);
+        kruntime = createKogitoProcessRuntime("BPMN2-ExceptionServiceProcess-Signalling.bpmn2");
+        StandaloneBPMNProcessTest.runTestSignallingExceptionServiceTask(kruntime);
     }
 
     @Test
     public void testSignalBoundaryEventOnSubprocessTakingDifferentPaths() throws Exception {
-        KieBase kbase = createKnowledgeBase(
+        kruntime = createKogitoProcessRuntime(
                 "BPMN2-SignalBoundaryOnSubProcess.bpmn");
-        StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
 
         KogitoProcessInstance processInstance = kruntime.startProcess("jbpm.testing.signal");
         assertProcessInstanceActive(processInstance);
 
         kruntime.signalEvent("continue", null, processInstance.getStringId());
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
-        ksession.dispose();
-
-        ksession = createKnowledgeSession(kbase);
-        kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
 
         processInstance = kruntime.startProcess("jbpm.testing.signal");
         assertProcessInstanceActive(processInstance);
 
         kruntime.signalEvent("forward", null);
-        assertProcessInstanceFinished(processInstance, ksession);
-
-        ksession.dispose();
+        assertProcessInstanceFinished(processInstance, kruntime);
     }
 
     @Test
-    public void testIntermediateCatchEventSameSignalOnTwoKsessions() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-IntermediateCatchEventSignal.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", new SystemOutWorkItemHandler());
+    public void testIntermediateCatchEventSameSignalOnTwokruntimes() throws Exception {
+        kruntime = createKogitoProcessRuntime("BPMN2-IntermediateCatchEventSignal.bpmn2");        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", new SystemOutWorkItemHandler());
         KogitoProcessInstance processInstance = kruntime.startProcess("IntermediateCatchEvent");
 
-        KieBase kbase2 = createKnowledgeBase("BPMN2-IntermediateCatchEventSignal2.bpmn2");
-        KieSession ksession2 = createKnowledgeSession(kbase2);
-        KogitoProcessRuntime kruntime2 = KogitoProcessRuntime.asKogitoProcessRuntime( ksession2 );
+        kruntime2 = createKogitoProcessRuntime("BPMN2-IntermediateCatchEventSignal2.bpmn2");
         kruntime2.getWorkItemManager().registerWorkItemHandler("Human Task", new SystemOutWorkItemHandler());
         KogitoProcessInstance processInstance2 = kruntime2.startProcess("IntermediateCatchEvent2");
 
         assertProcessInstanceActive(processInstance);
         assertProcessInstanceActive(processInstance2);
-        ksession = restoreSession(ksession, true);
-        ksession2 = restoreSession(ksession2, true);
+        
         // now signal process instance
         kruntime.signalEvent("MyMessage", "SomeValue");
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
         assertProcessInstanceActive(processInstance2);
 
         // now signal the other one
         kruntime2.signalEvent("MyMessage", "SomeValue");
-        assertProcessInstanceFinished(processInstance2, ksession2);
-        ksession2.dispose();
+        assertProcessInstanceFinished(processInstance2, kruntime2);
     }
     
     @Test
     public void testIntermediateCatchEventNoIncommingConnection() throws Exception {
         try {
-	    	KieBase kbase = createKnowledgeBase("BPMN2-IntermediateCatchEventNoIncommingConnection.bpmn2");
-	        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+	    	kruntime = createKogitoProcessRuntime("BPMN2-IntermediateCatchEventNoIncommingConnection.bpmn2");
+	                
+        
         } catch (RuntimeException e) {
             assertThat(e.getMessage()).isNotNull();
             assertThat(e.getMessage().contains("has no incoming connection")).isTrue();
@@ -1898,16 +1707,14 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testSignalBoundaryEventOnMultiInstanceSubprocess() throws Exception {
-        KieBase kbase = createKnowledgeBase(
+        kruntime = createKogitoProcessRuntime(
                 "subprocess/BPMN2-MultiInstanceSubprocessWithBoundarySignal.bpmn2");
-        StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
 
         TestWorkItemHandler handler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", handler);
 
-        Map<String, Object> params = new HashMap<String, Object>();
-        List<String> approvers = new ArrayList<String>();
+        Map<String, Object> params = new HashMap<>();
+        List<String> approvers = new ArrayList<>();
         approvers.add("john");
         approvers.add("john");
 
@@ -1921,23 +1728,20 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         assertThat(workItems.size()).isEqualTo(2);
 
         kruntime.signalEvent("Outside", null, processInstance.getStringId());
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
-        ksession.dispose();
     }
 
     @Test
     public void testSignalBoundaryEventNoInteruptOnMultiInstanceSubprocess() throws Exception {
-        KieBase kbase = createKnowledgeBase(
+        kruntime = createKogitoProcessRuntime(
                 "subprocess/BPMN2-MultiInstanceSubprocessWithBoundarySignalNoInterupting.bpmn2");
-        StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
 
         TestWorkItemHandler handler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", handler);
 
-        Map<String, Object> params = new HashMap<String, Object>();
-        List<String> approvers = new ArrayList<String>();
+        Map<String, Object> params = new HashMap<>();
+        List<String> approvers = new ArrayList<>();
         approvers.add("john");
         approvers.add("john");
 
@@ -1952,28 +1756,25 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
 
         kruntime.signalEvent("Outside", null, processInstance.getStringId());
 
-        assertProcessInstanceActive(processInstance.getStringId(), ksession);
+        assertProcessInstanceActive(processInstance.getStringId(), kruntime);
 
         for (KogitoWorkItem wi : workItems) {
         	kruntime.getWorkItemManager().completeWorkItem(wi.getStringId(), null);
         }
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
-        ksession.dispose();
     }
 
     @Test
     public void testErrorBoundaryEventOnMultiInstanceSubprocess() throws Exception {
-        KieBase kbase = createKnowledgeBase(
+        kruntime = createKogitoProcessRuntime(
                 "subprocess/BPMN2-MultiInstanceSubprocessWithBoundaryError.bpmn2");
-        StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
 
         TestWorkItemHandler handler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", handler);
 
-        Map<String, Object> params = new HashMap<String, Object>();
-        List<String> approvers = new ArrayList<String>();
+        Map<String, Object> params = new HashMap<>();
+        List<String> approvers = new ArrayList<>();
         approvers.add("john");
         approvers.add("john");
 
@@ -2000,21 +1801,17 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         assertThat(workItems.size()).isEqualTo(2);
 
         kruntime.signalEvent("Inside", null, processInstance.getStringId());
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
-        ksession.dispose();
     }
 
     @Test
     public void testIntermediateCatchEventSignalAndBoundarySignalEvent() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-BoundaryEventWithSignals.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        TestWorkItemHandler handler = new TestWorkItemHandler();
+        kruntime = createKogitoProcessRuntime("BPMN2-BoundaryEventWithSignals.bpmn2");        TestWorkItemHandler handler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", handler);
         KogitoProcessInstance processInstance = kruntime.startProcess("boundaryeventtest");
         assertProcessInstanceActive(processInstance);
-        ksession = restoreSession(ksession, true);
+        
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", handler);
         // now signal process instance
         kruntime.signalEvent("moveon", "", processInstance.getStringId());
@@ -2026,30 +1823,28 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         // signal boundary event on user task
         kruntime.signalEvent("moveon", "", processInstance.getStringId());
 
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
     }
 
     @Test
     @Disabled("Transfomer has been disabled")
     public void testSignalIntermediateThrowEventWithTransformation() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper(
+        kruntime = createKogitoProcessRuntime(
                 "BPMN2-BoundarySignalEventOnTaskbpmn2.bpmn",
                 "BPMN2-IntermediateThrowEventSignalWithTransformation.bpmn2");
-        StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
 
         TestWorkItemHandler handler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 handler);
 
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", "john");
         KogitoProcessInstance processInstance = kruntime.startProcess("BoundarySignalOnTask");
 
         KogitoProcessInstance processInstance2 = kruntime.startProcess("SignalIntermediateEvent", params);
-        assertProcessInstanceFinished(processInstance2, ksession);
+        assertProcessInstanceFinished(processInstance2, kruntime);
 
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
         String var = getProcessVarValue(processInstance, "x");
         assertThat(var).isEqualTo("JOHN");
@@ -2058,24 +1853,22 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     @Test
     @Disabled("Transfomer has been disabled")
     public void testSignalBoundaryEventWithTransformation() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper(
+        kruntime = createKogitoProcessRuntime(
                 "BPMN2-BoundarySignalEventOnTaskWithTransformation.bpmn",
                 "BPMN2-IntermediateThrowEventSignal.bpmn2");
-        StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
 
         TestWorkItemHandler handler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 handler);
 
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", "john");
         KogitoProcessInstance processInstance = kruntime.startProcess("BoundarySignalOnTask");
 
         KogitoProcessInstance processInstance2 = kruntime.startProcess("SignalIntermediateEvent", params);
-        assertProcessInstanceFinished(processInstance2, ksession);
+        assertProcessInstanceFinished(processInstance2, kruntime);
 
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
         String var = getProcessVarValue(processInstance, "x");
         assertThat(var).isEqualTo("JOHN");
@@ -2084,10 +1877,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     @Test
     @Disabled("Transfomer has been disabled")
     public void testMessageIntermediateThrowWithTransformation() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-IntermediateThrowEventMessageWithTransformation.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        final StringBuffer messageContent = new StringBuffer();
+        kruntime = createKogitoProcessRuntime("BPMN2-IntermediateThrowEventMessageWithTransformation.bpmn2");        final StringBuffer messageContent = new StringBuffer();
         kruntime.getWorkItemManager().registerWorkItemHandler("Send Task",
                 new SendTaskHandler(){
 
@@ -2099,7 +1889,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
 					}
 
         });
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", "MyValue");
         KogitoProcessInstance processInstance = kruntime.startProcess(
                 "MessageIntermediateEvent", params);
@@ -2112,17 +1902,14 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     @Test
     @Disabled("Transfomer has been disabled")
     public void testIntermediateCatchEventSignalWithTransformation() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-IntermediateCatchEventSignalWithTransformation.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
+        kruntime = createKogitoProcessRuntime("BPMN2-IntermediateCatchEventSignalWithTransformation.bpmn2");        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 new SystemOutWorkItemHandler());
         KogitoProcessInstance processInstance = kruntime.startProcess("IntermediateCatchEvent");
         assertProcessInstanceActive(processInstance);
-        ksession = restoreSession(ksession, true);
+        
         // now signal process instance
         kruntime.signalEvent("MyMessage", "SomeValue", processInstance.getStringId());
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
         assertNodeTriggered(processInstance.getStringId(), "StartProcess", "UserTask", "EndProcess", "event");
         String var = getProcessVarValue(processInstance, "x");
         assertThat(var).isNotNull();
@@ -2132,17 +1919,14 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     @Test
     @Disabled("Transfomer has been disabled")
     public void testIntermediateCatchEventMessageWithTransformation() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-IntermediateCatchEventMessageWithTransformation.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
+        kruntime = createKogitoProcessRuntime("BPMN2-IntermediateCatchEventMessageWithTransformation.bpmn2");        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 new SystemOutWorkItemHandler());
         KogitoProcessInstance processInstance = kruntime.startProcess("IntermediateCatchEvent");
         assertProcessInstanceActive(processInstance);
-        ksession = restoreSession(ksession, true);
+        
         // now signal process instance
         kruntime.signalEvent("Message-HelloMessage", "SomeValue", processInstance.getStringId());
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
         String var = getProcessVarValue(processInstance, "x");
         assertThat(var).isNotNull();
         assertThat(var).isEqualTo("SOMEVALUE");
@@ -2151,20 +1935,17 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     @Test
     @Disabled("Transfomer has been disabled")
     public void testEventSubprocessSignalWithTransformation() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-EventSubprocessSignalWithTransformation.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-
+        kruntime = createKogitoProcessRuntime("BPMN2-EventSubprocessSignalWithTransformation.bpmn2");
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                 workItemHandler);
         KogitoProcessInstance processInstance = kruntime.startProcess("BPMN2-EventSubprocessSignal");
         assertProcessInstanceActive(processInstance);
-        ksession = restoreSession(ksession, true);
+        
 
         kruntime.signalEvent("MySignal", "john", processInstance.getStringId());
 
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
         assertNodeTriggered(processInstance.getStringId(), "start", "User Task 1",
                 "Sub Process 1", "start-sub", "end-sub");
 
@@ -2176,32 +1957,26 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testMultipleMessageSignalSubprocess() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-MultipleMessageSignalSubprocess.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-
+        kruntime = createKogitoProcessRuntime("BPMN2-MultipleMessageSignalSubprocess.bpmn2");
         KogitoProcessInstance processInstance = kruntime.startProcess("com.sample.bpmn.Multiple_MessageSignal_Subprocess");
 		logger.debug("Parent Process ID: " + processInstance.getStringId());
 
 		kruntime.signalEvent("Message-Message 1","Test",processInstance.getStringId());
-		assertProcessInstanceActive(processInstance.getStringId(), ksession);
+		assertProcessInstanceActive(processInstance.getStringId(), kruntime);
 
 		kruntime.signalEvent("Message-Message 1","Test",processInstance.getStringId());
-		assertProcessInstanceCompleted(processInstance.getStringId(), ksession);
+		assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
     }
 
     @Test
     public void testIntermediateCatchEventSignalWithRef() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-IntermediateCatchEventSignalWithRef.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", new SystemOutWorkItemHandler());
+        kruntime = createKogitoProcessRuntime("BPMN2-IntermediateCatchEventSignalWithRef.bpmn2");        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", new SystemOutWorkItemHandler());
         KogitoProcessInstance processInstance = kruntime.startProcess("IntermediateCatchEvent");
         assertProcessInstanceActive(processInstance);
-        ksession = restoreSession(ksession, true);
+        
         // now signal process instance
         kruntime.signalEvent("Signal1", "SomeValue", processInstance.getStringId());
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
         assertNodeTriggered(processInstance.getStringId(), "StartProcess", "UserTask", "EndProcess", "event");
 
     }
@@ -2210,11 +1985,8 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     @Timeout(10)
     public void testTimerMultipleInstances() throws Exception {
         NodeLeftCountDownProcessEventListener countDownListener = new NodeLeftCountDownProcessEventListener("timer", 3);
-        KieBase kbase = createKnowledgeBase("BPMN2-MultiInstanceLoopBoundaryTimer.bpmn2");
-
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        ksession.addEventListener(countDownListener);
+        kruntime = createKogitoProcessRuntime("BPMN2-MultiInstanceLoopBoundaryTimer.bpmn2");
+        kruntime.getProcessEventManager().addEventListener(countDownListener);
         TestWorkItemHandler handler = new TestWorkItemHandler();
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", handler);
@@ -2231,7 +2003,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
             kruntime.getWorkItemManager().completeWorkItem(wi.getStringId(), null);
         }
 
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
     }
 
    
@@ -2242,13 +2014,10 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         NodeLeftCountDownProcessEventListener countDownListener = new NodeLeftCountDownProcessEventListener("Timer1", 1);
         NodeLeftCountDownProcessEventListener countDownListener2 = new NodeLeftCountDownProcessEventListener("Timer2", 1);
         NodeLeftCountDownProcessEventListener countDownListener3 = new NodeLeftCountDownProcessEventListener("Timer3", 1);
-        KieBase kbase = createKnowledgeBase("timer/BPMN2-IntermediateTimerParallelGateway.bpmn2");
-
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        ksession.addEventListener(countDownListener);
-        ksession.addEventListener(countDownListener2);
-        ksession.addEventListener(countDownListener3);
+        kruntime = createKogitoProcessRuntime("timer/BPMN2-IntermediateTimerParallelGateway.bpmn2");
+        kruntime.getProcessEventManager().addEventListener(countDownListener);
+        kruntime.getProcessEventManager().addEventListener(countDownListener2);
+        kruntime.getProcessEventManager().addEventListener(countDownListener3);
         TestWorkItemHandler handler = new TestWorkItemHandler();
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", handler);
@@ -2258,7 +2027,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         countDownListener.waitTillCompleted();
         countDownListener2.waitTillCompleted();
         countDownListener3.waitTillCompleted();
-        assertProcessInstanceCompleted(processInstance.getStringId(), ksession);
+        assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
 
     }
 
@@ -2266,11 +2035,8 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     @Timeout(10)
     public void testIntermediateTimerEventMI() throws Exception {
         NodeLeftCountDownProcessEventListener countDownListener = new NodeLeftCountDownProcessEventListener("After timer", 3);
-        KieBase kbase = createKnowledgeBase("timer/BPMN2-IntermediateTimerEventMI.bpmn2");
-
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        ksession.addEventListener(countDownListener);
+        kruntime = createKogitoProcessRuntime("timer/BPMN2-IntermediateTimerEventMI.bpmn2");
+        kruntime.getProcessEventManager().addEventListener(countDownListener);
         TestWorkItemHandler handler = new TestWorkItemHandler();
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", handler);
@@ -2278,23 +2044,20 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         assertProcessInstanceActive(processInstance);
 
         countDownListener.waitTillCompleted();
-        assertProcessInstanceActive(processInstance.getStringId(), ksession);
+        assertProcessInstanceActive(processInstance.getStringId(), kruntime);
 
         kruntime.abortProcessInstance(processInstance.getStringId());
 
-        assertProcessInstanceAborted(processInstance.getStringId(), ksession);
+        assertProcessInstanceAborted(processInstance.getStringId(), kruntime);
     }
 
     @Test
     public void testThrowIntermediateSignalWithScope() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2IntermediateThrowEventScope.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-
+        kruntime = createKogitoProcessRuntime("BPMN2IntermediateThrowEventScope.bpmn2");
         TestWorkItemHandler handler = new TestWorkItemHandler();
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", handler);
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
 
         KogitoProcessInstance processInstance = kruntime.startProcess("intermediate-event-scope", params);
         KogitoProcessInstance processInstance2 = kruntime.startProcess("intermediate-event-scope", params);
@@ -2302,21 +2065,21 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         assertProcessInstanceActive(processInstance);
         assertProcessInstanceActive(processInstance2);
 
-        assertNodeActive(processInstance.getStringId(), ksession, "Complete work", "Wait");
-        assertNodeActive(processInstance2.getStringId(), ksession, "Complete work", "Wait");
+        assertNodeActive(processInstance.getStringId(), kruntime, "Complete work", "Wait");
+        assertNodeActive(processInstance2.getStringId(), kruntime, "Complete work", "Wait");
 
         List<KogitoWorkItem> items = handler.getWorkItems();
 
         KogitoWorkItem wi = items.get(0);
 
-        Map<String, Object> result = new HashMap<String, Object>();
+        Map<String, Object> result = new HashMap<>();
         result.put("_output", "sending event");
 
         kruntime.getWorkItemManager().completeWorkItem(wi.getStringId(), result);
 
         assertProcessInstanceCompleted(processInstance);
         assertProcessInstanceActive(processInstance2);
-        assertNodeActive(processInstance2.getStringId(), ksession, "Complete work", "Wait");
+        assertNodeActive(processInstance2.getStringId(), kruntime, "Complete work", "Wait");
 
         wi = items.get(1);
         kruntime.getWorkItemManager().completeWorkItem(wi.getStringId(), result);
@@ -2326,14 +2089,11 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testThrowEndSignalWithScope() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2EndThrowEventScope.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-
+        kruntime = createKogitoProcessRuntime("BPMN2EndThrowEventScope.bpmn2");
         TestWorkItemHandler handler = new TestWorkItemHandler();
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", handler);
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
 
         KogitoProcessInstance processInstance = kruntime.startProcess("end-event-scope", params);
         KogitoProcessInstance processInstance2 = kruntime.startProcess("end-event-scope", params);
@@ -2341,21 +2101,21 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         assertProcessInstanceActive(processInstance);
         assertProcessInstanceActive(processInstance2);
 
-        assertNodeActive(processInstance.getStringId(), ksession, "Complete work", "Wait");
-        assertNodeActive(processInstance2.getStringId(), ksession, "Complete work", "Wait");
+        assertNodeActive(processInstance.getStringId(), kruntime, "Complete work", "Wait");
+        assertNodeActive(processInstance2.getStringId(), kruntime, "Complete work", "Wait");
 
         List<KogitoWorkItem> items = handler.getWorkItems();
 
         KogitoWorkItem wi = items.get(0);
 
-        Map<String, Object> result = new HashMap<String, Object>();
+        Map<String, Object> result = new HashMap<>();
         result.put("_output", "sending event");
 
         kruntime.getWorkItemManager().completeWorkItem(wi.getStringId(), result);
 
         assertProcessInstanceCompleted(processInstance);
         assertProcessInstanceActive(processInstance2);
-        assertNodeActive(processInstance2.getStringId(), ksession, "Complete work", "Wait");
+        assertNodeActive(processInstance2.getStringId(), kruntime, "Complete work", "Wait");
 
         wi = items.get(1);
         kruntime.getWorkItemManager().completeWorkItem(wi.getStringId(), result);
@@ -2367,12 +2127,9 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testThrowIntermediateSignalWithExternalScope() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-IntermediateThrowEventExternalScope.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-
+        kruntime = createKogitoProcessRuntime("BPMN2-IntermediateThrowEventExternalScope.bpmn2");
         TestWorkItemHandler handler = new TestWorkItemHandler();
-        WorkItemHandler externalHandler = new KogitoWorkItemHandler() {
+        KogitoWorkItemHandler externalHandler = new KogitoWorkItemHandler() {
 
             @Override
             public void executeWorkItem(KogitoWorkItem workItem, KogitoWorkItemManager manager) {
@@ -2390,19 +2147,19 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", handler);
         kruntime.getWorkItemManager().registerWorkItemHandler("External Send Task", externalHandler);
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
 
         KogitoProcessInstance processInstance = kruntime.startProcess("intermediate-event-scope", params);
 
         assertProcessInstanceActive(processInstance);
 
-        assertNodeActive(processInstance.getStringId(), ksession, "Complete work", "Wait");
+        assertNodeActive(processInstance.getStringId(), kruntime, "Complete work", "Wait");
 
         List<KogitoWorkItem> items = handler.getWorkItems();
         assertThat(items.size()).isEqualTo(1);
         KogitoWorkItem wi = items.get(0);
 
-        Map<String, Object> result = new HashMap<String, Object>();
+        Map<String, Object> result = new HashMap<>();
         result.put("_output", "sending event");
 
         kruntime.getWorkItemManager().completeWorkItem(wi.getStringId(), result);
@@ -2413,58 +2170,46 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testIntermediateCatchEventSignalWithVariable() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-IntermediateCatchEventSignalWithVariable.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", new SystemOutWorkItemHandler());
+        kruntime = createKogitoProcessRuntime("BPMN2-IntermediateCatchEventSignalWithVariable.bpmn2");        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", new SystemOutWorkItemHandler());
 
         String signalVar = "myVarSignal";
-        Map<String, Object> parameters = new HashMap<String, Object>();
+        Map<String, Object> parameters = new HashMap<>();
         parameters.put("signalName", signalVar);
         KogitoProcessInstance processInstance = kruntime.startProcess("IntermediateCatchEvent", parameters);
         assertProcessInstanceActive(processInstance);
 
-        ksession = restoreSession(ksession, true);
-        kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-
         // now signal process instance
         kruntime.signalEvent(signalVar, "SomeValue", processInstance.getStringId());
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
         assertNodeTriggered(processInstance.getStringId(), "StartProcess", "UserTask", "EndProcess", "event");
 
     }
 
     @Test
     public void testSignalIntermediateThrowWithVariable() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-IntermediateThrowEventSignalWithVariable.bpmn2", "BPMN2-IntermediateCatchEventSignalWithVariable.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", new SystemOutWorkItemHandler());
+        kruntime = createKogitoProcessRuntime("BPMN2-IntermediateThrowEventSignalWithVariable.bpmn2", "BPMN2-IntermediateCatchEventSignalWithVariable.bpmn2");        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", new SystemOutWorkItemHandler());
         // create catch process instance
         String signalVar = "myVarSignal";
-        Map<String, Object> parameters = new HashMap<String, Object>();
+        Map<String, Object> parameters = new HashMap<>();
         parameters.put("signalName", signalVar);
         KogitoProcessInstance processInstance = kruntime.startProcess("IntermediateCatchEvent", parameters);
         assertProcessInstanceActive(processInstance);
 
-        ksession = restoreSession(ksession, true);
-        kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", "MyValue");
         params.put("signalName", signalVar);
         KogitoProcessInstance processInstanceThrow = kruntime.startProcess("SignalIntermediateEvent", params);
         assertThat(processInstanceThrow.getState()).isEqualTo(KogitoProcessInstance.STATE_COMPLETED);
 
         // catch process instance should now be completed
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
     }
 
     @Test
     public void testInvalidDateTimerBoundary() throws Exception {
         try {
-            createKnowledgeBase("timer/BPMN2-TimerBoundaryEventDateInvalid.bpmn2");
+            createKogitoProcessRuntime("timer/BPMN2-TimerBoundaryEventDateInvalid.bpmn2");
             fail("Should fail as timer expression is not valid");
         } catch (RuntimeException e) {
             assertThat(e.getMessage().contains("Could not parse date 'abcdef'")).isTrue();
@@ -2474,7 +2219,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     @Test
     public void testInvalidDurationTimerBoundary() throws Exception {
         try {
-            createKnowledgeBase("timer/BPMN2-TimerBoundaryEventDurationInvalid.bpmn2");
+            createKogitoProcessRuntime("timer/BPMN2-TimerBoundaryEventDurationInvalid.bpmn2");
             fail("Should fail as timer expression is not valid");
         } catch (Exception e) {
             assertThat(e.getMessage().contains("Could not parse delay 'abcdef'")).isTrue();
@@ -2484,7 +2229,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     @Test
     public void testInvalidCycleTimerBoundary() throws Exception {
         try {
-            createKnowledgeBase("timer/BPMN2-TimerBoundaryEventCycleInvalid.bpmn2");
+            createKogitoProcessRuntime("timer/BPMN2-TimerBoundaryEventCycleInvalid.bpmn2");
             fail("Should fail as timer expression is not valid");
         } catch (Exception e) {
             assertThat(e.getMessage().contains("Could not parse delay 'abcdef'")).isTrue();
@@ -2493,24 +2238,17 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testIntermediateCatchEventConditionSetVariableAfter() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-IntermediateCatchEventConditionSetVariableAfter.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        ksession.addEventListener(new RuleAwareProcessEventListener());
+        kruntime = createKogitoProcessRuntime("BPMN2-IntermediateCatchEventConditionSetVariableAfter.bpmn2");        kruntime.getProcessEventManager().addEventListener(new RuleAwareProcessEventListener());
         KogitoProcessInstance processInstance = kruntime.startProcess("IntermediateCatchEvent");
         assertProcessInstanceActive(processInstance);
-        ksession = restoreSession(ksession, true);
-        ksession.addEventListener(new RuleAwareProcessEventListener());
+        
+        kruntime.getProcessEventManager().addEventListener(new RuleAwareProcessEventListener());
 
-        Collection<? extends Object> processInstances = ksession.getObjects(new ObjectFilter() {
-
-            @Override
-            public boolean accept(Object object) {
-                if (object instanceof KogitoProcessInstance) {
-                    return true;
-                }
-                return false;
+        Collection<? extends Object> processInstances = kruntime.getKieSession().getObjects(object -> {
+            if (object instanceof KogitoProcessInstance) {
+                return true;
             }
+            return false;
         });
         assertThat(processInstances).isNotNull();
         assertThat(processInstances.size()).isEqualTo(1);
@@ -2518,18 +2256,14 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         // now activate condition
         Person person = new Person();
         person.setName("Jack");
-        ksession.insert(person);
-        assertProcessInstanceFinished(processInstance, ksession);
+        kruntime.getKieSession().insert(person);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
-        processInstances = ksession.getObjects(new ObjectFilter() {
-
-            @Override
-            public boolean accept(Object object) {
-                if (object instanceof KogitoProcessInstance) {
-                    return true;
-                }
-                return false;
+        processInstances = kruntime.getKieSession().getObjects(object -> {
+            if (object instanceof KogitoProcessInstance) {
+                return true;
             }
+            return false;
         });
         assertThat(processInstances).isNotNull();
         assertThat(processInstances.size()).isEqualTo(0);
@@ -2537,24 +2271,17 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testIntermediateCatchEventConditionRemovePIAfter() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-IntermediateCatchEventCondition.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        ksession.addEventListener(new RuleAwareProcessEventListener());
+        kruntime = createKogitoProcessRuntime("BPMN2-IntermediateCatchEventCondition.bpmn2");        kruntime.getProcessEventManager().addEventListener(new RuleAwareProcessEventListener());
         KogitoProcessInstance processInstance = kruntime.startProcess("IntermediateCatchEvent");
         assertProcessInstanceActive(processInstance);
-        ksession = restoreSession(ksession, true);
-        ksession.addEventListener(new RuleAwareProcessEventListener());
+        
+        kruntime.getProcessEventManager().addEventListener(new RuleAwareProcessEventListener());
 
-        Collection<? extends Object> processInstances = ksession.getObjects(new ObjectFilter() {
-
-            @Override
-            public boolean accept(Object object) {
-                if (object instanceof KogitoProcessInstance) {
-                    return true;
-                }
-                return false;
+        Collection<? extends Object> processInstances = kruntime.getKieSession().getObjects(object -> {
+            if (object instanceof KogitoProcessInstance) {
+                return true;
             }
+            return false;
         });
         assertThat(processInstances).isNotNull();
         assertThat(processInstances.size()).isEqualTo(1);
@@ -2562,18 +2289,14 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         // now activate condition
         Person person = new Person();
         person.setName("Jack");
-        ksession.insert(person);
-        assertProcessInstanceFinished(processInstance, ksession);
+        kruntime.getKieSession().insert(person);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
-        processInstances = ksession.getObjects(new ObjectFilter() {
-
-            @Override
-            public boolean accept(Object object) {
-                if (object instanceof KogitoProcessInstance) {
-                    return true;
-                }
-                return false;
+        processInstances = kruntime.getKieSession().getObjects(object -> {
+            if (object instanceof KogitoProcessInstance) {
+                return true;
             }
+            return false;
         });
         assertThat(processInstances).isNotNull();
         assertThat(processInstances.size()).isEqualTo(0);
@@ -2590,19 +2313,19 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
             NodeLeftCountDownProcessEventListener countDownListener2 = new NodeLeftCountDownProcessEventListener("Request an online review", 1);
             NodeLeftCountDownProcessEventListener countDownListener3 = new NodeLeftCountDownProcessEventListener("Send a thank you card", 1);
             NodeLeftCountDownProcessEventListener countDownListener4 = new NodeLeftCountDownProcessEventListener("Request an online review", 1);
-            KieBase kbase = createKnowledgeBase("timer/BPMN2-CronTimerWithEventBasedGateway.bpmn2");
-            ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+            kruntime = createKogitoProcessRuntime("timer/BPMN2-CronTimerWithEventBasedGateway.bpmn2");
+                    
+        
             
             TestWorkItemHandler handler = new TestWorkItemHandler();
             kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", handler);       
-            ksession.addEventListener(countDownListener);
-            ksession.addEventListener(countDownListener2);
-            ksession.addEventListener(countDownListener3);
-            ksession.addEventListener(countDownListener4);
+            kruntime.getProcessEventManager().addEventListener(countDownListener);
+            kruntime.getProcessEventManager().addEventListener(countDownListener2);
+            kruntime.getProcessEventManager().addEventListener(countDownListener3);
+            kruntime.getProcessEventManager().addEventListener(countDownListener4);
             
             KogitoProcessInstance processInstance = kruntime.startProcess("timerWithEventBasedGateway");
-            assertProcessInstanceActive(processInstance.getStringId(), ksession);
+            assertProcessInstanceActive(processInstance.getStringId(), kruntime);
             
             countDownListener.waitTillCompleted();
             logger.debug("First timer triggered");
@@ -2626,76 +2349,61 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     
     @Test
     public void testEventSubprocessWithEmbeddedSignals() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-EventSubprocessErrorSignalEmbedded.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-               
+        kruntime = createKogitoProcessRuntime("BPMN2-EventSubprocessErrorSignalEmbedded.bpmn2");               
         KogitoProcessInstance processInstance = kruntime.startProcess("project2.myerrorprocess");
         
-        assertProcessInstanceActive(processInstance.getStringId(), ksession);
-        assertProcessInstanceActive(processInstance);
-        ksession = restoreSession(ksession, true);
-        
-        kruntime.signalEvent("signal1", null, processInstance.getStringId());        
-        assertProcessInstanceActive(processInstance.getStringId(), ksession);
+        assertProcessInstanceActive(processInstance.getStringId(), kruntime);
+        assertProcessInstanceActive(processInstance);kruntime.signalEvent("signal1", null, processInstance.getStringId());        
+        assertProcessInstanceActive(processInstance.getStringId(), kruntime);
   
         kruntime.signalEvent("signal2", null, processInstance.getStringId());
-        assertProcessInstanceActive(processInstance.getStringId(), ksession);
+        assertProcessInstanceActive(processInstance.getStringId(), kruntime);
         
         kruntime.signalEvent("signal3", null, processInstance.getStringId());
 
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
     }
     
     @Test
     public void testEventSubprocessWithExpression() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-EventSubprocessSignalExpression.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        TestWorkItemHandler handler = new TestWorkItemHandler();
+        kruntime = createKogitoProcessRuntime("BPMN2-EventSubprocessSignalExpression.bpmn2");        TestWorkItemHandler handler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", handler);
                
         Map<String, Object> params = new HashMap<>();
         params.put("x", "signalling");
         KogitoProcessInstance processInstance = kruntime.startProcess("BPMN2-EventSubprocessSignalExpression", params);
         
-        assertProcessInstanceActive(processInstance.getStringId(), ksession);
-        assertProcessInstanceActive(processInstance);
-        ksession = restoreSession(ksession, true);
-        
-        kruntime.signalEvent("signalling", null, processInstance.getStringId());        
+        assertProcessInstanceActive(processInstance.getStringId(), kruntime);
+        assertProcessInstanceActive(processInstance);kruntime.signalEvent("signalling", null, processInstance.getStringId());        
   
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
     }
     
     @Test
     public void testConditionalProcessFactInsertedBefore() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-IntermediateCatchEventConditionPI.bpmn2", "BPMN2-IntermediateCatchEventSignal.bpmn2");        
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        TestWorkItemHandler handler = new TestWorkItemHandler();
+        kruntime = createKogitoProcessRuntime("BPMN2-IntermediateCatchEventConditionPI.bpmn2", "BPMN2-IntermediateCatchEventSignal.bpmn2");        TestWorkItemHandler handler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", handler);
         
         Person person0 = new Person("john");
-        ksession.insert(person0);
+        kruntime.getKieSession().insert(person0);
         
-        Map<String, Object> params0 = new HashMap<String, Object>();
+        Map<String, Object> params0 = new HashMap<>();
         params0.put("name", "john");
         KogitoProcessInstance pi0 = kruntime.startProcess("IntermediateCatchEvent", params0);
-        ksession.insert(pi0);
+        kruntime.getKieSession().insert(pi0);
 
         Person person = new Person("Jack");
-        ksession.insert(person);
+        kruntime.getKieSession().insert(person);
 
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("name", "Poul");
         KogitoProcessInstance pi = kruntime.startProcess("IntermediateCatchEventPI", params);
-        ksession.insert(pi);
+        kruntime.getKieSession().insert(pi);
         pi = kruntime.getProcessInstance(pi.getStringId());
         assertThat(pi).isNotNull();
         
         Person person2 = new Person("Poul");
-        ksession.insert(person2);
+        kruntime.getKieSession().insert(person2);
         
         pi = kruntime.getProcessInstance(pi.getStringId());
         assertThat(pi).isNull();
@@ -2704,10 +2412,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testBoundarySignalEventOnSubprocessWithVariableResolution() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-SubprocessWithSignalEndEventAndSignalBoundaryEvent.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        ksession.addEventListener(LOGGING_EVENT_LISTENER);
+        kruntime = createKogitoProcessRuntime("BPMN2-SubprocessWithSignalEndEventAndSignalBoundaryEvent.bpmn2");        kruntime.getProcessEventManager().addEventListener(LOGGING_EVENT_LISTENER);
 
         Map<String, Object> params = new HashMap<>();
         params.put("document-ref", "signalling");
@@ -2717,18 +2422,16 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         assertNodeTriggered(processInstance.getStringId(), "sysout from boundary", "end2");
         assertNotNodeTriggered(processInstance.getStringId(),"end1");
 
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
     }
     
     @Test
     public void testSignalEndWithData() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-IntermediateThrowEventSignalWithData.bpmn2");
-        StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-IntermediateThrowEventSignalWithData.bpmn2");
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                                                               new SystemOutWorkItemHandler());
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         KogitoProcessInstance processInstance = kruntime.startProcess("testThrowingSignalEvent", params);
 
         assertProcessInstanceActive(processInstance);
@@ -2741,15 +2444,12 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     
     @Test
     public void testDynamicCatchEventSignal() throws Exception {
-        KieBase kbase = createKnowledgeBase("subprocess/dynamic-signal-parent.bpmn2", "subprocess/dynamic-signal-child.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        TestWorkItemHandler handler = new TestWorkItemHandler();
+        kruntime = createKogitoProcessRuntime("subprocess/dynamic-signal-parent.bpmn2", "subprocess/dynamic-signal-child.bpmn2");        TestWorkItemHandler handler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", handler);
         
         final List<String> instances = new ArrayList<>();
         
-        ksession.addEventListener(new DefaultProcessEventListener() {
+        kruntime.getProcessEventManager().addEventListener(new DefaultKogitoProcessEventListener() {
 
             @Override
             public void beforeProcessStarted(ProcessStartedEvent event) {
@@ -2759,10 +2459,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         });
         
         KogitoProcessInstance processInstance = kruntime.startProcess("src.father");
-        assertProcessInstanceActive(processInstance);
-        ksession = restoreSession(ksession, true);
-        
-        assertThat(instances).hasSize(4);
+        assertProcessInstanceActive(processInstance);assertThat(instances).hasSize(4);
         
         // remove the parent process instance
         instances.remove(processInstance.getStringId());
@@ -2778,7 +2475,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         
         kruntime.getWorkItemManager().completeWorkItem(workItem.getStringId(), null);
         
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
         
         for (String id : instances) {
             assertNull(kruntime.getProcessInstance(id), "Child process instance has not been finished.");
@@ -2787,15 +2484,12 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testDynamicCatchEventSignalWithVariableUpdated() throws Exception {        
-        KieBase kbase = createKnowledgeBase("subprocess/dynamic-signal-parent.bpmn2", "subprocess/dynamic-signal-child.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        TestWorkItemHandler handler = new TestWorkItemHandler();
+        kruntime = createKogitoProcessRuntime("subprocess/dynamic-signal-parent.bpmn2", "subprocess/dynamic-signal-child.bpmn2");        TestWorkItemHandler handler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", handler);
         
         final List<String> instances = new ArrayList<>();
         
-        ksession.addEventListener(new DefaultProcessEventListener() {
+        kruntime.getProcessEventManager().addEventListener(new DefaultKogitoProcessEventListener() {
 
             @Override
             public void beforeProcessStarted(ProcessStartedEvent event) {
@@ -2805,10 +2499,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         });
         
         KogitoProcessInstance processInstance = kruntime.startProcess("src.father");
-        assertProcessInstanceActive(processInstance);
-        ksession = restoreSession(ksession, true);
-        
-        assertThat(instances).hasSize(4);
+        assertProcessInstanceActive(processInstance);assertThat(instances).hasSize(4);
         
         // remove the parent process instance
         instances.remove(processInstance.getStringId());
@@ -2822,7 +2513,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         String changeProcessInstanceId = instances.remove(0);
         Map<String, Object> updatedVariables = new HashMap<>();
         updatedVariables.put("fatherId", "999");
-        ksession.execute(new KogitoSetProcessInstanceVariablesCommand(changeProcessInstanceId, updatedVariables));
+        kruntime.getKieSession().execute(new KogitoSetProcessInstanceVariablesCommand(changeProcessInstanceId, updatedVariables));
         
         // now complete user task to signal all child instances to stop
         KogitoWorkItem workItem = handler.getWorkItem();
@@ -2830,7 +2521,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         
         kruntime.getWorkItemManager().completeWorkItem(workItem.getStringId(), null);
         
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
         
         for (String id : instances) {
             assertNull(kruntime.getProcessInstance(id), "Child process instance has not been finished.");
@@ -2840,21 +2531,18 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         assertProcessInstanceActive(updatedChild);
         
         kruntime.signalEvent("stopChild:999", null, changeProcessInstanceId);
-        assertProcessInstanceFinished(updatedChild, ksession);
+        assertProcessInstanceFinished(updatedChild, kruntime);
     }
     
     @RequirePersistence
     @Test
     public void testDynamicCatchEventSignalWithVariableUpdatedBroadcastSignal() throws Exception {        
-        KieBase kbase = createKnowledgeBase("subprocess/dynamic-signal-parent.bpmn2", "subprocess/dynamic-signal-child.bpmn2");
-        ksession = createKnowledgeSession(kbase);        
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        TestWorkItemHandler handler = new TestWorkItemHandler();
+        kruntime = createKogitoProcessRuntime("subprocess/dynamic-signal-parent.bpmn2", "subprocess/dynamic-signal-child.bpmn2");        TestWorkItemHandler handler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", handler);
         
         final List<String> instances = new ArrayList<>();
         
-        ksession.addEventListener(new DefaultProcessEventListener() {
+        kruntime.getProcessEventManager().addEventListener(new DefaultKogitoProcessEventListener() {
 
             @Override
             public void beforeProcessStarted(ProcessStartedEvent event) {
@@ -2864,10 +2552,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         });
         
         KogitoProcessInstance processInstance = kruntime.startProcess("src.father");
-        assertProcessInstanceActive(processInstance);
-        ksession = restoreSession(ksession, true);
-        
-        assertThat(instances).hasSize(4);
+        assertProcessInstanceActive(processInstance);assertThat(instances).hasSize(4);
         
         // remove the parent process instance
         instances.remove(processInstance.getStringId());
@@ -2881,7 +2566,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         String changeProcessInstanceId = instances.remove(0);
         Map<String, Object> updatedVariables = new HashMap<>();
         updatedVariables.put("fatherId", "999");
-        ksession.execute(new KogitoSetProcessInstanceVariablesCommand(changeProcessInstanceId, updatedVariables));
+        kruntime.getKieSession().execute(new KogitoSetProcessInstanceVariablesCommand(changeProcessInstanceId, updatedVariables));
         
         // now complete user task to signal all child instances to stop
         KogitoWorkItem workItem = handler.getWorkItem();
@@ -2889,7 +2574,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         
         kruntime.getWorkItemManager().completeWorkItem(workItem.getStringId(), null);
         
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
         
         for (String id : instances) {
             assertNull(kruntime.getProcessInstance(id), "Child process instance has not been finished.");
@@ -2899,6 +2584,6 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         assertProcessInstanceActive(updatedChild);
         
         kruntime.signalEvent("stopChild:999", null, updatedChild.getStringId());
-        assertProcessInstanceFinished(updatedChild, ksession);
+        assertProcessInstanceFinished(updatedChild, kruntime);
     }
 }

--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/ProcessFactoryTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/ProcessFactoryTest.java
@@ -23,12 +23,9 @@ import org.jbpm.ruleflow.core.RuleFlowProcessFactory;
 import org.jbpm.test.util.NodeLeftCountDownProcessEventListener;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.kie.api.KieBase;
 import org.kie.api.io.Resource;
 import org.kie.internal.io.ResourceFactory;
-import org.kie.internal.runtime.StatefulKnowledgeSession;
 import org.kie.kogito.internal.process.runtime.KogitoProcessInstance;
-import org.kie.kogito.internal.process.runtime.KogitoProcessRuntime;
 
 import static org.jbpm.ruleflow.core.Metadata.CANCEL_ACTIVITY;
 import static org.jbpm.ruleflow.core.Metadata.EVENT_TYPE_TIMER;
@@ -65,10 +62,8 @@ public class ProcessFactoryTest extends JbpmBpmn2TestCase {
         RuleFlowProcess process = factory.validate().getProcess();
         Resource res = ResourceFactory.newByteArrayResource(XmlBPMNProcessDumper.INSTANCE.dump(process).getBytes());
         res.setSourcePath("/tmp/processFactory.bpmn2"); // source path or target path must be set to be added into kbase
-        KieBase kbase = createKnowledgeBaseFromResources(res);
-        StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
-        ksession.startProcess("org.jbpm.process");
-        ksession.dispose();
+        kruntime = createKogitoProcessRuntime(res);
+        kruntime.startProcess("org.jbpm.process");
     }
 
     @Test
@@ -112,15 +107,12 @@ public class ProcessFactoryTest extends JbpmBpmn2TestCase {
 
         Resource res = ResourceFactory.newByteArrayResource(XmlBPMNProcessDumper.INSTANCE.dump(process).getBytes());
         res.setSourcePath("/tmp/processFactory.bpmn2"); // source path or target path must be set to be added into kbase
-        KieBase kbase = createKnowledgeBaseFromResources(res);
-        StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime(res);
         KogitoProcessInstance pi = kruntime.startProcess("org.jbpm.process");
 
         assertEquals(KogitoProcessInstance.STATE_COMPLETED,
                      pi.getState());
 
-        ksession.dispose();
     }
 
     @Test
@@ -166,14 +158,12 @@ public class ProcessFactoryTest extends JbpmBpmn2TestCase {
 
         Resource res = ResourceFactory.newByteArrayResource(XmlBPMNProcessDumper.INSTANCE.dump(process).getBytes());
         res.setSourcePath("/tmp/processFactory.bpmn2"); // source path or target path must be set to be added into kbase
-        KieBase kbase = createKnowledgeBaseFromResources(res);
-        StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
+        kruntime = createKogitoProcessRuntime(res);
         TestWorkItemHandler testHandler = new TestWorkItemHandler();
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                                                               testHandler);
-        ksession.addEventListener(countDownListener);
+        kruntime.getProcessEventManager().addEventListener(countDownListener);
 
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
         KogitoProcessInstance pi = kruntime.startProcess("org.jbpm.process");
         assertProcessInstanceActive(pi);
 
@@ -187,7 +177,6 @@ public class ProcessFactoryTest extends JbpmBpmn2TestCase {
                                                        null);
         assertProcessInstanceCompleted(pi);
 
-        ksession.dispose();
     }
 
     @Test
@@ -233,14 +222,12 @@ public class ProcessFactoryTest extends JbpmBpmn2TestCase {
 
         Resource res = ResourceFactory.newByteArrayResource(XmlBPMNProcessDumper.INSTANCE.dump(process).getBytes());
         res.setSourcePath("/tmp/processFactory.bpmn2"); // source path or target path must be set to be added into kbase
-        KieBase kbase = createKnowledgeBaseFromResources(res);
-        StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
+        kruntime = createKogitoProcessRuntime(res);
         TestWorkItemHandler testHandler = new TestWorkItemHandler();
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
                                                               testHandler);
-        ksession.addEventListener(countDownListener);
+        kruntime.getProcessEventManager().addEventListener(countDownListener);
 
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
         KogitoProcessInstance pi = kruntime.startProcess("org.jbpm.process");
         assertProcessInstanceActive(pi);
 
@@ -254,7 +241,6 @@ public class ProcessFactoryTest extends JbpmBpmn2TestCase {
                                                        null);
         assertProcessInstanceCompleted(pi);
 
-        ksession.dispose();
     }
 
     @Test
@@ -306,10 +292,8 @@ public class ProcessFactoryTest extends JbpmBpmn2TestCase {
 
         Resource res = ResourceFactory.newByteArrayResource(XmlBPMNProcessDumper.INSTANCE.dump(process).getBytes());
         res.setSourcePath("/tmp/processFactory.bpmn2"); // source path or target path must be set to be added into kbase
-        KieBase kbase = createKnowledgeBaseFromResources(res);
-        StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
+        kruntime = createKogitoProcessRuntime(res);
 
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
         KogitoProcessInstance pi = kruntime.startProcess("org.jbpm.process");
 
         assertNotNull(pi);
@@ -323,7 +307,6 @@ public class ProcessFactoryTest extends JbpmBpmn2TestCase {
         assertEquals(KogitoProcessInstance.STATE_COMPLETED,
                      pi.getState());
 
-        ksession.dispose();
     }
 
     @Test
@@ -353,10 +336,8 @@ public class ProcessFactoryTest extends JbpmBpmn2TestCase {
 
         Resource res = ResourceFactory.newByteArrayResource(XmlBPMNProcessDumper.INSTANCE.dump(process).getBytes());
         res.setSourcePath("/tmp/processFactory.bpmn2");
-        KieBase kbase = createKnowledgeBaseFromResources(res);
-        StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
+        kruntime = createKogitoProcessRuntime(res);
 
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
         KogitoProcessInstance pi = kruntime.startProcess("org.jbpm.process");
 
         assertNotNull(pi);
@@ -364,6 +345,5 @@ public class ProcessFactoryTest extends JbpmBpmn2TestCase {
         assertEquals(KogitoProcessInstance.STATE_COMPLETED,
                      pi.getState());
 
-        ksession.dispose();
     }
 }

--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/ResourceTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/ResourceTest.java
@@ -17,9 +17,7 @@
 package org.jbpm.bpmn2;
 
 import org.junit.jupiter.api.Test;
-import org.kie.api.KieBase;
-import org.kie.api.runtime.process.ProcessInstance;
-import org.kie.internal.runtime.StatefulKnowledgeSession;
+import org.kie.kogito.internal.process.runtime.KogitoProcessInstance;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -27,18 +25,16 @@ public class ResourceTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testResourceType() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-MinimalProcess.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        ksession.startProcess("Minimal");
+        kruntime = createKogitoProcessRuntime("BPMN2-MinimalProcess.bpmn2");
+        kruntime.startProcess("Minimal");
     }
 
     @Test
     public void testMultipleProcessInOneFile() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-MultipleProcessInOneFile.bpmn2");
-        ksession = createKnowledgeSession(kbase);
-        ProcessInstance processInstance = ksession.startProcess("Evaluation");
+        kruntime = createKogitoProcessRuntime("BPMN2-MultipleProcessInOneFile.bpmn2");
+        KogitoProcessInstance processInstance = kruntime.startProcess("Evaluation");
         assertNotNull(processInstance);
-        ProcessInstance processInstance2 = ksession.startProcess("Simple");
+        KogitoProcessInstance processInstance2 = kruntime.startProcess("Simple");
         assertNotNull(processInstance2);
     }
 

--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/SLAComplianceTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/SLAComplianceTest.java
@@ -25,17 +25,14 @@ import java.util.concurrent.TimeUnit;
 import org.jbpm.bpmn2.objects.TestWorkItemHandler;
 import org.jbpm.process.instance.impl.demo.SystemOutWorkItemHandler;
 import org.junit.jupiter.api.Test;
-import org.kie.api.KieBase;
-import org.kie.api.event.process.DefaultProcessEventListener;
-import org.kie.api.event.process.ProcessEventListener;
 import org.kie.api.event.process.SLAViolatedEvent;
-import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.process.NodeInstance;
 import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.api.runtime.process.WorkflowProcessInstance;
+import org.kie.kogito.internal.process.event.DefaultKogitoProcessEventListener;
+import org.kie.kogito.internal.process.event.KogitoProcessEventListener;
 import org.kie.kogito.internal.process.runtime.KogitoNodeInstance;
 import org.kie.kogito.internal.process.runtime.KogitoProcessInstance;
-import org.kie.kogito.internal.process.runtime.KogitoProcessRuntime;
 import org.kie.kogito.internal.process.runtime.KogitoWorkItem;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -48,7 +45,7 @@ public class SLAComplianceTest extends JbpmBpmn2TestCase {
     @Test
     public void testSLAonProcessViolated() throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
-        final ProcessEventListener listener = new DefaultProcessEventListener(){
+        final KogitoProcessEventListener listener = new DefaultKogitoProcessEventListener(){
 
             @Override
             public void afterSLAViolated(SLAViolatedEvent event) {
@@ -56,16 +53,14 @@ public class SLAComplianceTest extends JbpmBpmn2TestCase {
             }
             
         };
-        KieBase kbase = createKnowledgeBase("BPMN2-UserTaskWithSLA.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-UserTaskWithSLA.bpmn2");
 
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
-        ksession.addEventListener(listener);
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
+        kruntime.getProcessEventManager().addEventListener(listener);
         
         KogitoProcessInstance processInstance = kruntime.startProcess("UserTask");
-        assertTrue(processInstance.getState() == ProcessInstance.STATE_ACTIVE);
+        assertEquals(ProcessInstance.STATE_ACTIVE, processInstance.getState());
 
         KogitoWorkItem workItem = workItemHandler.getWorkItem();
         assertNotNull(workItem);
@@ -75,31 +70,28 @@ public class SLAComplianceTest extends JbpmBpmn2TestCase {
         assertTrue(slaViolated, "SLA was not violated while it is expected");
 
         processInstance = kruntime.getProcessInstance(processInstance.getStringId());
-        assertTrue(processInstance.getState() == ProcessInstance.STATE_ACTIVE);
+        assertEquals(ProcessInstance.STATE_ACTIVE, processInstance.getState());
 
         int slaCompliance = getSLAComplianceForProcessInstance(processInstance);
         assertEquals(ProcessInstance.SLA_VIOLATED, slaCompliance);
 
         kruntime.getWorkItemManager().completeWorkItem(workItem.getStringId(), null);
-        assertProcessInstanceFinished(processInstance, ksession);        
+        assertProcessInstanceFinished(processInstance, kruntime);
         
         slaCompliance = getSLAComplianceForProcessInstance(processInstance);
         assertEquals(ProcessInstance.SLA_VIOLATED, slaCompliance);
         
-        ksession.dispose();
     }
     
     @Test
     public void testSLAonProcessMet() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-UserTaskWithSLA.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-UserTaskWithSLA.bpmn2");
 
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);        
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);        
         
         KogitoProcessInstance processInstance = kruntime.startProcess("UserTask");
-        assertTrue(processInstance.getState() == ProcessInstance.STATE_ACTIVE);
+        assertEquals(ProcessInstance.STATE_ACTIVE, processInstance.getState());
 
         KogitoWorkItem workItem = workItemHandler.getWorkItem();
         assertNotNull(workItem);
@@ -109,19 +101,18 @@ public class SLAComplianceTest extends JbpmBpmn2TestCase {
         assertTrue(processInstance.getState() == ProcessInstance.STATE_ACTIVE);
 
         kruntime.getWorkItemManager().completeWorkItem(workItem.getStringId(), null);
-        assertProcessInstanceFinished(processInstance, ksession);        
+        assertProcessInstanceFinished(processInstance, kruntime);
         
         int slaCompliance = getSLAComplianceForProcessInstance(processInstance);
         assertEquals(ProcessInstance.SLA_MET, slaCompliance);
         
-        ksession.dispose();
     }
     
     
     @Test
     public void testSLAonUserTaskViolated() throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
-        final ProcessEventListener listener = new DefaultProcessEventListener(){
+        final KogitoProcessEventListener listener = new DefaultKogitoProcessEventListener(){
 
             @Override
             public void afterSLAViolated(SLAViolatedEvent event) {
@@ -129,16 +120,14 @@ public class SLAComplianceTest extends JbpmBpmn2TestCase {
             }
             
         };
-        KieBase kbase = createKnowledgeBase("BPMN2-UserTaskWithSLAOnTask.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-UserTaskWithSLAOnTask.bpmn2");
 
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
-        ksession.addEventListener(listener);
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
+        kruntime.getProcessEventManager().addEventListener(listener);
         
         KogitoProcessInstance processInstance = kruntime.startProcess("UserTask");
-        assertTrue(processInstance.getState() == ProcessInstance.STATE_ACTIVE);
+        assertEquals(ProcessInstance.STATE_ACTIVE, processInstance.getState());
 
         KogitoWorkItem workItem = workItemHandler.getWorkItem();
         assertNotNull(workItem);
@@ -148,7 +137,7 @@ public class SLAComplianceTest extends JbpmBpmn2TestCase {
         assertTrue(slaViolated, "SLA was not violated while it is expected");
 
         processInstance = kruntime.getProcessInstance(processInstance.getStringId());
-        assertTrue(processInstance.getState() == ProcessInstance.STATE_ACTIVE);
+        assertEquals(ProcessInstance.STATE_ACTIVE, processInstance.getState());
 
         int slaCompliance = getSLAComplianceForProcessInstance(processInstance);
         assertEquals(ProcessInstance.SLA_NA, slaCompliance);
@@ -162,35 +151,32 @@ public class SLAComplianceTest extends JbpmBpmn2TestCase {
         assertEquals(ProcessInstance.SLA_VIOLATED, slaCompliance);
 
         kruntime.getWorkItemManager().completeWorkItem(workItem.getStringId(), null);
-        assertProcessInstanceFinished(processInstance, ksession);        
+        assertProcessInstanceFinished(processInstance, kruntime);
         
         slaCompliance = getSLAComplianceForProcessInstance(processInstance);
         assertEquals(ProcessInstance.SLA_NA, slaCompliance);
         
         slaCompliance = getSLAComplianceForNodeInstance(processInstance.getStringId(), (org.jbpm.workflow.instance.NodeInstance) userTaskNode, 1);
         assertEquals(ProcessInstance.SLA_VIOLATED, slaCompliance);
-        
-        ksession.dispose();
+
     }
     
     @Test
     public void testSLAonUserTaskMet() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-UserTaskWithSLAOnTask.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-UserTaskWithSLAOnTask.bpmn2");
 
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);        
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);        
         
         KogitoProcessInstance processInstance = kruntime.startProcess("UserTask");
-        assertTrue(processInstance.getState() == ProcessInstance.STATE_ACTIVE);
+        assertEquals(ProcessInstance.STATE_ACTIVE, processInstance.getState());
 
         KogitoWorkItem workItem = workItemHandler.getWorkItem();
         assertNotNull(workItem);
         assertEquals("john", workItem.getParameter("ActorId"));
                 
         processInstance = kruntime.getProcessInstance(processInstance.getStringId());
-        assertTrue(processInstance.getState() == ProcessInstance.STATE_ACTIVE);
+        assertEquals(ProcessInstance.STATE_ACTIVE, processInstance.getState());
 
         Collection<NodeInstance> active = ((WorkflowProcessInstance)processInstance).getNodeInstances();
         assertEquals(1, active.size());
@@ -198,7 +184,7 @@ public class SLAComplianceTest extends JbpmBpmn2TestCase {
         NodeInstance userTaskNode = active.iterator().next();
 
         kruntime.getWorkItemManager().completeWorkItem(workItem.getStringId(), null);
-        assertProcessInstanceFinished(processInstance, ksession);        
+        assertProcessInstanceFinished(processInstance, kruntime);
         
         int slaCompliance = getSLAComplianceForProcessInstance(processInstance);
         assertEquals(ProcessInstance.SLA_NA, slaCompliance);
@@ -210,14 +196,13 @@ public class SLAComplianceTest extends JbpmBpmn2TestCase {
 
         slaCompliance = getSLAComplianceForNodeInstance(processInstance.getStringId(), (org.jbpm.workflow.instance.NodeInstance) userTaskNode, 1);
         assertEquals(ProcessInstance.SLA_MET, slaCompliance);
-        
-        ksession.dispose();
+
     }
     
     @Test
     public void testSLAonProcessViolatedExternalTracking() throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
-        final ProcessEventListener listener = new DefaultProcessEventListener(){
+        final KogitoProcessEventListener listener = new DefaultKogitoProcessEventListener(){
 
             @Override
             public void afterSLAViolated(SLAViolatedEvent event) {
@@ -225,17 +210,15 @@ public class SLAComplianceTest extends JbpmBpmn2TestCase {
             }
             
         };
-        KieBase kbase = createKnowledgeBase("BPMN2-UserTaskWithSLA.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-UserTaskWithSLA.bpmn2");
 
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
-        ksession.addEventListener(listener);
-        ksession.getEnvironment().set("SLATimerMode", "false");
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
+        kruntime.getProcessEventManager().addEventListener(listener);
+        kruntime.getKieRuntime().getEnvironment().set("SLATimerMode", "false");
         
         KogitoProcessInstance processInstance = kruntime.startProcess("UserTask");
-        assertTrue(processInstance.getState() == ProcessInstance.STATE_ACTIVE);
+        assertEquals(ProcessInstance.STATE_ACTIVE, processInstance.getState());
 
         KogitoWorkItem workItem = workItemHandler.getWorkItem();
         assertNotNull(workItem);
@@ -252,24 +235,23 @@ public class SLAComplianceTest extends JbpmBpmn2TestCase {
         assertTrue(slaViolated, "SLA was not violated while it is expected");
 
         processInstance = kruntime.getProcessInstance(processInstance.getStringId());
-        assertTrue(processInstance.getState() == ProcessInstance.STATE_ACTIVE);
+        assertEquals(ProcessInstance.STATE_ACTIVE, processInstance.getState());
 
         int slaCompliance = getSLAComplianceForProcessInstance(processInstance);
         assertEquals(ProcessInstance.SLA_VIOLATED, slaCompliance);
         
         kruntime.getWorkItemManager().completeWorkItem(workItem.getStringId(), null);
-        assertProcessInstanceFinished(processInstance, ksession);        
+        assertProcessInstanceFinished(processInstance, kruntime);
         
         slaCompliance = getSLAComplianceForProcessInstance(processInstance);
         assertEquals(ProcessInstance.SLA_VIOLATED, slaCompliance);
-        
-        ksession.dispose();
+
     }
 
     @Test
     public void testSLAonUserTaskViolatedExternalTracking() throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
-        final ProcessEventListener listener = new DefaultProcessEventListener(){
+        final KogitoProcessEventListener listener = new DefaultKogitoProcessEventListener(){
 
             @Override
             public void afterSLAViolated(SLAViolatedEvent event) {
@@ -277,17 +259,15 @@ public class SLAComplianceTest extends JbpmBpmn2TestCase {
             }
 
         };
-        KieBase kbase = createKnowledgeBase("BPMN2-UserTaskWithSLAOnTask.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-UserTaskWithSLAOnTask.bpmn2");
 
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
-        ksession.addEventListener(listener);
-        ksession.getEnvironment().set("SLATimerMode", "false");
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
+        kruntime.getProcessEventManager().addEventListener(listener);
+        kruntime.getKieRuntime().getEnvironment().set("SLATimerMode", "false");
 
         KogitoProcessInstance processInstance = kruntime.startProcess("UserTask");
-        assertTrue(processInstance.getState() == ProcessInstance.STATE_ACTIVE);
+        assertEquals(ProcessInstance.STATE_ACTIVE, processInstance.getState());
 
         KogitoWorkItem workItem = workItemHandler.getWorkItem();
         assertNotNull(workItem);
@@ -297,7 +277,7 @@ public class SLAComplianceTest extends JbpmBpmn2TestCase {
         assertFalse(slaViolated, "SLA should not violated by timer");
 
         processInstance = kruntime.getProcessInstance(processInstance.getStringId());
-        assertTrue(processInstance.getState() == ProcessInstance.STATE_ACTIVE);
+        assertEquals(ProcessInstance.STATE_ACTIVE, processInstance.getState());
 
         Collection<NodeInstance> active = ((WorkflowProcessInstance)processInstance).getNodeInstances();
         assertEquals(1, active.size());
@@ -311,7 +291,7 @@ public class SLAComplianceTest extends JbpmBpmn2TestCase {
         assertTrue(slaViolated, "SLA was not violated while it is expected");
 
         kruntime.getWorkItemManager().completeWorkItem(workItem.getStringId(), null);
-        assertProcessInstanceFinished(processInstance, ksession);
+        assertProcessInstanceFinished(processInstance, kruntime);
 
         int slaCompliance = getSLAComplianceForProcessInstance(processInstance);
         assertEquals(ProcessInstance.SLA_NA, slaCompliance);
@@ -322,13 +302,12 @@ public class SLAComplianceTest extends JbpmBpmn2TestCase {
         slaCompliance = getSLAComplianceForNodeInstance(processInstance.getStringId(), (org.jbpm.workflow.instance.NodeInstance) userTaskNode, 1);
         assertEquals(ProcessInstance.SLA_VIOLATED, slaCompliance);
 
-        ksession.dispose();
     }
 
     @Test
     public void testSLAonProcessViolatedWithExpression() throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
-        final ProcessEventListener listener = new DefaultProcessEventListener(){
+        final KogitoProcessEventListener listener = new DefaultKogitoProcessEventListener(){
 
             @Override
             public void afterSLAViolated(SLAViolatedEvent event) {
@@ -336,19 +315,17 @@ public class SLAComplianceTest extends JbpmBpmn2TestCase {
             }
             
         };
-        KieBase kbase = createKnowledgeBase("BPMN2-UserTaskWithSLAExpr.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-UserTaskWithSLAExpr.bpmn2");
 
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
-        ksession.addEventListener(listener);
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
+        kruntime.getProcessEventManager().addEventListener(listener);
         
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("s", "3s");
         
         KogitoProcessInstance processInstance = kruntime.startProcess("UserTask", parameters);
-        assertTrue(processInstance.getState() == ProcessInstance.STATE_ACTIVE);
+        assertEquals(ProcessInstance.STATE_ACTIVE, processInstance.getState());
 
         KogitoWorkItem workItem = workItemHandler.getWorkItem();
         assertNotNull(workItem);
@@ -358,24 +335,23 @@ public class SLAComplianceTest extends JbpmBpmn2TestCase {
         assertTrue(slaViolated, "SLA was not violated while it is expected");
 
         processInstance = kruntime.getProcessInstance(processInstance.getStringId());
-        assertTrue(processInstance.getState() == ProcessInstance.STATE_ACTIVE);
+        assertEquals(ProcessInstance.STATE_ACTIVE, processInstance.getState());
 
         int slaCompliance = getSLAComplianceForProcessInstance(processInstance);
         assertEquals(ProcessInstance.SLA_VIOLATED, slaCompliance);
 
         kruntime.getWorkItemManager().completeWorkItem(workItem.getStringId(), null);
-        assertProcessInstanceFinished(processInstance, ksession);        
+        assertProcessInstanceFinished(processInstance, kruntime);
         
         slaCompliance = getSLAComplianceForProcessInstance(processInstance);
         assertEquals(ProcessInstance.SLA_VIOLATED, slaCompliance);
-        
-        ksession.dispose();
+
     }
     
     @Test
     public void testSLAonProcessViolatedNoTracking() throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
-        final ProcessEventListener listener = new DefaultProcessEventListener(){
+        final KogitoProcessEventListener listener = new DefaultKogitoProcessEventListener(){
 
             @Override
             public void afterSLAViolated(SLAViolatedEvent event) {
@@ -383,17 +359,15 @@ public class SLAComplianceTest extends JbpmBpmn2TestCase {
             }
             
         };
-        KieBase kbase = createKnowledgeBase("BPMN2-UserTaskWithSLA.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-UserTaskWithSLA.bpmn2");
 
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
-        ksession.addEventListener(listener);
-        ksession.getEnvironment().set("SLATimerMode", "false");
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
+        kruntime.getProcessEventManager().addEventListener(listener);
+        kruntime.getKieRuntime().getEnvironment().set("SLATimerMode", "false");
         
         KogitoProcessInstance processInstance = kruntime.startProcess("UserTask");
-        assertTrue(processInstance.getState() == ProcessInstance.STATE_ACTIVE);
+        assertEquals(ProcessInstance.STATE_ACTIVE, processInstance.getState());
 
         KogitoWorkItem workItem = workItemHandler.getWorkItem();
         assertNotNull(workItem);
@@ -410,18 +384,17 @@ public class SLAComplianceTest extends JbpmBpmn2TestCase {
         assertEquals(ProcessInstance.SLA_PENDING, slaCompliance);
 
         kruntime.getWorkItemManager().completeWorkItem(workItem.getStringId(), null);
-        assertProcessInstanceFinished(processInstance, ksession);        
+        assertProcessInstanceFinished(processInstance, kruntime);
         
         slaCompliance = getSLAComplianceForProcessInstance(processInstance);
         assertEquals(ProcessInstance.SLA_VIOLATED, slaCompliance);
-        
-        ksession.dispose();
+
     }
     
     @Test
     public void testSLAonCatchEventViolated() throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
-        final ProcessEventListener listener = new DefaultProcessEventListener(){
+        final KogitoProcessEventListener listener = new DefaultKogitoProcessEventListener(){
 
             @Override
             public void afterSLAViolated(SLAViolatedEvent event) {
@@ -429,21 +402,19 @@ public class SLAComplianceTest extends JbpmBpmn2TestCase {
             }
             
         };
-        KieBase kbase = createKnowledgeBase("BPMN2-IntermediateCatchEventSignalWithSLAOnEvent.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-IntermediateCatchEventSignalWithSLAOnEvent.bpmn2");
 
-        ksession.addEventListener(listener);
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task", new SystemOutWorkItemHandler());
+        kruntime.getProcessEventManager().addEventListener(listener);
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", new SystemOutWorkItemHandler());
         
         KogitoProcessInstance processInstance = kruntime.startProcess("IntermediateCatchEvent");
-        assertTrue(processInstance.getState() == ProcessInstance.STATE_ACTIVE);
+        assertEquals(ProcessInstance.STATE_ACTIVE, processInstance.getState());
 
         boolean slaViolated = latch.await(5, TimeUnit.SECONDS);
         assertTrue(slaViolated, "SLA should be violated by timer");
 
         processInstance = kruntime.getProcessInstance(processInstance.getStringId());
-        assertTrue(processInstance.getState() == ProcessInstance.STATE_ACTIVE);
+        assertEquals(ProcessInstance.STATE_ACTIVE, processInstance.getState());
 
         Collection<NodeInstance> active = ((WorkflowProcessInstance)processInstance).getNodeInstances();
         assertEquals(1, active.size());
@@ -452,7 +423,7 @@ public class SLAComplianceTest extends JbpmBpmn2TestCase {
 
         kruntime.signalEvent("MyMessage", null, processInstance.getStringId());
         
-        assertProcessInstanceFinished(processInstance, ksession);        
+        assertProcessInstanceFinished(processInstance, kruntime);
         
         int slaCompliance = getSLAComplianceForProcessInstance(processInstance);
         assertEquals(ProcessInstance.SLA_NA, slaCompliance);
@@ -462,14 +433,13 @@ public class SLAComplianceTest extends JbpmBpmn2TestCase {
 
         slaCompliance = getSLAComplianceForNodeInstance(processInstance.getStringId(), (org.jbpm.workflow.instance.NodeInstance) eventNode, 1);
         assertEquals(ProcessInstance.SLA_VIOLATED, slaCompliance);
-        
-        ksession.dispose();
+
     }
     
     @Test
     public void testSLAonCatchEventNotViolated() throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
-        final ProcessEventListener listener = new DefaultProcessEventListener(){
+        final KogitoProcessEventListener listener = new DefaultKogitoProcessEventListener(){
 
             @Override
             public void afterSLAViolated(SLAViolatedEvent event) {
@@ -477,15 +447,13 @@ public class SLAComplianceTest extends JbpmBpmn2TestCase {
             }
             
         };
-        KieBase kbase = createKnowledgeBase("BPMN2-IntermediateCatchEventSignalWithSLAOnEvent.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-IntermediateCatchEventSignalWithSLAOnEvent.bpmn2");
 
-        ksession.addEventListener(listener);
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task", new SystemOutWorkItemHandler());
+        kruntime.getProcessEventManager().addEventListener(listener);
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", new SystemOutWorkItemHandler());
         
         KogitoProcessInstance processInstance = kruntime.startProcess("IntermediateCatchEvent");
-        assertTrue(processInstance.getState() == ProcessInstance.STATE_ACTIVE);
+        assertEquals(ProcessInstance.STATE_ACTIVE, processInstance.getState());
 
         Collection<NodeInstance> active = ((WorkflowProcessInstance)processInstance).getNodeInstances();
         assertEquals(1, active.size());
@@ -494,7 +462,7 @@ public class SLAComplianceTest extends JbpmBpmn2TestCase {
 
         kruntime.signalEvent("MyMessage", null, processInstance.getStringId());
         
-        assertProcessInstanceFinished(processInstance, ksession);        
+        assertProcessInstanceFinished(processInstance, kruntime);
         
         int slaCompliance = getSLAComplianceForProcessInstance(processInstance);
         assertEquals(ProcessInstance.SLA_NA, slaCompliance);
@@ -506,7 +474,6 @@ public class SLAComplianceTest extends JbpmBpmn2TestCase {
         boolean slaViolated = latch.await(3, TimeUnit.SECONDS);
         assertFalse(slaViolated, "SLA should not violated by timer");
 
-        ksession.dispose();
     }
     
     /*

--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/StandaloneBPMNProcessTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/StandaloneBPMNProcessTest.java
@@ -25,8 +25,6 @@ import java.util.List;
 import java.util.Map;
 
 import javax.xml.parsers.DocumentBuilderFactory;
-import org.drools.core.impl.InternalKnowledgeBase;
-import org.drools.core.impl.KnowledgeBaseFactory;
 import org.drools.core.util.IoUtils;
 import org.jbpm.bpmn2.handler.ReceiveTaskHandler;
 import org.jbpm.bpmn2.handler.SendTaskHandler;
@@ -42,20 +40,14 @@ import org.jbpm.test.util.NodeLeftCountDownProcessEventListener;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.kie.api.KieBase;
-import org.kie.api.event.process.DefaultProcessEventListener;
 import org.kie.api.event.process.ProcessStartedEvent;
 import org.kie.api.io.Resource;
-import org.kie.api.io.ResourceType;
-import org.kie.api.runtime.KieSession;
-import org.kie.api.runtime.process.WorkflowProcessInstance;
-import org.kie.internal.builder.KnowledgeBuilder;
-import org.kie.internal.builder.KnowledgeBuilderError;
-import org.kie.internal.builder.KnowledgeBuilderFactory;
 import org.kie.internal.io.ResourceFactory;
+import org.kie.kogito.internal.process.event.DefaultKogitoProcessEventListener;
 import org.kie.kogito.internal.process.runtime.KogitoProcessInstance;
 import org.kie.kogito.internal.process.runtime.KogitoProcessRuntime;
 import org.kie.kogito.internal.process.runtime.KogitoWorkItem;
+import org.kie.kogito.internal.process.runtime.KogitoWorkflowProcessInstance;
 import org.w3c.dom.Document;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -64,56 +56,44 @@ public class StandaloneBPMNProcessTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testMinimalProcess() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-MinimalProcess.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-MinimalProcess.bpmn2");
         KogitoProcessInstance processInstance = kruntime.startProcess("Minimal");
         assertThat(processInstance.getState()).isEqualTo(KogitoProcessInstance.STATE_COMPLETED);
     }
 
     @Test
     public void testMinimalProcessWithGraphical() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-MinimalProcessWithGraphical.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-MinimalProcessWithGraphical.bpmn2");
         KogitoProcessInstance processInstance = kruntime.startProcess("Minimal");
         assertThat(processInstance.getState()).isEqualTo(KogitoProcessInstance.STATE_COMPLETED);
     }
 
     @Test
     public void testMinimalProcessWithDIGraphical() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-MinimalProcessWithDIGraphical.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-MinimalProcessWithDIGraphical.bpmn2");
         KogitoProcessInstance processInstance = kruntime.startProcess("Minimal");
         assertThat(processInstance.getState()).isEqualTo(KogitoProcessInstance.STATE_COMPLETED);
     }
 
     @Test
     public void testCompositeProcessWithDIGraphical() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-CompositeProcessWithDIGraphical.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-CompositeProcessWithDIGraphical.bpmn2");
         KogitoProcessInstance processInstance = kruntime.startProcess("Composite");
         assertThat(processInstance.getState()).isEqualTo(KogitoProcessInstance.STATE_COMPLETED);
     }
 
     @Test
     public void testScriptTask() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-ScriptTask.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-ScriptTask.bpmn2");
         KogitoProcessInstance processInstance = kruntime.startProcess("ScriptTask");
         assertThat(processInstance.getState()).isEqualTo(KogitoProcessInstance.STATE_COMPLETED);
     }
 
     @Test
     public void testDataObject() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-DataObject.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-DataObject.bpmn2");
 
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("employee", "UserId-12345");
         KogitoProcessInstance processInstance = kruntime.startProcess("Evaluation", params);
         assertThat(processInstance.getState()).isEqualTo(KogitoProcessInstance.STATE_COMPLETED);
@@ -121,13 +101,11 @@ public class StandaloneBPMNProcessTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testEvaluationProcess() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-EvaluationProcess.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-EvaluationProcess.bpmn2");
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", new SystemOutWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("RegisterRequest", new SystemOutWorkItemHandler());
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("employee", "UserId-12345");
         KogitoProcessInstance processInstance = kruntime.startProcess("Evaluation", params);
         assertThat(processInstance.getState()).isEqualTo(KogitoProcessInstance.STATE_COMPLETED);
@@ -135,12 +113,10 @@ public class StandaloneBPMNProcessTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testEvaluationProcess2() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-EvaluationProcess2.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-EvaluationProcess2.bpmn2");
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", new SystemOutWorkItemHandler());
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("employee", "UserId-12345");
         KogitoProcessInstance processInstance = kruntime.startProcess("com.sample.evaluation", params);
         assertThat(processInstance.getState()).isEqualTo(KogitoProcessInstance.STATE_COMPLETED);
@@ -148,13 +124,11 @@ public class StandaloneBPMNProcessTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testEvaluationProcess3() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-EvaluationProcess3.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        
+        kruntime = createKogitoProcessRuntime("BPMN2-EvaluationProcess3.bpmn2");
+
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", new SystemOutWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("RegisterRequest", new SystemOutWorkItemHandler());
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("employee", "john2");
         KogitoProcessInstance processInstance = kruntime.startProcess("Evaluation", params);
         assertThat(processInstance.getState()).isEqualTo(KogitoProcessInstance.STATE_COMPLETED);
@@ -162,63 +136,54 @@ public class StandaloneBPMNProcessTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testUserTask() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-UserTask.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-UserTask.bpmn2");
 
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
         
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         String varId = "s";
         String varValue = "initialValue";
         params.put(varId, varValue);
         KogitoProcessInstance processInstance = kruntime.startProcess("UserTask", params);
         assertThat(processInstance.getState()).isEqualTo(KogitoProcessInstance.STATE_ACTIVE);       
         
-        ksession = restoreSession(ksession, true);
         KogitoWorkItem workItem = workItemHandler.getWorkItem();
         assertThat(workItem).isNotNull();
         assertThat(workItem.getParameter("ActorId")).isEqualTo("john");
         kruntime.getWorkItemManager().completeWorkItem(workItem.getStringId(), null);
-        assertProcessInstanceCompleted(processInstance.getStringId(), ksession);
+        assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
     }
 
     @Test
     public void testLane() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-Lane.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-Lane.bpmn2");
 
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
         KogitoProcessInstance processInstance = kruntime.startProcess("UserTask");
         assertThat(processInstance.getState()).isEqualTo(KogitoProcessInstance.STATE_ACTIVE);
-        ksession = restoreSession(ksession, true);
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
         KogitoWorkItem workItem = workItemHandler.getWorkItem();
         assertThat(workItem).isNotNull();
         assertThat(workItem.getParameter("ActorId")).isEqualTo("john");
-        Map<String, Object> results = new HashMap<String, Object>();
+        Map<String, Object> results = new HashMap<>();
         ((HumanTaskWorkItemImpl) workItem).setActualOwner("mary");
         kruntime.getWorkItemManager().completeWorkItem(workItem.getStringId(), results);
-        ksession = restoreSession(ksession, true);
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
         workItem = workItemHandler.getWorkItem();
         assertThat(workItem).isNotNull();
         assertThat(workItem.getParameter("SwimlaneActorId")).isEqualTo("mary");
         kruntime.getWorkItemManager().completeWorkItem(workItem.getStringId(), null);
-        assertProcessInstanceCompleted(processInstance.getStringId(), ksession);
+        assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
     }
 
     @Test
     public void testExclusiveSplit() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-ExclusiveSplit.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-ExclusiveSplit.bpmn2");
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Email", new SystemOutWorkItemHandler());
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", "First");
         params.put("y", "Second");
         KogitoProcessInstance processInstance = kruntime.startProcess("com.sample.test", params);
@@ -227,12 +192,10 @@ public class StandaloneBPMNProcessTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testExclusiveSplitDefault() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-ExclusiveSplitDefault.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-ExclusiveSplitDefault.bpmn2");
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Email", new SystemOutWorkItemHandler());
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", "NotFirst");
         params.put("y", "Second");
         KogitoProcessInstance processInstance = kruntime.startProcess("com.sample.test", params);
@@ -241,11 +204,9 @@ public class StandaloneBPMNProcessTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testInclusiveSplit() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-InclusiveSplit.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-InclusiveSplit.bpmn2");
 
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", 15);
         KogitoProcessInstance processInstance = kruntime.startProcess("com.sample.test", params);
         assertThat(processInstance.getState()).isEqualTo(KogitoProcessInstance.STATE_COMPLETED);
@@ -253,11 +214,9 @@ public class StandaloneBPMNProcessTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testInclusiveSplitDefault() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-InclusiveSplitDefault.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-InclusiveSplitDefault.bpmn2");
 
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", -5);
         KogitoProcessInstance processInstance = kruntime.startProcess("com.sample.test", params);
         assertThat(processInstance.getState()).isEqualTo(KogitoProcessInstance.STATE_COMPLETED);
@@ -266,17 +225,15 @@ public class StandaloneBPMNProcessTest extends JbpmBpmn2TestCase {
     @Test
     @Disabled
     public void testExclusiveSplitXPath() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-ExclusiveSplitXPath.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        
+        kruntime = createKogitoProcessRuntime("BPMN2-ExclusiveSplitXPath.bpmn2");
+
         kruntime.getWorkItemManager().registerWorkItemHandler("Email", new SystemOutWorkItemHandler());
         Document document = DocumentBuilderFactory
                 .newInstance()
                 .newDocumentBuilder()
                 .parse(new ByteArrayInputStream(
                         "<myDocument><chapter1>BlaBla</chapter1><chapter2>MoreBlaBla</chapter2></myDocument>".getBytes()));
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", document);
         params.put("y", "SomeString");
         KogitoProcessInstance processInstance = kruntime.startProcess("com.sample.test", params);
@@ -285,43 +242,36 @@ public class StandaloneBPMNProcessTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testEventBasedSplit() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-EventBasedSplit.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-EventBasedSplit.bpmn2");
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1", new SystemOutWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("Email2", new SystemOutWorkItemHandler());
         // Yes
         KogitoProcessInstance processInstance = kruntime.startProcess("com.sample.test");
         assertThat(processInstance.getState()).isEqualTo(KogitoProcessInstance.STATE_ACTIVE);
-        ksession = restoreSession(ksession, true);
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1", new SystemOutWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("Email2", new SystemOutWorkItemHandler());
         kruntime.signalEvent("Yes", "YesValue", processInstance.getStringId());
-        assertProcessInstanceCompleted(processInstance.getStringId(), ksession);
+        assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
         // No
         processInstance = kruntime.startProcess("com.sample.test");
         assertThat(processInstance.getState()).isEqualTo(KogitoProcessInstance.STATE_ACTIVE);
-        ksession = restoreSession(ksession, true);
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1", new SystemOutWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("Email2", new SystemOutWorkItemHandler());
         kruntime.signalEvent("No", "NoValue", processInstance.getStringId());
-        assertProcessInstanceCompleted(processInstance.getStringId(), ksession);
+        assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
     }
 
     @Test
     public void testEventBasedSplitBefore() throws Exception {
         // signaling before the split is reached should have no effect
-        KieBase kbase = createKnowledgeBase("BPMN2-EventBasedSplit.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-EventBasedSplit.bpmn2");
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1", new DoNothingWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("Email2", new DoNothingWorkItemHandler());
         // Yes
         KogitoProcessInstance processInstance = kruntime.startProcess("com.sample.test");
         assertThat(processInstance.getState()).isEqualTo(KogitoProcessInstance.STATE_ACTIVE);
-        ksession = restoreSession(ksession, true);
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1", new DoNothingWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("Email2", new DoNothingWorkItemHandler());
         kruntime.signalEvent("Yes", "YesValue", processInstance.getStringId());
@@ -329,7 +279,6 @@ public class StandaloneBPMNProcessTest extends JbpmBpmn2TestCase {
         // No
         processInstance = kruntime.startProcess("com.sample.test");
         assertThat(processInstance.getState()).isEqualTo(KogitoProcessInstance.STATE_ACTIVE);
-        ksession = restoreSession(ksession, true);
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1", new DoNothingWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("Email2", new DoNothingWorkItemHandler());
         kruntime.signalEvent("No", "NoValue", processInstance.getStringId());
@@ -340,21 +289,17 @@ public class StandaloneBPMNProcessTest extends JbpmBpmn2TestCase {
     public void testEventBasedSplitAfter() throws Exception {
         // signaling the other alternative after one has been selected should
         // have no effect
-        KieBase kbase = createKnowledgeBase("BPMN2-EventBasedSplit.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-EventBasedSplit.bpmn2");
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1", new SystemOutWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("Email2", new DoNothingWorkItemHandler());
         // Yes
         KogitoProcessInstance processInstance = kruntime.startProcess("com.sample.test");
         assertThat(processInstance.getState()).isEqualTo(KogitoProcessInstance.STATE_ACTIVE);
-        ksession = restoreSession(ksession, true);
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1", new SystemOutWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("Email2", new DoNothingWorkItemHandler());
         kruntime.signalEvent("Yes", "YesValue", processInstance.getStringId());
         assertThat(processInstance.getState()).isEqualTo(KogitoProcessInstance.STATE_ACTIVE);
-        ksession = restoreSession(ksession, true);
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1", new SystemOutWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("Email2", new DoNothingWorkItemHandler());
         // No
@@ -365,29 +310,24 @@ public class StandaloneBPMNProcessTest extends JbpmBpmn2TestCase {
     @Timeout(10)
     public void testEventBasedSplit2() throws Exception {
         NodeLeftCountDownProcessEventListener countDownListener = new NodeLeftCountDownProcessEventListener("timer", 2);
-        KieBase kbase = createKnowledgeBase("BPMN2-EventBasedSplit2.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-EventBasedSplit2.bpmn2");
 
-        ksession.addEventListener(countDownListener);
+        kruntime.getProcessEventManager().addEventListener(countDownListener);
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1", new SystemOutWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("Email2", new SystemOutWorkItemHandler());
         // Yes
         KogitoProcessInstance processInstance = kruntime.startProcess("com.sample.test");
         assertThat(processInstance.getState()).isEqualTo(KogitoProcessInstance.STATE_ACTIVE);
-        ksession = restoreSession(ksession, true);
-        ksession.addEventListener(countDownListener);
+        kruntime.getProcessEventManager().addEventListener(countDownListener);
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1", new SystemOutWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("Email2", new SystemOutWorkItemHandler());
         kruntime.signalEvent("Yes", "YesValue", processInstance.getStringId());
-        assertProcessInstanceCompleted(processInstance.getStringId(), ksession);
-        
-        ksession = restoreSession(ksession, true);
-        ksession.addEventListener(countDownListener);
+        assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
+
+        kruntime.getProcessEventManager().addEventListener(countDownListener);
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1", new SystemOutWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("Email2", new SystemOutWorkItemHandler());
-        ksession = restoreSession(ksession, true);
-        ksession.addEventListener(countDownListener);
+        kruntime.getProcessEventManager().addEventListener(countDownListener);
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1", new SystemOutWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("Email2", new SystemOutWorkItemHandler());
         // Timer
@@ -395,19 +335,16 @@ public class StandaloneBPMNProcessTest extends JbpmBpmn2TestCase {
         assertThat(processInstance.getState()).isEqualTo(KogitoProcessInstance.STATE_ACTIVE);
         
         countDownListener.waitTillCompleted();
-        ksession = restoreSession(ksession, true);
-        ksession.addEventListener(countDownListener);
+        kruntime.getProcessEventManager().addEventListener(countDownListener);
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1", new SystemOutWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("Email2", new SystemOutWorkItemHandler());
-        assertProcessInstanceCompleted(processInstance.getStringId(), ksession);
+        assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
     }
 
     @Test
     @Disabled("process does not complete")
     public void testEventBasedSplit3() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-EventBasedSplit3.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-EventBasedSplit3.bpmn2");
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1", new SystemOutWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("Email2", new SystemOutWorkItemHandler());
@@ -416,118 +353,92 @@ public class StandaloneBPMNProcessTest extends JbpmBpmn2TestCase {
         // Yes
         KogitoProcessInstance processInstance = kruntime.startProcess("com.sample.test");
         assertThat(processInstance.getState()).isEqualTo(KogitoProcessInstance.STATE_ACTIVE);
-        ksession = restoreSession(ksession);
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1", new SystemOutWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("Email2", new SystemOutWorkItemHandler());
         kruntime.signalEvent("Yes", "YesValue", processInstance.getStringId());
-        assertProcessInstanceCompleted(processInstance.getStringId(), ksession);
+        assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
         // Condition
         processInstance = kruntime.startProcess("com.sample.test");
         assertThat(processInstance.getState()).isEqualTo(KogitoProcessInstance.STATE_ACTIVE);
-        ksession = restoreSession(ksession);
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1", new SystemOutWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("Email2", new SystemOutWorkItemHandler());
-        ksession.insert(jack);
-        assertProcessInstanceCompleted(processInstance.getStringId(), ksession);
+        kruntime.getKieSession().insert(jack);
+        assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
     }
 
     @Test
     public void testEventBasedSplit4() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-EventBasedSplit4.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-EventBasedSplit4.bpmn2");
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1", new SystemOutWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("Email2", new SystemOutWorkItemHandler());
         // Yes
         KogitoProcessInstance processInstance = kruntime.startProcess("com.sample.test");
         assertThat(processInstance.getState()).isEqualTo(KogitoProcessInstance.STATE_ACTIVE);
-        ksession = restoreSession(ksession, true);
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1", new SystemOutWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("Email2", new SystemOutWorkItemHandler());
         kruntime.signalEvent("Message-YesMessage", "YesValue", processInstance.getStringId());
-        assertProcessInstanceCompleted(processInstance.getStringId(), ksession);
-        ksession = restoreSession(ksession, true);
+        assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1", new SystemOutWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("Email2", new SystemOutWorkItemHandler());
         // No
         processInstance = kruntime.startProcess("com.sample.test");
         kruntime.signalEvent("Message-NoMessage", "NoValue", processInstance.getStringId());
-        assertProcessInstanceCompleted(processInstance.getStringId(), ksession);
+        assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
     }
 
     @Test
     public void testEventBasedSplit5() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-EventBasedSplit5.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-EventBasedSplit5.bpmn2");
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1", new SystemOutWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("Email2", new SystemOutWorkItemHandler());
-        ReceiveTaskHandler receiveTaskHandler = new ReceiveTaskHandler(ksession);
+        ReceiveTaskHandler receiveTaskHandler = new ReceiveTaskHandler(kruntime);
         kruntime.getWorkItemManager().registerWorkItemHandler("Receive Task", receiveTaskHandler);
         // Yes
         KogitoProcessInstance processInstance = kruntime.startProcess("com.sample.test");
         assertThat(processInstance.getState()).isEqualTo(KogitoProcessInstance.STATE_ACTIVE);
-        ksession = restoreSession(ksession, true);
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1", new SystemOutWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("Email2", new SystemOutWorkItemHandler());
-        receiveTaskHandler.setKnowledgeRuntime(ksession);
+        receiveTaskHandler.setKnowledgeRuntime(kruntime);
         kruntime.getWorkItemManager().registerWorkItemHandler("Receive Task", receiveTaskHandler);
         receiveTaskHandler.messageReceived("YesMessage", "YesValue");
-        assertProcessInstanceCompleted(processInstance.getStringId(), ksession);
+        assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
         receiveTaskHandler.messageReceived("NoMessage", "NoValue");
-        ksession = restoreSession(ksession, true);
         kruntime.getWorkItemManager().registerWorkItemHandler("Email1", new SystemOutWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("Email2", new SystemOutWorkItemHandler());
-        receiveTaskHandler.setKnowledgeRuntime(ksession);
+        receiveTaskHandler.setKnowledgeRuntime(kruntime);
         kruntime.getWorkItemManager().registerWorkItemHandler("Receive Task", receiveTaskHandler);
         // No
         processInstance = kruntime.startProcess("com.sample.test");
         receiveTaskHandler.messageReceived("NoMessage", "NoValue");
-        assertProcessInstanceCompleted(processInstance.getStringId(), ksession);
+        assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
         receiveTaskHandler.messageReceived("YesMessage", "YesValue");
     }
 
     @Test
     public void testCallActivity() throws Exception {
-        KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
-        kbuilder.add(ResourceFactory.newClassPathResource("BPMN2-CallActivity.bpmn2"), ResourceType.BPMN2);
-        kbuilder.add(ResourceFactory.newClassPathResource("BPMN2-CallActivitySubProcess.bpmn2"), ResourceType.BPMN2);
-        if (!kbuilder.getErrors().isEmpty()) {
-            for (KnowledgeBuilderError error : kbuilder.getErrors()) {
-                logger.error("{}", error);
-            }
-            throw new IllegalArgumentException("Errors while parsing knowledge base");
-        }
-        InternalKnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
-        kbase.addPackages(kbuilder.getKnowledgePackages());
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-CallActivity.bpmn2", "BPMN2-CallActivitySubProcess.bpmn2");
 
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", "oldValue");
         KogitoProcessInstance processInstance = kruntime.startProcess("ParentProcess", params);
         assertThat(processInstance.getState()).isEqualTo(KogitoProcessInstance.STATE_COMPLETED);
-        assertThat(((WorkflowProcessInstance) processInstance).getVariable("y")).isEqualTo("new value");
+        assertThat(((KogitoWorkflowProcessInstance) processInstance).getVariable("y")).isEqualTo("new value");
     }
 
     @Test
     public void testSubProcess() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-SubProcess.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-SubProcess.bpmn2");
         KogitoProcessInstance processInstance = kruntime.startProcess("SubProcess");
         assertThat(processInstance.getState()).isEqualTo(KogitoProcessInstance.STATE_COMPLETED);
     }
 
     @Test
     public void testMultiInstanceLoopCharacteristicsProcess() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-MultiInstanceLoopCharacteristicsProcess.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        Map<String, Object> params = new HashMap<String, Object>();
-        List<String> myList = new ArrayList<String>();
+        kruntime = createKogitoProcessRuntime("BPMN2-MultiInstanceLoopCharacteristicsProcess.bpmn2");
+        Map<String, Object> params = new HashMap<>();
+        List<String> myList = new ArrayList<>();
         myList.add("First Item");
         myList.add("Second Item");
         params.put("list", myList);
@@ -537,81 +448,69 @@ public class StandaloneBPMNProcessTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testErrorBoundaryEvent() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-ErrorBoundaryEventInterrupting.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-ErrorBoundaryEventInterrupting.bpmn2");
 
         kruntime.getWorkItemManager().registerWorkItemHandler("MyTask", new DoNothingWorkItemHandler());
         KogitoProcessInstance processInstance = kruntime.startProcess("ErrorBoundaryEvent");
-        assertProcessInstanceCompleted(processInstance.getStringId(), ksession);
+        assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
     }
 
     @Test
     @Timeout(10)
     public void testTimerBoundaryEvent() throws Exception {
         NodeLeftCountDownProcessEventListener countDownListener = new NodeLeftCountDownProcessEventListener("TimerEvent", 1);
-        KieBase kbase = createKnowledgeBase("BPMN2-TimerBoundaryEventDuration.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-TimerBoundaryEventDuration.bpmn2");
 
-        ksession.addEventListener(countDownListener);
+        kruntime.getProcessEventManager().addEventListener(countDownListener);
         kruntime.getWorkItemManager().registerWorkItemHandler("MyTask", new DoNothingWorkItemHandler());
         KogitoProcessInstance processInstance = kruntime.startProcess("TimerBoundaryEvent");
         assertThat(processInstance.getState()).isEqualTo(KogitoProcessInstance.STATE_ACTIVE);
         countDownListener.waitTillCompleted();
-        assertProcessInstanceCompleted(processInstance.getStringId(), ksession);
+        assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
     }
 
     @Test
     @Timeout(10)
     public void testTimerBoundaryEventInterrupting() throws Exception {
         NodeLeftCountDownProcessEventListener countDownListener = new NodeLeftCountDownProcessEventListener("TimerEvent", 1);
-        KieBase kbase = createKnowledgeBase("BPMN2-TimerBoundaryEventInterrupting.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-TimerBoundaryEventInterrupting.bpmn2");
 
-        ksession.addEventListener(countDownListener);
+        kruntime.getProcessEventManager().addEventListener(countDownListener);
         kruntime.getWorkItemManager().registerWorkItemHandler("MyTask", new DoNothingWorkItemHandler());
         KogitoProcessInstance processInstance = kruntime.startProcess("TimerBoundaryEvent");
         assertThat(processInstance.getState()).isEqualTo(KogitoProcessInstance.STATE_ACTIVE);
         countDownListener.waitTillCompleted();
-        assertProcessInstanceCompleted(processInstance.getStringId(), ksession);
+        assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
     }
 
     @Test
     @Disabled("Process does not complete.")
     public void testAdHocSubProcess() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-AdHocSubProcess.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        
+        kruntime = createKogitoProcessRuntime("BPMN2-AdHocSubProcess.bpmn2");
+
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
         KogitoProcessInstance processInstance = kruntime.startProcess("AdHocSubProcess");
         assertThat(processInstance.getState()).isEqualTo(KogitoProcessInstance.STATE_ACTIVE);
         KogitoWorkItem workItem = workItemHandler.getWorkItem();
         assertThat(workItem).isNull();
-        ksession = restoreSession(ksession);
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
-        ksession.fireAllRules();
+        kruntime.getKieSession().fireAllRules();
         
         kruntime.signalEvent("Hello2", null, processInstance.getStringId());
         workItem = workItemHandler.getWorkItem();
         assertThat(workItem).isNotNull();
-        ksession = restoreSession(ksession);
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
         kruntime.getWorkItemManager().completeWorkItem(workItem.getStringId(), null);
         
-        assertProcessInstanceCompleted(processInstance.getStringId(), ksession);
+        assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
     }
 
     @Test
     @Disabled("Process does not complete.")
     public void testAdHocSubProcessAutoComplete() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-AdHocSubProcessAutoComplete.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        
+        kruntime = createKogitoProcessRuntime("BPMN2-AdHocSubProcessAutoComplete.bpmn2");
+
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
         KogitoProcessInstance processInstance = kruntime.startProcess("AdHocSubProcess");
@@ -619,165 +518,138 @@ public class StandaloneBPMNProcessTest extends JbpmBpmn2TestCase {
 
         KogitoWorkItem workItem = workItemHandler.getWorkItem();
         assertThat(workItem).isNull();
-        ksession = restoreSession(ksession);
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
-        ksession.fireAllRules();
+        kruntime.getKieSession().fireAllRules();
         workItem = workItemHandler.getWorkItem();
         assertThat(workItem).isNotNull().withFailMessage("KogitoWorkItem should not be null.");
-        ksession = restoreSession(ksession);
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
         kruntime.getWorkItemManager().completeWorkItem(workItem.getStringId(), null);
         
-        assertProcessInstanceCompleted(processInstance.getStringId(), ksession);
+        assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
     }
 
     @Test
     public void testIntermediateCatchEventSignal() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-IntermediateCatchEventSignal.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-IntermediateCatchEventSignal.bpmn2");
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", new SystemOutWorkItemHandler());
         KogitoProcessInstance processInstance = kruntime.startProcess("IntermediateCatchEvent");
         assertThat(processInstance.getState()).isEqualTo(KogitoProcessInstance.STATE_ACTIVE);
-        ksession = restoreSession(ksession, true);
         // now signal process instance
         kruntime.signalEvent("MyMessage", "SomeValue", processInstance.getStringId());
-        assertProcessInstanceCompleted(processInstance.getStringId(), ksession);
+        assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
     }
 
     @Test
     public void testIntermediateCatchEventMessage() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-IntermediateCatchEventMessage.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-IntermediateCatchEventMessage.bpmn2");
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", new SystemOutWorkItemHandler());
 
         KogitoProcessInstance processInstance = kruntime.startProcess("IntermediateCatchEvent");
         assertThat(processInstance.getState()).isEqualTo(KogitoProcessInstance.STATE_ACTIVE);
-        ksession = restoreSession(ksession, true);
         // now signal process instance
         kruntime.signalEvent("Message-HelloMessage", "SomeValue", processInstance.getStringId());
-        assertProcessInstanceCompleted(processInstance.getStringId(), ksession);
+        assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
     }
 
     @Test
     @Timeout(10)
     public void testIntermediateCatchEventTimer() throws Exception {
         NodeLeftCountDownProcessEventListener countDownListener = new NodeLeftCountDownProcessEventListener("timer", 1);
-        KieBase kbase = createKnowledgeBase("BPMN2-IntermediateCatchEventTimerDuration.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-IntermediateCatchEventTimerDuration.bpmn2");
 
-        ksession.addEventListener(countDownListener);
+        kruntime.getProcessEventManager().addEventListener(countDownListener);
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", new DoNothingWorkItemHandler());
         KogitoProcessInstance processInstance = kruntime.startProcess("IntermediateCatchEvent");
         assertThat(processInstance.getState()).isEqualTo(KogitoProcessInstance.STATE_ACTIVE);
         // now wait for 1 second for timer to trigger
         countDownListener.waitTillCompleted();
-        ksession = restoreSession(ksession, true);
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", new DoNothingWorkItemHandler());
-        assertProcessInstanceCompleted(processInstance.getStringId(), ksession);
+        assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
     }
 
     @Test
     @Disabled("process does not complete")
     public void testIntermediateCatchEventCondition() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-IntermediateCatchEventCondition.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-IntermediateCatchEventCondition.bpmn2");
 
         KogitoProcessInstance processInstance = kruntime.startProcess("IntermediateCatchEvent");
         assertThat(processInstance.getState()).isEqualTo(KogitoProcessInstance.STATE_ACTIVE);
-        ksession = restoreSession(ksession);
         // now activate condition
         Person person = new Person();
         person.setName("Jack");
-        ksession.insert(person);
-        assertProcessInstanceCompleted(processInstance.getStringId(), ksession);
+        kruntime.getKieSession().insert(person);
+        assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
     }
 
     @Test
     public void testErrorEndEventProcess() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-ErrorEndEvent.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-ErrorEndEvent.bpmn2");
 
         KogitoProcessInstance processInstance = kruntime.startProcess("ErrorEndEvent");
-        assertProcessInstanceAborted(processInstance.getStringId(), ksession);
+        assertProcessInstanceAborted(processInstance.getStringId(), kruntime);
     }
 
     @Test
     public void testServiceTask() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-ServiceProcess.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-ServiceProcess.bpmn2");
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Service Task", new ServiceTaskHandler());
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("s", "john");
-        WorkflowProcessInstance processInstance = (WorkflowProcessInstance) kruntime.startProcess("ServiceProcess", params);
-        assertProcessInstanceCompleted( (( KogitoProcessInstance ) processInstance).getStringId(), ksession);
+        KogitoWorkflowProcessInstance processInstance = (KogitoWorkflowProcessInstance) kruntime.startProcess("ServiceProcess", params);
+        assertProcessInstanceCompleted( processInstance.getStringId(), kruntime);
         assertThat(processInstance.getVariable("s")).isEqualTo("Hello john!");
     }
 
     @Test
     public void testSendTask() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-SendTask.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-SendTask.bpmn2");
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Send Task", new SendTaskHandler());
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("s", "john");
-        WorkflowProcessInstance processInstance = (WorkflowProcessInstance) kruntime.startProcess("SendTask", params);
-        assertProcessInstanceCompleted((( KogitoProcessInstance ) processInstance).getStringId(), ksession);
+        KogitoWorkflowProcessInstance processInstance = (KogitoWorkflowProcessInstance) kruntime.startProcess("SendTask", params);
+        assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
     }
 
     @Test
     public void testReceiveTask() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-ReceiveTask.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-ReceiveTask.bpmn2");
 
-        ReceiveTaskHandler receiveTaskHandler = new ReceiveTaskHandler(ksession);
+        ReceiveTaskHandler receiveTaskHandler = new ReceiveTaskHandler(kruntime);
         kruntime.getWorkItemManager().registerWorkItemHandler("Receive Task", receiveTaskHandler);
-        WorkflowProcessInstance processInstance = (WorkflowProcessInstance) kruntime.startProcess("ReceiveTask");
+        KogitoWorkflowProcessInstance processInstance = (KogitoWorkflowProcessInstance) kruntime.startProcess("ReceiveTask");
         assertThat(processInstance.getState()).isEqualTo(KogitoProcessInstance.STATE_ACTIVE);
-        ksession = restoreSession(ksession);
         receiveTaskHandler.messageReceived("HelloMessage", "Hello john!");
-        assertProcessInstanceCompleted((( KogitoProcessInstance ) processInstance).getStringId(), ksession);
+        assertProcessInstanceCompleted((( KogitoProcessInstance ) processInstance).getStringId(), kruntime);
     }
 
     @Test
     @Disabled("bpmn does not compile")
     public void testConditionalStart() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-ConditionalStart.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-ConditionalStart.bpmn2");
 
         Person person = new Person();
         person.setName("jack");
-        ksession.insert(person);
-        ksession.fireAllRules();
+        kruntime.getKieSession().insert(person);
+        kruntime.getKieSession().fireAllRules();
         person = new Person();
         person.setName("john");
-        ksession.insert(person);
-        ksession.fireAllRules();
+        kruntime.getKieSession().insert(person);
+        kruntime.getKieSession().fireAllRules();
     }
 
     @Test
     @Timeout(1000)
     public void testTimerStart() throws Exception {
         NodeLeftCountDownProcessEventListener countDownListener = new NodeLeftCountDownProcessEventListener("StartProcess", 5);
-        KieBase kbase = createKnowledgeBase("BPMN2-TimerStart.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-TimerStart.bpmn2");
 
-        ksession.addEventListener(countDownListener);
+        kruntime.getProcessEventManager().addEventListener(countDownListener);
         final List<String> list = new ArrayList<>();
-        ksession.addEventListener(new DefaultProcessEventListener() { 
+        kruntime.getProcessEventManager().addEventListener(new DefaultKogitoProcessEventListener() {
             
             public void beforeProcessStarted(ProcessStartedEvent event) {
                 list.add( (( KogitoProcessInstance ) event.getProcessInstance()).getStringId());
@@ -792,11 +664,9 @@ public class StandaloneBPMNProcessTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testSignalStart() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-SignalStart.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-SignalStart.bpmn2");
         final List<String> list = new ArrayList<>();
-        ksession.addEventListener(new DefaultProcessEventListener() {
+        kruntime.getProcessEventManager().addEventListener(new DefaultKogitoProcessEventListener() {
             public void afterProcessStarted(ProcessStartedEvent event) {
                 list.add((( KogitoProcessInstance ) event.getProcessInstance()).getStringId());
             }
@@ -807,21 +677,17 @@ public class StandaloneBPMNProcessTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testSignalEnd() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-SignalEndEvent.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        Map<String, Object> params = new HashMap<String, Object>();
+        kruntime = createKogitoProcessRuntime("BPMN2-SignalEndEvent.bpmn2");
+        Map<String, Object> params = new HashMap<>();
         params.put("x", "MyValue");
         kruntime.startProcess("SignalEndEvent", params);
     }
 
     @Test
     public void testMessageStart() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-MessageStart.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-MessageStart.bpmn2");
         final List<String> list = new ArrayList<>();
-        ksession.addEventListener(new DefaultProcessEventListener() {
+        kruntime.getProcessEventManager().addEventListener(new DefaultKogitoProcessEventListener() {
             public void afterProcessStarted(ProcessStartedEvent event) {
                 list.add((( KogitoProcessInstance ) event.getProcessInstance()).getStringId());
             }
@@ -832,11 +698,9 @@ public class StandaloneBPMNProcessTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testMessageEnd() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-MessageEndEvent.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-MessageEndEvent.bpmn2");
         kruntime.getWorkItemManager().registerWorkItemHandler("Send Task", new SendTaskHandler());
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", "MyValue");
         KogitoProcessInstance processInstance = kruntime.startProcess("MessageEndEvent", params);
         assertThat(processInstance.getState()).isEqualTo(KogitoProcessInstance.STATE_COMPLETED);
@@ -844,11 +708,9 @@ public class StandaloneBPMNProcessTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testMessageIntermediateThrow() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-IntermediateThrowEventMessage.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-IntermediateThrowEventMessage.bpmn2");
         kruntime.getWorkItemManager().registerWorkItemHandler("Send Task", new SendTaskHandler());
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("x", "MyValue");
         KogitoProcessInstance processInstance = kruntime.startProcess("MessageIntermediateEvent", params);
         assertThat(processInstance.getState()).isEqualTo(KogitoProcessInstance.STATE_COMPLETED);
@@ -856,10 +718,8 @@ public class StandaloneBPMNProcessTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testSignalIntermediateThrow() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-IntermediateThrowEventSignal.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        Map<String, Object> params = new HashMap<String, Object>();
+        kruntime = createKogitoProcessRuntime("BPMN2-IntermediateThrowEventSignal.bpmn2");
+        Map<String, Object> params = new HashMap<>();
         params.put("x", "MyValue");
         KogitoProcessInstance processInstance = kruntime.startProcess("SignalIntermediateEvent", params);
         assertThat(processInstance.getState()).isEqualTo(KogitoProcessInstance.STATE_COMPLETED);
@@ -867,24 +727,20 @@ public class StandaloneBPMNProcessTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testNoneIntermediateThrow() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-IntermediateThrowEventNone.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-IntermediateThrowEventNone.bpmn2");
         KogitoProcessInstance processInstance = kruntime.startProcess("NoneIntermediateEvent");
         assertThat(processInstance.getState()).isEqualTo(KogitoProcessInstance.STATE_COMPLETED);
     }
     
     @Test
     public void testErrorSignallingExceptionServiceTask() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-ExceptionServiceProcess-ErrorSignalling.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        
-        runTestErrorSignallingExceptionServiceTask(ksession);
+        kruntime = createKogitoProcessRuntime("BPMN2-ExceptionServiceProcess-ErrorSignalling.bpmn2");
+
+        runTestErrorSignallingExceptionServiceTask(kruntime);
     }
     
-    public static void runTestErrorSignallingExceptionServiceTask(KieSession ksession) throws Exception {
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
-        
+    public static void runTestErrorSignallingExceptionServiceTask(KogitoProcessRuntime kruntime) throws Exception {
+
         // Setup
         String eventType = "Error-code";
         SignallingTaskHandlerDecorator signallingTaskWrapper = new SignallingTaskHandlerDecorator(ServiceTaskHandler.class, eventType);
@@ -899,7 +755,7 @@ public class StandaloneBPMNProcessTest extends JbpmBpmn2TestCase {
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
         
         // Start process
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         String input = "this is my service input";
         params.put("serviceInputItem", input );
         KogitoProcessInstance processInstance = kruntime.startProcess("ServiceProcess", params);
@@ -927,10 +783,9 @@ public class StandaloneBPMNProcessTest extends JbpmBpmn2TestCase {
     public void testSignallingExceptionServiceTask() throws Exception {
         // dump/reread functionality seems to work for this test 
         // .. but I'm pretty sure that's more coincidence than design (mriet, 2013-03-06)
-        KieBase kbase = createKnowledgeBase("BPMN2-ExceptionServiceProcess-Signalling.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        
-        runTestSignallingExceptionServiceTask(ksession);
+        kruntime = createKogitoProcessRuntime("BPMN2-ExceptionServiceProcess-Signalling.bpmn2");
+
+        runTestSignallingExceptionServiceTask(kruntime);
     }
     
     @Test
@@ -958,10 +813,8 @@ public class StandaloneBPMNProcessTest extends JbpmBpmn2TestCase {
     	Resource resource = ResourceFactory.newReaderResource(new StringReader(processAsString));
     	resource.setSourcePath(processResource.getSourcePath());
     	resource.setTargetPath(processResource.getTargetPath());
-    	
-        KieBase kbase = createKnowledgeBaseFromResources(resource);
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+
+    	kruntime = createKogitoProcessRuntime(resource);
         KogitoProcessInstance processInstance = kruntime.startProcess("async-examples.bp1");
         
         String var1 = getProcessVarValue(processInstance, "testScript1");
@@ -974,9 +827,7 @@ public class StandaloneBPMNProcessTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testVariableRefInIntermediateThrowEvent() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-WorkingMessageModel.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-WorkingMessageModel.bpmn2");
 
         kruntime.getWorkItemManager().registerWorkItemHandler("Send Task", new DoNothingWorkItemHandler());
         kruntime.getWorkItemManager().registerWorkItemHandler("Service Task", new DoNothingWorkItemHandler());
@@ -988,8 +839,7 @@ public class StandaloneBPMNProcessTest extends JbpmBpmn2TestCase {
         assertThat(processInstance).isNotNull();
     }
 
-    public static void runTestSignallingExceptionServiceTask(KieSession ksession) throws Exception {
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+    public static void runTestSignallingExceptionServiceTask(KogitoProcessRuntime kruntime) throws Exception {
 
         // Setup
         String eventType = "exception-signal";
@@ -1002,7 +852,7 @@ public class StandaloneBPMNProcessTest extends JbpmBpmn2TestCase {
         ExceptionService.setCaughtEventObjectHolder(caughtEventObjectHolder);
         
         // Start process
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         String input = "this is my service input";
         params.put("serviceInputItem", input );
         KogitoProcessInstance processInstance = kruntime.startProcess("ServiceProcess", params);

--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/handler/LoggingTaskHandlerWrapperTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/handler/LoggingTaskHandlerWrapperTest.java
@@ -23,37 +23,33 @@ import java.util.Map;
 
 import org.jbpm.bpmn2.JbpmBpmn2TestCase;
 import org.jbpm.bpmn2.handler.LoggingTaskHandlerDecorator.InputParameter;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.kie.api.KieBase;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class LoggingTaskHandlerWrapperTest extends JbpmBpmn2TestCase {
     
     @Test
     public void testLimitExceptionInfoList() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-ExceptionThrowingServiceProcess.bpmn2");
-        ksession = createKnowledgeSession(kbase);
+        kruntime = createKogitoProcessRuntime("BPMN2-ExceptionThrowingServiceProcess.bpmn2");
         
         LoggingTaskHandlerDecorator loggingTaskHandlerWrapper = new LoggingTaskHandlerDecorator(ServiceTaskHandler.class, 2);
         loggingTaskHandlerWrapper.setPrintStackTrace(false);
-        ksession.getWorkItemManager().registerWorkItemHandler("Service Task", loggingTaskHandlerWrapper);
+        kruntime.getWorkItemManager().registerWorkItemHandler("Service Task", loggingTaskHandlerWrapper);
 
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("serviceInputItem", "exception message");
-        ksession.startProcess("ServiceProcess", params);
-        ksession.startProcess("ServiceProcess", params);
-        ksession.startProcess("ServiceProcess", params);
+        kruntime.startProcess("ServiceProcess", params);
+        kruntime.startProcess("ServiceProcess", params);
+        kruntime.startProcess("ServiceProcess", params);
 
-        int size = loggingTaskHandlerWrapper.getWorkItemExceptionInfoList().size(); 
-        assertTrue( size == 2, "WorkItemExceptionInfoList is too large: " + size);
+        int size = loggingTaskHandlerWrapper.getWorkItemExceptionInfoList().size();
+        assertEquals(2, size, "WorkItemExceptionInfoList is too large: " + size);
     }
     
     @Test
     public void testFormatLoggingError() throws Exception {
-        KieBase kbase = createKnowledgeBase("BPMN2-ExceptionThrowingServiceProcess.bpmn2");
-        ksession = createKnowledgeSession(kbase);
+        kruntime = createKogitoProcessRuntime("BPMN2-ExceptionThrowingServiceProcess.bpmn2");
         
         LoggingTaskHandlerDecorator loggingTaskHandlerWrapper = new LoggingTaskHandlerDecorator(ServiceTaskHandler.class, 2);
         loggingTaskHandlerWrapper.setLoggedMessageFormat("{0} - {1} - {2} - {3}");
@@ -66,13 +62,13 @@ public class LoggingTaskHandlerWrapperTest extends JbpmBpmn2TestCase {
         loggingTaskHandlerWrapper.setLoggedMessageInput(inputParameters);
         
         loggingTaskHandlerWrapper.setPrintStackTrace(false);
-        ksession.getWorkItemManager().registerWorkItemHandler("Service Task", loggingTaskHandlerWrapper);
+        kruntime.getWorkItemManager().registerWorkItemHandler("Service Task", loggingTaskHandlerWrapper);
 
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("serviceInputItem", "exception message");
-        ksession.startProcess("ServiceProcess", params);
-        ksession.startProcess("ServiceProcess", params);
-        ksession.startProcess("ServiceProcess", params);
+        kruntime.startProcess("ServiceProcess", params);
+        kruntime.startProcess("ServiceProcess", params);
+        kruntime.startProcess("ServiceProcess", params);
     }
 
 }

--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/handler/WorkItemHandlerExceptionHandlingTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/handler/WorkItemHandlerExceptionHandlingTest.java
@@ -25,13 +25,8 @@ import org.jbpm.process.core.context.variable.VariableScope;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.kie.api.KieBase;
-import org.kie.api.runtime.KieSession;
-import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.api.runtime.process.ProcessWorkItemHandlerException.HandlingStrategy;
-import org.kie.api.runtime.process.WorkItem;
 import org.kie.kogito.internal.process.runtime.KogitoProcessInstance;
-import org.kie.kogito.internal.process.runtime.KogitoProcessRuntime;
 import org.kie.kogito.internal.process.runtime.KogitoWorkItem;
 
 import static org.jbpm.process.core.context.variable.VariableScope.VARIABLE_STRICT_ENABLED_PROPERTY;
@@ -54,33 +49,30 @@ public class WorkItemHandlerExceptionHandlingTest extends JbpmBpmn2TestCase {
     @Test
     public void testErrornousHandlerWithStrategyComplete() throws Exception {
           
-        KieBase kbase = createKnowledgeBaseWithoutDumper("handler/BPMN2-UserTaskWithBooleanOutput.bpmn2", "handler/BPMN2-ScriptTask.bpmn2");
+        kruntime = createKogitoProcessRuntime("handler/BPMN2-UserTaskWithBooleanOutput.bpmn2", "handler/BPMN2-ScriptTask.bpmn2");
 
-        KieSession ksession = createKnowledgeSession(kbase);
         ErrornousWorkItemHandler workItemHandler = new ErrornousWorkItemHandler("ScriptTask", HandlingStrategy.COMPLETE);
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
-        ProcessInstance processInstance = ksession.startProcess("com.sample.boolean");
-        assertEquals(ProcessInstance.STATE_COMPLETED, processInstance.getState());
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
+        KogitoProcessInstance processInstance = kruntime.startProcess("com.sample.boolean");
+        assertEquals(KogitoProcessInstance.STATE_COMPLETED, processInstance.getState());
         
         assertProcessVarValue(processInstance, "isChecked", "true");
         
-        WorkItem handledWorkItem = workItemHandler.getWorkItem();
-        assertEquals(WorkItem.COMPLETED, handledWorkItem.getState());
+        KogitoWorkItem handledWorkItem = (KogitoWorkItem) workItemHandler.getWorkItem();
+        assertEquals(KogitoWorkItem.COMPLETED, handledWorkItem.getState());
     }
 
     @Test
     public void testErrornousHandlerWithStrategyCompleteWaitState() throws Exception {
-          
-        KieBase kbase = createKnowledgeBaseWithoutDumper("handler/BPMN2-UserTaskWithBooleanOutput.bpmn2", "handler/BPMN2-ReceiveTask.bpmn2");
 
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("handler/BPMN2-UserTaskWithBooleanOutput.bpmn2", "handler/BPMN2-ReceiveTask.bpmn2");
+
         TestWorkItemHandler testHandler = new TestWorkItemHandler();
         ErrornousWorkItemHandler workItemHandler = new ErrornousWorkItemHandler("ReceiveTask", HandlingStrategy.COMPLETE);
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
-        ksession.getWorkItemManager().registerWorkItemHandler("Receive Task", testHandler);
-        ProcessInstance processInstance = ksession.startProcess("com.sample.boolean");
-        assertEquals(ProcessInstance.STATE_ACTIVE, processInstance.getState());
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
+        kruntime.getWorkItemManager().registerWorkItemHandler("Receive Task", testHandler);
+        KogitoProcessInstance processInstance = kruntime.startProcess("com.sample.boolean");
+        assertEquals(KogitoProcessInstance.STATE_ACTIVE, processInstance.getState());
         
         KogitoWorkItem receiveWorkItem = testHandler.getWorkItem();
         
@@ -94,40 +86,37 @@ public class WorkItemHandlerExceptionHandlingTest extends JbpmBpmn2TestCase {
     
     @Test
     public void testErrornousHandlerWithStrategyAbort() throws Exception {
-          
-        KieBase kbase = createKnowledgeBaseWithoutDumper("handler/BPMN2-UserTaskWithBooleanOutput.bpmn2", "handler/BPMN2-ScriptTask.bpmn2");
 
-        KieSession ksession = createKnowledgeSession(kbase);
+        kruntime = createKogitoProcessRuntime("handler/BPMN2-UserTaskWithBooleanOutput.bpmn2", "handler/BPMN2-ScriptTask.bpmn2");
+
         ErrornousWorkItemHandler workItemHandler = new ErrornousWorkItemHandler("ScriptTask", HandlingStrategy.ABORT);
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
         
         Map<String, Object> params = new HashMap<>();
         params.put("isChecked", false);
-        ProcessInstance processInstance = ksession.startProcess("com.sample.boolean", params);
-        assertEquals(ProcessInstance.STATE_COMPLETED, processInstance.getState());
+        KogitoProcessInstance processInstance = kruntime.startProcess("com.sample.boolean", params);
+        assertEquals(KogitoProcessInstance.STATE_COMPLETED, processInstance.getState());
         assertProcessVarValue(processInstance, "isChecked", "false");
         
-        WorkItem handledWorkItem = workItemHandler.getWorkItem();
-        assertEquals(WorkItem.ABORTED, handledWorkItem.getState());
+        KogitoWorkItem handledWorkItem = (KogitoWorkItem) workItemHandler.getWorkItem();
+        assertEquals(KogitoWorkItem.ABORTED, handledWorkItem.getState());
         
     }
     
     @Test
     public void testErrornousHandlerWithStrategyAbortWaitState() throws Exception {
-          
-        KieBase kbase = createKnowledgeBaseWithoutDumper("handler/BPMN2-UserTaskWithBooleanOutput.bpmn2", "handler/BPMN2-ReceiveTask.bpmn2");
 
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("handler/BPMN2-UserTaskWithBooleanOutput.bpmn2", "handler/BPMN2-ReceiveTask.bpmn2");
+
         ErrornousWorkItemHandler workItemHandler = new ErrornousWorkItemHandler("ReceiveTask", HandlingStrategy.ABORT);
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
         TestWorkItemHandler testHandler = new TestWorkItemHandler();
-        ksession.getWorkItemManager().registerWorkItemHandler("Receive Task", testHandler);
+        kruntime.getWorkItemManager().registerWorkItemHandler("Receive Task", testHandler);
         
         Map<String, Object> params = new HashMap<>();
         params.put("isChecked", false);
-        ProcessInstance processInstance = ksession.startProcess("com.sample.boolean", params);
-        assertEquals(ProcessInstance.STATE_ACTIVE, processInstance.getState());
+        KogitoProcessInstance processInstance = kruntime.startProcess("com.sample.boolean", params);
+        assertEquals(KogitoProcessInstance.STATE_ACTIVE, processInstance.getState());
         
         KogitoWorkItem receiveWorkItem = testHandler.getWorkItem();
         
@@ -142,52 +131,48 @@ public class WorkItemHandlerExceptionHandlingTest extends JbpmBpmn2TestCase {
     
     @Test
     public void testErrornousHandlerWithStrategyRethrow() throws Exception {
-          
-        KieBase kbase = createKnowledgeBaseWithoutDumper("handler/BPMN2-UserTaskWithBooleanOutput.bpmn2", "handler/BPMN2-ScriptTask.bpmn2");
 
-        KieSession ksession = createKnowledgeSession(kbase);
+        kruntime = createKogitoProcessRuntime("handler/BPMN2-UserTaskWithBooleanOutput.bpmn2", "handler/BPMN2-ScriptTask.bpmn2");
+
         ErrornousWorkItemHandler workItemHandler = new ErrornousWorkItemHandler("ScriptTask", HandlingStrategy.RETHROW);
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
     
         Map<String, Object> params = new HashMap<>();
         params.put("isChecked", false);
-        ProcessInstance processInstance = ksession.startProcess("com.sample.boolean", params);
+        KogitoProcessInstance processInstance = kruntime.startProcess("com.sample.boolean", params);
         assertEquals( KogitoProcessInstance.STATE_ERROR, processInstance.getState());
     }
     
     @Test
     public void testErrornousHandlerWithStrategyRetry() throws Exception {
-          
-        KieBase kbase = createKnowledgeBaseWithoutDumper("handler/BPMN2-UserTaskWithBooleanOutput.bpmn2", "handler/BPMN2-ScriptTask.bpmn2");
 
-        KieSession ksession = createKnowledgeSession(kbase);
+        kruntime = createKogitoProcessRuntime("handler/BPMN2-UserTaskWithBooleanOutput.bpmn2", "handler/BPMN2-ScriptTask.bpmn2");
+
         ErrornousWorkItemHandler workItemHandler = new ErrornousWorkItemHandler("ScriptTask", HandlingStrategy.RETRY);
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
         
         Map<String, Object> params = new HashMap<>();
         params.put("isChecked", false);
-        ProcessInstance processInstance = ksession.startProcess("com.sample.boolean", params);
-        assertEquals(ProcessInstance.STATE_COMPLETED, processInstance.getState());
+        KogitoProcessInstance processInstance = kruntime.startProcess("com.sample.boolean", params);
+        assertEquals(KogitoProcessInstance.STATE_COMPLETED, processInstance.getState());
         assertProcessVarValue(processInstance, "isChecked", "true");
               
     }
     
     @Test
     public void testErrornousHandlerWithStrategyRetryWaitState() throws Exception {
-          
-        KieBase kbase = createKnowledgeBaseWithoutDumper("handler/BPMN2-UserTaskWithBooleanOutput.bpmn2", "handler/BPMN2-ReceiveTask.bpmn2");
 
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("handler/BPMN2-UserTaskWithBooleanOutput.bpmn2", "handler/BPMN2-ReceiveTask.bpmn2");
+
         ErrornousWorkItemHandler workItemHandler = new ErrornousWorkItemHandler("ReceiveTask", HandlingStrategy.RETRY);
-        ksession.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
+        kruntime.getWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
         TestWorkItemHandler testHandler = new TestWorkItemHandler();
-        ksession.getWorkItemManager().registerWorkItemHandler("Receive Task", testHandler);
+        kruntime.getWorkItemManager().registerWorkItemHandler("Receive Task", testHandler);
         
         Map<String, Object> params = new HashMap<>();
         params.put("isChecked", false);
-        ProcessInstance processInstance = ksession.startProcess("com.sample.boolean", params);
-        assertEquals(ProcessInstance.STATE_ACTIVE, processInstance.getState());
+        KogitoProcessInstance processInstance = kruntime.startProcess("com.sample.boolean", params);
+        assertEquals(KogitoProcessInstance.STATE_ACTIVE, processInstance.getState());
         
         KogitoWorkItem receiveWorkItem = testHandler.getWorkItem();
         

--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/structureref/StructureRefTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/structureref/StructureRefTest.java
@@ -24,10 +24,7 @@ import org.jbpm.bpmn2.objects.TestWorkItemHandler;
 import org.jbpm.process.core.context.variable.VariableScope;
 import org.jbpm.process.core.datatype.impl.coverter.TypeConverterRegistry;
 import org.junit.jupiter.api.Test;
-import org.kie.api.KieBase;
-import org.kie.api.runtime.KieSession;
 import org.kie.kogito.internal.process.runtime.KogitoProcessInstance;
-import org.kie.kogito.internal.process.runtime.KogitoProcessRuntime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -37,9 +34,7 @@ public class StructureRefTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testStringStructureRef() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-StringStructureRef.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-StringStructureRef.bpmn2");
 
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
@@ -52,14 +47,12 @@ public class StructureRefTest extends JbpmBpmn2TestCase {
         kruntime.getWorkItemManager().completeWorkItem(
                 workItemHandler.getWorkItem().getStringId(), res);
 
-        assertProcessInstanceCompleted(processInstance.getStringId(), ksession);
+        assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
     }
 
     @Test
     public void testBooleanStructureRef() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-BooleanStructureRef.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-BooleanStructureRef.bpmn2");
 
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
@@ -72,14 +65,12 @@ public class StructureRefTest extends JbpmBpmn2TestCase {
         kruntime.getWorkItemManager().completeWorkItem(
                 workItemHandler.getWorkItem().getStringId(), res);
 
-        assertProcessInstanceCompleted(processInstance.getStringId(), ksession);
+        assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
     }
 
     @Test
     public void testIntegerStructureRef() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-IntegerStructureRef.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-IntegerStructureRef.bpmn2");
 
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
@@ -92,14 +83,12 @@ public class StructureRefTest extends JbpmBpmn2TestCase {
         kruntime.getWorkItemManager().completeWorkItem(
                 workItemHandler.getWorkItem().getStringId(), res);
 
-        assertProcessInstanceCompleted(processInstance.getStringId(), ksession);
+        assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
     }
 
     @Test
     public void testFloatStructureRef() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-FloatStructureRef.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-FloatStructureRef.bpmn2");
 
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
@@ -112,7 +101,7 @@ public class StructureRefTest extends JbpmBpmn2TestCase {
         kruntime.getWorkItemManager().completeWorkItem(
                 workItemHandler.getWorkItem().getStringId(), res);
 
-        assertProcessInstanceCompleted(processInstance.getStringId(), ksession);
+        assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
     }
 
     @Test
@@ -122,9 +111,7 @@ public class StructureRefTest extends JbpmBpmn2TestCase {
         TypeConverterRegistry.get().register("org.jbpm.bpmn2.objects.Person", (s) -> 
             new XStream().fromXML(personAsXml)
         );
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-ObjectStructureRef.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-ObjectStructureRef.bpmn2");
 
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
@@ -137,7 +124,7 @@ public class StructureRefTest extends JbpmBpmn2TestCase {
         kruntime.getWorkItemManager().completeWorkItem(
                 workItemHandler.getWorkItem().getStringId(), res);
 
-        assertProcessInstanceCompleted(processInstance.getStringId(), ksession);
+        assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
     }
 
     @Test
@@ -145,9 +132,7 @@ public class StructureRefTest extends JbpmBpmn2TestCase {
 
         String value = "simple text for testing";
 
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-DefaultObjectStructureRef.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-DefaultObjectStructureRef.bpmn2");
 
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
@@ -160,14 +145,12 @@ public class StructureRefTest extends JbpmBpmn2TestCase {
         kruntime.getWorkItemManager().completeWorkItem(
                 workItemHandler.getWorkItem().getStringId(), res);
 
-        assertProcessInstanceCompleted(processInstance.getStringId(), ksession);
+        assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
     }
 
     @Test
     public void testNotExistingVarBooleanStructureRefOnStart() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-BooleanStructureRef.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-BooleanStructureRef.bpmn2");
 
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
@@ -181,9 +164,7 @@ public class StructureRefTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testInvalidBooleanStructureRefOnStart() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-BooleanStructureRef.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-BooleanStructureRef.bpmn2");
 
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
@@ -196,9 +177,7 @@ public class StructureRefTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testInvalidBooleanStructureRefOnWIComplete() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-IntegerStructureRef.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-IntegerStructureRef.bpmn2");
 
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
@@ -223,9 +202,7 @@ public class StructureRefTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testInvalidBooleanStructureRefOnStartVerifyErrorMsg() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-BooleanStructureRef.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-BooleanStructureRef.bpmn2");
 
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
@@ -244,9 +221,7 @@ public class StructureRefTest extends JbpmBpmn2TestCase {
     public void testInvalidBooleanStructureRefOnStartWithDisabledCheck() throws Exception {
     	// Temporarily disable check for variables strict that is enabled by default for tests
     	VariableScope.setVariableStrictOption(false);
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-BooleanStructureRef.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+    	kruntime = createKogitoProcessRuntime("BPMN2-BooleanStructureRef.bpmn2");
 
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",
@@ -261,9 +236,7 @@ public class StructureRefTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testNotExistingBooleanStructureRefOnWIComplete() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-IntegerStructureRef.bpmn2");
-        KieSession ksession = createKnowledgeSession(kbase);
-        KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime( ksession );
+        kruntime = createKogitoProcessRuntime("BPMN2-IntegerStructureRef.bpmn2");
 
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
         kruntime.getWorkItemManager().registerWorkItemHandler("Human Task",

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/DummyKnowledgeRuntime.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/DummyKnowledgeRuntime.java
@@ -27,6 +27,7 @@ import org.drools.core.time.TimerService;
 import org.jbpm.workflow.instance.impl.CodegenNodeInstanceFactoryRegistry;
 import org.kie.api.KieBase;
 import org.kie.api.event.process.ProcessEventListener;
+import org.kie.api.event.process.ProcessEventManager;
 import org.kie.api.event.rule.AgendaEventListener;
 import org.kie.api.event.rule.RuleRuntimeEventListener;
 import org.kie.api.logger.KieRuntimeLogger;
@@ -35,6 +36,7 @@ import org.kie.api.runtime.Channel;
 import org.kie.api.runtime.Environment;
 import org.kie.api.runtime.Globals;
 import org.kie.api.runtime.KieRuntime;
+import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.KieSessionConfiguration;
 import org.kie.api.runtime.ObjectFilter;
 import org.kie.api.runtime.process.ProcessInstance;
@@ -103,6 +105,11 @@ class DummyKnowledgeRuntime implements InternalKnowledgeRuntime, KogitoProcessRu
     }
 
     @Override
+    public ProcessEventManager getProcessEventManager() {
+        return processRuntime;
+    }
+
+    @Override
     public Environment getEnvironment() {
         return environment;
     }
@@ -158,6 +165,11 @@ class DummyKnowledgeRuntime implements InternalKnowledgeRuntime, KogitoProcessRu
 
     @Override
     public KieBase getKieBase() {
+        return null;
+    }
+
+    @Override
+    public KieSession getKieSession() {
         return null;
     }
 

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/KogitoProcessRuntimeImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/KogitoProcessRuntimeImpl.java
@@ -20,7 +20,9 @@ import java.util.Collection;
 import java.util.Map;
 
 import org.kie.api.KieBase;
+import org.kie.api.event.process.ProcessEventManager;
 import org.kie.api.runtime.KieRuntime;
+import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.AgendaFilter;
 import org.kie.kogito.jobs.JobsService;
 import org.kie.kogito.internal.process.event.KogitoProcessEventSupport;
@@ -93,7 +95,7 @@ public class KogitoProcessRuntimeImpl implements KogitoProcessRuntime {
 
     @Override
     public KogitoProcessInstance getProcessInstance(String id, boolean readOnly) {
-        return (KogitoProcessInstance) delegate.getProcessInstanceManager().getProcessInstance(id, readOnly);
+        return delegate.getProcessInstanceManager().getProcessInstance(id, readOnly);
     }
 
     @Override
@@ -116,6 +118,11 @@ public class KogitoProcessRuntimeImpl implements KogitoProcessRuntime {
     }
 
     @Override
+    public ProcessEventManager getProcessEventManager() {
+        return delegate;
+    }
+
+    @Override
     public JobsService getJobsService() {
         return delegate.getJobsService();
     }
@@ -130,7 +137,15 @@ public class KogitoProcessRuntimeImpl implements KogitoProcessRuntime {
         return delegate.getInternalKieRuntime().getKieBase();
     }
 
-    public KogitoProcessInstance startProcess( String processId, Map<String, Object> parameters, String trigger, AgendaFilter agendaFilter) {
+    @Override
+    public KieSession getKieSession() {
+        if (delegate.getInternalKieRuntime() instanceof KieSession) {
+            return (KieSession) delegate.getInternalKieRuntime();
+        }
+        return null;
+    }
+
+    public KogitoProcessInstance startProcess(String processId, Map<String, Object> parameters, String trigger, AgendaFilter agendaFilter) {
         KogitoProcessInstance processInstance = createProcessInstance(processId, parameters);
         if ( processInstance != null ) {
             // start process instance

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/LightProcessRuntime.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/LightProcessRuntime.java
@@ -222,7 +222,7 @@ public class LightProcessRuntime extends AbstractProcessRuntime {
     }
 
     public KogitoProcessInstance getProcessInstance(String id, boolean readOnly) {
-        return (KogitoProcessInstance) processInstanceManager.getProcessInstance(id, readOnly);
+        return processInstanceManager.getProcessInstance(id, readOnly);
     }
 
     public void removeProcessInstance(KogitoProcessInstance processInstance) {

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/LightWorkItemManager.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/LightWorkItemManager.java
@@ -45,8 +45,8 @@ import org.kie.kogito.signal.SignalManager;
 import static org.jbpm.process.instance.impl.humantask.HumanTaskWorkItemHandler.transitionToPhase;
 import static org.jbpm.process.instance.impl.workitem.Abort.ID;
 import static org.jbpm.process.instance.impl.workitem.Abort.STATUS;
-import static org.kie.api.runtime.process.WorkItem.ABORTED;
-import static org.kie.api.runtime.process.WorkItem.COMPLETED;
+import static org.kie.kogito.internal.process.runtime.KogitoWorkItem.ABORTED;
+import static org.kie.kogito.internal.process.runtime.KogitoWorkItem.COMPLETED;
 
 public class LightWorkItemManager implements KogitoWorkItemManager {
  

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/event/listeners/TriggerRulesEventListener.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/event/listeners/TriggerRulesEventListener.java
@@ -24,7 +24,7 @@ import org.kie.api.event.rule.MatchCancelledEvent;
 import org.kie.api.event.rule.MatchCreatedEvent;
 import org.kie.api.event.rule.RuleFlowGroupActivatedEvent;
 import org.kie.api.event.rule.RuleFlowGroupDeactivatedEvent;
-import org.kie.api.runtime.KieSession;
+import org.kie.kogito.internal.process.runtime.KogitoProcessRuntime;
 
 /**
  * Dedicated AgendaEventListener that will fireAllRules as soon as:
@@ -37,11 +37,11 @@ import org.kie.api.runtime.KieSession;
  */
 public class TriggerRulesEventListener implements AgendaEventListener {
     
-    private KieSession ksession;
+    private KogitoProcessRuntime kruntime;
     
-    public TriggerRulesEventListener(KieSession ksession) {
+    public TriggerRulesEventListener(KogitoProcessRuntime kruntime) {
 
-        this.ksession = ksession;
+        this.kruntime = kruntime;
     }
 
     @Override
@@ -80,7 +80,7 @@ public class TriggerRulesEventListener implements AgendaEventListener {
 
     @Override
     public void afterRuleFlowGroupActivated(RuleFlowGroupActivatedEvent event) {
-        ksession.fireAllRules();
+        kruntime.getKieSession().fireAllRules();
         
     }
 

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/DynamicUtils.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/DynamicUtils.java
@@ -41,7 +41,6 @@ import org.kie.api.runtime.ExecutableRunner;
 import org.kie.api.runtime.KieRuntime;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.process.NodeInstance;
-import org.kie.api.runtime.process.WorkItem;
 import org.kie.internal.KieInternalServices;
 import org.kie.internal.command.RegistryContext;
 import org.kie.internal.process.CorrelationKey;
@@ -50,6 +49,7 @@ import org.kie.internal.runtime.StatefulKnowledgeSession;
 import org.kie.kogito.internal.process.runtime.KogitoProcessInstance;
 import org.kie.kogito.internal.process.event.KogitoProcessEventSupport;
 import org.kie.kogito.internal.process.runtime.KogitoProcessRuntime;
+import org.kie.kogito.internal.process.runtime.KogitoWorkItem;
 import org.kie.kogito.process.workitems.KogitoWorkItemManager;
 import org.kie.kogito.process.workitems.impl.KogitoWorkItemImpl;
 import org.slf4j.Logger;
@@ -91,7 +91,7 @@ public class DynamicUtils {
             String workItemName,
             Map<String, Object> parameters) {
         final KogitoWorkItemImpl workItem = new KogitoWorkItemImpl();
-        workItem.setState(WorkItem.ACTIVE);
+        workItem.setState(KogitoWorkItem.ACTIVE);
         workItem.setProcessInstanceId(processInstance.getStringId());
         workItem.setDeploymentId((String) ksession.getEnvironment().get(EnvironmentName.DEPLOYMENT_ID));
         workItem.setName(workItemName);

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/WorkItemNodeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/WorkItemNodeInstance.java
@@ -80,12 +80,12 @@ import org.slf4j.LoggerFactory;
 import static org.jbpm.process.core.context.variable.VariableScope.VARIABLE_SCOPE;
 import static org.kie.kogito.internal.process.runtime.KogitoProcessInstance.STATE_ABORTED;
 import static org.kie.kogito.internal.process.runtime.KogitoProcessInstance.STATE_COMPLETED;
-import static org.kie.api.runtime.process.WorkItem.ABORTED;
-import static org.kie.api.runtime.process.WorkItem.COMPLETED;
+import static org.kie.kogito.internal.process.runtime.KogitoWorkItem.ABORTED;
+import static org.kie.kogito.internal.process.runtime.KogitoWorkItem.COMPLETED;
 
 /**
  * Runtime counterpart of a work item node.
- * 
+ *
  */
 public class WorkItemNodeInstance extends StateBasedNodeInstance implements EventListener, ContextInstanceContainer {
 

--- a/jbpm/process-workitems/src/main/java/org/kie/kogito/process/workitems/impl/KogitoDefaultWorkItemManager.java
+++ b/jbpm/process-workitems/src/main/java/org/kie/kogito/process/workitems/impl/KogitoDefaultWorkItemManager.java
@@ -35,8 +35,8 @@ import org.kie.kogito.process.workitems.KogitoWorkItem;
 import org.kie.kogito.process.workitems.KogitoWorkItemHandlerNotFoundException;
 import org.kie.kogito.process.workitems.KogitoWorkItemManager;
 
-import static org.kie.api.runtime.process.WorkItem.ABORTED;
-import static org.kie.api.runtime.process.WorkItem.COMPLETED;
+import static org.kie.kogito.internal.process.runtime.KogitoWorkItem.ABORTED;
+import static org.kie.kogito.internal.process.runtime.KogitoWorkItem.COMPLETED;
 
 public class KogitoDefaultWorkItemManager implements KogitoWorkItemManager {
 


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-4356

The whole test suite is using `KieSession` interface as entry point but in the majority of the cases this is not needed. Moreover this hard link to `KieSession` API makes harder to decouple APIs.
Migrate the whole test suites to use `KogitoProcessRuntime` with a fallback on `KieSession` only for legacy (to be removed?) codepath

Details:
- Now `JbpmBpmn2TestCase` has abstract methods only to return `KogitoRuntimeProcess` so that in the future it should be possible to remove the internal KieSession completely if needed.
- `KogitoRuntimeProcess` has a fallback method to return `KieSession` if available
- Removed unused/empty methods in `JbpmBpmn2TestCase`
- It is easy now to check legacy codepath: it is enough to check `getKieBase()`, `getKieRuntime()` and `getKieSession()` usages
- Note: no test has been removed/disabled