### PR TITLE
KOGITO-4376 Review license header validation during maven build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,12 @@ To contribute, use GitHub Pull Requests, from your **own** fork.
 
 ### Java Coding Guidelines
 
-We decided to disallow `@author` tags in the Javadoc: they are hard to maintain, especially in a very active project, and we use the Git history to track authorship. GitHub also has [this nice page with your contributions](https://github.com/kiegroup/kogito-runtimes/graphs/contributors). 
+We decided to disallow `@author` tags in the Javadoc: they are hard to maintain, especially in a very active project, and we use the Git history to track authorship. GitHub also has [this nice page with your contributions](https://github.com/kiegroup/kogito-runtimes/graphs/contributors).
+
+Copyright headers format is enforced during build time. In order to automatically format your files, you could run the following Maven command:
+```bash
+mvn com.mycila:license-maven-plugin:format
+```
 
 ### Requirements for Dependencies
 

--- a/kogito-build-parent/pom.xml
+++ b/kogito-build-parent/pom.xml
@@ -23,7 +23,24 @@
       - Version properties must be sorted alphabetically (other form of sorting were found to be unclear and ambiguous).
   -->
   <properties>
-    <checkstyle.header.template>.*</checkstyle.header.template>
+    <checkstyle.header.template><![CDATA[
+^\/\*$\n^
+\* Copyright \d\d\d\d Red Hat, Inc\. and\/or its affiliates\.$\n^
+\*$\n^
+\* Licensed under the Apache License, Version 2\.0 \(the &quot;License&quot;\);$\n^
+\* you may not use this file except in compliance with the License\.$\n^
+\* You may obtain a copy of the License at$\n^
+\*$\n^
+\*       http:\/\/www\.apache\.org\/licenses\/LICENSE-2\.0$\n^
+\*$\n^
+\* Unless required by applicable law or agreed to in writing, software$\n^
+\* distributed under the License is distributed on an &quot;AS IS&quot; BASIS,$\n^
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied\.$\n^
+\* See the License for the specific language governing permissions and$\n^
+\* limitations under the License\.$\n^
+\*\/$
+]]>
+    </checkstyle.header.template>
     <checkstyle.header.extensions>java</checkstyle.header.extensions>
    
     <!-- container images for testing -->
@@ -64,7 +81,7 @@
     <version.javadoc.plugin>3.0.1</version.javadoc.plugin>
     <version.javancss.plugin>2.0</version.javancss.plugin>
     <version.jdocbook.plugin>2.3.9</version.jdocbook.plugin>
-    <version.license.plugin>1.8.0</version.license.plugin>
+    <version.license.plugin>4.0.rc2</version.license.plugin>
     <version.archetype.plugin>3.0.1</version.archetype.plugin>
     <version.enforcer.plugin>3.0.0-M2</version.enforcer.plugin>
     <version.de.skuzzle.enforcer>1.1.0</version.de.skuzzle.enforcer>
@@ -892,6 +909,43 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-checkstyle-plugin</artifactId>
+          <version>${version.checkstyle.plugin}</version>
+          <configuration>
+            <checkstyleRules>
+              <module name="Checker">
+                <module name="RegexpHeader">
+                  <property name="header" value="${checkstyle.header.template}"/>
+                  <property name="fileExtensions" value="${checkstyle.header.extensions}"/>
+                </module>
+                <module name="TreeWalker">
+                  <module name="RegexpSinglelineJava">
+                    <property name="format" value="@author"/>
+                    <property name="message" value="No @author tag allowed"/>
+                  </module>
+                </module>
+              </module>
+            </checkstyleRules>
+            <outputFile>${project.build.directory}/checkstyle.log</outputFile>
+            <includeTestSourceDirectory>true</includeTestSourceDirectory>
+            <includeResources>true</includeResources>
+            <includeTestResources>true</includeTestResources>
+            <consoleOutput>false</consoleOutput>
+            <failsOnError>false</failsOnError>
+            <logViolationsToConsole>true</logViolationsToConsole>
+            <failOnViolation>false</failOnViolation>
+          </configuration>
+          <executions>
+            <execution>
+              <phase>validate</phase>
+              <goals>
+                <goal>check</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
           <artifactId>maven-archetype-plugin</artifactId>
           <version>${version.archetype.plugin}</version>
           <configuration>
@@ -1136,21 +1190,44 @@
           </configuration>
         </plugin>
         <plugin>
-          <groupId>com.mycila.maven-license-plugin</groupId>
-          <artifactId>maven-license-plugin</artifactId>
+          <groupId>com.mycila</groupId>
+          <artifactId>license-maven-plugin</artifactId>
           <version>${version.license.plugin}</version>
           <configuration>
-            <!-- TODO this is buggy as it only works for first level modules -->
-            <header>${basedir}/../LICENSE-ASL-2.0-HEADER.txt</header>
-            <includes>
-              <include>**/*.java</include>
-              <include>**/*.drl</include>
-            </includes>
+            <licenseSets>
+              <licenseSet>
+                <inlineHeader>
+Copyright ${license.git.copyrightCreationYear} Red Hat, Inc. and/or its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+                </inlineHeader>
+                <includes>
+                  <include>**/*.java</include>
+                  <include>**/*.drl</include>
+                </includes>
+              </licenseSet>
+            </licenseSets>
             <mapping>
               <drl>JAVADOC_STYLE</drl>
             </mapping>
-            <encoding>UTF-8</encoding>
           </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>com.mycila</groupId>
+              <artifactId>license-maven-plugin-git</artifactId>
+              <version>${version.license.plugin}</version>
+            </dependency>
+          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -1266,6 +1343,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
 - Centralize license header settings in `kogito-build-parent` bom
 - Use checkstyle to validate license header based on regex ( no git dependency )
 - For now Checkstyle will log errors in console but not break the build, this will allow changes to be pushed later on before we turned it on
 - For automatically formatting classes we will still use `license-maven-plugin`. To format code please run:  `mvn com.mycila:license-maven-plugin:format`

Assembly:
- https://github.com/kiegroup/kogito-examples/pull/553
- https://github.com/kiegroup/kogito-runtimes/pull/1046