### PR TITLE
[KOGITO-4404] Fix spring boot testing environment

### DIFF
--- a/integration-tests/integration-tests-springboot/src/it/settings.xml
+++ b/integration-tests/integration-tests-springboot/src/it/settings.xml
@@ -34,11 +34,4 @@
             </pluginRepositories>
         </profile>
     </profiles>
-    <mirrors>
-        <mirror>
-            <id>local.mirror</id>
-            <mirrorOf>*</mirrorOf>
-            <url>@localRepositoryUrl@</url>
-        </mirror>
-    </mirrors>
 </settings>


### PR DESCRIPTION
Removing mirror section from settings.xml so dependencies are checked
from external repo if not present

