### PR TITLE
[KOGITO-4411] null pointer exception when process is started

### DIFF
--- a/integration-tests/integration-tests-quarkus-processes/src/test/java/org/kie/kogito/integrationtests/quarkus/BasicRestTest.java
+++ b/integration-tests/integration-tests-quarkus-processes/src/test/java/org/kie/kogito/integrationtests/quarkus/BasicRestTest.java
@@ -24,6 +24,7 @@ import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
+import org.acme.travels.Traveller;
 import org.junit.jupiter.api.Test;
 import org.kie.kogito.testcontainers.quarkus.InfinispanQuarkusTestResource;
 
@@ -68,6 +69,31 @@ class BasicRestTest {
                 .statusCode(200)
                 .body("id", equalTo(id))
                 .body("var1", equalTo("Kermit"));
+    }
+
+    @Test
+    void testWithInaccurateModel() {
+
+        Traveller traveller = new Traveller("Javierito", "Dimequienes", "pepe@pepe.com", "Spanish");
+        String processId = given()
+                .contentType(ContentType.JSON)
+                .body(traveller)
+                .when()
+                .post("/approvals")
+                .then()
+                .statusCode(201)
+                .extract()
+                .path("id");
+
+        given()
+                .contentType(ContentType.JSON)
+                .queryParam("user", "admin")
+                .queryParam("group", "managers")
+                .pathParam("processId", processId)
+                .when()
+                .get("/approvals/{processId}/tasks")
+                .then()
+                .statusCode(200);
     }
 
     @Test

--- a/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/test/java/org/kie/kogito/integrationtests/springboot/BasicRestTest.java
+++ b/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/test/java/org/kie/kogito/integrationtests/springboot/BasicRestTest.java
@@ -17,6 +17,7 @@
 package org.kie.kogito.integrationtests.springboot;
 
 import java.util.HashMap;
+
 import java.util.Map;
 import java.util.UUID;
 
@@ -33,6 +34,8 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.acme.travels.Traveller;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = KogitoSpringbootApplication.class)
 @ContextConfiguration(initializers = InfinispanSpringBootTestResource.Conditional.class)
@@ -64,6 +67,31 @@ class BasicRestTest extends BaseRestTest {
                 .statusCode(200)
                 .body("id", equalTo(id))
                 .body("var1", equalTo("Kermit"));
+    }
+    
+    @Test
+    void testWithInaccurateModel () {
+        
+        Traveller traveller = new Traveller ("Javierito","Dimequienes","pepe@pepe.com","Spanish", null);
+        String processId = given()
+                .contentType(ContentType.JSON)
+                .body(traveller)
+                .when()
+                .post("/approvals")
+                .then()
+                .statusCode(201)
+                .extract()
+                .path("id");
+        
+        given()
+                .contentType(ContentType.JSON)
+                .queryParam("user", "admin")
+                .queryParam("group", "managers")
+                .pathParam("processId", processId)
+                .when()
+                .get("/approvals/{processId}/tasks")
+                .then()
+                .statusCode(200);
     }
 
     @Test

--- a/jbpm/process-serialization-protobuf/src/main/java/org/jbpm/marshalling/impl/AbstractProtobufProcessInstanceMarshaller.java
+++ b/jbpm/process-serialization-protobuf/src/main/java/org/jbpm/marshalling/impl/AbstractProtobufProcessInstanceMarshaller.java
@@ -802,11 +802,11 @@ public abstract class AbstractProtobufProcessInstanceMarshaller
             }
         }
 
+        Context variableScope = ((org.jbpm.process.core.Process) process)
+                .getDefaultContext( VariableScope.VARIABLE_SCOPE );
+        VariableScopeInstance variableScopeInstance = (VariableScopeInstance) processInstance
+                .getContextInstance( variableScope );
         if ( _instance.getVariableCount() > 0 ) {
-            Context variableScope = ((org.jbpm.process.core.Process) process)
-                    .getDefaultContext( VariableScope.VARIABLE_SCOPE );
-            VariableScopeInstance variableScopeInstance = (VariableScopeInstance) processInstance
-                    .getContextInstance( variableScope );
             for ( JBPMMessages.Variable _variable : _instance.getVariableList() ) {
                 try {
                     Object _value = ProtobufProcessMarshaller.unmarshallVariableValue( context, _variable );


### PR DESCRIPTION
Setting variable context from marshaller even if there are no properties