### PR TITLE
KOGITO-4430 Remove native-image mojo usage in Quarkus ITs

### DIFF
--- a/integration-tests/integration-tests-quarkus-decisions/pom.xml
+++ b/integration-tests/integration-tests-quarkus-decisions/pom.xml
@@ -138,6 +138,9 @@
           <name>native</name>
         </property>
       </activation>
+      <properties>
+        <quarkus.package.type>native</quarkus.package.type>
+      </properties>
       <build>
         <plugins>
           <plugin>
@@ -154,23 +157,6 @@
                     <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
                   </systemProperties>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>native-image</id>
-                <goals>
-                  <goal>native-image</goal>
-                </goals>
-                <configuration>
-                  <cleanupServer>true</cleanupServer>
-                  <enableHttpUrlHandler>true</enableHttpUrlHandler>
-                  <graalvmHome>${graalvmHome}</graalvmHome>
                 </configuration>
               </execution>
             </executions>

--- a/integration-tests/integration-tests-quarkus-predictions/pom.xml
+++ b/integration-tests/integration-tests-quarkus-predictions/pom.xml
@@ -138,6 +138,9 @@
           <name>native</name>
         </property>
       </activation>
+      <properties>
+        <quarkus.package.type>native</quarkus.package.type>
+      </properties>
       <build>
         <plugins>
           <plugin>
@@ -153,23 +156,6 @@
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
                   </systemProperties>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>native-image</id>
-                <goals>
-                  <goal>native-image</goal>
-                </goals>
-                <configuration>
-                  <cleanupServer>true</cleanupServer>
-                  <enableHttpUrlHandler>true</enableHttpUrlHandler>
-                  <graalvmHome>${graalvmHome}</graalvmHome>
                 </configuration>
               </execution>
             </executions>

--- a/integration-tests/integration-tests-quarkus-processes/pom.xml
+++ b/integration-tests/integration-tests-quarkus-processes/pom.xml
@@ -199,6 +199,9 @@
           <name>native</name>
         </property>
       </activation>
+      <properties>
+        <quarkus.package.type>native</quarkus.package.type>
+      </properties>
       <build>
         <plugins>
           <plugin>
@@ -214,23 +217,6 @@
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
                   </systemProperties>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>native-image</id>
-                <goals>
-                  <goal>native-image</goal>
-                </goals>
-                <configuration>
-                  <cleanupServer>true</cleanupServer>
-                  <enableHttpUrlHandler>true</enableHttpUrlHandler>
-                  <graalvmHome>${graalvmHome}</graalvmHome>
                 </configuration>
               </execution>
             </executions>

--- a/integration-tests/integration-tests-quarkus-rules/pom.xml
+++ b/integration-tests/integration-tests-quarkus-rules/pom.xml
@@ -142,6 +142,9 @@
           <name>native</name>
         </property>
       </activation>
+      <properties>
+        <quarkus.package.type>native</quarkus.package.type>
+      </properties>
       <build>
         <plugins>
           <plugin>
@@ -157,23 +160,6 @@
                   <systemProperties>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
                   </systemProperties>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>native-image</id>
-                <goals>
-                  <goal>native-image</goal>
-                </goals>
-                <configuration>
-                  <cleanupServer>true</cleanupServer>
-                  <enableHttpUrlHandler>true</enableHttpUrlHandler>
-                  <graalvmHome>${graalvmHome}</graalvmHome>
                 </configuration>
               </execution>
             </executions>


### PR DESCRIPTION
This is a follow-up of https://github.com/kiegroup/kogito-runtimes/pull/1067 .

I somehow missed that you also had Quarkus ITs outside of the extension repository.