### PR TITLE
KOGITO-4501 Clean node in pipelines

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,9 +52,9 @@ pipeline {
                 }
             }
             post {
-                always {
+                cleanup {
                     script {
-                        cloud.cleanContainersAndImages('docker')
+                        cleanContainers()
                     }
                 }
             }
@@ -68,9 +68,9 @@ pipeline {
                 }
             }
             post {
-                always {
+                cleanup {
                     script {
-                        cloud.cleanContainersAndImages('docker')
+                        cleanContainers()
                     }
                 }
             }
@@ -88,9 +88,9 @@ pipeline {
                 }
             }
             post {
-                always {
+                cleanup {
                     script {
-                        cloud.cleanContainersAndImages('docker')
+                        cleanContainers()
                     }
                 }
             }
@@ -102,9 +102,9 @@ pipeline {
                 }
             }
             post {
-                always {
+                cleanup {
                     script {
-                        cloud.cleanContainersAndImages('docker')
+                        cleanContainers()
                     }
                 }
             }
@@ -116,9 +116,9 @@ pipeline {
                 }
             }
             post {
-                always {
+                cleanup {
                     script {
-                        cloud.cleanContainersAndImages('docker')
+                        cleanContainers()
                     }
                 }
             }
@@ -132,9 +132,9 @@ pipeline {
                 }
             }
             post {
-                always {
+                cleanup {
                     script {
-                        cloud.cleanContainersAndImages('docker')
+                        cleanContainers()
                     }
                 }
             }
@@ -148,9 +148,9 @@ pipeline {
                 }
             }
             post {
-                always {
+                cleanup {
                     script {
-                        cloud.cleanContainersAndImages('docker')
+                        cleanContainers()
                     }
                 }
             }
@@ -161,8 +161,6 @@ pipeline {
             script {
                 sh '$WORKSPACE/trace.sh'
                 junit '**/target/surefire-reports/**/*.xml, **/target/failsafe-reports/**/*.xml'
-                cleanWs()
-                cloud.cleanContainersAndImages('docker')
             }
         }
         failure {
@@ -178,6 +176,11 @@ pipeline {
         fixed {
             script {
                 mailer.sendEmail_fixedPR()
+            }
+        }
+        cleanup {
+            script {
+                util.cleanNode('docker')
             }
         }
     }
@@ -209,4 +212,8 @@ MavenCommand getMavenCommand(String directory){
     return new MavenCommand(this, ['-fae'])
                 .withSettingsXmlId('kogito_release_settings')
                 .inDirectory(directory)
+}
+
+void cleanContainers() {
+    cloud.cleanContainersAndImages('docker')
 }

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -156,9 +156,11 @@ pipeline {
                 def propertiesStr = deployProperties.collect { entry ->  "${entry.key}=${entry.value}" }.join('\n')
                 writeFile(text: propertiesStr, file: 'deployment.properties')
                 archiveArtifacts(artifacts: 'deployment.properties')
-                
-                cleanWs()
-                cloud.cleanContainersAndImages('docker')
+            }
+        }
+        cleanup {
+            script {
+                util.cleanNode('docker')
             }
         }
     }

--- a/Jenkinsfile.drools
+++ b/Jenkinsfile.drools
@@ -64,7 +64,7 @@ pipeline {
             post {
                 always {
                     script {
-                        cloud.cleanContainersAndImages('docker')
+                        cleanContainers()
                     }
                 }
             }
@@ -80,7 +80,7 @@ pipeline {
             post {
                 always {
                     script {
-                        cloud.cleanContainersAndImages('docker')
+                        cleanContainers()
                     }
                 }
             }
@@ -95,7 +95,7 @@ pipeline {
             post {
                 always {
                     script {
-                        cloud.cleanContainersAndImages('docker')
+                        cleanContainers()
                     }
                 }
             }
@@ -110,7 +110,7 @@ pipeline {
             post {
                 always {
                     script {
-                        cloud.cleanContainersAndImages('docker')
+                        cleanContainers()
                     }
                 }
             }
@@ -125,7 +125,7 @@ pipeline {
             post {
                 always {
                     script {
-                        cloud.cleanContainersAndImages('docker')
+                        cleanContainers()
                     }
                 }
             }
@@ -141,7 +141,7 @@ pipeline {
             post {
                 always {
                     script {
-                        cloud.cleanContainersAndImages('docker')
+                        cleanContainers()
                     }
                 }
             }
@@ -157,7 +157,7 @@ pipeline {
             post {
                 always {
                     script {
-                        cloud.cleanContainersAndImages('docker')
+                        cleanContainers()
                     }
                 }
             }
@@ -170,8 +170,11 @@ pipeline {
         always {
             script {
                 junit '**/target/surefire-reports/**/*.xml, **/target/failsafe-reports/**/*.xml'
-                cleanWs()
-                cloud.cleanContainersAndImages('docker')
+            }
+        }
+        cleanup {
+            script {
+                util.cleanNode('docker')
             }
         }
     }
@@ -216,4 +219,8 @@ MavenCommand getMavenCommandWithDroolsVersion(String directory) {
                 .withSettingsXmlId('kogito_release_settings')
                 .inDirectory(directory)
                 .withProperty('version.org.kie7', "${DROOLS_VERSION}")
+}
+
+void cleanContainers() {
+    cloud.cleanContainersAndImages('docker')
 }

--- a/Jenkinsfile.native
+++ b/Jenkinsfile.native
@@ -37,7 +37,7 @@ pipeline {
             post {
                 always {
                     script {
-                        cloud.cleanContainersAndImages('docker')
+                        cleanContainers()
                     }
                 }
             }
@@ -52,7 +52,7 @@ pipeline {
             post {
                 always {
                     script {
-                        cloud.cleanContainersAndImages('docker')
+                        cleanContainers()
                     }
                 }
             }
@@ -67,7 +67,7 @@ pipeline {
             post {
                 always {
                     script {
-                        cloud.cleanContainersAndImages('docker')
+                        cleanContainers()
                     }
                 }
             }
@@ -82,7 +82,7 @@ pipeline {
             post {
                 always {
                     script {
-                        cloud.cleanContainersAndImages('docker')
+                        cleanContainers()
                     }
                 }
             }
@@ -95,8 +95,11 @@ pipeline {
         always {
             script {
                 junit '**/target/surefire-reports/**/*.xml, **/target/failsafe-reports/**/*.xml'
-                cleanWs()
-                cloud.cleanContainersAndImages('docker')
+            }
+        }
+        cleanup {
+            script {
+                util.cleanNode('docker')
             }
         }
     }
@@ -141,4 +144,8 @@ MavenCommand getNativeMavenCommand(String directory) {
                 .withProfiles(['native'])
                 .withProperty('quarkus.native.container-build', true)
                 .withProperty('quarkus.native.container-runtime', 'docker')
+}
+
+void cleanContainers() {
+    cloud.cleanContainersAndImages('docker')
 }

--- a/Jenkinsfile.promote
+++ b/Jenkinsfile.promote
@@ -88,10 +88,9 @@ pipeline {
         }
     }
     post {
-        always {
+        cleanup {
             script {
-                cleanWs()
-                cloud.cleanContainersAndImages('docker')
+                util.cleanNode('docker')
             }
         }
     }

--- a/Jenkinsfile.quarkus
+++ b/Jenkinsfile.quarkus
@@ -46,7 +46,7 @@ pipeline {
             post {
                 always {
                     script {
-                        cloud.cleanContainersAndImages('docker')
+                        cleanContainers()
                     }
                 }
             }
@@ -61,7 +61,7 @@ pipeline {
             post {
                 always {
                     script {
-                        cloud.cleanContainersAndImages('docker')
+                        cleanContainers()
                     }
                 }
             }
@@ -77,7 +77,7 @@ pipeline {
             post {
                 always {
                     script {
-                        cloud.cleanContainersAndImages('docker')
+                        cleanContainers()
                     }
                 }
             }
@@ -92,7 +92,7 @@ pipeline {
             post {
                 always {
                     script {
-                        cloud.cleanContainersAndImages('docker')
+                        cleanContainers()
                     }
                 }
             }
@@ -107,7 +107,7 @@ pipeline {
             post {
                 always {
                     script {
-                        cloud.cleanContainersAndImages('docker')
+                        cleanContainers()
                     }
                 }
             }
@@ -122,7 +122,7 @@ pipeline {
             post {
                 always {
                     script {
-                        cloud.cleanContainersAndImages('docker')
+                        cleanContainers()
                     }
                 }
             }
@@ -138,7 +138,7 @@ pipeline {
             post {
                 always {
                     script {
-                        cloud.cleanContainersAndImages('docker')
+                        cleanContainers()
                     }
                 }
             }
@@ -154,7 +154,7 @@ pipeline {
             post {
                 always {
                     script {
-                        cloud.cleanContainersAndImages('docker')
+                        cleanContainers()
                     }
                 }
             }
@@ -167,8 +167,11 @@ pipeline {
         always {
             script {
                 junit '**/target/surefire-reports/**/*.xml, **/target/failsafe-reports/**/*.xml'
-                cleanWs()
-                cloud.cleanContainersAndImages('docker')
+            }
+        }
+        cleanup {
+            script {
+                util.cleanNode('docker')
             }
         }
     }
@@ -221,4 +224,8 @@ MavenCommand getMavenCommand(String directory, boolean addQuarkusVersion=true) {
 
 String getQuarkusBranch() {
     return env['QUARKUS_BRANCH'] ?: 'master'
+}
+
+void cleanContainers() {
+    cloud.cleanContainersAndImages('docker')
 }

--- a/Jenkinsfile.sonarcloud
+++ b/Jenkinsfile.sonarcloud
@@ -58,8 +58,11 @@ pipeline {
         always {
             script {
                 junit '**/target/surefire-reports/**/*.xml, **/target/failsafe-reports/**/*.xml'
-                cleanWs()
-                cloud.cleanContainersAndImages('docker')
+            }
+        }
+        cleanup {
+            script {
+                util.cleanNode('docker')
             }
         }
     }


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-4501

Use shared library to clean the node used by Jenkins.
This will also allow to improve the shared lib later on without having to modify all pipelines.

Related PRs:
- https://github.com/kiegroup/kogito-runtimes/pull/1090
- https://github.com/kiegroup/optaplanner/pull/1172
- https://github.com/kiegroup/kogito-apps/pull/665
- https://github.com/kiegroup/kogito-examples/pull/584

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/droolsjbpm-build-bootstrap/tree/master/ide-configuration)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
