### PR TITLE
KOGITO-4558 escape properties to defer expansion

### DIFF
--- a/archetypes/kogito-quarkus-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/kogito-quarkus-archetype/src/main/resources/archetype-resources/pom.xml
@@ -125,7 +125,7 @@
                 </goals>
                 <configuration>
                   <systemPropertyVariables>
-                    <native.image.path>\${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                    <native.image.path>\${project.build.directory}/\${project.build.finalName}-runner</native.image.path>
                     <java.util.logging.manager>${quarkus.logging.manager}</java.util.logging.manager>
                     <maven.home>\${maven.home}</maven.home>
                   </systemPropertyVariables>

--- a/archetypes/kogito-quarkus-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/kogito-quarkus-archetype/src/main/resources/archetype-resources/pom.xml
@@ -84,7 +84,7 @@
         <configuration>
           <systemPropertyVariables>
             <java.util.logging.manager>${quarkus.logging.manager}</java.util.logging.manager>
-            <maven.home>${maven.home}</maven.home>
+            <maven.home>\${maven.home}</maven.home>
           </systemPropertyVariables>
         </configuration>
       </plugin>
@@ -125,9 +125,9 @@
                 </goals>
                 <configuration>
                   <systemPropertyVariables>
-                    <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                    <native.image.path>\${project.build.directory}/${project.build.finalName}-runner</native.image.path>
                     <java.util.logging.manager>${quarkus.logging.manager}</java.util.logging.manager>
-                    <maven.home>${maven.home}</maven.home>
+                    <maven.home>\${maven.home}</maven.home>
                   </systemPropertyVariables>
                 </configuration>
               </execution>


### PR DESCRIPTION
Jira: [KOGITO-4558](https://issues.redhat.com/browse/KOGITO-4558)

Escaping properties in archetype-resources to defer their expansion.
