### PR TITLE
[KOGITO-4586] Fixing reflect-config.json generation

### DIFF
--- a/kogito-codegen-modules/kogito-codegen-predictions/src/test/resources/prediction/test_scorecard.pmml
+++ b/kogito-codegen-modules/kogito-codegen-predictions/src/test/resources/prediction/test_scorecard.pmml
@@ -1,0 +1,38 @@
+<PMML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.2" xsi:schemaLocation="http://www.dmg.org/PMML-4_2 http://www.dmg.org/v4-2-1/pmml-4-2.xsd" xmlns="http://www.dmg.org/PMML-4_2">
+  <Header/>
+  <DataDictionary>
+    <DataField name="input1" optype="continuous" dataType="double"/>
+    <DataField name="input2" optype="continuous" dataType="double"/>
+    <DataField name="score" optype="continuous" dataType="double"/>
+  </DataDictionary>
+  <Scorecard modelName="SimpleScorecard" functionName="regression" useReasonCodes="true" reasonCodeAlgorithm="pointsBelow" initialScore="5" baselineMethod="other">
+    <MiningSchema>
+      <MiningField name="input1" usageType="active" invalidValueTreatment="asMissing"/>
+      <MiningField name="input2" usageType="active" invalidValueTreatment="asMissing"/>
+      <MiningField name="score" usageType="target"/>
+    </MiningSchema>
+    <Output>
+      <OutputField name="Score" feature="predictedValue" dataType="double" optype="continuous"/>
+      <OutputField name="Reason Code 1" rank="1" feature="reasonCode" dataType="string" optype="categorical"/>
+      <OutputField name="Reason Code 2" rank="2" feature="reasonCode" dataType="string" optype="categorical"/>
+    </Output>
+    <Characteristics>
+      <Characteristic name="input1Score" baselineScore="4" reasonCode="Input1ReasonCode">
+        <Attribute partialScore="-12">
+          <SimplePredicate field="input1" operator="lessOrEqual" value="10"/>
+        </Attribute>
+        <Attribute partialScore="50">
+          <SimplePredicate field="input1" operator="greaterThan" value="10"/>
+        </Attribute>
+      </Characteristic>
+      <Characteristic name="input2Score" baselineScore="8" reasonCode="Input2ReasonCode">
+        <Attribute partialScore="-8">
+          <SimplePredicate field="input2" operator="lessOrEqual" value="-5"/>
+        </Attribute>
+        <Attribute partialScore="32">
+          <SimplePredicate field="input2" operator="greaterThan" value="-5"/>
+        </Attribute>
+      </Characteristic>
+    </Characteristics>
+  </Scorecard>
+</PMML>


### PR DESCRIPTION
@danielezonca @evacchi  @jiripetrlik

See https://issues.redhat.com/browse/KOGITO-4586

This PR restore the reflect-config.json generation that was wrongly removed by https://issues.redhat.com/browse/DROOLS-5702

