### PR TITLE
[KOGITO-4456] - Fix CloudEvents Kogito extension naming

### DIFF
--- a/addons/events/knative-eventing-addon/src/main/java/org/kie/kogito/events/knative/ce/extensions/KogitoProcessExtension.java
+++ b/addons/events/knative-eventing-addon/src/main/java/org/kie/kogito/events/knative/ce/extensions/KogitoProcessExtension.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import org.kie.kogito.services.event.impl.ProcessInstanceEventBody;
+import org.kie.kogito.event.CloudEventExtensionConstants;
 
 import io.cloudevents.CloudEventExtensions;
 import io.cloudevents.Extension;
@@ -34,25 +34,17 @@ import io.cloudevents.Extension;
  */
 public class KogitoProcessExtension implements Extension {
 
-    // these keys don't have the period cause CloudEvents serialized on JSON won't have them
-
-    public static final String PROCESS_INSTANCE_ID = ProcessInstanceEventBody.PROCESS_ID_META_DATA.replace(".", "");
-    public static final String ROOT_PROCESS_INSTANCE_ID = ProcessInstanceEventBody.ROOT_PROCESS_ID_META_DATA.replace(".", "");
-    public static final String ROOT_PROCESS_ID = ProcessInstanceEventBody.ROOT_PROCESS_ID_META_DATA.replace(".", "");
-    public static final String PROCESS_INSTANCE_STATE = ProcessInstanceEventBody.STATE_META_DATA.replace(".", "");
-    public static final String PROCESS_ID = "kogitoprocessid";
-    public static final String ADDONS = "kogitoaddons";
-    public static final String PARENT_PROCESS_INSTANCE_ID = "kogitoparentprocessinstanceid";
-    public static final String REF_ID = "kogitoreferenceid";
     static final Set<String> ALL_KEYS = new HashSet<>(
             Arrays.asList(
-                    PROCESS_INSTANCE_ID,
-                    ROOT_PROCESS_INSTANCE_ID,
-                    PROCESS_ID,
-                    ROOT_PROCESS_ID,
-                    ADDONS,
-                    PARENT_PROCESS_INSTANCE_ID,
-                    PROCESS_INSTANCE_STATE, REF_ID));
+                    CloudEventExtensionConstants.PROCESS_INSTANCE_ID,
+                    CloudEventExtensionConstants.PROCESS_ROOT_PROCESS_INSTANCE_ID,
+                    CloudEventExtensionConstants.PROCESS_ID,
+                    CloudEventExtensionConstants.PROCESS_ROOT_PROCESS_ID,
+                    CloudEventExtensionConstants.ADDONS,
+                    CloudEventExtensionConstants.PROCESS_PARENT_PROCESS_INSTANCE_ID,
+                    CloudEventExtensionConstants.PROCESS_INSTANCE_STATE,
+                    CloudEventExtensionConstants.PROCESS_REFERENCE_ID,
+                    CloudEventExtensionConstants.PROCESS_START_FROM_NODE));
 
     private final Map<String, Object> innerValues;
     private String kogitoProcessInstanceId;
@@ -63,6 +55,7 @@ public class KogitoProcessExtension implements Extension {
     private String kogitoParentProcessinstanceId;
     private String kogitoProcessInstanceState;
     private String kogitoReferenceId;
+    private String kogitoStartFromNode;
 
     public KogitoProcessExtension() {
         this.innerValues = new HashMap<>();
@@ -74,7 +67,7 @@ public class KogitoProcessExtension implements Extension {
 
     public void setKogitoProcessInstanceId(String kogitoProcessInstanceId) {
         this.kogitoProcessInstanceId = kogitoProcessInstanceId;
-        this.innerValues.put(PROCESS_INSTANCE_ID, this.kogitoProcessInstanceId);
+        this.innerValues.put(CloudEventExtensionConstants.PROCESS_INSTANCE_ID, this.kogitoProcessInstanceId);
     }
 
     public String getKogitoRootProcessInstanceId() {
@@ -83,7 +76,7 @@ public class KogitoProcessExtension implements Extension {
 
     public void setKogitoRootProcessInstanceId(String kogitoRootProcessInstanceId) {
         this.kogitoRootProcessInstanceId = kogitoRootProcessInstanceId;
-        this.innerValues.put(ROOT_PROCESS_INSTANCE_ID, this.kogitoRootProcessInstanceId);
+        this.innerValues.put(CloudEventExtensionConstants.PROCESS_ROOT_PROCESS_INSTANCE_ID, this.kogitoRootProcessInstanceId);
     }
 
     public String getKogitoProcessId() {
@@ -92,7 +85,7 @@ public class KogitoProcessExtension implements Extension {
 
     public void setKogitoProcessId(String kogitoProcessId) {
         this.kogitoProcessId = kogitoProcessId;
-        this.innerValues.put(PROCESS_ID, this.kogitoProcessId);
+        this.innerValues.put(CloudEventExtensionConstants.PROCESS_ID, this.kogitoProcessId);
     }
 
     public String getKogitoRootProcessId() {
@@ -101,7 +94,7 @@ public class KogitoProcessExtension implements Extension {
 
     public void setKogitoRootProcessId(String kogitoRootProcessId) {
         this.kogitoRootProcessId = kogitoRootProcessId;
-        this.innerValues.put(ROOT_PROCESS_ID, this.kogitoRootProcessId);
+        this.innerValues.put(CloudEventExtensionConstants.PROCESS_ROOT_PROCESS_ID, this.kogitoRootProcessId);
     }
 
     public String getKogitoAddons() {
@@ -110,7 +103,7 @@ public class KogitoProcessExtension implements Extension {
 
     public void setKogitoAddons(String kogitoAddons) {
         this.kogitoAddons = kogitoAddons;
-        this.innerValues.put(ADDONS, this.kogitoAddons);
+        this.innerValues.put(CloudEventExtensionConstants.ADDONS, this.kogitoAddons);
     }
 
     public String getKogitoParentProcessinstanceId() {
@@ -119,7 +112,7 @@ public class KogitoProcessExtension implements Extension {
 
     public void setKogitoParentProcessinstanceId(String kogitoParentProcessinstanceId) {
         this.kogitoParentProcessinstanceId = kogitoParentProcessinstanceId;
-        this.innerValues.put(PARENT_PROCESS_INSTANCE_ID, this.kogitoParentProcessinstanceId);
+        this.innerValues.put(CloudEventExtensionConstants.PROCESS_PARENT_PROCESS_INSTANCE_ID, this.kogitoParentProcessinstanceId);
     }
 
     public String getKogitoProcessInstanceState() {
@@ -128,7 +121,7 @@ public class KogitoProcessExtension implements Extension {
 
     public void setKogitoProcessInstanceState(String kogitoProcessInstanceState) {
         this.kogitoProcessInstanceState = kogitoProcessInstanceState;
-        this.innerValues.put(PROCESS_INSTANCE_STATE, this.kogitoProcessInstanceState);
+        this.innerValues.put(CloudEventExtensionConstants.PROCESS_INSTANCE_STATE, this.kogitoProcessInstanceState);
     }
 
     public String getKogitoReferenceId() {
@@ -137,19 +130,29 @@ public class KogitoProcessExtension implements Extension {
 
     public void setKogitoReferenceId(String kogitoReferenceId) {
         this.kogitoReferenceId = kogitoReferenceId;
-        this.innerValues.put(REF_ID, this.kogitoReferenceId);
+        this.innerValues.put(CloudEventExtensionConstants.PROCESS_REFERENCE_ID, this.kogitoReferenceId);
+    }
+
+    public String getKogitoStartFromNode() {
+        return kogitoStartFromNode;
+    }
+
+    public void setKogitoStartFromNode(String kogitoStartFromNode) {
+        this.kogitoStartFromNode = kogitoStartFromNode;
+        this.innerValues.put(CloudEventExtensionConstants.PROCESS_START_FROM_NODE, this.kogitoStartFromNode);
     }
 
     @Override
     public void readFrom(CloudEventExtensions extensions) {
-        this.setKogitoAddons(getExtension(extensions, ADDONS));
-        this.setKogitoParentProcessinstanceId(getExtension(extensions, PARENT_PROCESS_INSTANCE_ID));
-        this.setKogitoProcessId(getExtension(extensions, PROCESS_ID));
-        this.setKogitoProcessInstanceId(getExtension(extensions, PROCESS_INSTANCE_ID));
-        this.setKogitoProcessInstanceState(getExtension(extensions, PROCESS_INSTANCE_STATE));
-        this.setKogitoReferenceId(getExtension(extensions, REF_ID));
-        this.setKogitoRootProcessId(getExtension(extensions, ROOT_PROCESS_ID));
-        this.setKogitoRootProcessInstanceId(getExtension(extensions, ROOT_PROCESS_INSTANCE_ID));
+        this.setKogitoAddons(getExtension(extensions, CloudEventExtensionConstants.ADDONS));
+        this.setKogitoParentProcessinstanceId(getExtension(extensions, CloudEventExtensionConstants.PROCESS_PARENT_PROCESS_INSTANCE_ID));
+        this.setKogitoProcessId(getExtension(extensions, CloudEventExtensionConstants.PROCESS_ID));
+        this.setKogitoProcessInstanceId(getExtension(extensions, CloudEventExtensionConstants.PROCESS_INSTANCE_ID));
+        this.setKogitoProcessInstanceState(getExtension(extensions, CloudEventExtensionConstants.PROCESS_INSTANCE_STATE));
+        this.setKogitoReferenceId(getExtension(extensions, CloudEventExtensionConstants.PROCESS_REFERENCE_ID));
+        this.setKogitoRootProcessId(getExtension(extensions, CloudEventExtensionConstants.PROCESS_ROOT_PROCESS_ID));
+        this.setKogitoRootProcessInstanceId(getExtension(extensions, CloudEventExtensionConstants.PROCESS_ROOT_PROCESS_INSTANCE_ID));
+        this.setKogitoStartFromNode(getExtension(extensions, CloudEventExtensionConstants.PROCESS_START_FROM_NODE));
     }
 
     private String getExtension(CloudEventExtensions extensions, String key) {
@@ -185,21 +188,22 @@ public class KogitoProcessExtension implements Extension {
                 Objects.equals(kogitoAddons, that.kogitoAddons) &&
                 Objects.equals(kogitoParentProcessinstanceId, that.kogitoParentProcessinstanceId) &&
                 Objects.equals(kogitoProcessInstanceState, that.kogitoProcessInstanceState) &&
-                Objects.equals(kogitoReferenceId, that.kogitoReferenceId);
+                Objects.equals(kogitoReferenceId, that.kogitoReferenceId) &&
+                Objects.equals(kogitoStartFromNode, that.kogitoStartFromNode);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(kogitoProcessInstanceId, kogitoRootProcessInstanceId, kogitoProcessId, kogitoRootProcessId, kogitoAddons, kogitoParentProcessinstanceId, kogitoProcessInstanceState,
-                kogitoReferenceId);
+                kogitoReferenceId, kogitoStartFromNode);
     }
 
     @Override
     public String toString() {
         return "KogitoProcessExtension{" +
-                "kogitoProcessinstanceId='" + kogitoProcessInstanceId + '\'' +
-                ", kogitoProcessId='" + kogitoProcessId + '\'' +
-                ", kogitoReferenceId='" + kogitoReferenceId + '\'' +
+                "procInstanceId='" + kogitoProcessInstanceId + '\'' +
+                ", processId='" + kogitoProcessId + '\'' +
+                ", referenceId='" + kogitoReferenceId + '\'' +
                 '}';
     }
 }

--- a/addons/events/knative-eventing-addon/src/test/java/org/kie/kogito/events/knative/ce/CloudEventConverterTest.java
+++ b/addons/events/knative-eventing-addon/src/test/java/org/kie/kogito/events/knative/ce/CloudEventConverterTest.java
@@ -20,6 +20,7 @@ import java.net.URI;
 import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
+import org.kie.kogito.event.CloudEventExtensionConstants;
 import org.kie.kogito.services.event.AbstractProcessDataEvent;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -91,7 +92,7 @@ class CloudEventConverterTest {
     void verifyDataEventWithProcessDataCloudEventConversion() throws IOException {
         // this is a typical HTTP post message
         final String messageJson = "{\n" +
-                "  \"kogitoReferenceId\": \"12345\",\n" +
+                "  \"" + CloudEventExtensionConstants.PROCESS_REFERENCE_ID + "\": \"12345\",\n" +
                 "  \"specversion\": \"0.3\",\n" +
                 "  \"id\": \"21627e26-31eb-43e7-8343-92a696fd96b1\",\n" +
                 "  \"source\": \"/process/instance/12345\",\n" +
@@ -112,7 +113,7 @@ class CloudEventConverterTest {
         final String convertedEvent = new String(objectMapper.writeValueAsBytes(event));
         assertThat(convertedEvent)
                 .contains("jan.kowalski@example.com")
-                .contains("kogitoReferenceId")
+                .contains(CloudEventExtensionConstants.PROCESS_REFERENCE_ID)
                 .contains("12345");
     }
 

--- a/addons/events/knative-eventing-addon/src/test/java/org/kie/kogito/events/knative/ce/extensions/KogitoProcessExtensionTest.java
+++ b/addons/events/knative-eventing-addon/src/test/java/org/kie/kogito/events/knative/ce/extensions/KogitoProcessExtensionTest.java
@@ -20,6 +20,7 @@ import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.kie.kogito.event.CloudEventExtensionConstants;
 
 import io.cloudevents.CloudEvent;
 import io.cloudevents.core.builder.CloudEventBuilder;
@@ -38,14 +39,14 @@ class KogitoProcessExtensionTest {
     void verifyKogitoExtensionCanBeRead() {
         final KogitoProcessExtension kpe = new KogitoProcessExtension();
         kpe.readFrom(getExampleCloudEvent());
-        assertThat(kpe.getValue(KogitoProcessExtension.REF_ID)).isNotNull().isInstanceOf(String.class).isEqualTo("12345");
-        assertThat(kpe.getValue(KogitoProcessExtension.PROCESS_ID)).isNotNull().isInstanceOf(String.class).isEqualTo("super_process");
-        assertThat((String) kpe.getValue(KogitoProcessExtension.PROCESS_INSTANCE_ID)).isBlank();
-        assertThat((String) kpe.getValue(KogitoProcessExtension.PROCESS_INSTANCE_STATE)).isBlank();
-        assertThat((String) kpe.getValue(KogitoProcessExtension.ROOT_PROCESS_INSTANCE_ID)).isBlank();
-        assertThat((String) kpe.getValue(KogitoProcessExtension.ROOT_PROCESS_ID)).isBlank();
-        assertThat((String) kpe.getValue(KogitoProcessExtension.PARENT_PROCESS_INSTANCE_ID)).isBlank();
-        assertThat((String) kpe.getValue(KogitoProcessExtension.ADDONS)).isBlank();
+        assertThat(kpe.getValue(CloudEventExtensionConstants.PROCESS_REFERENCE_ID)).isNotNull().isInstanceOf(String.class).isEqualTo("12345");
+        assertThat(kpe.getValue(CloudEventExtensionConstants.PROCESS_ID)).isNotNull().isInstanceOf(String.class).isEqualTo("super_process");
+        assertThat((String) kpe.getValue(CloudEventExtensionConstants.PROCESS_INSTANCE_ID)).isBlank();
+        assertThat((String) kpe.getValue(CloudEventExtensionConstants.PROCESS_INSTANCE_STATE)).isBlank();
+        assertThat((String) kpe.getValue(CloudEventExtensionConstants.PROCESS_ROOT_PROCESS_INSTANCE_ID)).isBlank();
+        assertThat((String) kpe.getValue(CloudEventExtensionConstants.PROCESS_ROOT_PROCESS_ID)).isBlank();
+        assertThat((String) kpe.getValue(CloudEventExtensionConstants.PROCESS_PARENT_PROCESS_INSTANCE_ID)).isBlank();
+        assertThat((String) kpe.getValue(CloudEventExtensionConstants.ADDONS)).isBlank();
     }
 
     @Test
@@ -60,8 +61,8 @@ class KogitoProcessExtensionTest {
                 .withType("example.demo")
                 .withSource(URI.create("http://example.com"))
                 .withData("application/json", "{}".getBytes())
-                .withExtension(KogitoProcessExtension.REF_ID, "12345")
-                .withExtension(KogitoProcessExtension.PROCESS_ID, "super_process")
+                .withExtension(CloudEventExtensionConstants.PROCESS_REFERENCE_ID, "12345")
+                .withExtension(CloudEventExtensionConstants.PROCESS_ID, "super_process")
                 .build();
     }
 }

--- a/addons/events/knative-eventing-addon/src/test/java/org/kie/kogito/events/knative/ce/http/CloudEventListenerResourceTest.java
+++ b/addons/events/knative-eventing-addon/src/test/java/org/kie/kogito/events/knative/ce/http/CloudEventListenerResourceTest.java
@@ -15,8 +15,6 @@
  */
 package org.kie.kogito.events.knative.ce.http;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
@@ -26,6 +24,7 @@ import javax.ws.rs.core.Response;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.kie.kogito.event.CloudEventExtensionConstants;
 
 import io.cloudevents.jackson.JsonFormat;
 import io.quarkus.test.junit.QuarkusTest;
@@ -51,7 +50,7 @@ class CloudEventListenerResourceTest {
                 .header("ce-source", "/from/unit/test")
                 .header("ce-specversion", "1.0")
                 .header("ce-id", UUID.randomUUID().toString())
-                .header("ce-kogitoReferenceId", "12345")
+                .header("ce-referenceid", "12345")
                 .header(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_PLAIN)
                 .post("/")
                 .then()
@@ -67,17 +66,17 @@ class CloudEventListenerResourceTest {
                 .header("ce-source", source)
                 .header("ce-specversion", "1.0")
                 .header("ce-id", UUID.randomUUID().toString())
-                .header("ce-kogitoReferenceId", "12345")
+                .header("ce-referenceid", "12345")
                 .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
                 .post("/")
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
                 .body(Matchers.equalTo("{ \"message\": \"Hola Mundo!\" }"))
-                .header("ce-kogitoreferenceid", "12345");
+                .header("ce-referenceid", "12345");
     }
 
     @Test
-    void verifyHttpRequestWithJSONPayloadExpectsPOJO() throws URISyntaxException, IOException {
+    void verifyHttpRequestWithJSONPayloadExpectsPOJO() {
         final String source = "/from/unit/test";
 
         Message msg = given()
@@ -87,7 +86,7 @@ class CloudEventListenerResourceTest {
                 .header("ce-source", source)
                 .header("ce-specversion", "1.0")
                 .header("ce-id", UUID.randomUUID().toString())
-                .header("ce-kogitoReferenceId", "12345")
+                .header("ce-referenceId", "12345")
                 .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
                 .post("/")
                 .then()
@@ -99,23 +98,21 @@ class CloudEventListenerResourceTest {
     }
 
     @Test
-    void verifyHttpRequestWithCEPayloadExpectsPOJO() throws URISyntaxException, IOException {
+    void verifyHttpRequestWithCEPayloadExpectsPOJO() {
         final String source = "/from/unit/test";
-
-        final Message msg = given().when()
-                .body("{\"kogitoReferenceId\":\"12345!\", \"data\":{\"message\":\"Hi World!\"},\"id\":\"x10\",\"source\":\"/from/unit/test\",\"specversion\":\"1.0\",\"type\":\"myevent\",\"datacontenttype\":\"application/json\"}")
+        given().when()
+                .body("{\"" + CloudEventExtensionConstants.PROCESS_REFERENCE_ID
+                        + "\":\"12345!\", \"data\":{\"message\":\"Hi World!\"},\"id\":\"x10\",\"source\":\"/from/unit/test\",\"specversion\":\"1.0\",\"type\":\"myevent\",\"datacontenttype\":\"application/json\"}")
                 .contentType(MediaType.valueOf(JsonFormat.CONTENT_TYPE).withCharset(StandardCharsets.UTF_8.name()).toString())
                 .post("/")
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
                 .header("ce-source", source)
-                .header("ce-kogitoReferenceId", "12345!")
-                .extract().body().as(Message.class);
-
+                .header("ce-referenceId", "12345!");
     }
 
     @Test
-    void verifyHttpRequestWithCEPayloadExpectsString() throws URISyntaxException, IOException {
+    void verifyHttpRequestWithCEPayloadExpectsString() {
         final String source = "/from/unit/test";
         final Message msg = given().when()
                 .body("{\"data\":{\"message\":\"Hi World!\"},\"id\":\"x10\",\"source\":\"/from/unit/test\",\"specversion\":\"1.0\",\"type\":\"myevent\",\"datacontenttype\":\"application/json\"}")

--- a/addons/events/knative-eventing-addon/src/test/java/org/kie/kogito/events/knative/ce/http/CloudEventListenerResourceTest.java
+++ b/addons/events/knative-eventing-addon/src/test/java/org/kie/kogito/events/knative/ce/http/CloudEventListenerResourceTest.java
@@ -50,7 +50,7 @@ class CloudEventListenerResourceTest {
                 .header("ce-source", "/from/unit/test")
                 .header("ce-specversion", "1.0")
                 .header("ce-id", UUID.randomUUID().toString())
-                .header("ce-referenceid", "12345")
+                .header("ce-" + CloudEventExtensionConstants.PROCESS_REFERENCE_ID, "12345")
                 .header(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_PLAIN)
                 .post("/")
                 .then()
@@ -66,13 +66,13 @@ class CloudEventListenerResourceTest {
                 .header("ce-source", source)
                 .header("ce-specversion", "1.0")
                 .header("ce-id", UUID.randomUUID().toString())
-                .header("ce-referenceid", "12345")
+                .header("ce-" + CloudEventExtensionConstants.PROCESS_REFERENCE_ID, "12345")
                 .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
                 .post("/")
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
                 .body(Matchers.equalTo("{ \"message\": \"Hola Mundo!\" }"))
-                .header("ce-referenceid", "12345");
+                .header("ce-" + CloudEventExtensionConstants.PROCESS_REFERENCE_ID, "12345");
     }
 
     @Test
@@ -86,7 +86,7 @@ class CloudEventListenerResourceTest {
                 .header("ce-source", source)
                 .header("ce-specversion", "1.0")
                 .header("ce-id", UUID.randomUUID().toString())
-                .header("ce-referenceId", "12345")
+                .header("ce-" + CloudEventExtensionConstants.PROCESS_REFERENCE_ID, "12345")
                 .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
                 .post("/")
                 .then()
@@ -108,7 +108,7 @@ class CloudEventListenerResourceTest {
                 .then()
                 .statusCode(Response.Status.OK.getStatusCode())
                 .header("ce-source", source)
-                .header("ce-referenceId", "12345!");
+                .header("ce-" + CloudEventExtensionConstants.PROCESS_REFERENCE_ID, "12345!");
     }
 
     @Test

--- a/api/kogito-events-api/pom.xml
+++ b/api/kogito-events-api/pom.xml
@@ -28,6 +28,18 @@
       <groupId>org.reactivestreams</groupId>
       <artifactId>reactive-streams</artifactId>
     </dependency>
+
+    <!-- Tests -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/api/kogito-events-api/src/main/java/org/kie/kogito/event/AbstractDataEvent.java
+++ b/api/kogito-events-api/src/main/java/org/kie/kogito/event/AbstractDataEvent.java
@@ -65,13 +65,22 @@ public abstract class AbstractDataEvent<T> implements DataEvent<T> {
 
     private T data;
 
+    @JsonProperty(CloudEventExtensionConstants.PROCESS_INSTANCE_ID)
     private String kogitoProcessinstanceId;
+
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonProperty(CloudEventExtensionConstants.PROCESS_ROOT_PROCESS_INSTANCE_ID)
     private String kogitoRootProcessinstanceId;
+
+    @JsonProperty(CloudEventExtensionConstants.PROCESS_ID)
     private String kogitoProcessId;
+
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonProperty(CloudEventExtensionConstants.PROCESS_ROOT_PROCESS_ID)
     private String kogitoRootProcessId;
+
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonProperty(CloudEventExtensionConstants.ADDONS)
     private String kogitoAddons;
 
     public AbstractDataEvent() {

--- a/api/kogito-events-api/src/main/java/org/kie/kogito/event/CloudEventExtensionConstants.java
+++ b/api/kogito-events-api/src/main/java/org/kie/kogito/event/CloudEventExtensionConstants.java
@@ -23,15 +23,15 @@ package org.kie.kogito.event;
  */
 public final class CloudEventExtensionConstants {
 
-    public static final String PROCESS_INSTANCE_ID = "procinstanceid";
-    public static final String PROCESS_REFERENCE_ID = "referenceid";
-    public static final String PROCESS_INSTANCE_STATE = "procinstancestate";
-    public static final String PROCESS_ID = "procid";
-    public static final String PROCESS_PARENT_PROCESS_INSTANCE_ID = "parentprocinstanceid";
-    public static final String PROCESS_ROOT_PROCESS_INSTANCE_ID = "rootprocinstanceid";
-    public static final String PROCESS_ROOT_PROCESS_ID = "rootprocid";
-    public static final String PROCESS_START_FROM_NODE = "startfromnode";
-    public static final String ADDONS = "addons";
+    public static final String PROCESS_INSTANCE_ID = "kogitoprocinstanceid";
+    public static final String PROCESS_REFERENCE_ID = "kogitoprocrefid";
+    public static final String PROCESS_INSTANCE_STATE = "kogitoprocist";
+    public static final String PROCESS_ID = "kogitoprocid";
+    public static final String PROCESS_PARENT_PROCESS_INSTANCE_ID = "kogitoparentprociid";
+    public static final String PROCESS_ROOT_PROCESS_INSTANCE_ID = "kogitorootprociid";
+    public static final String PROCESS_ROOT_PROCESS_ID = "kogitorootprocid";
+    public static final String PROCESS_START_FROM_NODE = "kogitoprocstartfrom";
+    public static final String ADDONS = "kogitoaddons";
 
     private CloudEventExtensionConstants() {
         // utility class

--- a/api/kogito-events-api/src/main/java/org/kie/kogito/event/CloudEventExtensionConstants.java
+++ b/api/kogito-events-api/src/main/java/org/kie/kogito/event/CloudEventExtensionConstants.java
@@ -23,6 +23,8 @@ package org.kie.kogito.event;
  */
 public final class CloudEventExtensionConstants {
 
+    // whenever a new extension is added, please add to the CloudEventExtensionConstantsTest to verify the CE spec requirements
+
     public static final String PROCESS_INSTANCE_ID = "kogitoprocinstanceid";
     public static final String PROCESS_REFERENCE_ID = "kogitoprocrefid";
     public static final String PROCESS_INSTANCE_STATE = "kogitoprocist";
@@ -31,6 +33,8 @@ public final class CloudEventExtensionConstants {
     public static final String PROCESS_ROOT_PROCESS_INSTANCE_ID = "kogitorootprociid";
     public static final String PROCESS_ROOT_PROCESS_ID = "kogitorootprocid";
     public static final String PROCESS_START_FROM_NODE = "kogitoprocstartfrom";
+    public static final String PROCESS_USER_TASK_INSTANCE_ID = "kogitousertaskiid";
+    public static final String PROCESS_USER_TASK_INSTANCE_STATE = "kogitousertaskist";
     public static final String ADDONS = "kogitoaddons";
 
     private CloudEventExtensionConstants() {

--- a/api/kogito-events-api/src/main/java/org/kie/kogito/event/CloudEventExtensionConstants.java
+++ b/api/kogito-events-api/src/main/java/org/kie/kogito/event/CloudEventExtensionConstants.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.event;
+
+/**
+ * Includes all naming required for Kogito CloudEvent constants.
+ * Must respect the required naming from the CloudEvent Specification.
+ *
+ * @see <a href="https://github.com/cloudevents/spec/blob/v1.0.1/spec.md#attribute-naming-convention">Attribute Naming Convention</a>
+ */
+public final class CloudEventExtensionConstants {
+
+    public static final String PROCESS_INSTANCE_ID = "procinstanceid";
+    public static final String PROCESS_REFERENCE_ID = "referenceid";
+    public static final String PROCESS_INSTANCE_STATE = "procinstancestate";
+    public static final String PROCESS_ID = "procid";
+    public static final String PROCESS_PARENT_PROCESS_INSTANCE_ID = "parentprocinstanceid";
+    public static final String PROCESS_ROOT_PROCESS_INSTANCE_ID = "rootprocinstanceid";
+    public static final String PROCESS_ROOT_PROCESS_ID = "rootprocid";
+    public static final String PROCESS_START_FROM_NODE = "startfromnode";
+    public static final String ADDONS = "addons";
+
+    private CloudEventExtensionConstants() {
+        // utility class
+    }
+
+}

--- a/api/kogito-events-api/src/test/java/org/kie/kogito/event/CloudEventExtensionConstantsTest.java
+++ b/api/kogito-events-api/src/test/java/org/kie/kogito/event/CloudEventExtensionConstantsTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.event;
+
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CloudEventExtensionConstantsTest {
+
+    @Test
+    void verifyKeysNamingConvention() {
+        final Pattern nameValidation = Pattern.compile("^[a-z0-9]{1,20}$");
+        assertThat(CloudEventExtensionConstants.ADDONS).matches(nameValidation);
+        assertThat(CloudEventExtensionConstants.PROCESS_ID).matches(nameValidation);
+        assertThat(CloudEventExtensionConstants.PROCESS_PARENT_PROCESS_INSTANCE_ID).matches(nameValidation);
+        assertThat(CloudEventExtensionConstants.PROCESS_INSTANCE_ID).matches(nameValidation);
+        assertThat(CloudEventExtensionConstants.PROCESS_INSTANCE_STATE).matches(nameValidation);
+        assertThat(CloudEventExtensionConstants.PROCESS_REFERENCE_ID).matches(nameValidation);
+        assertThat(CloudEventExtensionConstants.PROCESS_ROOT_PROCESS_ID).matches(nameValidation);
+        assertThat(CloudEventExtensionConstants.PROCESS_ROOT_PROCESS_INSTANCE_ID).matches(nameValidation);
+        assertThat(CloudEventExtensionConstants.PROCESS_START_FROM_NODE).matches(nameValidation);
+    }
+
+}

--- a/api/kogito-events-api/src/test/java/org/kie/kogito/event/CloudEventExtensionConstantsTest.java
+++ b/api/kogito-events-api/src/test/java/org/kie/kogito/event/CloudEventExtensionConstantsTest.java
@@ -35,6 +35,8 @@ class CloudEventExtensionConstantsTest {
         assertThat(CloudEventExtensionConstants.PROCESS_ROOT_PROCESS_ID).matches(nameValidation);
         assertThat(CloudEventExtensionConstants.PROCESS_ROOT_PROCESS_INSTANCE_ID).matches(nameValidation);
         assertThat(CloudEventExtensionConstants.PROCESS_START_FROM_NODE).matches(nameValidation);
+        assertThat(CloudEventExtensionConstants.PROCESS_USER_TASK_INSTANCE_ID).matches(nameValidation);
+        assertThat(CloudEventExtensionConstants.PROCESS_USER_TASK_INSTANCE_STATE).matches(nameValidation);
     }
 
 }

--- a/api/kogito-services/src/main/java/org/kie/kogito/services/event/AbstractProcessDataEvent.java
+++ b/api/kogito-services/src/main/java/org/kie/kogito/services/event/AbstractProcessDataEvent.java
@@ -27,7 +27,7 @@ public abstract class AbstractProcessDataEvent<T> extends AbstractDataEvent<T> {
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     protected String kogitoParentProcessinstanceId;
 
-    @JsonProperty(CloudEventExtensionConstants.PROCESS_ROOT_PROCESS_ID)
+    @JsonProperty(CloudEventExtensionConstants.PROCESS_USER_TASK_INSTANCE_STATE)
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     protected String kogitoProcessinstanceState;
 

--- a/api/kogito-services/src/main/java/org/kie/kogito/services/event/AbstractProcessDataEvent.java
+++ b/api/kogito-services/src/main/java/org/kie/kogito/services/event/AbstractProcessDataEvent.java
@@ -16,17 +16,26 @@
 package org.kie.kogito.services.event;
 
 import org.kie.kogito.event.AbstractDataEvent;
+import org.kie.kogito.event.CloudEventExtensionConstants;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public abstract class AbstractProcessDataEvent<T> extends AbstractDataEvent<T> {
 
+    @JsonProperty(CloudEventExtensionConstants.PROCESS_PARENT_PROCESS_INSTANCE_ID)
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     protected String kogitoParentProcessinstanceId;
+
+    @JsonProperty(CloudEventExtensionConstants.PROCESS_ROOT_PROCESS_ID)
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     protected String kogitoProcessinstanceState;
+
+    @JsonProperty(CloudEventExtensionConstants.PROCESS_REFERENCE_ID)
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     protected String kogitoReferenceId;
+
+    @JsonProperty(CloudEventExtensionConstants.PROCESS_START_FROM_NODE)
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     protected String kogitoStartFromNode;
 

--- a/api/kogito-services/src/main/java/org/kie/kogito/services/event/UserTaskInstanceDataEvent.java
+++ b/api/kogito-services/src/main/java/org/kie/kogito/services/event/UserTaskInstanceDataEvent.java
@@ -18,16 +18,20 @@ package org.kie.kogito.services.event;
 import java.util.Map;
 
 import org.kie.kogito.event.AbstractDataEvent;
+import org.kie.kogito.event.CloudEventExtensionConstants;
 import org.kie.kogito.services.event.impl.ProcessInstanceEventBody;
 import org.kie.kogito.services.event.impl.UserTaskInstanceEventBody;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class UserTaskInstanceDataEvent extends AbstractDataEvent<UserTaskInstanceEventBody> {
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonProperty(CloudEventExtensionConstants.PROCESS_USER_TASK_INSTANCE_ID)
     private final String kogitoUserTaskinstanceId;
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonProperty(CloudEventExtensionConstants.PROCESS_USER_TASK_INSTANCE_STATE)
     private final String kogitoUserTaskinstanceState;
 
     public UserTaskInstanceDataEvent(String source, String addons, Map<String, String> metaData, UserTaskInstanceEventBody body) {

--- a/jbpm/jbpm-flow/src/test/java/org/kie/kogito/event/impl/EventImplTest.java
+++ b/jbpm/jbpm-flow/src/test/java/org/kie/kogito/event/impl/EventImplTest.java
@@ -137,8 +137,8 @@ public class EventImplTest {
                 "\"source\": \"\"," +
                 "\"type\": \"dummyTopic\"," +
                 "\"time\": \"2019-10-01T12:02:23.812262+02:00[Europe/Warsaw]\"," +
-                "\"kogitoReferenceId\": \"1\"," +
-                "\"kogitoProcessinstanceId\": \"1\"," +
+                "\"referenceid\": \"1\"," +
+                "\"procinstanceid\": \"1\"," +
                 "\"data\": {\"dummyField\" : \"pepe\"}}";
 
         consumer.consume(application, process, payload, trigger);
@@ -159,7 +159,7 @@ public class EventImplTest {
                 "\"source\": \"\"," +
                 "\"type\": \"dummyTopic\"," +
                 "\"time\": \"2019-10-01T12:02:23.812262+02:00[Europe/Warsaw]\"," +
-                "\"kogitoProcessinstanceId\": \"1\"," +
+                "\"procinstanceid\": \"1\"," +
                 "\"data\": {\"dummyField\" : \"pepe\"}}";
 
         consumer.consume(application, process, payload, trigger);
@@ -189,7 +189,7 @@ public class EventImplTest {
         DummyEvent dataEvent = new DummyEvent("pepe");
         String jsonString = marshaller.marshall(dataEvent, DummyCloudEvent::new, Optional.empty());
         assertTrue(jsonString.contains("\"dummyField\":\"pepe\""));
-        assertTrue(jsonString.contains("\"kogitoProcessinstanceId\":\"1\""));
+        assertTrue(jsonString.contains("\"procinstanceid\":\"1\""));
     }
 
     @Test

--- a/jbpm/jbpm-flow/src/test/java/org/kie/kogito/event/impl/EventImplTest.java
+++ b/jbpm/jbpm-flow/src/test/java/org/kie/kogito/event/impl/EventImplTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.kie.kogito.Application;
 import org.kie.kogito.Model;
+import org.kie.kogito.event.CloudEventExtensionConstants;
 import org.kie.kogito.process.Process;
 import org.kie.kogito.process.ProcessInstance;
 import org.kie.kogito.process.ProcessInstances;
@@ -137,8 +138,8 @@ public class EventImplTest {
                 "\"source\": \"\"," +
                 "\"type\": \"dummyTopic\"," +
                 "\"time\": \"2019-10-01T12:02:23.812262+02:00[Europe/Warsaw]\"," +
-                "\"referenceid\": \"1\"," +
-                "\"procinstanceid\": \"1\"," +
+                "\"" + CloudEventExtensionConstants.PROCESS_REFERENCE_ID + "\": \"1\"," +
+                "\"" + CloudEventExtensionConstants.PROCESS_INSTANCE_ID + "\": \"1\"," +
                 "\"data\": {\"dummyField\" : \"pepe\"}}";
 
         consumer.consume(application, process, payload, trigger);
@@ -159,7 +160,7 @@ public class EventImplTest {
                 "\"source\": \"\"," +
                 "\"type\": \"dummyTopic\"," +
                 "\"time\": \"2019-10-01T12:02:23.812262+02:00[Europe/Warsaw]\"," +
-                "\"procinstanceid\": \"1\"," +
+                "\"" + CloudEventExtensionConstants.PROCESS_INSTANCE_ID + "\": \"1\"," +
                 "\"data\": {\"dummyField\" : \"pepe\"}}";
 
         consumer.consume(application, process, payload, trigger);
@@ -189,7 +190,7 @@ public class EventImplTest {
         DummyEvent dataEvent = new DummyEvent("pepe");
         String jsonString = marshaller.marshall(dataEvent, DummyCloudEvent::new, Optional.empty());
         assertTrue(jsonString.contains("\"dummyField\":\"pepe\""));
-        assertTrue(jsonString.contains("\"procinstanceid\":\"1\""));
+        assertTrue(jsonString.contains("\"" + CloudEventExtensionConstants.PROCESS_INSTANCE_ID + "\":\"1\""));
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

See: https://issues.redhat.com/browse/KOGITO-4456 

In this PR we adjust the extension CloudEvent data to match the required rules from the spec: https://github.com/cloudevents/spec/blob/v1.0.1/spec.md#attribute-naming-convention

I plan to remove the `knative-addon` module in https://issues.redhat.com/browse/KOGITO-4457 (cc @MarianMacik)

@kostola @danielezonca I think you can move the DMN extension properties to the `events-api` as well and verify if the names matches the specification.

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/master/kogito-ide-config)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
