### PR TITLE
KOGITO-4637: add dmn classes to DecisionsAssetsProcessor

### DIFF
--- a/kogito-quarkus-parent/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-deployment/src/main/java/org/kie/kogito/quarkus/decisions/deployment/DecisionsAssetsProcessor.java
+++ b/kogito-quarkus-parent/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-deployment/src/main/java/org/kie/kogito/quarkus/decisions/deployment/DecisionsAssetsProcessor.java
@@ -23,6 +23,7 @@ import org.jboss.jandex.DotName;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.CapabilityBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyIgnoreWarningBuildItem;
 
 /**
@@ -56,4 +57,12 @@ public class DecisionsAssetsProcessor {
         return result;
     }
 
+    @BuildStep
+    public List<ReflectiveClassBuildItem> reflectiveClassBuildItems() {
+        List<ReflectiveClassBuildItem> result = new ArrayList<>();
+        result.add(new ReflectiveClassBuildItem(true, true, "org.kie.kogito.dmn.rest.KogitoDMNDecisionResult"));
+        result.add(new ReflectiveClassBuildItem(true, true, "org.kie.kogito.dmn.rest.KogitoDMNMessage"));
+        result.add(new ReflectiveClassBuildItem(true, true, "org.kie.kogito.dmn.rest.KogitoDMNResult"));
+        return result;
+    }
 }

--- a/kogito-quarkus-parent/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoAssetsProcessor.java
+++ b/kogito-quarkus-parent/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoAssetsProcessor.java
@@ -148,8 +148,6 @@ public class KogitoAssetsProcessor {
         reflectiveClass.produce(
                 new ReflectiveClassBuildItem(true, true, "org.kie.kogito.services.event.impl.UserTaskInstanceEventBody"));
 
-        registerDmnClasses(reflectiveClass);
-
         if (context.getAddonsConfig().useMonitoring()) {
             registerMonitoringAddonClasses(reflectiveClass);
         }
@@ -167,15 +165,6 @@ public class KogitoAssetsProcessor {
             addChildrenClasses(index, "org.kie.kogito.event.AbstractDataEvent", reflectiveClass);
             addChildrenClasses(index, "org.kie.kogito.services.event.AbstractProcessDataEvent", reflectiveClass);
         });
-    }
-
-    private void registerDmnClasses(BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
-        reflectiveClass.produce(
-                new ReflectiveClassBuildItem(true, true, "org.kie.kogito.dmn.rest.KogitoDMNDecisionResult"));
-        reflectiveClass.produce(
-                new ReflectiveClassBuildItem(true, true, "org.kie.kogito.dmn.rest.KogitoDMNMessage"));
-        reflectiveClass.produce(
-                new ReflectiveClassBuildItem(true, true, "org.kie.kogito.dmn.rest.KogitoDMNResult"));
     }
 
     private void registerMonitoringAddonClasses(BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {

--- a/kogito-quarkus-parent/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoAssetsProcessor.java
+++ b/kogito-quarkus-parent/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoAssetsProcessor.java
@@ -148,6 +148,8 @@ public class KogitoAssetsProcessor {
         reflectiveClass.produce(
                 new ReflectiveClassBuildItem(true, true, "org.kie.kogito.services.event.impl.UserTaskInstanceEventBody"));
 
+        registerDmnClasses(reflectiveClass);
+
         if (context.getAddonsConfig().useMonitoring()) {
             registerMonitoringAddonClasses(reflectiveClass);
         }
@@ -165,6 +167,15 @@ public class KogitoAssetsProcessor {
             addChildrenClasses(index, "org.kie.kogito.event.AbstractDataEvent", reflectiveClass);
             addChildrenClasses(index, "org.kie.kogito.services.event.AbstractProcessDataEvent", reflectiveClass);
         });
+    }
+
+    private void registerDmnClasses(BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
+        reflectiveClass.produce(
+                new ReflectiveClassBuildItem(true, true, "org.kie.kogito.dmn.rest.KogitoDMNDecisionResult"));
+        reflectiveClass.produce(
+                new ReflectiveClassBuildItem(true, true, "org.kie.kogito.dmn.rest.KogitoDMNMessage"));
+        reflectiveClass.produce(
+                new ReflectiveClassBuildItem(true, true, "org.kie.kogito.dmn.rest.KogitoDMNResult"));
     }
 
     private void registerMonitoringAddonClasses(BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {


### PR DESCRIPTION
* [Jira task](https://issues.redhat.com/browse/KOGITO-4637)

## Description of the bug

Building [the dmn-event-driven-quarkus example from master](https://github.com/kiegroup/kogito-examples/tree/master/dmn-event-driven-quarkus) in native mode returns this error:

```
2021-03-10 09:06:32,599 ERROR [org.kie.kog.clo.CloudEventUtils] (vert.x-eventloop-thread-0) Unable to serialize CloudEvent data: com.fasterxml.jackson.databind.exc.InvalidDefinitionException: No serializer found for class org.kie.kogito.dmn.rest.KogitoDMNResult and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS)
    at com.fasterxml.jackson.databind.SerializerProvider.reportBadDefinition(SerializerProvider.java:1277)
```

## Fix

According to [Quarkus documentation](https://quarkus.io/guides/writing-native-applications-tips), the error is caused by some classes not being registered for reflection in native mode. I added them in `DecisionsAssetsProcessor`.
