### PR TITLE
KOGITO-4663 Disable strongly-typed DMN native build (currently broken)

### DIFF
--- a/kogito-quarkus-parent/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test/src/test/java/org/kie/kogito/quarkus/dmn/NativeDMNIT.java
+++ b/kogito-quarkus-parent/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test/src/test/java/org/kie/kogito/quarkus/dmn/NativeDMNIT.java
@@ -15,8 +15,11 @@
  */
 package org.kie.kogito.quarkus.dmn;
 
+import org.junit.jupiter.api.Disabled;
+
 import io.quarkus.test.junit.NativeImageTest;
 
+@Disabled("Blocked by because of https://issues.redhat.com/browse/KOGITO-4662 (classes not registed for reflection)")
 @NativeImageTest
 public class NativeDMNIT extends DMNTest {
 }


### PR DESCRIPTION
breaks Quarkus LTS **native** build
https://issues.redhat.com/browse/KOGITO-4663

building locally native image:

- [x] /kogito-quarkus-extension
- [x] /integration-tests

all green ☑️
