### PR TITLE
[1.4.x] KOGITO-4687 Fix Quarkus Ecosystem CI with Quarkus master

### DIFF
--- a/.github/quarkus-ecosystem-test
+++ b/.github/quarkus-ecosystem-test
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+
+# update the version
+mvn versions:set-property -pl kogito-build-parent -Dproperty=version.io.quarkus -DnewVersion=${QUARKUS_VERSION} -DgenerateBackupPoms=false
+
+# run the tests
+mvn --settings .github/quarkus-ecosystem-maven-settings.xml -B clean install -Dnative -Dquarkus.native.container-build=true

--- a/integration-tests/integration-tests-kogito-plugin/src/it/integration-tests-kogito-plugin-it/invoker.properties
+++ b/integration-tests/integration-tests-kogito-plugin/src/it/integration-tests-kogito-plugin-it/invoker.properties
@@ -1,3 +1,3 @@
 # disable verbose local download output
 invoker.mavenOpts=-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-invoker.goals = clean compile kogito:scaffold compile verify -Dquarkus.version=${version.io.quarkus}
+invoker.goals = clean compile kogito:scaffold compile verify


### PR DESCRIPTION
cherry pick #1142 

Do not push versions as system properties as it does not work very well
with the invoker.

Also no need to push the version manually to the invoker, things are
only handled in the pom.

