### PR TITLE
KOGITO-4693 Use static method in process codegen (workaround Quarkus)

### DIFF
--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/RestResourceQuarkusTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/RestResourceQuarkusTemplate.java
@@ -145,4 +145,11 @@ public class $Type$Resource {
                       .orElseThrow(() -> new NotFoundException());
     }
 
+    private static <T,U extends org.kie.kogito.MapOutput> ProcessInstance<T> doTransitionWorkItem(ProcessInstance<T> pi, String workItemId, String phase, U model, String user, List<String> groups) {
+        pi.transitionWorkItem(
+                workItemId,
+                HumanTaskTransition.withModel(phase, model, Policies.of(user, groups)));
+        return pi;
+    }
+
 }

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/RestResourceUserTaskQuarkusTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/RestResourceUserTaskQuarkusTemplate.java
@@ -90,22 +90,18 @@ public class $Type$Resource {
                                        @QueryParam("user") final String user,
                                        @QueryParam("group") final List<String> groups,
                                        final $TaskOutput$ model) {
+
         return UnitOfWorkExecutor
                 .executeInUnitOfWork(
                         application.unitOfWorkManager(),
                         () -> process
                                 .instances()
                                 .findById(id)
-                                .map(pi -> {
-                                    pi.transitionWorkItem(
-                                            workItemId,
-                                            HumanTaskTransition.withModel(phase, model, Policies.of(user, groups)));
-                                    return pi.variables().toOutput();
-                                }))
-                                .orElseThrow(() -> new NotFoundException());
+                                .map(pi -> doTransitionWorkItem(pi, workItemId, phase, model, user, groups))
+                                .map(pi -> pi.variables().toOutput())
+                                .orElseThrow(() -> new NotFoundException()));
     }
-    
-    
+
     @PATCH
     @Path("/{id}/$taskName$/{workItemId}")
     @Consumes(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-4693

a particularly contrived nested lambda case causes Quarkus monitoring feature to break with the following trace during hot reload

```
Caused by: java.lang.IllegalArgumentException: Cannot find method lambda$taskTransition_Task_0$16[class java.lang.String, class java.lang.String, class java.lang.String, class com.example.New_text_process_2_TaskOutput, class java.lang.String, interface java.util.List] on class com.example.New_text_processResource
    at io.quarkus.arc.impl.Reflections.findMethodInternal(Reflections.java:110)
    at io.quarkus.arc.impl.Reflections.access$100(Reflections.java:24)
    at io.quarkus.arc.impl.Reflections$2.apply(Reflections.java:40)
    at io.quarkus.arc.impl.Reflections$2.apply(Reflections.java:37)
    at io.quarkus.arc.impl.ComputingCache$1.get(ComputingCache.java:52)
    at io.quarkus.arc.impl.LazyValue.get(LazyValue.java:26)
    at io.quarkus.arc.impl.ComputingCache.computeIfAbsent(ComputingCache.java:69)
    at io.quarkus.arc.impl.ComputingCache.computeIfAbsent(ComputingCache.java:49)
    at io.quarkus.arc.impl.ComputingCache.getValue(ComputingCache.java:40)
    at io.quarkus.arc.impl.Reflections.findMethod(Reflections.java:81)
    at com.example.New_text_processResource_Subclass.<init>(New_text_processResource_Subclass.zig:766)
    at com.example.New_text_processResource_Bean.create(New_text_processResource_Bean.zig:195)
    at com.example.New_text_processResource_Bean.create(New_text_processResource_Bean.zig:299)
    at io.quarkus.arc.impl.AbstractSharedContext.createInstanceHandle(AbstractSharedContext.java:96)
    at io.quarkus.arc.impl.AbstractSharedContext.access$000(AbstractSharedContext.java:14)
    at io.quarkus.arc.impl.AbstractSharedContext$1.get(AbstractSharedContext.java:29)
    at io.quarkus.arc.impl.AbstractSharedContext$1.get(AbstractSharedContext.java:26)
    at io.quarkus.arc.impl.LazyValue.get(LazyValue.java:26)
    at io.quarkus.arc.impl.ComputingCache.computeIfAbsent(ComputingCache.java:69)
    at io.quarkus.arc.impl.AbstractSharedContext.get(AbstractSharedContext.java:26)
    at io.quarkus.arc.impl.ClientProxies.getApplicationScopedDelegate(ClientProxies.java:17)
    at com.example.New_text_processResource_ClientProxy.arc$delegate(New_text_processResource_ClientProxy.zig:67)
    at com.example.New_text_processResource_ClientProxy.arc_contextualInstance(New_text_processResource_ClientProxy.zig:82)
    at io.quarkus.arc.runtime.ClientProxyUnwrapper.apply(ClientProxyUnwrapper.java:11)
    at io.quarkus.resteasy.common.runtime.ResteasyInjectorFactoryRecorder$1.apply(ResteasyInjectorFactoryRecorder.java:22)
    at io.quarkus.resteasy.common.runtime.QuarkusInjectorFactory$UnwrappingPropertyInjector.inject(QuarkusInjectorFactory.java:71)
    at org.jboss.resteasy.plugins.server.resourcefactory.POJOResourceFactory.createResource(POJOResourceFactory.java:80)
    at org.jboss.resteasy.core.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:386)
    at org.jboss.resteasy.core.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:68)
    at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:492)
    ... 47 more
    
```
    
see https://gist.github.com/evacchi/10fe2b795136f12e93fda19dacfe109a

it is possible to work around with `quarkus.arc.dev-mode.monitoring-enabled=false`

a workaround on our side is to slightly refactor codegen to force a non-capturing lambda (i.e. basically refactor to static methods)
read more here https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/Kogito.20extension.3A.20instrumentation.20may.20not.20reload.20some.20cla.2E.2E.2E
