### PR TITLE
[KOGITO-4697] - Fix Native compilation on OpenApi Codegen for Quarkus…

### DIFF
--- a/kogito-build-parent/pom.xml
+++ b/kogito-build-parent/pom.xml
@@ -745,6 +745,12 @@
         <groupId>io.rest-assured</groupId>
         <artifactId>rest-assured</artifactId>
         <version>${version.io.rest-assured}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>
@@ -842,6 +848,12 @@
         <groupId>io.serverlessworkflow</groupId>
         <artifactId>serverlessworkflow-api</artifactId>
         <version>${version.io.serverlessworkflow}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>io.serverlessworkflow</groupId>

--- a/kogito-codegen-modules/kogito-codegen-openapi/src/main/java/org/kie/kogito/codegen/openapi/client/OpenApiClientCodegen.java
+++ b/kogito-codegen-modules/kogito-codegen-openapi/src/main/java/org/kie/kogito/codegen/openapi/client/OpenApiClientCodegen.java
@@ -115,7 +115,7 @@ public class OpenApiClientCodegen extends AbstractGenerator {
                         PathResolverFactory.newResolver(descriptor, this.context()).resolve(descriptor);
                 // generate the openapi client files
                 final List<GeneratedFile> files =
-                        OpenApiClientGeneratorWrapper.newInstance(resolvedPath, openApiGeneratorOutputDir, this.context().name())
+                        OpenApiClientGeneratorWrapper.newInstance(resolvedPath, openApiGeneratorOutputDir, this.context())
                                 .withPackage(this.getBasePackageFor(descriptor))
                                 .generate(descriptor)
                                 .stream()

--- a/kogito-codegen-modules/kogito-codegen-openapi/src/main/java/org/kie/kogito/codegen/openapi/client/OpenApiClientCodegen.java
+++ b/kogito-codegen-modules/kogito-codegen-openapi/src/main/java/org/kie/kogito/codegen/openapi/client/OpenApiClientCodegen.java
@@ -115,7 +115,7 @@ public class OpenApiClientCodegen extends AbstractGenerator {
                         PathResolverFactory.newResolver(descriptor, this.context()).resolve(descriptor);
                 // generate the openapi client files
                 final List<GeneratedFile> files =
-                        OpenApiClientGeneratorWrapper.newInstance(resolvedPath, openApiGeneratorOutputDir)
+                        OpenApiClientGeneratorWrapper.newInstance(resolvedPath, openApiGeneratorOutputDir, this.context().name())
                                 .withPackage(this.getBasePackageFor(descriptor))
                                 .generate(descriptor)
                                 .stream()

--- a/kogito-codegen-modules/kogito-codegen-openapi/src/main/java/org/kie/kogito/codegen/openapi/client/generator/KogitoJavaClientCodegen.java
+++ b/kogito-codegen-modules/kogito-codegen-openapi/src/main/java/org/kie/kogito/codegen/openapi/client/generator/KogitoJavaClientCodegen.java
@@ -42,8 +42,9 @@ public class KogitoJavaClientCodegen extends JavaClientCodegen {
     private static final String CUSTOM_API_CLIENT_TEMPLATE = "kogitoApiClient.mustache";
     private static final String CUSTOM_API_CLIENT_FILENAME = "KogitoApiClient.java";
     private final DefaultGenerator generator;
+    private final String customApiClientTemplate;
 
-    protected KogitoJavaClientCodegen(final DefaultGenerator generator) {
+    protected KogitoJavaClientCodegen(final DefaultGenerator generator, final String apiClientTemplate) {
         this.generator = generator;
         this.generator.setGeneratorPropertyDefault(CodegenConstants.MODELS, "false");
         this.setLibrary(JavaClientCodegen.RESTEASY);
@@ -51,6 +52,11 @@ public class KogitoJavaClientCodegen extends JavaClientCodegen {
         this.setDateLibrary(AbstractJavaCodegen.JAVA8_MODE);
         // not working, see #postProcessSupportingFileData
         this.setUseRuntimeException(true);
+        if (apiClientTemplate == null || apiClientTemplate.isEmpty()) {
+            this.customApiClientTemplate = CUSTOM_API_CLIENT_TEMPLATE;
+        } else {
+            this.customApiClientTemplate = apiClientTemplate;
+        }
     }
 
     /**
@@ -95,7 +101,7 @@ public class KogitoJavaClientCodegen extends JavaClientCodegen {
                 .filter(f -> f.getTemplateType() == TemplateFileType.SupportingFiles && f.getDestinationFilename().equals("ApiClient.java"))
                 .findFirst().orElseThrow(() -> new IllegalArgumentException("Can't find ApiClient.java supporting file, impossible to generate OpenApi Client application"));
         // our custom ApiClient will be generated in the same folder
-        this.supportingFiles().add(new SupportingFile(CUSTOM_API_CLIENT_TEMPLATE, apiClientFile.getFolder(), CUSTOM_API_CLIENT_FILENAME));
+        this.supportingFiles().add(new SupportingFile(this.customApiClientTemplate, apiClientFile.getFolder(), CUSTOM_API_CLIENT_FILENAME));
     }
 
     @Override

--- a/kogito-codegen-modules/kogito-codegen-openapi/src/main/java/org/kie/kogito/codegen/openapi/client/generator/OpenApiClientGeneratorWrapper.java
+++ b/kogito-codegen-modules/kogito-codegen-openapi/src/main/java/org/kie/kogito/codegen/openapi/client/generator/OpenApiClientGeneratorWrapper.java
@@ -18,6 +18,7 @@ package org.kie.kogito.codegen.openapi.client.generator;
 import java.io.File;
 import java.util.List;
 
+import org.kie.kogito.codegen.api.context.KogitoBuildContext;
 import org.kie.kogito.codegen.api.context.impl.QuarkusKogitoBuildContext;
 import org.kie.kogito.codegen.openapi.client.OpenApiSpecDescriptor;
 import org.openapitools.codegen.CodegenConstants;
@@ -80,8 +81,8 @@ public class OpenApiClientGeneratorWrapper {
      * @param outputDir a valid path in the local system where the files will be generated
      * @return a new instance of {@link OpenApiClientGeneratorWrapper}
      */
-    public static OpenApiClientGeneratorWrapper newInstance(final String specFilePath, final String outputDir, final String runtime) {
-        return new OpenApiClientGeneratorWrapper(specFilePath, outputDir, runtime);
+    public static OpenApiClientGeneratorWrapper newInstance(final String specFilePath, final String outputDir, final KogitoBuildContext context) {
+        return new OpenApiClientGeneratorWrapper(specFilePath, outputDir, context.name());
     }
 
     public OpenApiClientGeneratorWrapper withPackage(final String pkg) {

--- a/kogito-codegen-modules/kogito-codegen-openapi/src/main/java/org/kie/kogito/codegen/openapi/client/generator/OpenApiClientGeneratorWrapper.java
+++ b/kogito-codegen-modules/kogito-codegen-openapi/src/main/java/org/kie/kogito/codegen/openapi/client/generator/OpenApiClientGeneratorWrapper.java
@@ -18,6 +18,7 @@ package org.kie.kogito.codegen.openapi.client.generator;
 import java.io.File;
 import java.util.List;
 
+import org.kie.kogito.codegen.api.context.impl.QuarkusKogitoBuildContext;
 import org.kie.kogito.codegen.openapi.client.OpenApiSpecDescriptor;
 import org.openapitools.codegen.CodegenConstants;
 import org.openapitools.codegen.DefaultGenerator;
@@ -41,12 +42,17 @@ public class OpenApiClientGeneratorWrapper {
     private static final String GENERATOR_NAME = "java";
     private static final String VERBOSE = "verbose";
     private static final String ONCE_LOGGER = "org.openapitools.codegen.utils.oncelogger.enabled";
+    private static final String QUARKUS_API_CLIENT_TEMPLATE = "kogitoQuarkusApiClient.mustache";
 
     private final KogitoJavaClientCodegen kogitoCodegen;
     private final CodegenConfigurator configurator;
     private final DefaultGenerator generator;
 
-    private OpenApiClientGeneratorWrapper(final String specFilePath, final String outputDir) {
+    private OpenApiClientGeneratorWrapper(final String specFilePath, final String outputDir, final String runtime) {
+        String customApiTemplate = "";
+        if (QuarkusKogitoBuildContext.CONTEXT_NAME.equals(runtime)) {
+            customApiTemplate = QUARKUS_API_CLIENT_TEMPLATE;
+        }
         // do not generate docs nor tests
         GlobalSettings.setProperty(CodegenConstants.API_DOCS, FALSE);
         GlobalSettings.setProperty(CodegenConstants.API_TESTS, FALSE);
@@ -63,7 +69,7 @@ public class OpenApiClientGeneratorWrapper {
         this.configurator.setInputSpec(specFilePath);
         this.configurator.setGeneratorName(GENERATOR_NAME);
         this.generator = new DefaultGenerator();
-        this.kogitoCodegen = new KogitoJavaClientCodegen(this.generator);
+        this.kogitoCodegen = new KogitoJavaClientCodegen(this.generator, customApiTemplate);
         this.kogitoCodegen.setOutputDir(outputDir);
     }
 
@@ -74,8 +80,8 @@ public class OpenApiClientGeneratorWrapper {
      * @param outputDir a valid path in the local system where the files will be generated
      * @return a new instance of {@link OpenApiClientGeneratorWrapper}
      */
-    public static OpenApiClientGeneratorWrapper newInstance(final String specFilePath, final String outputDir) {
-        return new OpenApiClientGeneratorWrapper(specFilePath, outputDir);
+    public static OpenApiClientGeneratorWrapper newInstance(final String specFilePath, final String outputDir, final String runtime) {
+        return new OpenApiClientGeneratorWrapper(specFilePath, outputDir, runtime);
     }
 
     public OpenApiClientGeneratorWrapper withPackage(final String pkg) {

--- a/kogito-codegen-modules/kogito-codegen-openapi/src/main/resources/custom-templates/resteasy/ApiClient.mustache
+++ b/kogito-codegen-modules/kogito-codegen-openapi/src/main/resources/custom-templates/resteasy/ApiClient.mustache
@@ -1,0 +1,767 @@
+package {{invokerPackage}};
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.TimeZone;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+{{#jsr310}}
+{{#threetenbp}}
+import org.threeten.bp.OffsetDateTime;
+{{/threetenbp}}
+{{^threetenbp}}
+import java.time.OffsetDateTime;
+{{/threetenbp}}
+{{/jsr310}}
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Form;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.client.jaxrs.internal.ClientConfiguration;
+import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataOutput;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+
+import {{invokerPackage}}.auth.Authentication;
+import {{invokerPackage}}.auth.HttpBasicAuth;
+import {{invokerPackage}}.auth.HttpBearerAuth;
+import {{invokerPackage}}.auth.ApiKeyAuth;
+{{#hasOAuthMethods}}
+import {{invokerPackage}}.auth.OAuth;
+{{/hasOAuthMethods}}
+
+{{>generatedAnnotation}}
+public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
+  private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
+  private Map<String, String> defaultCookieMap = new HashMap<String, String>();
+  private String basePath = "{{{basePath}}}";
+  private boolean debugging = false;
+
+  private Client httpClient;
+  private JSON json;
+  private String tempFolderPath = null;
+
+  private Map<String, Authentication> authentications;
+
+  private int statusCode;
+  private Map<String, List<String>> responseHeaders;
+
+  private DateFormat dateFormat;
+
+  public ApiClient() {
+    json = new JSON();
+    httpClient = buildHttpClient(debugging);
+
+    this.dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX", Locale.ROOT);
+
+    // Use UTC as the default time zone.
+    this.dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+    this.json.setDateFormat((DateFormat) dateFormat.clone());
+
+    // Set default User-Agent.
+    setUserAgent("{{#httpUserAgent}}{{{.}}}{{/httpUserAgent}}{{^httpUserAgent}}OpenAPI-Generator/{{{artifactVersion}}}/java{{/httpUserAgent}}");
+
+    // Setup authentications (key: authentication name, value: authentication).
+    authentications = new HashMap<String, Authentication>();{{#authMethods}}{{#isBasic}}{{#isBasicBasic}}
+    authentications.put("{{name}}", new HttpBasicAuth());{{/isBasicBasic}}{{^isBasicBasic}}
+    authentications.put("{{name}}", new HttpBearerAuth("{{scheme}}"));{{/isBasicBasic}}{{/isBasic}}{{#isApiKey}}
+    authentications.put("{{name}}", new ApiKeyAuth({{#isKeyInHeader}}"header"{{/isKeyInHeader}}{{#isKeyInQuery}}"query"{{/isKeyInQuery}}{{#isKeyInCookie}}"cookie"{{/isKeyInCookie}}, "{{keyParamName}}"));{{/isApiKey}}{{#isOAuth}}
+    authentications.put("{{name}}", new OAuth());{{/isOAuth}}{{/authMethods}}
+    // Prevent the authentications from being modified.
+    authentications = Collections.unmodifiableMap(authentications);
+  }
+
+  /**
+   * Gets the JSON instance to do JSON serialization and deserialization.
+   * @return the JSON utility class
+   */
+  public JSON getJSON() {
+    return json;
+  }
+
+  public Client getHttpClient() {
+    return httpClient;
+  }
+
+  public ApiClient setHttpClient(Client httpClient) {
+    this.httpClient = httpClient;
+    return this;
+  }
+
+  public String getBasePath() {
+    return basePath;
+  }
+
+  public ApiClient setBasePath(String basePath) {
+    this.basePath = basePath;
+    return this;
+  }
+
+  /**
+   * Gets the status code of the previous request
+   * @return the status code of the previous request
+   */
+  public int getStatusCode() {
+    return statusCode;
+  }
+
+  /**
+   * Gets the response headers of the previous request
+   * @return the response headers of the previous request
+   */
+  public Map<String, List<String>> getResponseHeaders() {
+    return responseHeaders;
+  }
+
+  /**
+   * Get authentications (key: authentication name, value: authentication).
+   * @return the authentications
+   */
+  public Map<String, Authentication> getAuthentications() {
+    return authentications;
+  }
+
+  /**
+   * Get authentication for the given name.
+   *
+   * @param authName The authentication name
+   * @return The authentication, null if not found
+   */
+  public Authentication getAuthentication(String authName) {
+    return authentications.get(authName);
+  }
+
+  /**
+   * Helper method to set username for the first HTTP basic authentication.
+   * @param username the username
+   */
+  public void setUsername(String username) {
+    for (Authentication auth : authentications.values()) {
+      if (auth instanceof HttpBasicAuth) {
+        ((HttpBasicAuth) auth).setUsername(username);
+        return;
+      }
+    }
+    throw new RuntimeException("No HTTP basic authentication configured!");
+  }
+
+  /**
+   * Helper method to set password for the first HTTP basic authentication.
+   * @param password the password
+   */
+  public void setPassword(String password) {
+    for (Authentication auth : authentications.values()) {
+      if (auth instanceof HttpBasicAuth) {
+        ((HttpBasicAuth) auth).setPassword(password);
+        return;
+      }
+    }
+    throw new RuntimeException("No HTTP basic authentication configured!");
+  }
+
+  /**
+   * Helper method to set API key value for the first API key authentication.
+   * @param apiKey the API key
+   */
+  public void setApiKey(String apiKey) {
+    for (Authentication auth : authentications.values()) {
+      if (auth instanceof ApiKeyAuth) {
+        ((ApiKeyAuth) auth).setApiKey(apiKey);
+        return;
+      }
+    }
+    throw new RuntimeException("No API key authentication configured!");
+  }
+
+  /**
+   * Helper method to set API key prefix for the first API key authentication.
+   * @param apiKeyPrefix the API key prefix
+   */
+  public void setApiKeyPrefix(String apiKeyPrefix) {
+    for (Authentication auth : authentications.values()) {
+      if (auth instanceof ApiKeyAuth) {
+        ((ApiKeyAuth) auth).setApiKeyPrefix(apiKeyPrefix);
+        return;
+      }
+    }
+    throw new RuntimeException("No API key authentication configured!");
+  }
+
+  {{#hasOAuthMethods}}
+  /**
+   * Helper method to set access token for the first OAuth2 authentication.
+   * @param accessToken the access token
+   */
+  public void setAccessToken(String accessToken) {
+    for (Authentication auth : authentications.values()) {
+      if (auth instanceof OAuth) {
+        ((OAuth) auth).setAccessToken(accessToken);
+        return;
+      }
+    }
+    throw new RuntimeException("No OAuth2 authentication configured!");
+  }
+
+  {{/hasOAuthMethods}}
+  /**
+   * Set the User-Agent header's value (by adding to the default header map).
+   * @param userAgent the User-Agent header value
+   * @return this {@code ApiClient}
+   */
+  public ApiClient setUserAgent(String userAgent) {
+    addDefaultHeader("User-Agent", userAgent);
+    return this;
+  }
+
+  /**
+   * Add a default header.
+   *
+   * @param key The header's key
+   * @param value The header's value
+   * @return this {@code ApiClient}
+   */
+  public ApiClient addDefaultHeader(String key, String value) {
+    defaultHeaderMap.put(key, value);
+    return this;
+  }
+
+  /**
+   * Check that whether debugging is enabled for this API client.
+   * @return {@code true} if debugging is enabled for this API client
+   */
+  public boolean isDebugging() {
+    return debugging;
+  }
+
+  /**
+   * Enable/disable debugging for this API client.
+   *
+   * @param debugging To enable (true) or disable (false) debugging
+   * @return this {@code ApiClient}
+   */
+  public ApiClient setDebugging(boolean debugging) {
+    this.debugging = debugging;
+    // Rebuild HTTP Client according to the new "debugging" value.
+    this.httpClient = buildHttpClient(debugging);
+    return this;
+  }
+
+  /**
+   * The path of temporary folder used to store downloaded files from endpoints
+   * with file response. The default value is <code>null</code>, i.e. using
+   * the system's default tempopary folder.
+   *
+   * @return the temporary folder path
+   * @see <a href="https://docs.oracle.com/javase/7/docs/api/java/nio/file/Files.html#createTempFile(java.lang.String,%20java.lang.String,%20java.nio.file.attribute.FileAttribute...)">createTempFile</a>
+   */
+  public String getTempFolderPath() {
+    return tempFolderPath;
+  }
+
+  public ApiClient setTempFolderPath(String tempFolderPath) {
+    this.tempFolderPath = tempFolderPath;
+    return this;
+  }
+
+  /**
+   * Get the date format used to parse/format date parameters.
+   * @return the date format used to parse/format date parameters
+   */
+  public DateFormat getDateFormat() {
+    return dateFormat;
+  }
+
+  /**
+   * Set the date format used to parse/format date parameters.
+   * @param dateFormat a date format used to parse/format date parameters
+   * @return this {@code ApiClient}
+   */
+  public ApiClient setDateFormat(DateFormat dateFormat) {
+    this.dateFormat = dateFormat;
+    // also set the date format for model (de)serialization with Date properties
+    this.json.setDateFormat((DateFormat) dateFormat.clone());
+    return this;
+  }
+
+  /**
+   * Parse the given string into Date object.
+   * @param str a string to parse
+   * @return a {@code Date} object
+   */
+  public Date parseDate(String str) {
+    try {
+      return dateFormat.parse(str);
+    } catch (java.text.ParseException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Format the given Date object into string.
+   * @param date a {@code Date} object to format
+   * @return the {@code String} version of the {@code Date} object
+   */
+  public String formatDate(Date date) {
+    return dateFormat.format(date);
+  }
+
+  /**
+   * Format the given parameter object into string.
+   * @param param an object to format
+   * @return the {@code String} version of the object
+   */
+  public String parameterToString(Object param) {
+    if (param == null) {
+      return "";
+    } else if (param instanceof Date) {
+      return formatDate((Date) param);
+    } {{#jsr310}}else if (param instanceof OffsetDateTime) {
+      return formatOffsetDateTime((OffsetDateTime) param);
+    } {{/jsr310}}else if (param instanceof Collection) {
+      StringBuilder b = new StringBuilder();
+      for(Object o : (Collection)param) {
+        if(b.length() > 0) {
+          b.append(",");
+        }
+        b.append(String.valueOf(o));
+      }
+      return b.toString();
+    } else {
+      return String.valueOf(param);
+    }
+  }
+
+  /*
+    Format to {@code Pair} objects.
+  */
+  public List<Pair> parameterToPairs(String collectionFormat, String name, Object value){
+    List<Pair> params = new ArrayList<Pair>();
+
+    // preconditions
+    if (name == null || name.isEmpty() || value == null) return params;
+
+    Collection valueCollection = null;
+    if (value instanceof Collection) {
+      valueCollection = (Collection) value;
+    } else {
+      params.add(new Pair(name, parameterToString(value)));
+      return params;
+    }
+
+    if (valueCollection.isEmpty()){
+      return params;
+    }
+
+    // get the collection format
+    collectionFormat = (collectionFormat == null || collectionFormat.isEmpty() ? "csv" : collectionFormat); // default: csv
+
+    // create the params based on the collection format
+    if (collectionFormat.equals("multi")) {
+      for (Object item : valueCollection) {
+        params.add(new Pair(name, parameterToString(item)));
+      }
+
+      return params;
+    }
+
+    String delimiter = ",";
+
+    if (collectionFormat.equals("csv")) {
+      delimiter = ",";
+    } else if (collectionFormat.equals("ssv")) {
+      delimiter = " ";
+    } else if (collectionFormat.equals("tsv")) {
+      delimiter = "\t";
+    } else if (collectionFormat.equals("pipes")) {
+      delimiter = "|";
+    }
+
+    StringBuilder sb = new StringBuilder() ;
+    for (Object item : valueCollection) {
+      sb.append(delimiter);
+      sb.append(parameterToString(item));
+    }
+
+    params.add(new Pair(name, sb.substring(1)));
+
+    return params;
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  public boolean isJsonMime(String mime) {
+    String jsonMime = "(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$";
+    return mime != null && (mime.matches(jsonMime) || mime.equals("*/*"));
+  }
+
+  /**
+   * Select the Accept header's value from the given accepts array:
+   *   if JSON exists in the given array, use it;
+   *   otherwise use all of them (joining into a string)
+   *
+   * @param accepts The accepts array to select from
+   * @return The Accept header to use. If the given array is empty,
+   *   null will be returned (not to set the Accept header explicitly).
+   */
+  public String selectHeaderAccept(String[] accepts) {
+    if (accepts.length == 0) {
+      return null;
+    }
+    for (String accept : accepts) {
+      if (isJsonMime(accept)) {
+        return accept;
+      }
+    }
+    return StringUtil.join(accepts, ",");
+  }
+
+  /**
+   * Select the Content-Type header's value from the given array:
+   *   if JSON exists in the given array, use it;
+   *   otherwise use the first one of the array.
+   *
+   * @param contentTypes The Content-Type array to select from
+   * @return The Content-Type header to use. If the given array is empty,
+   *   JSON will be used.
+   */
+  public String selectHeaderContentType(String[] contentTypes) {
+    if (contentTypes.length == 0) {
+      return "application/json";
+    }
+    for (String contentType : contentTypes) {
+      if (isJsonMime(contentType)) {
+        return contentType;
+      }
+    }
+    return contentTypes[0];
+  }
+
+  /**
+   * Escape the given string to be used as URL query value.
+   * @param str a {@code String} to escape
+   * @return the escaped version of the {@code String}
+   */
+  public String escapeString(String str) {
+    try {
+      return URLEncoder.encode(str, "utf8").replaceAll("\\+", "%20");
+    } catch (UnsupportedEncodingException e) {
+      return str;
+    }
+  }
+
+  /**
+   * Serialize the given Java object into string entity according the given
+   * Content-Type (only JSON is supported for now).
+   * @param obj the object to serialize
+   * @param formParams the form parameters
+   * @param contentType the content type
+   * @return an {@code Entity}
+   * @throws ApiException on failure to serialize
+   */
+  public Entity<?> serialize(Object obj, Map<String, Object> formParams, String contentType) throws ApiException {
+    Entity<?> entity = null;
+    if (contentType.startsWith("multipart/form-data")) {
+      MultipartFormDataOutput multipart = new MultipartFormDataOutput();
+      //MultiPart multiPart = new MultiPart();
+      for (Entry<String, Object> param: formParams.entrySet()) {
+        if (param.getValue() instanceof File) {
+          File file = (File) param.getValue();
+          try {
+            multipart.addFormData(param.getValue().toString(),new FileInputStream(file),MediaType.APPLICATION_OCTET_STREAM_TYPE);
+          } catch (FileNotFoundException e) {
+            throw new ApiException("Could not serialize multipart/form-data "+e.getMessage());
+          }
+        } else {
+          multipart.addFormData(param.getValue().toString(),param.getValue().toString(),MediaType.APPLICATION_OCTET_STREAM_TYPE);
+        }
+      }
+      entity = Entity.entity(multipart.getFormData(), MediaType.MULTIPART_FORM_DATA_TYPE);
+    } else if (contentType.startsWith("application/x-www-form-urlencoded")) {
+      Form form = new Form();
+      for (Entry<String, Object> param: formParams.entrySet()) {
+        form.param(param.getKey(), parameterToString(param.getValue()));
+      }
+      entity = Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+    } else {
+      // We let jersey handle the serialization
+      entity = Entity.entity(obj, contentType);
+    }
+    return entity;
+  }
+
+  /**
+   * Deserialize response body to Java object according to the Content-Type.
+   * @param <T> a Java type parameter
+   * @param response the response body to deserialize
+   * @param returnType a Java type to deserialize into
+   * @return a deserialized Java object
+   * @throws ApiException on failure to deserialize
+   */
+  public <T> T deserialize(Response response, GenericType<T> returnType) throws ApiException {
+    if (response == null || returnType == null) {
+      return null;
+    }
+
+    if ("byte[]".equals(returnType.toString())) {
+      // Handle binary response (byte array).
+      return (T) response.readEntity(byte[].class);
+    } else if (returnType.equals(File.class)) {
+      // Handle file downloading.
+      @SuppressWarnings("unchecked")
+      T file = (T) downloadFileFromResponse(response);
+      return file;
+    }
+
+    String contentType = null;
+    List<Object> contentTypes = response.getHeaders().get("Content-Type");
+    if (contentTypes != null && !contentTypes.isEmpty())
+      contentType = String.valueOf(contentTypes.get(0));
+    if (contentType == null)
+      throw new ApiException(500, "missing Content-Type in response");
+
+    return response.readEntity(returnType);
+  }
+
+  /**
+   * Download file from the given response.
+   * @param response a response
+   * @return a file from the given response
+   * @throws ApiException If fail to read file content from response and write to disk
+   */
+  public File downloadFileFromResponse(Response response) throws ApiException {
+    try {
+      File file = prepareDownloadFile(response);
+      Files.copy(response.readEntity(InputStream.class), file.toPath());
+      return file;
+    } catch (IOException e) {
+      throw new ApiException(e);
+    }
+  }
+
+  public File prepareDownloadFile(Response response) throws IOException {
+    String filename = null;
+    String contentDisposition = (String) response.getHeaders().getFirst("Content-Disposition");
+    if (contentDisposition != null && !"".equals(contentDisposition)) {
+      // Get filename from the Content-Disposition header.
+      Pattern pattern = Pattern.compile("filename=['\"]?([^'\"\\s]+)['\"]?");
+      Matcher matcher = pattern.matcher(contentDisposition);
+      if (matcher.find())
+        filename = matcher.group(1);
+    }
+
+    String prefix = null;
+    String suffix = null;
+    if (filename == null) {
+      prefix = "download-";
+      suffix = "";
+    } else {
+      int pos = filename.lastIndexOf(".");
+      if (pos == -1) {
+        prefix = filename + "-";
+      } else {
+        prefix = filename.substring(0, pos) + "-";
+        suffix = filename.substring(pos);
+      }
+      // Files.createTempFile requires the prefix to be at least three characters long
+      if (prefix.length() < 3)
+        prefix = "download-";
+    }
+
+    if (tempFolderPath == null)
+      return Files.createTempFile(prefix, suffix).toFile();
+    else
+      return Files.createTempFile(Paths.get(tempFolderPath), prefix, suffix).toFile();
+  }
+
+  /**
+   * Invoke API by sending HTTP request with the given options.
+   *
+   * @param <T> a Java type parameter
+   * @param path The sub-path of the HTTP URL
+   * @param method The request method, one of "GET", "POST", "PUT", "HEAD" and "DELETE"
+   * @param queryParams The query parameters
+   * @param body The request body object
+   * @param headerParams The header parameters
+   * @param cookieParams The cookie parameters
+   * @param formParams The form parameters
+   * @param accept The request's Accept header
+   * @param contentType The request's Content-Type header
+   * @param authNames The authentications to apply
+   * @param returnType The return type into which to deserialize the response
+   * @return The response body in type of string
+   * @throws ApiException if the invocation failed
+   */
+  public <T> T invokeAPI(String path, String method, List<Pair> queryParams, Object body, Map<String, String> headerParams, Map<String, String> cookieParams, Map<String, Object> formParams, String accept, String contentType, String[] authNames, GenericType<T> returnType) throws ApiException {
+    updateParamsForAuth(authNames, queryParams, headerParams, cookieParams);
+
+    // Not using `.target(this.basePath).path(path)` below,
+    // to support (constant) query string in `path`, e.g. "/posts?draft=1"
+    WebTarget target = httpClient.target(this.basePath + path);
+
+    if (queryParams != null) {
+      for (Pair queryParam : queryParams) {
+        if (queryParam.getValue() != null) {
+          target = target.queryParam(queryParam.getName(), queryParam.getValue());
+        }
+      }
+    }
+
+    Invocation.Builder invocationBuilder = target.request().accept(accept);
+
+    for (Entry<String, String> headerParamsEnrty : headerParams.entrySet()) {
+      String value = headerParamsEnrty.getValue();
+      if (value != null) {
+        invocationBuilder = invocationBuilder.header(headerParamsEnrty.getKey(), value);
+      }
+    }
+
+    for (Entry<String, String> defaultHeaderEnrty: defaultHeaderMap.entrySet()) {
+      if (!headerParams.containsKey(defaultHeaderEnrty.getKey())) {
+        String value = defaultHeaderEnrty.getValue();
+        if (value != null) {
+          invocationBuilder = invocationBuilder.header(defaultHeaderEnrty.getKey(), value);
+        }
+      }
+    }
+
+    for (Entry<String, String> cookieParamsEntry : cookieParams.entrySet()) {
+      String value = cookieParamsEntry.getValue();
+      if (value != null) {
+        invocationBuilder = invocationBuilder.cookie(cookieParamsEntry.getKey(), value);
+      }
+    }
+
+    for (Entry<String, String> defaultCookieEntry: defaultHeaderMap.entrySet()) {
+      if (!cookieParams.containsKey(defaultCookieEntry.getKey())) {
+        String value = defaultCookieEntry.getValue();
+        if (value != null) {
+          invocationBuilder = invocationBuilder.cookie(defaultCookieEntry.getKey(), value);
+        }
+      }
+    }
+
+    Entity<?> entity = serialize(body, formParams, contentType);
+
+    Response response = null;
+
+    if ("GET".equals(method)) {
+      response = invocationBuilder.get();
+    } else if ("POST".equals(method)) {
+      response = invocationBuilder.post(entity);
+    } else if ("PUT".equals(method)) {
+      response = invocationBuilder.put(entity);
+    } else if ("DELETE".equals(method)) {
+      response = invocationBuilder.method("DELETE", entity);
+    } else if ("PATCH".equals(method)) {
+      response = invocationBuilder.method("PATCH", entity);
+    } else if ("HEAD".equals(method)) {
+      response = invocationBuilder.head();
+    } else if ("OPTIONS".equals(method)) {
+      response = invocationBuilder.options();
+    } else if ("TRACE".equals(method)) {
+      response = invocationBuilder.trace();
+    } else {
+      throw new ApiException(500, "unknown method type " + method);
+    }
+
+    statusCode = response.getStatusInfo().getStatusCode();
+    responseHeaders = buildResponseHeaders(response);
+
+    if (response.getStatus() == Status.NO_CONTENT.getStatusCode()) {
+      return null;
+    } else if (response.getStatusInfo().getFamily().equals(Status.Family.SUCCESSFUL)) {
+      if (returnType == null)
+        return null;
+      else
+        return deserialize(response, returnType);
+    } else {
+      String message = "error";
+      String respBody = null;
+      if (response.hasEntity()) {
+        try {
+          respBody = String.valueOf(response.readEntity(String.class));
+          message = respBody;
+        } catch (RuntimeException e) {
+          // e.printStackTrace();
+        }
+      }
+      throw new ApiException(
+        response.getStatus(),
+        message,
+        buildResponseHeaders(response),
+        respBody);
+    }
+  }
+
+   /**
+   * Build the Client used to make HTTP requests.
+   */
+  protected Client buildHttpClient(boolean debugging) {
+    final ClientConfiguration clientConfig = new ClientConfiguration(ResteasyProviderFactory.getInstance());
+    clientConfig.register(json);
+    if(debugging){
+      clientConfig.register(Logger.class);
+    }
+    return ClientBuilder.newClient(clientConfig);
+  }
+  private Map<String, List<String>> buildResponseHeaders(Response response) {
+    Map<String, List<String>> responseHeaders = new HashMap<String, List<String>>();
+    for (Entry<String, List<Object>> entry: response.getHeaders().entrySet()) {
+      List<Object> values = entry.getValue();
+      List<String> headers = new ArrayList<String>();
+      for (Object o : values) {
+        headers.add(String.valueOf(o));
+      }
+      responseHeaders.put(entry.getKey(), headers);
+    }
+    return responseHeaders;
+  }
+
+  /**
+   * Update query and header parameters based on authentication settings.
+   *
+   * @param authNames The authentications to apply
+   */
+  private void updateParamsForAuth(String[] authNames, List<Pair> queryParams, Map<String, String> headerParams, Map<String, String> cookieParams) {
+    for (String authName : authNames) {
+      Authentication auth = authentications.get(authName);
+      if (auth == null) throw new RuntimeException("Authentication undefined: " + authName);
+      auth.applyToParams(queryParams, headerParams, cookieParams);
+    }
+  }
+}

--- a/kogito-codegen-modules/kogito-codegen-openapi/src/main/resources/custom-templates/resteasy/Configuration.mustache
+++ b/kogito-codegen-modules/kogito-codegen-openapi/src/main/resources/custom-templates/resteasy/Configuration.mustache
@@ -1,0 +1,29 @@
+{{>licenseInfo}}
+
+package {{invokerPackage}};
+
+{{>generatedAnnotation}}
+public class Configuration {
+
+    private static ApiClient defaultApiClient;
+
+    /**
+     * Get the default API client, which would be used when creating API
+     * instances without providing an API client.
+     *
+     * @return Default API client
+     */
+    public static ApiClient getDefaultApiClient() {
+        return defaultApiClient;
+    }
+
+    /**
+     * Set the default API client, which would be used when creating API
+     * instances without providing an API client.
+     *
+     * @param apiClient API client
+     */
+    public static void setDefaultApiClient(ApiClient apiClient) {
+        defaultApiClient = apiClient;
+    }
+}

--- a/kogito-codegen-modules/kogito-codegen-openapi/src/main/resources/custom-templates/resteasy/README.md
+++ b/kogito-codegen-modules/kogito-codegen-openapi/src/main/resources/custom-templates/resteasy/README.md
@@ -3,3 +3,5 @@ them to play along our required features.
 
 If you've ever need to modify these files, please check
 their [documentation](https://openapi-generator.tech/docs/templating).
+
+The templates we are likely to override are the [RestEasy](https://github.com/OpenAPITools/openapi-generator/tree/master/modules/openapi-generator/src/main/resources/Java/libraries/resteasy) and [Java client](https://github.com/OpenAPITools/openapi-generator/tree/master/modules/openapi-generator/src/main/resources/Java) ones.

--- a/kogito-codegen-modules/kogito-codegen-openapi/src/main/resources/custom-templates/resteasy/kogitoQuarkusApiClient.mustache
+++ b/kogito-codegen-modules/kogito-codegen-openapi/src/main/resources/custom-templates/resteasy/kogitoQuarkusApiClient.mustache
@@ -1,0 +1,47 @@
+package {{invokerPackage}};
+
+import java.util.Optional;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.jboss.logging.Logger;
+
+{{>generatedAnnotation}}
+public class KogitoApiClient extends ApiClient {
+
+    Optional<String> username;
+    Optional<String> password;
+    Optional<String> apiKey;
+    Optional<String> apiKeyPrefix;
+    Optional<String> basePath;
+
+    @javax.annotation.PostConstruct
+    public void init() {
+        if (username.isPresent()) {
+            super.setUsername(username.get());
+        }
+        if (password.isPresent()) {
+            super.setPassword(password.get());
+        }
+        if (apiKey.isPresent()) {
+            super.setApiKey(apiKey.get());
+        }
+        if (apiKeyPrefix.isPresent()) {
+            super.setApiKeyPrefix(apiKeyPrefix.get());
+        }
+        if (basePath.isPresent()) {
+            super.setBasePath(basePath.get());
+        }
+    }
+
+    protected Client buildHttpClient(boolean debugging) {
+        final RestClientBuilder restClientBuilder = RestClientBuilder.newBuilder();
+        restClientBuilder.register(getJSON());
+        if (debugging) {
+            restClientBuilder.register(Logger.class);
+        }
+        return ClientBuilder.newClient(restClientBuilder.getConfiguration());
+    }
+}


### PR DESCRIPTION
… runtime

See: https://issues.redhat.com/browse/KOGITO-4697

The `RestClientBuilder` originally used by the OpenAPI generator breaks the native compilation on the `httpclient` package. For Quarkus applications, we borrow the MicroProfile `RestClientBuilder` to create our clients. It's not ideal since it's meant to be used for interfaces registered with RestEasy.

I opened [KOGITO-4701](https://issues.redhat.com/browse/KOGITO-4701) to consider moving our code generation to MicroProfile Rest Client instead. It can be tricky and bring problems to SpringBoot applications. I considered this workaround for now to unblock the native feature.

The `ApiClient.mustache` is a copy of the original template provided by the OpenAPI Tool Generator. I'd rather extend the generated class instead of modifying their template, but unfortunately, the `buildHttpClient` function is private, so we can't overload it. I would talk to the OpenAPI generator community to consider a CDI "friendly" approach for these classes, but since we are considering moving to Microprofile, I'll leave this conversation for now.

The culprit of the native compilation was the `Configuration.mustache` template, which used to generate a class with a private static field forcing the initialization of the `ApiClient`. This is another thing to consider open a PR for them if we do not move to Microprofile.

The `commons-logging` library was clashing with natively compiled code since we use `jboss-logging`, which also has the same interfaces and implementations. For the SW SDK, I'll remove it from the SDK pom file.

Signed-off-by: Ricardo Zanini <zanini@redhat.com>

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/master/kogito-ide-config)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>