### PR TITLE
KOGITO-4737 Quarkus Extension: Should use same compiler flags in CompilationProvider and BuildStep

### DIFF
--- a/kogito-quarkus-parent/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/InMemoryCompiler.java
+++ b/kogito-quarkus-parent/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/InMemoryCompiler.java
@@ -47,10 +47,15 @@ public class InMemoryCompiler {
 
     public InMemoryCompiler(
             Collection<Path> classesPaths,
-            Collection<AppDependency> userDependencies) {
+            Collection<AppDependency> userDependencies,
+            boolean useDebugSymbols) {
         javaCompiler = JavaParserCompiler.getCompiler();
         compilerSettings = javaCompiler.createDefaultSettings();
         compilerSettings.addOption("-proc:none"); // force disable annotation processing
+        if (useDebugSymbols) {
+            compilerSettings.setDebug(true);
+            compilerSettings.addOption("-g");
+        }
         for (Path classPath : classesPaths) {
             compilerSettings.addClasspath(classPath.toString());
         }

--- a/kogito-quarkus-parent/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/InMemoryCompiler.java
+++ b/kogito-quarkus-parent/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/InMemoryCompiler.java
@@ -53,8 +53,8 @@ public class InMemoryCompiler {
         compilerSettings = javaCompiler.createDefaultSettings();
         compilerSettings.addOption("-proc:none"); // force disable annotation processing
         if (useDebugSymbols) {
-            compilerSettings.setDebug(true);
             compilerSettings.addOption("-g");
+            compilerSettings.addOption("-parameters");
         }
         for (Path classPath : classesPaths) {
             compilerSettings.addClasspath(classPath.toString());

--- a/kogito-quarkus-parent/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoAssetsProcessor.java
+++ b/kogito-quarkus-parent/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoAssetsProcessor.java
@@ -90,7 +90,8 @@ public class KogitoAssetsProcessor {
         Optional<IndexView> optionalIndex = compileAndIndexJavaSources(
                 context,
                 generatedFiles,
-                generatedBeans);
+                generatedBeans,
+                liveReload.isLiveReload());
 
         registerDataEventsForReflection(optionalIndex, context, reflectiveClass);
 
@@ -111,12 +112,13 @@ public class KogitoAssetsProcessor {
     private Optional<IndexView> compileAndIndexJavaSources(
             KogitoBuildContext context,
             Collection<GeneratedFile> generatedFiles,
-            BuildProducer<GeneratedBeanBuildItem> generatedBeans) throws IOException {
+            BuildProducer<GeneratedBeanBuildItem> generatedBeans,
+            boolean useDebugSymbols) throws IOException {
 
         List<AppDependency> dependencies = curateOutcomeBuildItem.getEffectiveModel().getUserDependencies();
 
         Collection<GeneratedBeanBuildItem> generatedBeanBuildItems =
-                compileGeneratedSources(context, dependencies, generatedFiles);
+                compileGeneratedSources(context, dependencies, generatedFiles, useDebugSymbols);
         generatedBeanBuildItems.forEach(generatedBeans::produce);
         return Optional.of(indexBuildItems(context, generatedBeanBuildItems));
     }

--- a/kogito-quarkus-parent/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoQuarkusResourceUtils.java
+++ b/kogito-quarkus-parent/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoQuarkusResourceUtils.java
@@ -111,8 +111,11 @@ public class KogitoQuarkusResourceUtils {
         }
     }
 
-    public static Collection<GeneratedBeanBuildItem> compileGeneratedSources(KogitoBuildContext context, List<AppDependency> dependencies, Collection<GeneratedFile> generatedFiles)
-            throws IOException {
+    public static Collection<GeneratedBeanBuildItem> compileGeneratedSources(
+            KogitoBuildContext context,
+            List<AppDependency> dependencies,
+            Collection<GeneratedFile> generatedFiles,
+            boolean useDebugSymbols) throws IOException {
         Collection<GeneratedFile> javaFiles =
                 generatedFiles.stream()
                         .filter(f -> f.category() == GeneratedFileType.Category.SOURCE)
@@ -123,8 +126,11 @@ public class KogitoQuarkusResourceUtils {
             return Collections.emptyList();
         }
 
-        InMemoryCompiler inMemoryCompiler = new InMemoryCompiler(context.getAppPaths().getClassesPaths(),
-                dependencies);
+        InMemoryCompiler inMemoryCompiler =
+                new InMemoryCompiler(
+                        context.getAppPaths().getClassesPaths(),
+                        dependencies,
+                        useDebugSymbols);
         inMemoryCompiler.compile(javaFiles);
         return makeBuildItems(
                 context.getAppPaths(),

--- a/kogito-quarkus-parent/kogito-quarkus-extension/kogito-quarkus-deployment/src/main/java/org/kie/kogito/quarkus/deployment/ProcessesAssetsProcessor.java
+++ b/kogito-quarkus-parent/kogito-quarkus-extension/kogito-quarkus-deployment/src/main/java/org/kie/kogito/quarkus/deployment/ProcessesAssetsProcessor.java
@@ -128,7 +128,8 @@ public class ProcessesAssetsProcessor {
                 generatedBeans,
                 resource,
                 reflectiveClass,
-                runTimeConfiguration);
+                runTimeConfiguration,
+                liveReload.isLiveReload());
 
         // Json schema files
         generatedFiles.addAll(generateJsonSchema(context, aggregatedIndex));
@@ -148,7 +149,8 @@ public class ProcessesAssetsProcessor {
             BuildProducer<GeneratedBeanBuildItem> generatedBeans,
             BuildProducer<NativeImageResourceBuildItem> resource,
             BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
-            BuildProducer<RunTimeConfigurationDefaultBuildItem> runTimeConfiguration) throws IOException {
+            BuildProducer<RunTimeConfigurationDefaultBuildItem> runTimeConfiguration,
+            boolean useDebugSymbols) throws IOException {
 
         if (context.getAddonsConfig().usePersistence()) {
             resource.produce(new NativeImageResourceBuildItem("kogito-types.proto"));
@@ -159,7 +161,7 @@ public class ProcessesAssetsProcessor {
         validateGeneratedFileTypes(persistenceGeneratedFiles, asList(GeneratedFileType.Category.SOURCE, GeneratedFileType.Category.RESOURCE));
 
         List<AppDependency> dependencies = curateOutcomeBuildItem.getEffectiveModel().getUserDependencies();
-        compileGeneratedSources(context, dependencies, persistenceGeneratedFiles)
+        compileGeneratedSources(context, dependencies, persistenceGeneratedFiles, useDebugSymbols)
                 .forEach(generatedBeans::produce);
 
         return persistenceGeneratedFiles.stream()


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-4737

CompilatIonProviders use `-g -parameters` while in the BuildStep (InMemoryCompiler) we do not propagate these flags, not even in dev mode.

This PR propagates such flags when (if) CompilationProvider is used together with the BuildStep (see https://github.com/kiegroup/kogito-runtimes/pull/1123)

(this currently does not really happen because BuildStep-based early quit in DevMode, subsumed by the CompilationProvider, but in another PR we will probably enable this flow)