### PR TITLE
KOGITO-4740 Quarkus Extension should not dump class files to target/classes

### DIFF
--- a/kogito-quarkus-parent/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoCompilationProvider.java
+++ b/kogito-quarkus-parent/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoCompilationProvider.java
@@ -27,9 +27,7 @@ import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.kie.kogito.codegen.api.GeneratedFile;
 import org.kie.kogito.codegen.api.GeneratedFileType;

--- a/kogito-quarkus-parent/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoCompilationProvider.java
+++ b/kogito-quarkus-parent/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoCompilationProvider.java
@@ -44,7 +44,6 @@ import io.quarkus.deployment.dev.JavaCompilationProvider;
 
 public abstract class KogitoCompilationProvider extends JavaCompilationProvider {
 
-    public static final Map<Path, Path> classToSource = new ConcurrentHashMap<>();
     private static final Logger LOGGER = LoggerFactory.getLogger(KogitoCompilationProvider.class);
 
     @Override
@@ -92,15 +91,6 @@ public abstract class KogitoCompilationProvider extends JavaCompilationProvider 
         } catch (IOException e) {
             throw new UncheckedIOException("Exception while closing URLClassLoader", e);
         }
-    }
-
-    @Override
-    public Path getSourcePath(Path classFilePath, Set<String> sourcePaths, String classesPath) {
-        if (classToSource.containsKey(classFilePath)) {
-            return classToSource.get(classFilePath);
-        }
-
-        return null;
     }
 
     protected abstract Generator getGenerator(KogitoBuildContext context,

--- a/kogito-quarkus-parent/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoQuarkusResourceUtils.java
+++ b/kogito-quarkus-parent/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoQuarkusResourceUtils.java
@@ -156,14 +156,10 @@ public class KogitoQuarkusResourceUtils {
             String className = toClassName(fileName);
             buildItems.add(new GeneratedBeanBuildItem(className, data));
 
-            Path path = pathOf(location.toString(), fileName);
-            Files.write(path, data);
-
             String sourceFile = location.toString().replaceFirst("\\.class", ".java");
             if (sourceFile.contains("$")) {
                 sourceFile = sourceFile.substring(0, sourceFile.indexOf("$")) + ".java";
             }
-            KogitoCompilationProvider.classToSource.put(path, Paths.get(sourceFile));
         }
 
         return buildItems;

--- a/kogito-quarkus-parent/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoQuarkusResourceUtils.java
+++ b/kogito-quarkus-parent/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoQuarkusResourceUtils.java
@@ -16,7 +16,6 @@
 package org.kie.kogito.quarkus.common.deployment;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-4740

when Kogito extension is enabled a full reload is attempted every time a endpoint is hit
this is because class files are being written to target/classes
this is not necessary