### PR TITLE
Fixing native compilation on Process Integration Tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -258,8 +258,10 @@ MavenCommand getMavenCommand(String directory, boolean addQuarkusVersion=true, b
     }
     if (canNative && isNative()) {
         mvnCmd.withProfiles(['native'])
-        // Added due to https://github.com/quarkusio/quarkus/issues/13341
-        mvnCmd.withProperty('quarkus.profile', 'native')
+            .withProperty('quarkus.native.container-build', true)
+            .withProperty('quarkus.native.container-runtime', 'docker')
+            .withProperty('quarkus.profile', 'native') // Added due to https://github.com/quarkusio/quarkus/issues/13341
+
     }
     return mvnCmd
 }

--- a/integration-tests/integration-tests-quarkus-processes/pom.xml
+++ b/integration-tests/integration-tests-quarkus-processes/pom.xml
@@ -62,11 +62,6 @@
     </dependency>
 
     <dependency>
-      <groupId>io.smallrye.reactive</groupId>
-      <artifactId>smallrye-reactive-messaging-http</artifactId>
-    </dependency>
-    
-    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-infinispan-client</artifactId>
       <scope>test</scope>

--- a/integration-tests/integration-tests-quarkus-processes/src/main/resources/application.properties
+++ b/integration-tests/integration-tests-quarkus-processes/src/main/resources/application.properties
@@ -2,8 +2,5 @@ quarkus.swagger-ui.always-include=true
 
 quarkus.log.level=INFO
 
-mp.messaging.outgoing.processedtravellers.connector=smallrye-http
-mp.messaging.outgoing.processedtravellers.url=http://localhost:8181
-
 # Maximum Java heap to be used during the native image generation
 quarkus.native.native-image-xmx=4g


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

See: https://github.com/quarkusio/quarkus/issues/12486#issuecomment-802169769


<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>