### PR TITLE
KOGITO-4847 Fix local builds for integration tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -249,6 +249,7 @@ void checkoutOptaplannerRepo() {
 MavenCommand getMavenCommand(String directory, boolean addQuarkusVersion=true, boolean canNative = false) {
     mvnCmd = new MavenCommand(this, ['-fae'])
                 .withSettingsXmlId('kogito_release_settings')
+                .withSnapshotsDisabledInSettings()
                 // add timestamp to Maven logs
                 .withOptions(['-Dorg.slf4j.simpleLogger.showDateTime=true', '-Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS'])
                 .inDirectory(directory)

--- a/addons/cloudevents/cloudevents-spring-boot-addon-it/pom.xml
+++ b/addons/cloudevents/cloudevents-spring-boot-addon-it/pom.xml
@@ -25,6 +25,16 @@
       <artifactId>kogito-maven-plugin</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-springboot-starter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-cloudevents-spring-boot-addon</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -33,9 +43,6 @@
             <artifactId>maven-invoker-plugin</artifactId>
             <configuration>
                 <streamLogs>true</streamLogs>
-                <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
-                <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
-                <useLocalRepository>true</useLocalRepository>
                 <postBuildHookScript>verify</postBuildHookScript> <!-- no extension required -->
             </configuration>
             <executions>

--- a/addons/cloudevents/cloudevents-spring-boot-addon-it/pom.xml
+++ b/addons/cloudevents/cloudevents-spring-boot-addon-it/pom.xml
@@ -27,6 +27,13 @@
     </dependency>
     <dependency>
       <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-bom</artifactId>
+      <version>${project.version}</version>
+      <type>pom</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-springboot-starter</artifactId>
       <scope>test</scope>
     </dependency>

--- a/addons/explainability-addon/explainability-quarkus-addon/pom.xml
+++ b/addons/explainability-addon/explainability-quarkus-addon/pom.xml
@@ -82,9 +82,9 @@
                     <excludes>
                         <exclude>**/Native*IT.java</exclude>
                     </excludes>
-                    <systemProperties>
+                    <systemPropertyVariables combine.children="append">
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                    </systemProperties>
+                    </systemPropertyVariables>
                 </configuration>
                 <executions>
                     <execution>

--- a/addons/persistence/infinispan-quarkus-health-addon/pom.xml
+++ b/addons/persistence/infinispan-quarkus-health-addon/pom.xml
@@ -96,7 +96,7 @@
               <goal>verify</goal>
             </goals>
             <configuration>
-              <systemPropertyVariables>
+              <systemPropertyVariables combine.children="append">
                 <container.image.infinispan>${container.image.infinispan}</container.image.infinispan>
               </systemPropertyVariables>
             </configuration>

--- a/addons/task-management/task-management-quarkus-addon/pom.xml
+++ b/addons/task-management/task-management-quarkus-addon/pom.xml
@@ -95,7 +95,7 @@
           <includes>
             <include>org/kie/kogito/task/management/test/*</include>
           </includes>
-          <systemPropertyVariables>
+          <systemPropertyVariables combine.children="append">
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
             <container.image.infinispan>${container.image.infinispan}</container.image.infinispan>
           </systemPropertyVariables>

--- a/archetypes/kogito-quarkus-archetype/pom.xml
+++ b/archetypes/kogito-quarkus-archetype/pom.xml
@@ -30,6 +30,18 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-quarkus-bom</artifactId>
+      <version>${project.version}</version>
+      <type>pom</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-quarkus</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/archetypes/kogito-quarkus-dm-archetype/pom.xml
+++ b/archetypes/kogito-quarkus-dm-archetype/pom.xml
@@ -30,6 +30,28 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-quarkus-bom</artifactId>
+      <version>${project.version}</version>
+      <type>pom</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-quarkus-rules</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-quarkus-decisions</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-quarkus-predictions</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/archetypes/kogito-springboot-archetype/pom.xml
+++ b/archetypes/kogito-springboot-archetype/pom.xml
@@ -20,6 +20,12 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-springboot-starter</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/archetypes/kogito-springboot-dm-archetype/pom.xml
+++ b/archetypes/kogito-springboot-dm-archetype/pom.xml
@@ -20,6 +20,12 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-springboot-starter</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/archetypes/pom.xml
+++ b/archetypes/pom.xml
@@ -22,7 +22,6 @@
           <artifactId>maven-archetype-plugin</artifactId>
           <configuration>
             <localRepositoryPath>${session.request.localRepositoryPath.path}</localRepositoryPath>
-            <settingsFile>${session.request.userSettingsFile.path}</settingsFile>
           </configuration>
         </plugin>
       </plugins>
@@ -33,7 +32,9 @@
     <profile>
       <id>default</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!productized</name>
+        </property>
       </activation>
       <modules>
         <module>kogito-springboot-archetype</module>
@@ -51,6 +52,29 @@
         <module>kogito-springboot-dm-archetype</module>
         <module>kogito-quarkus-dm-archetype</module>
       </modules>
+    </profile>
+    <profile>
+      <!--
+        This profile serves at optionally passing settingsFile property to archetype::integration-test goal.
+        Reason is that the ${session.request.userSettingsFile.path} property defaults to ~/.m2/settings.xml even
+        if that file does not actually exist. Tests were in such case failing.
+      -->
+      <id>set-settings-when-provided</id>
+      <activation>
+        <file><exists>${session.request.userSettingsFile.path}</exists></file>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <artifactId>maven-archetype-plugin</artifactId>
+              <configuration>
+                <settingsFile>${session.request.userSettingsFile.path}</settingsFile>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
     </profile>
   </profiles>
 

--- a/archetypes/pom.xml
+++ b/archetypes/pom.xml
@@ -15,6 +15,20 @@
     <maven.compiler.release>11</maven.compiler.release> 
   </properties>
 
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-archetype-plugin</artifactId>
+          <configuration>
+            <localRepositoryPath>${session.request.localRepositoryPath.path}</localRepositoryPath>
+            <settingsFile>${session.request.userSettingsFile.path}</settingsFile>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
   <profiles>
     <profile>
       <id>default</id>

--- a/integration-tests/integration-tests-kogito-plugin/pom.xml
+++ b/integration-tests/integration-tests-kogito-plugin/pom.xml
@@ -22,6 +22,13 @@
     </dependency>
     <dependency>
       <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-bom</artifactId>
+      <version>${project.version}</version>
+      <type>pom</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-quarkus-bom</artifactId>
       <version>${project.version}</version>
       <type>pom</type>

--- a/integration-tests/integration-tests-kogito-plugin/pom.xml
+++ b/integration-tests/integration-tests-kogito-plugin/pom.xml
@@ -20,6 +20,19 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-quarkus-bom</artifactId>
+      <version>${project.version}</version>
+      <type>pom</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>process-management-addon</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -28,9 +41,6 @@
         <artifactId>maven-invoker-plugin</artifactId>
         <configuration>
           <streamLogs>true</streamLogs>
-          <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
-          <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
-          <useLocalRepository>true</useLocalRepository>
           <postBuildHookScript>verify</postBuildHookScript> <!-- no extension required -->
           <properties>
             <version.io.quarkus>${version.io.quarkus}</version.io.quarkus>

--- a/integration-tests/integration-tests-kogito-plugin/src/it/integration-tests-kogito-plugin-it/pom.xml
+++ b/integration-tests/integration-tests-kogito-plugin/src/it/integration-tests-kogito-plugin-it/pom.xml
@@ -98,13 +98,13 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>@version.surefire.plugin@</version>
                 <configuration>
-                    <systemProperties>
+                    <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         <maven.home>${maven.home}</maven.home>
                         <!-- quarkus plugin and being run by invoker, need to pass explicitly -->
                         <maven.repo.local>${session.request.localRepositoryPath.path}</maven.repo.local>
                         <maven.settings>${session.request.userSettingsFile.path}</maven.settings>
-                    </systemProperties>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
         </plugins>

--- a/integration-tests/integration-tests-quarkus-decisions/pom.xml
+++ b/integration-tests/integration-tests-quarkus-decisions/pom.xml
@@ -166,10 +166,10 @@
                   <goal>verify</goal>
                 </goals>
                 <configuration>
-                  <systemProperties>
+                  <systemPropertyVariables combine.children="append">
                     <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                  </systemProperties>
+                  </systemPropertyVariables>
                 </configuration>
               </execution>
             </executions>

--- a/integration-tests/integration-tests-quarkus-predictions/pom.xml
+++ b/integration-tests/integration-tests-quarkus-predictions/pom.xml
@@ -128,7 +128,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <systemPropertyVariables>
+          <systemPropertyVariables combine.children="append">
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
             <container.image.infinispan>${container.image.infinispan}</container.image.infinispan>
           </systemPropertyVariables>
@@ -160,9 +160,9 @@
                   <goal>verify</goal>
                 </goals>
                 <configuration>
-                  <systemProperties>
+                  <systemPropertyVariables combine.children="append">
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                  </systemProperties>
+                  </systemPropertyVariables>
                 </configuration>
               </execution>
             </executions>

--- a/integration-tests/integration-tests-quarkus-processes/pom.xml
+++ b/integration-tests/integration-tests-quarkus-processes/pom.xml
@@ -168,7 +168,7 @@
           <includes>
             <include>org/kie/kogito/integrationtests/quarkus/*</include>
           </includes>
-          <systemPropertyVariables>
+          <systemPropertyVariables combine.children="append">
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
             <container.image.infinispan>${container.image.infinispan}</container.image.infinispan>
           </systemPropertyVariables>
@@ -205,7 +205,7 @@
                 <include>org/kie/kogito/integrationtests/quarkus/*</include>
                 <include>org/kie/kogito/integrationtests/quarkus/infinispan/*</include>
               </includes>
-              <systemPropertyVariables>
+              <systemPropertyVariables combine.children="append">
                 <enable.resource.infinispan>true</enable.resource.infinispan>
               </systemPropertyVariables>
             </configuration>
@@ -241,9 +241,9 @@
                   <goal>verify</goal>
                 </goals>
                 <configuration>
-                  <systemProperties>
+                  <systemPropertyVariables combine.children="append">
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                  </systemProperties>
+                  </systemPropertyVariables>
                 </configuration>
               </execution>
             </executions>

--- a/integration-tests/integration-tests-quarkus-rules/pom.xml
+++ b/integration-tests/integration-tests-quarkus-rules/pom.xml
@@ -132,7 +132,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <systemPropertyVariables>
+          <systemPropertyVariables combine.children="append">
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
             <container.image.infinispan>${container.image.infinispan}</container.image.infinispan>
           </systemPropertyVariables>
@@ -164,9 +164,9 @@
                   <goal>verify</goal>
                 </goals>
                 <configuration>
-                  <systemProperties>
+                  <systemPropertyVariables combine.children="append">
                     <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                  </systemProperties>
+                  </systemPropertyVariables>
                 </configuration>
               </execution>
             </executions>

--- a/integration-tests/integration-tests-springboot/pom.xml
+++ b/integration-tests/integration-tests-springboot/pom.xml
@@ -34,6 +34,29 @@
        <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-cloudevents-spring-boot-addon</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-test-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>process-management-springboot-addon</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>task-management-springboot-addon</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.infinispan</groupId>
@@ -92,9 +115,6 @@
           <artifactId>maven-invoker-plugin</artifactId>
           <configuration>
             <streamLogs>true</streamLogs>
-            <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
-            <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
-            <useLocalRepository>true</useLocalRepository>
             <postBuildHookScript>verify</postBuildHookScript> <!-- no extension required -->
             <properties>
               <container.image.infinispan>${container.image.infinispan}</container.image.infinispan>

--- a/integration-tests/integration-tests-springboot/pom.xml
+++ b/integration-tests/integration-tests-springboot/pom.xml
@@ -43,28 +43,31 @@
     </dependency>
     <dependency>
       <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-quarkus-bom</artifactId>
+      <version>${project.version}</version>
+      <type>pom</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-cloudevents-spring-boot-addon</artifactId>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-test-utils</artifactId>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>process-management-springboot-addon</artifactId>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>task-management-springboot-addon</artifactId>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>org.infinispan</groupId>
       <artifactId>infinispan-spring-boot-starter-remote</artifactId>

--- a/integration-tests/integration-tests-springboot/pom.xml
+++ b/integration-tests/integration-tests-springboot/pom.xml
@@ -156,6 +156,13 @@
           <name>persistence</name>
         </property>
       </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.kie.kogito</groupId>
+          <artifactId>infinispan-persistence-addon</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
       <build>
         <plugins>
           <plugin>

--- a/integration-tests/integration-tests-springboot/pom.xml
+++ b/integration-tests/integration-tests-springboot/pom.xml
@@ -36,6 +36,13 @@
 
     <dependency>
       <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-bom</artifactId>
+      <version>${project.version}</version>
+      <type>pom</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-cloudevents-spring-boot-addon</artifactId>
       <scope>test</scope>
     </dependency>

--- a/jbpm/jbpm-bpmn2/pom.xml
+++ b/jbpm/jbpm-bpmn2/pom.xml
@@ -128,10 +128,10 @@
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <systemProperties>
+          <systemPropertyVariables>
             <!-- enforce strict variable checking for the sake of tests -->
             <org.jbpm.variable.strict>true</org.jbpm.variable.strict>
-          </systemProperties>
+          </systemPropertyVariables>
         </configuration>
       </plugin>
     </plugins>

--- a/kogito-build-parent/pom.xml
+++ b/kogito-build-parent/pom.xml
@@ -1095,6 +1095,10 @@
             <excludes>
               <exclude>${tests.surefire.include}</exclude>
             </excludes>
+            <systemPropertyVariables>
+              <maven.repo.local>${session.request.localRepositoryPath.path}</maven.repo.local>
+              <maven.settings>${session.request.userSettingsFile.path}</maven.settings>
+            </systemPropertyVariables>
           </configuration>
         </plugin>
         <plugin>
@@ -1114,6 +1118,8 @@
               <org.uberfire.nio.git.daemon.enabled>false</org.uberfire.nio.git.daemon.enabled>
               <org.uberfire.nio.git.ssh.enabled>false</org.uberfire.nio.git.ssh.enabled>
               <org.uberfire.sys.repo.monitor.disabled>true</org.uberfire.sys.repo.monitor.disabled>
+              <maven.repo.local>${session.request.localRepositoryPath.path}</maven.repo.local>
+              <maven.settings>${session.request.userSettingsFile.path}</maven.settings>
             </systemPropertyVariables>
           </configuration>
         </plugin>
@@ -1202,6 +1208,9 @@
             <skipInstallation>${skipTests}</skipInstallation>
             <skipInvocation>${skipTests}</skipInvocation>
             <failIfNoProjects>true</failIfNoProjects>
+            <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+            <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
+            <useLocalRepository>true</useLocalRepository>
           </configuration>
         </plugin>
         <plugin>

--- a/kogito-quarkus-parent/kogito-quarkus-extension/kogito-quarkus-integration-test-hot-reload/pom.xml
+++ b/kogito-quarkus-parent/kogito-quarkus-extension/kogito-quarkus-integration-test-hot-reload/pom.xml
@@ -108,11 +108,11 @@
                                     <goal>verify</goal>
                                 </goals>
                                 <configuration>
-                                    <systemProperties>
+                                    <systemPropertyVariables>
                                         <native.image.path>
                                             ${project.build.directory}/${project.build.finalName}-runner
                                         </native.image.path>
-                                    </systemProperties>
+                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>

--- a/kogito-quarkus-parent/kogito-quarkus-extension/kogito-quarkus-integration-test-maven-devmode/pom.xml
+++ b/kogito-quarkus-parent/kogito-quarkus-extension/kogito-quarkus-integration-test-maven-devmode/pom.xml
@@ -60,6 +60,20 @@
       <version>${version.io.quarkus}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-bom</artifactId>
+      <version>${project.version}</version>
+      <type>pom</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-quarkus-bom</artifactId>
+      <version>${project.version}</version>
+      <type>pom</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -73,7 +87,7 @@
       <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>
-          <systemPropertyVariables>
+          <systemPropertyVariables combine.children="append">
             <maven.home>${maven.home}</maven.home>
           </systemPropertyVariables>
         </configuration>

--- a/kogito-quarkus-parent/kogito-quarkus-extension/kogito-quarkus-integration-test-maven-devmode/src/test/java/io/quarkus/it/kogito/devmode/DevMojoIT.java
+++ b/kogito-quarkus-parent/kogito-quarkus-extension/kogito-quarkus-integration-test-maven-devmode/src/test/java/io/quarkus/it/kogito/devmode/DevMojoIT.java
@@ -45,6 +45,10 @@ import static org.hamcrest.Matchers.is;
 public class DevMojoIT extends RunAndCheckMojoTestBase {
 
     private static final String HTTP_TEST_PORT = "65535";
+    private static final String PROPERTY_MAVEN_REPO_LOCAL = "maven.repo.local";
+    private static final String PROPERTY_MAVEN_SETTINGS = "maven.settings";
+    private static final String MAVEN_REPO_LOCAL = System.getProperty(PROPERTY_MAVEN_REPO_LOCAL);
+    private static final String MAVEN_SETTINGS = System.getProperty(PROPERTY_MAVEN_SETTINGS);
 
     static {
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
@@ -90,7 +94,21 @@ public class DevMojoIT extends RunAndCheckMojoTestBase {
 
         // Since the Kogito extension split, this requires more memory, going for a default of 1GB, per surefire.
         args.add("-Djvm.args=-Xmx1024m");
+
+        args.addAll(getProvidedMavenProperties());
+
         running.execute(args, Collections.emptyMap());
+    }
+
+    private List<String> getProvidedMavenProperties() {
+        List<String> additionalArguments = new ArrayList<>();
+        if (MAVEN_REPO_LOCAL != null) {
+            additionalArguments.add(String.format("-D%s=%s", PROPERTY_MAVEN_REPO_LOCAL, MAVEN_REPO_LOCAL));
+        }
+        if (MAVEN_SETTINGS != null) {
+            additionalArguments.add(String.format("-s %s", MAVEN_SETTINGS));
+        }
+        return additionalArguments;
     }
 
     @Test

--- a/kogito-quarkus-parent/kogito-quarkus-extension/kogito-quarkus-integration-test-maven-devmode/src/test/java/io/quarkus/it/kogito/devmode/DevMojoIT.java
+++ b/kogito-quarkus-parent/kogito-quarkus-extension/kogito-quarkus-integration-test-maven-devmode/src/test/java/io/quarkus/it/kogito/devmode/DevMojoIT.java
@@ -106,11 +106,12 @@ public class DevMojoIT extends RunAndCheckMojoTestBase {
             additionalArguments.add(String.format("-D%s=%s", PROPERTY_MAVEN_REPO_LOCAL, MAVEN_REPO_LOCAL));
         }
         if (MAVEN_SETTINGS != null) {
-            /* Invoker would fail if the received settings.xml file did not exist.
-            *  That can happen when ${session.request.userSettingsFile.path} is passed as value for maven.settings
-            *  property from the pom.xml and at the same time user does not have settings.xml in ~/.m2/ nor they provided
-            *  specific settings.xml using -s argument.
-            */
+            /*
+             * Invoker would fail if the received settings.xml file did not exist.
+             * That can happen when ${session.request.userSettingsFile.path} is passed as value for maven.settings
+             * property from the pom.xml and at the same time user does not have settings.xml in ~/.m2/ nor they provided
+             * specific settings.xml using -s argument.
+             */
             if (new File(MAVEN_SETTINGS).exists()) {
                 additionalArguments.add(String.format("-s %s", MAVEN_SETTINGS));
             }

--- a/kogito-quarkus-parent/kogito-quarkus-extension/kogito-quarkus-integration-test-maven-devmode/src/test/java/io/quarkus/it/kogito/devmode/DevMojoIT.java
+++ b/kogito-quarkus-parent/kogito-quarkus-extension/kogito-quarkus-integration-test-maven-devmode/src/test/java/io/quarkus/it/kogito/devmode/DevMojoIT.java
@@ -106,7 +106,14 @@ public class DevMojoIT extends RunAndCheckMojoTestBase {
             additionalArguments.add(String.format("-D%s=%s", PROPERTY_MAVEN_REPO_LOCAL, MAVEN_REPO_LOCAL));
         }
         if (MAVEN_SETTINGS != null) {
-            additionalArguments.add(String.format("-s %s", MAVEN_SETTINGS));
+            /* Invoker would fail if the received settings.xml file did not exist.
+            *  That can happen when ${session.request.userSettingsFile.path} is passed as value for maven.settings
+            *  property from the pom.xml and at the same time user does not have settings.xml in ~/.m2/ nor they provided
+            *  specific settings.xml using -s argument.
+            */
+            if (new File(MAVEN_SETTINGS).exists()) {
+                additionalArguments.add(String.format("-s %s", MAVEN_SETTINGS));
+            }
         }
         return additionalArguments;
     }

--- a/kogito-quarkus-parent/kogito-quarkus-extension/kogito-quarkus-integration-test/pom.xml
+++ b/kogito-quarkus-parent/kogito-quarkus-extension/kogito-quarkus-integration-test/pom.xml
@@ -104,9 +104,9 @@
                                     <goal>verify</goal>
                                 </goals>
                                 <configuration>
-                                    <systemProperties>
+                                    <systemPropertyVariables>
                                         <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                                    </systemProperties>
+                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>

--- a/kogito-quarkus-parent/kogito-quarkus-predictions-extension/kogito-quarkus-predictions-integration-test/pom.xml
+++ b/kogito-quarkus-parent/kogito-quarkus-predictions-extension/kogito-quarkus-predictions-integration-test/pom.xml
@@ -102,9 +102,9 @@
                                     <goal>verify</goal>
                                 </goals>
                                 <configuration>
-                                    <systemProperties>
+                                    <systemPropertyVariables>
                                         <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                                    </systemProperties>
+                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>

--- a/kogito-quarkus-parent/pom.xml
+++ b/kogito-quarkus-parent/pom.xml
@@ -43,7 +43,7 @@
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <systemPropertyVariables>
+          <systemPropertyVariables combine.children="append">
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
           </systemPropertyVariables>
         </configuration>


### PR DESCRIPTION
[KOGITO-4847](https://issues.redhat.com/browse/KOGITO-4847)
* fixing surefire/filesafe systemProperties to systemPropertyVariables (https://maven.apache.org/surefire/maven-surefire-plugin/examples/system-properties.html, https://maven.apache.org/surefire/maven-failsafe-plugin/examples/system-properties.html)
* moving invoker properties to kogito-build-parent pluginManagement for invoker plugin.
* introducing explicit test dependencies in modules that use invoker to run other maven projects - aggregation of the dependencies need by those projects being invoked.
* Making sure all maven invocations respect `-Dmaven.repo.local=<path>` and `-s <path>/settings.xml` configurations
  * by setting explicitly in surefire/failsafe (for quarkus plugin)
  * by passing directly in code (IT tests for quarkus dev mode which use invoker from java) 

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>