### PR TITLE
[KOGITO-4845] Kogito doesn't show stack trace of executable model generic Runtime Errors

### DIFF
--- a/kogito-codegen-modules/kogito-codegen-rules/src/main/java/org/kie/kogito/codegen/rules/RuleCodegenError.java
+++ b/kogito-codegen-modules/kogito-codegen-rules/src/main/java/org/kie/kogito/codegen/rules/RuleCodegenError.java
@@ -42,7 +42,8 @@ public class RuleCodegenError extends Error {
                 ex.getMessage() + "\n" +
                 Arrays.stream(errors)
                         .map(DroolsError::toString)
-                        .collect(Collectors.joining("\n")));
+                        .collect(Collectors.joining("\n")),
+                ex);
         this.errors = errors;
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-4845

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>