### PR TITLE
KOGITO-4887 Bump Quarkus 1.13

### DIFF
--- a/kogito-build-parent/pom.xml
+++ b/kogito-build-parent/pom.xml
@@ -186,7 +186,7 @@
     <version.org.confluent.kafka>5.4.3</version.org.confluent.kafka>
     <version.org.kie7>7.52.0.Final</version.org.kie7>
     <version.org.mockito>3.6.0</version.org.mockito>
-    <version.org.mongo>4.1.0</version.org.mongo>
+    <version.org.mongo>4.2.3</version.org.mongo>
     <version.org.mvel>2.4.12.Final</version.org.mvel>
     <version.org.reactivestreams>1.0.3</version.org.reactivestreams>
     <version.org.reflections>0.9.11</version.org.reflections>

--- a/kogito-build-parent/pom.xml
+++ b/kogito-build-parent/pom.xml
@@ -117,17 +117,17 @@
     <version.org.jsonschema2pojo-maven-plugin>1.0.1</version.org.jsonschema2pojo-maven-plugin>
 
     <!-- this version property is used in plugins but also in dependencies too -->
-    <version.io.quarkus>1.11.5.Final</version.io.quarkus>
+    <version.io.quarkus>1.13.2.Final</version.io.quarkus>
 
     <!-- dependencies versions -->
     <version.ch.obermuhlner>2.0.1</version.ch.obermuhlner>
-    <version.com.fasterxml.jackson>2.11.3</version.com.fasterxml.jackson>
+    <version.com.fasterxml.jackson>2.12.1</version.com.fasterxml.jackson>
     <version.com.github.haifengl.smile>1.5.2</version.com.github.haifengl.smile>
     <version.com.github.javaparser>3.13.10</version.com.github.javaparser>
     <version.com.github.java-json-tools>2.2.10</version.com.github.java-json-tools>
     <version.com.github.victools>4.12.1</version.com.github.victools>
     <version.com.github.tomakehurst.wiremock>2.27.2</version.com.github.tomakehurst.wiremock>
-    <version.com.github.ben-manes.caffeine>2.8.5</version.com.github.ben-manes.caffeine>
+    <version.com.github.ben-manes.caffeine>2.9.0</version.com.github.ben-manes.caffeine>
     <version.com.google.protobuf>3.14.0</version.com.google.protobuf>
     <version.com.google.guava>16.0.1</version.com.google.guava>
     <version.org.openapitools>5.0.1</version.org.openapitools>
@@ -148,25 +148,24 @@
     <version.io.cloudevents>2.0.0-milestone3</version.io.cloudevents>
     <version.io.jredisearch>2.0.0</version.io.jredisearch>
     <version.io.fabric8.kubernetes-client>5.0.0</version.io.fabric8.kubernetes-client>
-    <version.io.micrometer>1.6.1</version.io.micrometer>
+    <version.io.micrometer>1.6.5</version.io.micrometer>
     <version.io.rest-assured>4.3.0</version.io.rest-assured>
     <version.io.rest-assured.springboot>3.3.0</version.io.rest-assured.springboot>    <!-- Manually override to 3.3.0 because Spring boot uses rest-assured-common@3.3.0, otherwise error: The type io.restassured.common.mapper.TypeRef cannot be resolved. It is indirectly referenced from required .class files -->
     <version.io.serverlessworkflow>2.0.0.Final</version.io.serverlessworkflow>
-    <version.io.smallrye-open-api-core>2.0.22</version.io.smallrye-open-api-core>
-    <version.io.smallrye.reactive>2.7.1</version.io.smallrye.reactive>
-    <version.io.smallrye.reactive.mutiny-vertx-web-client>1.3.0</version.io.smallrye.reactive.mutiny-vertx-web-client>
+    <version.io.smallrye-open-api-core>2.0.26</version.io.smallrye-open-api-core>
+    <version.io.smallrye.reactive>2.9.0</version.io.smallrye.reactive>
+    <version.io.smallrye.reactive.mutiny-vertx-web-client>1.5.0</version.io.smallrye.reactive.mutiny-vertx-web-client>
     <version.io.swagger.core.v3>2.0.6</version.io.swagger.core.v3>
     <version.io.swagger.parser.v3>2.0.24</version.io.swagger.parser.v3>
 
     <version.org.antlr>3.5.2</version.org.antlr>
     <version.org.antlr4>4.8</version.org.antlr4>
     <version.org.apache.commons>3.8.1</version.org.apache.commons>
-    <!-- Quarkus on 2.5.0, but faced the following issue: https://issues.apache.org/jira/browse/KAFKA-9127 -->
-    <version.org.apache.kafka>2.5.1</version.org.apache.kafka>
+    <version.org.apache.kafka>2.7.0</version.org.apache.kafka>
     <version.org.apache.xmlgraphics.batik>1.13</version.org.apache.xmlgraphics.batik>
-    <version.org.assertj>3.16.1</version.org.assertj>
+    <version.org.assertj>3.19.0</version.org.assertj>
     <version.org.eclipse.jdt>3.19.0</version.org.eclipse.jdt>
-    <version.org.graalvm.nativeimage>20.3.1.2</version.org.graalvm.nativeimage>
+    <version.org.graalvm.nativeimage>21.0.0</version.org.graalvm.nativeimage>
     <version.org.hamcrest>1.3</version.org.hamcrest> <!-- else old version coming from Mockito wins and breaks tests -->
 
     <version.org.infinispan>11.0.4.Final</version.org.infinispan>
@@ -177,13 +176,13 @@
     <version.org.jboss.resteasy>4.5.9.Final</version.org.jboss.resteasy>
     <version.org.json>20200518</version.org.json>
     <version.org.json-unit-assertj>2.9.0</version.org.json-unit-assertj>
-    <version.org.junit.minor>7.0</version.org.junit.minor> <!-- so that org.junit.platform and org.junit can share the same minor version -->
+    <version.org.junit.minor>7.1</version.org.junit.minor> <!-- so that org.junit.platform and org.junit can share the same minor version -->
     <version.org.junit>5.${version.org.junit.minor}</version.org.junit>
     <version.org.junit.jupiter>${version.org.junit}</version.org.junit.jupiter>
     <version.org.junit.vintage>${version.org.junit}</version.org.junit.vintage>
     <version.org.junit.platform>1.${version.org.junit.minor}</version.org.junit.platform> <!-- otherwise Quarkus brings its own, silently disabling some tests -->
     <version.org.junit.pioneer>1.0.0</version.org.junit.pioneer>
-    <version.org.keycloak>11.0.3</version.org.keycloak>
+    <version.org.keycloak>12.0.4</version.org.keycloak>
     <version.org.confluent.kafka>5.4.3</version.org.confluent.kafka>
     <version.org.kie7>7.52.0.Final</version.org.kie7>
     <version.org.mockito>3.6.0</version.org.mockito>

--- a/kogito-build-parent/pom.xml
+++ b/kogito-build-parent/pom.xml
@@ -117,7 +117,7 @@
     <version.org.jsonschema2pojo-maven-plugin>1.0.1</version.org.jsonschema2pojo-maven-plugin>
 
     <!-- this version property is used in plugins but also in dependencies too -->
-    <version.io.quarkus>1.13.0.Final</version.io.quarkus>
+    <version.io.quarkus>1.13.1.Final</version.io.quarkus>
 
     <!-- dependencies versions -->
     <version.ch.obermuhlner>2.0.1</version.ch.obermuhlner>

--- a/kogito-build-parent/pom.xml
+++ b/kogito-build-parent/pom.xml
@@ -147,7 +147,7 @@
 
     <version.io.cloudevents>2.0.0-milestone3</version.io.cloudevents>
     <version.io.jredisearch>2.0.0</version.io.jredisearch>
-    <version.io.fabric8.kubernetes-client>5.3.0</version.io.fabric8.kubernetes-client>
+    <version.io.fabric8.kubernetes-client>5.0.0</version.io.fabric8.kubernetes-client>
     <version.io.micrometer>1.6.5</version.io.micrometer>
     <version.io.rest-assured>4.3.3</version.io.rest-assured>
     <version.io.rest-assured.springboot>3.3.0</version.io.rest-assured.springboot>    <!-- Manually override to 3.3.0 because Spring boot uses rest-assured-common@3.3.0, otherwise error: The type io.restassured.common.mapper.TypeRef cannot be resolved. It is indirectly referenced from required .class files -->

--- a/kogito-build-parent/pom.xml
+++ b/kogito-build-parent/pom.xml
@@ -95,7 +95,7 @@
     <version.license.plugin>4.0.rc2</version.license.plugin>
     <version.enforcer.plugin>3.0.0-M2</version.enforcer.plugin>
     <version.de.skuzzle.enforcer>1.1.0</version.de.skuzzle.enforcer>
-    <version.maven>3.6.3</version.maven>
+    <version.maven>3.6.2</version.maven>
     <version.maven.plugin>3.6.0</version.maven.plugin>
     <version.native2ascii.plugin>1.0-beta-1</version.native2ascii.plugin>
     <version.plexus>1.6</version.plexus>

--- a/kogito-build-parent/pom.xml
+++ b/kogito-build-parent/pom.xml
@@ -95,8 +95,8 @@
     <version.license.plugin>4.0.rc2</version.license.plugin>
     <version.enforcer.plugin>3.0.0-M2</version.enforcer.plugin>
     <version.de.skuzzle.enforcer>1.1.0</version.de.skuzzle.enforcer>
-    <version.maven>3.6.2</version.maven>
-    <version.maven.plugin>3.4</version.maven.plugin>
+    <version.maven>3.6.3</version.maven>
+    <version.maven.plugin>3.6.0</version.maven.plugin>
     <version.native2ascii.plugin>1.0-beta-1</version.native2ascii.plugin>
     <version.plexus>1.6</version.plexus>
     <version.plexus.classworld>2.5.2</version.plexus.classworld>
@@ -132,7 +132,7 @@
     <version.com.google.guava>16.0.1</version.com.google.guava>
     <version.org.openapitools>5.0.1</version.org.openapitools>
     <version.org.openapitools.jackson.databind.nullable>0.2.0</version.org.openapitools.jackson.databind.nullable>
-    <version.com.squareup.okhttp3>3.14.6</version.com.squareup.okhttp3>
+    <version.com.squareup.okhttp3>3.14.9</version.com.squareup.okhttp3>
     <version.com.sun.xml.bind>2.3.0</version.com.sun.xml.bind>
     <version.com.sun.activation>1.2.0</version.com.sun.activation>
     <version.com.thoughtworks.xstream>1.4.14</version.com.thoughtworks.xstream>
@@ -143,13 +143,13 @@
     <version.javax.json>1.1.4</version.javax.json>
     <version.javax.json.bind>1.0</version.javax.json.bind>
     <version.javax.validation>2.0.1.Final</version.javax.validation>
-    <version.javax.xml.bind>2.3.0</version.javax.xml.bind>
+    <version.javax.xml.bind>2.3.1</version.javax.xml.bind>
 
     <version.io.cloudevents>2.0.0-milestone3</version.io.cloudevents>
     <version.io.jredisearch>2.0.0</version.io.jredisearch>
-    <version.io.fabric8.kubernetes-client>5.0.0</version.io.fabric8.kubernetes-client>
+    <version.io.fabric8.kubernetes-client>5.3.0</version.io.fabric8.kubernetes-client>
     <version.io.micrometer>1.6.5</version.io.micrometer>
-    <version.io.rest-assured>4.3.0</version.io.rest-assured>
+    <version.io.rest-assured>4.3.3</version.io.rest-assured>
     <version.io.rest-assured.springboot>3.3.0</version.io.rest-assured.springboot>    <!-- Manually override to 3.3.0 because Spring boot uses rest-assured-common@3.3.0, otherwise error: The type io.restassured.common.mapper.TypeRef cannot be resolved. It is indirectly referenced from required .class files -->
     <version.io.serverlessworkflow>2.0.0.Final</version.io.serverlessworkflow>
     <version.io.smallrye-open-api-core>2.0.26</version.io.smallrye-open-api-core>
@@ -160,7 +160,7 @@
 
     <version.org.antlr>3.5.2</version.org.antlr>
     <version.org.antlr4>4.8</version.org.antlr4>
-    <version.org.apache.commons>3.8.1</version.org.apache.commons>
+    <version.org.apache.commons>3.12.0</version.org.apache.commons>
     <version.org.apache.kafka>2.7.0</version.org.apache.kafka>
     <version.org.apache.xmlgraphics.batik>1.13</version.org.apache.xmlgraphics.batik>
     <version.org.assertj>3.19.0</version.org.assertj>
@@ -172,7 +172,7 @@
     <version.org.redis>2.0.4</version.org.redis>
     <version.org.infinispan.protostream>4.3.4.Final</version.org.infinispan.protostream>
     <version.org.infinispan.starter>2.3.3.Final</version.org.infinispan.starter>
-    <version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>1.0.1.Final</version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>
+    <version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>2.0.1.Final</version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>
     <version.org.jboss.resteasy>4.5.9.Final</version.org.jboss.resteasy>
     <version.org.json>20200518</version.org.json>
     <version.org.json-unit-assertj>2.9.0</version.org.json-unit-assertj>
@@ -199,7 +199,7 @@
     <version.io.netty>4.1.52.Final</version.io.netty>
     <version.io.projectreactor>3.3.10.RELEASE</version.io.projectreactor>
     <version.io.projectreactor.kafka>1.2.2.RELEASE</version.io.projectreactor.kafka>
-    <version.io.vertx>3.9.2</version.io.vertx>
+    <version.io.vertx>3.9.6</version.io.vertx>
     <version.xerces>2.11.0</version.xerces>
   </properties>
 

--- a/kogito-build-parent/pom.xml
+++ b/kogito-build-parent/pom.xml
@@ -187,6 +187,7 @@
     <version.org.kie7>7.52.0.Final</version.org.kie7>
     <version.org.mockito>3.6.0</version.org.mockito>
     <version.org.mongo>4.2.3</version.org.mongo>
+    <version.org.mongo.springboot>4.1.0</version.org.mongo.springboot> <!-- https://issues.redhat.com/browse/KOGITO-5031 -->
     <version.org.mvel>2.4.12.Final</version.org.mvel>
     <version.org.reactivestreams>1.0.3</version.org.reactivestreams>
     <version.org.reflections>0.9.11</version.org.reflections>

--- a/kogito-build-parent/pom.xml
+++ b/kogito-build-parent/pom.xml
@@ -117,7 +117,7 @@
     <version.org.jsonschema2pojo-maven-plugin>1.0.1</version.org.jsonschema2pojo-maven-plugin>
 
     <!-- this version property is used in plugins but also in dependencies too -->
-    <version.io.quarkus>1.13.2.Final</version.io.quarkus>
+    <version.io.quarkus>1.13.0.Final</version.io.quarkus>
 
     <!-- dependencies versions -->
     <version.ch.obermuhlner>2.0.1</version.ch.obermuhlner>

--- a/kogito-build-parent/pom.xml
+++ b/kogito-build-parent/pom.xml
@@ -117,7 +117,7 @@
     <version.org.jsonschema2pojo-maven-plugin>1.0.1</version.org.jsonschema2pojo-maven-plugin>
 
     <!-- this version property is used in plugins but also in dependencies too -->
-    <version.io.quarkus>1.13.2.Final</version.io.quarkus>
+    <version.io.quarkus>1.13.3.Final</version.io.quarkus>
 
     <!-- dependencies versions -->
     <version.ch.obermuhlner>2.0.1</version.ch.obermuhlner>

--- a/kogito-build-parent/pom.xml
+++ b/kogito-build-parent/pom.xml
@@ -117,7 +117,7 @@
     <version.org.jsonschema2pojo-maven-plugin>1.0.1</version.org.jsonschema2pojo-maven-plugin>
 
     <!-- this version property is used in plugins but also in dependencies too -->
-    <version.io.quarkus>1.13.1.Final</version.io.quarkus>
+    <version.io.quarkus>1.13.2.Final</version.io.quarkus>
 
     <!-- dependencies versions -->
     <version.ch.obermuhlner>2.0.1</version.ch.obermuhlner>


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-4887

### Bundle

- https://github.com/kiegroup/kogito-runtimes/pull/1200
- https://github.com/kiegroup/kogito-apps/pull/774
- https://github.com/kiegroup/kogito-examples/pull/667

### Highlights

- Upgrades Quarkus 1.13 to latest:
   - does not include ISPN 12 yet
   - adds a version override for MongoDB on spring boot (otherwise the version upgrade breaks)
- makes our life miserable in the process


🙈 

<details>

```diff
@@ -17,7 +17,7 @@
         <bouncycastle.version>1.68</bouncycastle.version>
         <bouncycastle.fips.version>1.0.2</bouncycastle.fips.version>
         <bouncycastle.tls.fips.version>1.0.11</bouncycastle.tls.fips.version>
-        <jandex.version>2.2.2.Final</jandex.version>
+        <jandex.version>2.2.3.Final</jandex.version>
         <resteasy.version>4.5.9.Final</resteasy.version>
         <opentracing.version>0.31.0</opentracing.version>
         <opentracing-jaxrs.version>0.4.1</opentracing-jaxrs.version>
@@ -25,12 +25,14 @@
         <opentracing-tracerresolver.version>0.1.8</opentracing-tracerresolver.version>
         <opentracing-concurrent.version>0.2.0</opentracing-concurrent.version>
         <opentracing-jdbc.version>0.0.12</opentracing-jdbc.version>
-        <opentracing-kafka.version>0.1.13</opentracing-kafka.version>
+        <opentracing-kafka.version>0.1.15</opentracing-kafka.version>
+        <opentelemetry.version>1.0.1</opentelemetry.version>
+        <opentelemetry-alpha.version>1.0.1-alpha</opentelemetry-alpha.version>
         <jaeger.version>0.34.3</jaeger.version>
-        <quarkus-http.version>3.0.18.Final</quarkus-http.version>
+        <quarkus-http.version>3.1.0.Beta2</quarkus-http.version>
         <jboss-servlet-api_4.0_spec.version>1.0.0.Final</jboss-servlet-api_4.0_spec.version>
         <threetenbp.version>1.4.3</threetenbp.version>
-        <micrometer.version>1.6.3</micrometer.version> <!-- when updating, verify if com.google.auth should not be updated too -->
+        <micrometer.version>1.6.5</micrometer.version> <!-- when updating, verify if com.google.auth should not be updated too -->
         <google-auth.version>0.22.0</google-auth.version>
         <microprofile-config-api.version>1.4</microprofile-config-api.version>
         <microprofile-metrics-api.version>2.3</microprofile-metrics-api.version>
@@ -38,19 +40,20 @@
         <microprofile-opentracing-api.version>1.3.3</microprofile-opentracing-api.version>
         <microprofile-reactive-streams-operators.version>1.0.1</microprofile-reactive-streams-operators.version>
         <microprofile-rest-client.version>1.4.1</microprofile-rest-client.version>
+        <microprofile-jwt.version>1.1.1</microprofile-jwt.version>
         <smallrye-common.version>1.5.0</smallrye-common.version>
-        <smallrye-config.version>1.10.2</smallrye-config.version>
-        <smallrye-health.version>2.2.5</smallrye-health.version>
+        <smallrye-config.version>1.11.1</smallrye-config.version>
+        <smallrye-health.version>2.2.6</smallrye-health.version>
         <smallrye-metrics.version>2.4.6</smallrye-metrics.version>
-        <smallrye-open-api.version>2.0.22</smallrye-open-api.version>
-        <smallrye-graphql.version>1.0.21</smallrye-graphql.version>
+        <smallrye-open-api.version>2.0.26</smallrye-open-api.version>
+        <smallrye-graphql.version>1.0.26</smallrye-graphql.version>
         <smallrye-opentracing.version>1.3.5</smallrye-opentracing.version>
         <smallrye-fault-tolerance.version>4.3.2</smallrye-fault-tolerance.version>
-        <smallrye-jwt.version>2.4.1</smallrye-jwt.version>
-        <smallrye-context-propagation.version>1.0.19</smallrye-context-propagation.version>
+        <smallrye-jwt.version>2.4.4</smallrye-jwt.version>
+        <smallrye-context-propagation.version>1.1.0</smallrye-context-propagation.version>
         <smallrye-reactive-streams-operators.version>1.0.13</smallrye-reactive-streams-operators.version>
-        <smallrye-converter-api.version>1.3.0</smallrye-converter-api.version>
-        <smallrye-reactive-messaging.version>2.7.1</smallrye-reactive-messaging.version>
+        <smallrye-converter-api.version>1.4.0</smallrye-converter-api.version>
+        <smallrye-reactive-messaging.version>2.9.0</smallrye-reactive-messaging.version>
         <jakarta.activation.version>1.2.1</jakarta.activation.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
         <jakarta.el-impl.version>3.0.3</jakarta.el-impl.version>
@@ -72,7 +75,7 @@
         <jaxb-api.version>2.3.1</jaxb-api.version>
         <jboss-jaxrs-api_2.1_spec.version>2.0.1.Final</jboss-jaxrs-api_2.1_spec.version>
         <jboss-jaxb-api_2.3_spec.version>2.0.0.Final</jboss-jaxb-api_2.3_spec.version>
-        <asm.version>9.0</asm.version>
+        <asm.version>9.1</asm.version>
         <commons-io.version>2.8.0</commons-io.version>
         <jboss-metadata-web.version>11.0.0.Final</jboss-metadata-web.version>
         <maven-core.version>3.6.3</maven-core.version>
@@ -83,31 +86,31 @@
         <maven-plugin-annotations.version>3.6.0</maven-plugin-annotations.version>
         <plexus-component-annotations.version>2.1.0</plexus-component-annotations.version>
         <!-- What we actually depend on for the annotations, as latest Graal is not available in Maven fast enough: -->
-        <graal-sdk.version>20.3.1</graal-sdk.version>
-        <gizmo.version>1.0.6.Final</gizmo.version>
-        <jackson.version>2.11.3</jackson.version>
+        <graal-sdk.version>21.0.0</graal-sdk.version>
+        <gizmo.version>1.0.7.Final</gizmo.version>
+        <jackson.version>2.12.1</jackson.version>
         <commons-logging-jboss-logging.version>1.0.0.Final</commons-logging-jboss-logging.version>
-        <commons-lang3.version>3.11</commons-lang3.version>
+        <commons-lang3.version>3.12.0</commons-lang3.version>
         <commons-codec.version>1.14</commons-codec.version>
         <classmate.version>1.3.4</classmate.version>
-        <hibernate-orm.version>5.4.27.SP1</hibernate-orm.version>
-        <hibernate-reactive.version>1.0.0.Beta2</hibernate-reactive.version>
+        <hibernate-orm.version>5.4.29.Final</hibernate-orm.version>
+        <hibernate-reactive.version>1.0.0.CR1</hibernate-reactive.version>
         <hibernate-validator.version>6.2.0.Final</hibernate-validator.version>
-        <hibernate-search.version>6.0.0.Final</hibernate-search.version>
+        <hibernate-search.version>6.0.2.Final</hibernate-search.version>
         <narayana.version>5.10.6.Final</narayana.version>
         <jboss-transaction-api_1.2_spec.version>1.1.1.Final</jboss-transaction-api_1.2_spec.version>
         <agroal.version>1.9</agroal.version>
         <jboss-transaction-spi.version>7.6.0.Final</jboss-transaction-spi.version>
         <elasticsearch-rest-client.version>7.10.0</elasticsearch-rest-client.version>
         <rxjava1.version>1.3.8</rxjava1.version>
-        <rxjava.version>2.2.20</rxjava.version>
+        <rxjava.version>2.2.21</rxjava.version>
         <wildfly.openssl.version>1.0.6.Final</wildfly.openssl.version>
         <jboss-logging-annotations.version>2.2.0.Final</jboss-logging-annotations.version>
         <slf4j.version>1.7.30</slf4j.version>
         <slf4j-jboss-logmanager.version>1.1.0.Final</slf4j-jboss-logmanager.version>
         <wildfly-common.version>1.5.4.Final-format-001</wildfly-common.version>
         <wildfly-client-config.version>1.0.1.Final</wildfly-client-config.version>
-        <wildfly-elytron.version>1.14.1.Final</wildfly-elytron.version>
+        <wildfly-elytron.version>1.15.1.Final</wildfly-elytron.version>
         <jboss-modules.version>1.8.7.Final</jboss-modules.version>
         <jboss-threads.version>3.2.0.Final</jboss-threads.version>
         <vertx.version>3.9.5</vertx.version>
@@ -117,7 +120,7 @@
         <cronutils.version>9.1.3</cronutils.version>
         <quartz.version>2.3.2</quartz.version>
         <h2.version>1.4.197</h2.version>  <!-- keep 1.4.197 as newer versions have severe regressions -->
-        <postgresql-jdbc.version>42.2.18</postgresql-jdbc.version>
+        <postgresql-jdbc.version>42.2.19</postgresql-jdbc.version>
         <mariadb-jdbc.version>2.7.2</mariadb-jdbc.version>
         <mysql-jdbc.version>8.0.23</mysql-jdbc.version>
         <mssql-jdbc.version>7.2.2.jre8</mssql-jdbc.version>
@@ -125,74 +128,72 @@
         <db2-jdbc.version>11.5.4.0</db2-jdbc.version>
         <shrinkwrap.version>1.2.6</shrinkwrap.version>
         <rest-assured.version>4.3.3</rest-assured.version>
-        <junit.jupiter.version>5.7.0</junit.jupiter.version>
+        <junit.jupiter.version>5.7.1</junit.jupiter.version>
         <testng.version>6.14.2</testng.version>
-        <assertj.version>3.18.1</assertj.version>
+        <assertj.version>3.19.0</assertj.version>
         <json-smart.version>2.3</json-smart.version>
-        <infinispan.version>11.0.8.Final</infinispan.version>
-        <infinispan.protostream.version>4.3.4.Final</infinispan.protostream.version>
-        <caffeine.version>2.8.8</caffeine.version>
+        <infinispan.version>12.0.1.Final</infinispan.version>
+        <infinispan.protostream.version>4.4.0.Alpha4</infinispan.protostream.version>
+        <caffeine.version>2.9.0</caffeine.version>
         <netty.version>4.1.49.Final</netty.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <jboss-logging.version>3.4.1.Final</jboss-logging.version>
-        <mutiny.version>0.12.5</mutiny.version>
-        <axle-client.version>1.3.0</axle-client.version>
-        <mutiny-client.version>1.3.0</mutiny-client.version>
-        <kafka2.version>2.5.0</kafka2.version>
+        <mutiny.version>0.14.0</mutiny.version>
+        <mutiny-vertx.version>1.5.0</mutiny-vertx.version>
+        <kafka2.version>2.7.0</kafka2.version>
         <zookeeper.version>3.5.7</zookeeper.version>
         <!-- Scala is used by Kafka so we need to choose a compatible version -->
-        <scala.version>2.12.9</scala.version>
+        <scala.version>2.12.13</scala.version>
         <tika.version>1.24.1</tika.version>
         <ooxml-schemas.version>1.4</ooxml-schemas.version>
         <aws-lambda-java.version>1.2.1</aws-lambda-java.version>
         <aws-lambda-java-events.version>3.7.0</aws-lambda-java-events.version>
         <aws-lambda-serverless-java-container.version>1.3.1</aws-lambda-serverless-java-container.version>
-        <aws-xray.version>2.4.0</aws-xray.version>
-        <awssdk.version>2.15.62</awssdk.version>
+        <aws-xray.version>2.8.0</aws-xray.version>
+        <awssdk.version>2.16.19</awssdk.version>
         <aws-alexa-sdk.version>2.37.1</aws-alexa-sdk.version>
-        <azure-functions-java-library.version>1.3.0</azure-functions-java-library.version>
-        <kotlin.version>1.4.20</kotlin.version>
+        <azure-functions-java-library.version>1.4.0</azure-functions-java-library.version>
+        <kotlin.version>1.4.31</kotlin.version>
         <dekorate.version>0.14.2</dekorate.version>
         <maven-artifact-transfer.version>0.10.0</maven-artifact-transfer.version>
-        <jline.version>2.14.6</jline.version>
         <maven-invoker.version>3.0.1</maven-invoker.version>
         <awaitility.version>4.0.3</awaitility.version>
         <jprocesses.version>1.6.5</jprocesses.version>
-        <jboss-logmanager.version>1.0.6</jboss-logmanager.version>
-        <jgit.version>5.10.0.202012080955-r</jgit.version>
-        <flyway.version>7.4.0 </flyway.version>
+        <jboss-logmanager.version>1.0.9</jboss-logmanager.version>
+        <jgit.version>5.11.0.202103091610-r</jgit.version>
+        <flyway.version>7.7.0</flyway.version>
         <yasson.version>1.0.8</yasson.version>
-        <liquibase.version>4.2.2</liquibase.version>
-        <snakeyaml.version>1.27</snakeyaml.version>
+        <liquibase.version>4.3.1</liquibase.version>
+        <snakeyaml.version>1.28</snakeyaml.version>
         <osgi.version>6.0.0</osgi.version>
-        <neo4j-java-driver.version>4.2.0</neo4j-java-driver.version>
+        <neo4j-java-driver.version>4.2.3</neo4j-java-driver.version>
         <mongo-client.version>4.1.0</mongo-client.version>
         <mongo-crypt.version>1.0.1</mongo-crypt.version>
-        <artemis.version>2.11.0</artemis.version>
+        <artemis.version>2.17.0</artemis.version>
         <proton-j.version>0.33.8</proton-j.version>
         <okhttp.version>3.14.9</okhttp.version>
-        <sentry.version>3.2.0</sentry.version>
+        <sentry.version>4.3.0</sentry.version>
         <subethasmtp.version>3.1.7</subethasmtp.version>
         <hibernate-quarkus-local-cache.version>0.1.0</hibernate-quarkus-local-cache.version>
-        <kubernetes-client.version>5.1.0</kubernetes-client.version>
+        <kubernetes-client.version>5.2.1</kubernetes-client.version>
         <flapdoodle.mongo.version>2.2.0</flapdoodle.mongo.version>
         <quarkus-spring-api.version>5.2.SP4</quarkus-spring-api.version>
         <quarkus-spring-data-api.version>2.1.SP2</quarkus-spring-data-api.version>
         <quarkus-spring-security-api.version>5.2.Final</quarkus-spring-security-api.version>
         <quarkus-spring-boot-api.version>2.1.SP1</quarkus-spring-boot-api.version>
         <htmlunit.version>2.40.0</htmlunit.version>
-        <mockito.version>3.7.0</mockito.version>
+        <mockito.version>3.8.0</mockito.version>
         <jna.version>5.3.1</jna.version><!-- should satisfy both testcontainers and mongodb -->
         <antlr.version>4.8</antlr.version>
-        <quarkus-security.version>1.1.3.Final</quarkus-security.version>
-        <keycloak.version>11.0.3</keycloak.version>
+        <quarkus-security.version>1.1.4.Final</quarkus-security.version>
+        <keycloak.version>12.0.4</keycloak.version>
         <logstash-gelf.version>1.14.1</logstash-gelf.version>
         <jsch.version>0.1.55</jsch.version>
         <jzlib.version>1.1.1</jzlib.version>
         <checker-qual.version>2.5.2</checker-qual.version>
         <error-prone-annotations.version>2.2.0</error-prone-annotations.version>
         <jib-core.version>0.17.0</jib-core.version>
-        <google-http-client.version>1.34.0</google-http-client.version>
+        <google-http-client.version>1.38.0</google-http-client.version>
         <scram-client.version>2.1</scram-client.version>
         <!-- Make sure to check compatibility between these 2 gRPC components before upgrade -->
         <grpc.version>1.34.0</grpc.version> <!-- when updating, verify if com.google.auth should not be updated too -->
@@ -209,6 +210,8 @@
         <log4j2-jboss-logmanager.version>1.0.0.Beta1</log4j2-jboss-logmanager.version>
         <log4j-jboss-logmanager.version>1.2.0.Final</log4j-jboss-logmanager.version>
         <avro.version>1.10.0</avro.version>
+        <jacoco.version>0.8.6</jacoco.version>
+        <testcontainers.version>1.15.2</testcontainers.version>
     </properties>
```

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](CONTRIBUTING.md)
- [ ] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/master/kogito-ide-config)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>