### PR TITLE
KOGITO-4895 add empty sonar.exclusions into kogito-build-parent

### DIFF
--- a/kogito-build-parent/pom.xml
+++ b/kogito-build-parent/pom.xml
@@ -1523,6 +1523,7 @@ limitations under the License.
         <!--suppress UnresolvedMavenProperty -->
         <sonar.login>${env.SONARCLOUD_TOKEN}</sonar.login>
         <sonar.organization>kiegroup</sonar.organization>
+        <sonar.exclusions></sonar.exclusions> <!-- KOGITO-4895 keep it here, if removed exclusions are not scoped to a particular defining module -->
       </properties>
       <build>
         <plugins>


### PR DESCRIPTION
Jira: [KOGITO-4895](https://issues.redhat.com/browse/KOGITO-4895)
Property sonar.exclusions defined in integration-tests module is affecting sonar reporting for all the modules for some reason. As a short-term solution, trying to replace the exclusions **/* with property sonar.skip, which should be scoped to a module based on the documentation.
Further investigation why is the issue occurring will be a follow-up task.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>