### PR TITLE
[KOGITO-4438] PostgreSQL research about doing optmistic locking

### DIFF
--- a/addons/persistence/postgresql-persistence-addon/src/main/java/org/kie/kogito/persistence/KogitoProcessInstancesFactory.java
+++ b/addons/persistence/postgresql-persistence-addon/src/main/java/org/kie/kogito/persistence/KogitoProcessInstancesFactory.java
@@ -46,8 +46,10 @@ public abstract class KogitoProcessInstancesFactory implements ProcessInstancesF
         return this.client;
     }
 
+    public abstract boolean lock();
+
     @Override
     public PostgreProcessInstances createProcessInstances(Process<?> process) {
-        return new PostgreProcessInstances(process, client(), autoDDL, queryTimeout);
+        return new PostgreProcessInstances(process, client(), autoDDL, queryTimeout, lock());
     }
 }

--- a/addons/persistence/postgresql-persistence-addon/src/main/java/org/kie/kogito/persistence/postgresql/PostgreProcessInstances.java
+++ b/addons/persistence/postgresql-persistence-addon/src/main/java/org/kie/kogito/persistence/postgresql/PostgreProcessInstances.java
@@ -20,7 +20,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -49,8 +48,14 @@ import io.vertx.sqlclient.RowIterator;
 import io.vertx.sqlclient.RowSet;
 import io.vertx.sqlclient.Tuple;
 
+import static org.kie.kogito.process.ProcessInstanceReadMode.MUTABLE;
+
 @SuppressWarnings({ "rawtypes" })
 public class PostgreProcessInstances implements MutableProcessInstances {
+
+    private static final String VERSION = "version";
+
+    private static final String PAYLOAD = "payload";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PostgreProcessInstances.class);
 
@@ -59,13 +64,16 @@ public class PostgreProcessInstances implements MutableProcessInstances {
     private final ProcessInstanceMarshallerService marshaller;
     private final boolean autoDDL;
     private final Long queryTimeoutMillis;
+    private final boolean lock;
 
-    public PostgreProcessInstances(Process<?> process, PgPool client, boolean autoDDL, Long queryTimeoutMillis) {
+    public PostgreProcessInstances(Process<?> process, PgPool client, boolean autoDDL, Long queryTimeoutMillis,
+            boolean lock) {
         this.process = process;
         this.client = client;
         this.autoDDL = autoDDL;
         this.queryTimeoutMillis = queryTimeoutMillis;
         this.marshaller = ProcessInstanceMarshallerService.newBuilder().withDefaultObjectMarshallerStrategies().build();
+        this.lock = lock;
         init();
     }
 
@@ -74,31 +82,64 @@ public class PostgreProcessInstances implements MutableProcessInstances {
         return findById(id).isPresent();
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public void create(String id, ProcessInstance instance) {
+        if (!isActive(instance)) {
+            disconnect(instance);
+            return;
+        }
         insertInternal(UUID.fromString(id), marshaller.marshallProcessInstance(instance));
         disconnect(instance);
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public void update(String id, ProcessInstance instance) {
-        updateInternal(UUID.fromString(id), marshaller.marshallProcessInstance(instance));
+        if (!isActive(instance)) {
+            disconnect(instance);
+            return;
+        }
+        if (lock) {
+            updateWithLock(UUID.fromString(id), marshaller.marshallProcessInstance(instance), instance.version());
+        } else {
+            updateInternal(UUID.fromString(id), marshaller.marshallProcessInstance(instance));
+        }
         disconnect(instance);
     }
 
     @Override
     public void remove(String id) {
-        deleteInternal(UUID.fromString(id));
+        boolean isDeleted = deleteInternal(UUID.fromString(id));
+        if (lock && !isDeleted) {
+            throw uncheckedException(null, "The document with ID: %s was updated or deleted by other request.", id);
+        }
     }
 
     @Override
     public Optional<ProcessInstance> findById(String id, ProcessInstanceReadMode mode) {
-        return findByIdInternal(UUID.fromString(id)).map(b -> marshaller.unmarshallProcessInstance(b, process));
+        Optional<Row> row = findByIdInternal(UUID.fromString(id));
+
+        if (row.isPresent()) {
+            Optional<byte[]> payload = row
+                    .map(r -> r.getBuffer(PAYLOAD))
+                    .map(Buffer::getBytes);
+            if (payload.isPresent()) {
+                ProcessInstance<?> instance = mode == MUTABLE ? marshaller.unmarshallProcessInstance(payload.get(),
+                        process)
+                        : marshaller.unmarshallReadOnlyProcessInstance(payload.get(), process);
+                ((AbstractProcessInstance) instance).setVersion(row.get().getLong(VERSION));
+                return Optional.of(instance);
+            }
+        }
+        return Optional.empty();
     }
 
     @Override
     public Collection<ProcessInstance> values(ProcessInstanceReadMode mode) {
-        return findAllInternal().stream().map(i -> marshaller.unmarshallProcessInstance(i, process)).collect(Collectors.toList());
+        return findAllInternal().stream().map(b -> mode == MUTABLE ? marshaller.unmarshallProcessInstance(b, process)
+                : marshaller.unmarshallReadOnlyProcessInstance(b, process))
+                .collect(Collectors.toList());
     }
 
     @Override
@@ -106,16 +147,27 @@ public class PostgreProcessInstances implements MutableProcessInstances {
         return countInternal().intValue();
     }
 
+    @Override
+    public boolean lock() {
+        return this.lock;
+    }
+
     private void disconnect(ProcessInstance instance) {
-        Supplier<byte[]> supplier = () -> findByIdInternal(UUID.fromString(instance.id())).get();
-        ((AbstractProcessInstance<?>) instance).internalRemoveProcessInstance(marshaller.createdReloadFunction(supplier));
+        Optional<Row> row = findByIdInternal(UUID.fromString(instance.id()));
+        if (row.isPresent()) {
+            Supplier<byte[]> supplier = () -> row
+                    .map(r -> r.getBuffer(PAYLOAD))
+                    .map(Buffer::getBytes).get();
+            ((AbstractProcessInstance<?>) instance).internalRemoveProcessInstance(marshaller.createdReloadFunction(supplier));
+            ((AbstractProcessInstance) instance).setVersion(row.get().getLong(VERSION));
+        }
     }
 
     private boolean insertInternal(UUID id, byte[] payload) {
         try {
             final CompletableFuture<RowSet<Row>> future = new CompletableFuture<>();
-            client.preparedQuery("INSERT INTO process_instances (id, payload, process_id) VALUES ($1, $2, $3)")
-                    .execute(Tuple.of(id, Buffer.buffer(payload), process.id()), getAsyncResultHandler(future));
+            client.preparedQuery("INSERT INTO process_instances (id, payload, process_id, version) VALUES ($1, $2, $3, $4)")
+                    .execute(Tuple.of(id, Buffer.buffer(payload), process.id(), 1L), getAsyncResultHandler(future));
             return getExecutedResult(future);
         } catch (Exception e) {
             throw uncheckedException(e, "Error inserting process instance %s", id);
@@ -139,7 +191,7 @@ public class PostgreProcessInstances implements MutableProcessInstances {
     private boolean updateInternal(UUID id, byte[] payload) {
         try {
             final CompletableFuture<RowSet<Row>> future = new CompletableFuture<>();
-            client.preparedQuery("UPDATE process_instances SET payload = $1 WHERE id = $2)")
+            client.preparedQuery("UPDATE process_instances SET payload = $1 WHERE id = $2")
                     .execute(Tuple.of(Buffer.buffer(payload), id), getAsyncResultHandler(future));
             return getExecutedResult(future);
         } catch (Exception e) {
@@ -158,16 +210,19 @@ public class PostgreProcessInstances implements MutableProcessInstances {
         }
     }
 
-    private Boolean getExecutedResult(CompletableFuture<RowSet<Row>> future) throws ExecutionException,
-            TimeoutException, InterruptedException {
-        return getResultFromFuture(future)
-                .map(RowSet::rowCount)
-                .map(count -> Objects.equals(count, 1))
-                .orElse(false);
+    private Boolean getExecutedResult(CompletableFuture<RowSet<Row>> future) throws ExecutionException, TimeoutException, InterruptedException {
+        try {
+            return getResultFromFuture(future)
+                    .map(RowSet::rowCount)
+                    .map(count -> count == 1)
+                    .orElse(false);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw e;
+        }
     }
 
-    private Optional<RowSet<Row>> getResultFromFuture(CompletableFuture<RowSet<Row>> future) throws ExecutionException,
-            TimeoutException, InterruptedException {
+    private Optional<RowSet<Row>> getResultFromFuture(CompletableFuture<RowSet<Row>> future) throws ExecutionException, TimeoutException, InterruptedException {
         try {
             return Optional.ofNullable(future.get(queryTimeoutMillis, TimeUnit.MILLISECONDS));
         } catch (InterruptedException e) {
@@ -176,17 +231,15 @@ public class PostgreProcessInstances implements MutableProcessInstances {
         }
     }
 
-    private Optional<byte[]> findByIdInternal(UUID id) {
+    private Optional<Row> findByIdInternal(UUID id) {
         try {
             final CompletableFuture<RowSet<Row>> future = new CompletableFuture<>();
-            client.preparedQuery("SELECT payload FROM process_instances WHERE id = $1")
+            client.preparedQuery("SELECT payload, version FROM process_instances WHERE id = $1")
                     .execute(Tuple.of(id), getAsyncResultHandler(future));
             return getResultFromFuture(future)
                     .map(RowSet::iterator)
                     .filter(Iterator::hasNext)
-                    .map(Iterator::next)
-                    .map(row -> row.getBuffer("payload"))
-                    .map(Buffer::getBytes);
+                    .map(Iterator::next);
         } catch (Exception e) {
             throw uncheckedException(e, "Error finding process instance %s", id);
         }
@@ -199,7 +252,7 @@ public class PostgreProcessInstances implements MutableProcessInstances {
                     .execute(Tuple.of(process.id()), getAsyncResultHandler(future));
             return getResultFromFuture(future)
                     .map(r -> StreamSupport.stream(r.spliterator(), false)
-                            .map(row -> row.getBuffer("payload"))
+                            .map(row -> row.getBuffer(PAYLOAD))
                             .map(Buffer::getBytes)
                             .collect(Collectors.toList()))
                     .orElseGet(Collections::emptyList);
@@ -278,12 +331,32 @@ public class PostgreProcessInstances implements MutableProcessInstances {
     }
 
     private String getQueryFromFile(String scriptName) {
-        try (InputStream stream = Thread.currentThread().getContextClassLoader().getResourceAsStream(String.format("sql/%s.sql", scriptName))) {
+        try (InputStream stream = Thread.currentThread().getContextClassLoader().getResourceAsStream(String.format(
+                "sql/%s.sql",
+                scriptName))) {
             byte[] buffer = new byte[stream.available()];
             stream.read(buffer);
             return new String(buffer);
         } catch (Exception e) {
             throw uncheckedException(e, "Error reading query script file %s", scriptName);
         }
+    }
+
+    private boolean updateWithLock(UUID id, byte[] payload, long version) {
+        try {
+            final CompletableFuture<RowSet<Row>> future = new CompletableFuture<>();
+            client.preparedQuery("UPDATE process_instances SET payload = $1, version = $2 WHERE id = $3 and version = $4")
+                    .execute(Tuple.of(Buffer.buffer(payload), version + 1, id, version), getAsyncResultHandler(future));
+            boolean result = getExecutedResult(future);
+            if (!result) {
+                throw uncheckedException(null, "The document with ID: %s was updated or deleted by other request.", id);
+            }
+            return result;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (Exception e) {
+            throw uncheckedException(e, "Error updating process instance %s", id);
+        }
+        return false;
     }
 }

--- a/addons/persistence/postgresql-persistence-addon/src/main/resources/sql/create_tables.sql
+++ b/addons/persistence/postgresql-persistence-addon/src/main/resources/sql/create_tables.sql
@@ -1,6 +1,7 @@
 CREATE TABLE process_instances(id uuid NOT NULL,
                                       payload bytea NOT NULL,
                                       process_id character varying NOT NULL,
+                                      version bigint,
                                       CONSTRAINT process_instances_pkey PRIMARY KEY (id)
                                       );
 CREATE INDEX idx_process_instances_process_id ON process_instances

--- a/addons/persistence/postgresql-persistence-addon/src/test/java/org/kie/persistence/postgresql/PostgreProcessInstancesIT.java
+++ b/addons/persistence/postgresql-persistence-addon/src/test/java/org/kie/persistence/postgresql/PostgreProcessInstancesIT.java
@@ -91,6 +91,11 @@ class PostgreProcessInstancesIT {
         PostgreProcessInstances processInstances = (PostgreProcessInstances) process.instances();
         assertThat(processInstances.size()).isOne();
         assertThat(processInstances.exists(processInstance.id())).isTrue();
+
+        ProcessInstance<?> readOnlyPI = process.instances().findById(processInstance.id(), ProcessInstanceReadMode.READ_ONLY).get();
+        assertThat(readOnlyPI.status()).isEqualTo(STATE_ACTIVE);
+        assertThat(process.instances().values(ProcessInstanceReadMode.READ_ONLY).size()).isOne();
+
         verify(processInstances).create(any(), any());
 
         String testVar = (String) processInstance.variables().get("test");
@@ -108,6 +113,7 @@ class PostgreProcessInstancesIT {
 
         processInstances = (PostgreProcessInstances) process.instances();
         verify(processInstances, times(2)).remove(processInstance.id());
+
         assertThat(processInstances.size()).isZero();
 
         assertThat(process.instances().values()).isEmpty();
@@ -123,6 +129,11 @@ class PostgreProcessInstancesIT {
         public PostgreProcessInstances createProcessInstances(Process<?> process) {
             PostgreProcessInstances instances = spy(super.createProcessInstances(process));
             return instances;
+        }
+
+        @Override
+        public boolean lock() {
+            return false;
         }
 
     }

--- a/addons/persistence/postgresql-persistence-addon/src/test/java/org/kie/persistence/postgresql/PostgreProcessInstancesWithLockIT.java
+++ b/addons/persistence/postgresql-persistence-addon/src/test/java/org/kie/persistence/postgresql/PostgreProcessInstancesWithLockIT.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.persistence.postgresql;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.Optional;
+
+import org.drools.core.io.impl.ClassPathResource;
+import org.jbpm.workflow.instance.WorkflowProcessInstance;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.kie.kogito.persistence.KogitoProcessInstancesFactory;
+import org.kie.kogito.persistence.postgresql.PostgreProcessInstances;
+import org.kie.kogito.process.Process;
+import org.kie.kogito.process.ProcessConfig;
+import org.kie.kogito.process.ProcessInstance;
+import org.kie.kogito.process.bpmn2.BpmnProcess;
+import org.kie.kogito.process.bpmn2.BpmnProcessInstance;
+import org.kie.kogito.process.bpmn2.BpmnVariables;
+import org.kie.kogito.process.impl.AbstractProcessInstance;
+import org.kie.kogito.testcontainers.KogitoPostgreSqlContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import io.vertx.pgclient.PgPool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@Testcontainers
+class PostgreProcessInstancesWithLockIT {
+
+    @Container
+    final static KogitoPostgreSqlContainer container = new KogitoPostgreSqlContainer();
+
+    private static PgPool client;
+    private static final String TEST_ID = "02ac3854-46ee-42b7-8b63-5186c9889d96";
+
+    @BeforeAll
+    public static void startContainerAndPublicPortIsAvailable() {
+        container.start();
+        client = client();
+    }
+
+    @AfterAll
+    public static void close() {
+        container.stop();
+    }
+
+    private BpmnProcess createProcess(ProcessConfig config, String fileName) {
+        BpmnProcess process = BpmnProcess.from(config, new ClassPathResource(fileName)).get(0);
+        process.setProcessInstancesFactory(new PostgreProcessInstancesFactory(client));
+        process.configure();
+        return process;
+    }
+
+    private static PgPool client() {
+        return PgPool.pool(container.getReactiveUrl());
+    }
+
+    @Test
+    public void testBasic() {
+        BpmnProcess process = createProcess(null, "BPMN2-UserTask.bpmn2");
+
+        PostgreProcessInstances pi = new PostgreProcessInstances(process, client, true, 1000L, false);
+        assertNotNull(pi);
+
+        WorkflowProcessInstance createPi = ((AbstractProcessInstance<?>) process.createInstance(BpmnVariables.create(Collections.singletonMap("test", "test")))).internalGetProcessInstance();
+        createPi.setId(TEST_ID);
+        createPi.setStartDate(new Date());
+
+        AbstractProcessInstance<?> mockCreatePi = mock(AbstractProcessInstance.class);
+        mockCreatePi.setVersion(1L);
+        when(mockCreatePi.status()).thenReturn(ProcessInstance.STATE_ACTIVE);
+        when(mockCreatePi.internalGetProcessInstance()).thenReturn(createPi);
+        when(mockCreatePi.id()).thenReturn(TEST_ID);
+        pi.create(TEST_ID, mockCreatePi);
+        assertThat(pi.size()).isOne();
+        assertTrue(pi.exists(TEST_ID));
+
+        WorkflowProcessInstance updatePi = ((AbstractProcessInstance<?>) process.createInstance(BpmnVariables.create(Collections.singletonMap("test", "test")))).internalGetProcessInstance();
+        updatePi.setId(TEST_ID);
+        updatePi.setStartDate(new Date());
+        AbstractProcessInstance<?> mockUpdatePi = mock(AbstractProcessInstance.class);
+        when(mockUpdatePi.status()).thenReturn(ProcessInstance.STATE_ACTIVE);
+        when(mockUpdatePi.internalGetProcessInstance()).thenReturn(updatePi);
+        when(mockUpdatePi.id()).thenReturn(TEST_ID);
+        pi.update(TEST_ID, mockUpdatePi);
+
+        pi.remove(TEST_ID);
+        assertFalse(pi.exists(TEST_ID));
+    }
+
+    @Test
+    public void testUpdate() {
+        BpmnProcess process = createProcess(null, "BPMN2-UserTask.bpmn2");
+        ProcessInstance<BpmnVariables> processInstance = process.createInstance(BpmnVariables.create(Collections.singletonMap("test", "test")));
+        processInstance.start();
+
+        PostgreProcessInstances processInstances = (PostgreProcessInstances) process.instances();
+        assertThat(processInstances.size()).isOne();
+        Optional<?> foundOne = processInstances.findById(processInstance.id());
+        BpmnProcessInstance instanceOne = (BpmnProcessInstance) foundOne.get();
+        foundOne = processInstances.findById(processInstance.id());
+        BpmnProcessInstance instanceTwo = (BpmnProcessInstance) foundOne.get();
+        assertEquals(1L, instanceOne.version());
+        assertEquals(1L, instanceTwo.version());
+        instanceOne.updateVariables(BpmnVariables.create(Collections.singletonMap("s", "test")));
+        try {
+            BpmnVariables testvar = BpmnVariables.create(Collections.singletonMap("ss", "test"));
+            instanceTwo.updateVariables(testvar);
+        } catch (RuntimeException e) {
+            assertThat(e.getMessage()).isEqualTo("Error updating process instance " + instanceOne.id());
+        }
+        foundOne = processInstances.findById(processInstance.id());
+        instanceOne = (BpmnProcessInstance) foundOne.get();
+        assertEquals(2L, instanceOne.version());
+
+        processInstances.remove(processInstance.id());
+        assertThat(processInstances.size()).isZero();
+        assertThat(process.instances().values()).isEmpty();
+
+    }
+
+    @Test
+    public void testRemove() {
+        BpmnProcess process = createProcess(null, "BPMN2-UserTask.bpmn2");
+        ProcessInstance<BpmnVariables> processInstance = process.createInstance(BpmnVariables.create(Collections.singletonMap("test", "test")));
+        processInstance.start();
+
+        PostgreProcessInstances processInstances = (PostgreProcessInstances) process.instances();
+        assertThat(processInstances.size()).isOne();
+        Optional<?> foundOne = processInstances.findById(processInstance.id());
+        BpmnProcessInstance instanceOne = (BpmnProcessInstance) foundOne.get();
+        foundOne = processInstances.findById(processInstance.id());
+        BpmnProcessInstance instanceTwo = (BpmnProcessInstance) foundOne.get();
+        assertEquals(1L, instanceOne.version());
+        assertEquals(1L, instanceTwo.version());
+
+        processInstances.remove(instanceOne.id());
+        try {
+            String id = instanceTwo.id();
+            processInstances.remove(id);
+        } catch (RuntimeException e) {
+            assertThat(e.getMessage()).isEqualTo("The document with ID: " + instanceOne.id() + " was updated or deleted by other request.");
+        }
+    }
+
+    private class PostgreProcessInstancesFactory extends KogitoProcessInstancesFactory {
+
+        public PostgreProcessInstancesFactory(PgPool client) {
+            super(client, true, 10000l);
+        }
+
+        @Override
+        public PostgreProcessInstances createProcessInstances(Process<?> process) {
+            PostgreProcessInstances instances = super.createProcessInstances(process);
+            return instances;
+        }
+
+        @Override
+        public boolean lock() {
+            return true;
+        }
+    }
+}

--- a/api/kogito-api/src/main/java/org/kie/kogito/process/MutableProcessInstances.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/process/MutableProcessInstances.java
@@ -29,4 +29,7 @@ public interface MutableProcessInstances<T> extends ProcessInstances<T> {
         return instance.status() == ProcessInstance.STATE_ACTIVE || instance.status() == ProcessInstance.STATE_ERROR;
     }
 
+    default boolean lock() {
+        return false;
+    }
 }

--- a/api/kogito-api/src/main/java/org/kie/kogito/process/ProcessInstance.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/process/ProcessInstance.java
@@ -230,4 +230,7 @@ public interface ProcessInstance<T> {
      * @return All the {@link AdHocFragment} in the process
      */
     Collection<AdHocFragment> adHocFragments();
+
+    Long version();
+
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/ProcessInstanceManager.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/ProcessInstanceManager.java
@@ -39,4 +39,6 @@ public interface ProcessInstanceManager {
 
     void clearProcessInstancesState();
 
+    void setLock(boolean lock);
+
 }

--- a/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcessInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcessInstance.java
@@ -85,6 +85,8 @@ public abstract class AbstractProcessInstance<T extends Model> implements Proces
 
     protected CompletionEventListener completionEventListener;
 
+    protected Long version;
+
     public AbstractProcessInstance(AbstractProcess<T> process, T variables, ProcessRuntime rt) {
         this(process, variables, null, rt);
     }
@@ -128,6 +130,7 @@ public abstract class AbstractProcessInstance<T extends Model> implements Proces
         if (processInstance.getKnowledgeRuntime() == null) {
             processInstance.setKnowledgeRuntime(getProcessRuntime().getInternalKieRuntime());
         }
+        getProcessRuntime().getProcessInstanceManager().setLock(((MutableProcessInstances<T>) process.instances()).lock());
         processInstance.reconnect();
         processInstance.setMetaData(KOGITO_PROCESS_INSTANCE, this);
         addCompletionEventListener();
@@ -215,6 +218,7 @@ public abstract class AbstractProcessInstance<T extends Model> implements Proces
             processInstance.setReferenceId(referenceId);
         }
 
+        getProcessRuntime().getProcessInstanceManager().setLock(((MutableProcessInstances<T>) process.instances()).lock());
         getProcessRuntime().getProcessInstanceManager().addProcessInstance(this.processInstance);
         this.id = processInstance.getStringId();
         addCompletionEventListener();
@@ -290,6 +294,15 @@ public abstract class AbstractProcessInstance<T extends Model> implements Proces
     @Override
     public Date startDate() {
         return this.processInstance != null ? this.processInstance.getStartDate() : null;
+    }
+
+    @Override
+    public Long version() {
+        return this.version;
+    }
+
+    public void setVersion(Long version) {
+        this.version = version;
     }
 
     @Override

--- a/jbpm/jbpm-flow/src/test/java/org/kie/kogito/process/impl/AbstractProcessInstanceTest.java
+++ b/jbpm/jbpm-flow/src/test/java/org/kie/kogito/process/impl/AbstractProcessInstanceTest.java
@@ -120,6 +120,12 @@ public class AbstractProcessInstanceTest {
         return nodeInstance;
     }
 
+    @Test
+    public void testVersion() {
+        processInstance.setVersion(10L);
+        assertThat(processInstance.version()).isEqualTo(10l);
+    }
+
     static class TestProcessInstance extends AbstractProcessInstance<TestModel> {
 
         public TestProcessInstance(AbstractProcess<TestModel> process, TestModel variables, InternalProcessRuntime rt) {

--- a/jbpm/jbpm-flow/src/test/java/org/kie/kogito/process/impl/DefaultProcessInstanceManagerTest.java
+++ b/jbpm/jbpm-flow/src/test/java/org/kie/kogito/process/impl/DefaultProcessInstanceManagerTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.process.impl;
+
+import java.util.UUID;
+
+import org.jbpm.process.instance.impl.DefaultProcessInstanceManager;
+import org.junit.jupiter.api.Test;
+import org.kie.kogito.internal.process.runtime.KogitoProcessInstance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class DefaultProcessInstanceManagerTest {
+
+    @Test
+    public void testCreateProcessInstance() {
+        DefaultProcessInstanceManager pim = new DefaultProcessInstanceManager();
+        final String processId = "processId";
+        final String instanceId = UUID.randomUUID().toString();
+        KogitoProcessInstance kpi = mock(KogitoProcessInstance.class);
+        when(kpi.getProcessId()).thenReturn(processId);
+        when(kpi.getStringId()).thenReturn(instanceId);
+
+        pim.setLock(false);
+        pim.internalAddProcessInstance(kpi);
+        KogitoProcessInstance processInstance = pim.getProcessInstance(instanceId);
+        assertThat(processInstance.getProcessId()).isEqualTo(processId);
+        pim.removeProcessInstance(kpi);
+
+        pim.setLock(true);
+        pim.internalAddProcessInstance(kpi);
+        processInstance = pim.getProcessInstance(instanceId, false);
+        assertThat(processInstance.getProcessId()).isEqualTo(processId);
+        processInstance = pim.getProcessInstance(instanceId, true);
+        assertThat(processInstance.getProcessId()).isEqualTo(processId);
+        pim.removeProcessInstance(kpi);
+        pim.clearProcessInstances();
+    }
+
+}


### PR DESCRIPTION
It includes optional lock for optimistic concurrency using version for PostgreSQL persistence.

Signed-off-by: Swati Kale <swkale@redhat.com>

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](CONTRIBUTING.md)
- [ ] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/master/kogito-ide-config)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>