### PR TITLE
KOGITO-4847 add local.central mirror for invoker

### DIFF
--- a/addons/cloudevents/cloudevents-spring-boot-addon-it/pom.xml
+++ b/addons/cloudevents/cloudevents-spring-boot-addon-it/pom.xml
@@ -51,6 +51,7 @@
             <configuration>
                 <streamLogs>true</streamLogs>
                 <postBuildHookScript>verify</postBuildHookScript> <!-- no extension required -->
+                <settingsFile>src/it/settings.xml</settingsFile>
             </configuration>
             <executions>
                 <execution>

--- a/addons/cloudevents/cloudevents-spring-boot-addon-it/src/it/settings.xml
+++ b/addons/cloudevents/cloudevents-spring-boot-addon-it/src/it/settings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<settings>
+    <profiles>
+        <profile>
+            <id>it-repo</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <repositories>
+                <repository>
+                    <id>local.central</id>
+                    <url>@localRepositoryUrl@</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>local.central</id>
+                    <url>@localRepositoryUrl@</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
+    </profiles>
+</settings>

--- a/integration-tests/integration-tests-kogito-plugin/pom.xml
+++ b/integration-tests/integration-tests-kogito-plugin/pom.xml
@@ -52,6 +52,7 @@
           <properties>
             <version.io.quarkus>${version.io.quarkus}</version.io.quarkus>
           </properties>
+          <settingsFile>src/it/settings.xml</settingsFile>
         </configuration>
         <executions>
           <execution>

--- a/integration-tests/integration-tests-kogito-plugin/src/it/settings.xml
+++ b/integration-tests/integration-tests-kogito-plugin/src/it/settings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<settings>
+    <profiles>
+        <profile>
+            <id>it-repo</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <repositories>
+                <repository>
+                    <id>local.central</id>
+                    <url>@localRepositoryUrl@</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>local.central</id>
+                    <url>@localRepositoryUrl@</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
+    </profiles>
+</settings>

--- a/integration-tests/integration-tests-springboot/pom.xml
+++ b/integration-tests/integration-tests-springboot/pom.xml
@@ -130,6 +130,7 @@
               <container.image.infinispan>${container.image.infinispan}</container.image.infinispan>
               <container.image.kafka>${container.image.kafka}</container.image.kafka>
             </properties>
+            <settingsFile>src/it/settings.xml</settingsFile>
           </configuration>
         </plugin>
       </plugins>

--- a/integration-tests/integration-tests-springboot/src/it/settings.xml
+++ b/integration-tests/integration-tests-springboot/src/it/settings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<settings>
+    <profiles>
+        <profile>
+            <id>it-repo</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <repositories>
+                <repository>
+                    <id>local.central</id>
+                    <url>@localRepositoryUrl@</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>local.central</id>
+                    <url>@localRepositoryUrl@</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
+    </profiles>
+</settings>


### PR DESCRIPTION
Here are additional changes to #1188. It turned out that to make maven-invoker-plugin to use artifacts from local maven repository in specific cases it needs to be provided a settings.xml file setting that repository explicitly in a profile.

Currently integration tests can be invoked from top-level with all deps in reactor:
```
cd kogito-runtimes
mvn clean install -pl :integration-tests-springboot -am
```

But not using
```
cd kogito-rutnimes
cd integration-tests/integration-tests-springboot
mvn clean install
```

Reason for this is:
1. using localRepositoryPath (referring to as `it-repo` further on) - to isolate it-tests from overall repo (prevent soiling local repo)
2. install goal of maven-invoker-plugin installs into the `it-repo` **ONLY** locally reachable parents and dependencies from **CURRENT** reactor (previously I expected all deps to be copied over into `it-repo` during install goal).
3. so even if local repository has the dependency, it is not copied into `it-repo` by any means.

The goals are now:
* specifying regular local maven repository in settings.xml will point invoker build to use it as first-level remote repository when not having artifacts in `it-repo` - no excessive download
* when it does have artifacts in `it-repo` (if deps are part of build reactor) it won't go into local repo, nor download from remote - using reactor dependencies primarily.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>