### PR TITLE
BXMSPROD-1208: redo the profile for community only modules

### DIFF
--- a/addons/cloudevents/cloudevents-quarkus-addon-it/pom.xml
+++ b/addons/cloudevents/cloudevents-quarkus-addon-it/pom.xml
@@ -57,22 +57,6 @@
       <artifactId>rest-assured</artifactId>
       <scope>test</scope>
     </dependency>
-
-    <!-- this is used implicitly by quarkus tests so let's make Maven aware of it -->
-    <dependency>
-      <groupId>org.kie.kogito</groupId>
-      <artifactId>kogito-quarkus-deployment</artifactId>
-      <version>${project.version}</version>
-      <type>pom</type>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
   </dependencies>
 
 </project>

--- a/addons/cloudevents/pom.xml
+++ b/addons/cloudevents/pom.xml
@@ -30,13 +30,24 @@
 
   <description>Kogito Cloud Events</description>
 
-  <modules>
-    <module>cloudevents-utils</module>
-    <module>cloudevents-common-addon</module>
-    <module>cloudevents-quarkus-addon</module>
-    <module>cloudevents-spring-boot-addon</module>
-    <module>cloudevents-quarkus-addon-it</module>
-    <module>cloudevents-spring-boot-addon-it</module>
-  </modules>
-
+    <modules>
+      <module>cloudevents-common-addon</module>
+      <module>cloudevents-quarkus-addon</module>
+      <module>cloudevents-spring-boot-addon</module>
+    </modules>
+  <profiles>
+    <profile>
+      <id>default</id>
+      <activation>
+        <property>
+          <name>!productized</name>
+        </property>
+      </activation>
+      <modules>
+        <module>cloudevents-utils</module>        
+        <module>cloudevents-quarkus-addon-it</module>
+        <module>cloudevents-spring-boot-addon-it</module>
+      </modules>
+    </profile>
+  </profiles>
 </project>

--- a/addons/events/pom.xml
+++ b/addons/events/pom.xml
@@ -10,11 +10,24 @@
   <name>Kogito :: Add-Ons :: Events</name>
 
   <description>Kogito Events</description>
-
+ 
   <modules>
     <module>kogito-event-driven-decisions</module>
-    <module>kogito-events-reactive-messaging-addon</module>
-    <module>kogito-events-spring-boot-addon</module>
   </modules>
+  
+  <profiles>
+    <profile>
+      <id>default</id>
+      <activation>
+        <property>
+          <name>!productized</name>
+        </property>
+      </activation>
+      <modules>
+        <module>kogito-events-reactive-messaging-addon</module>
+        <module>kogito-events-spring-boot-addon</module>
+      </modules>
+    </profile>
 
+  </profiles>
 </project>

--- a/addons/pom.xml
+++ b/addons/pom.xml
@@ -14,20 +14,33 @@
   <description>Various Add-Ons to the runtimes modules (administration, monitoring, etc)</description>
 
   <modules>
-    <module>mail</module>
-    <module>task-notification</module>
-    <module>persistence</module>
-    <module>cloudevents</module>
-    <module>events</module>
-    <module>jobs</module>
-    <module>predictions</module>
-    <module>process-management</module>
-    <module>kogito-rest-exception-handler</module>
-    <module>task-management</module>
-    <module>process-svg</module>
-    <module>tracing</module>
-    <module>monitoring</module>
-    <module>explainability-addon</module>
+      <module>cloudevents</module>
+      <module>events</module>
+      <module>monitoring</module>
   </modules>
 
+  <profiles>
+    <profile>
+      <id>default</id>
+      <activation>
+          <property>
+              <name>!productized</name>
+          </property>
+      </activation>
+      <modules>
+        <module>mail</module>
+        <module>task-notification</module>
+        <module>persistence</module>
+        <module>cloudevents</module>
+        <module>jobs</module>
+        <module>predictions</module>
+        <module>process-management</module>
+        <module>kogito-rest-exception-handler</module>
+        <module>task-management</module>
+        <module>process-svg</module>
+        <module>tracing</module>
+        <module>explainability-addon</module>
+      </modules>
+    </profile>
+  </profiles>
 </project>

--- a/archetypes/pom.xml
+++ b/archetypes/pom.xml
@@ -27,13 +27,24 @@
       </plugins>
     </pluginManagement>
   </build>
-
   <modules>
-    <module>kogito-springboot-archetype</module>
-    <module>kogito-quarkus-archetype</module>
+    <module>kogito-springboot-dm-archetype</module>
+    <module>kogito-quarkus-dm-archetype</module>
   </modules>
-
   <profiles>
+    <profile>
+      <id>default</id>
+      <activation>
+        <property>
+          <name>!productized</name>
+        </property>
+      </activation>
+      <modules>
+        <module>kogito-springboot-archetype</module>
+        <module>kogito-quarkus-archetype</module>
+      </modules>
+    </profile>
+
     <profile>
       <!--
         This profile serves at optionally passing settingsFile property to archetype::integration-test goal.

--- a/kogito-codegen-modules/pom.xml
+++ b/kogito-codegen-modules/pom.xml
@@ -15,16 +15,31 @@
 
     <name>Kogito :: Codegen Modules</name>
 
+
     <modules>
         <module>kogito-codegen-core</module>
         <module>kogito-codegen-api</module>
         <module>kogito-codegen-processes</module>
-        <module>kogito-codegen-openapi</module>
         <module>kogito-codegen-rules</module>
         <module>kogito-codegen-decisions</module>
         <module>kogito-codegen-predictions</module>
-        <module>kogito-codegen-integration-tests</module>
-        <module>kogito-codegen-sample</module>
-    </modules>
+
+    </modules>   
+            
+    <profiles>
+        <profile>
+        <id>default</id>
+        <activation>
+            <property>
+                <name>!productized</name>
+            </property>
+        </activation>
+        <modules>
+            <module>kogito-codegen-openapi</module>
+            <module>kogito-codegen-integration-tests</module>
+            <module>kogito-codegen-sample</module>
+        </modules>
+        </profile>
+    </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -117,23 +117,37 @@
   </pluginRepositories>
 
   <modules>
-    <module>kogito-ide-config</module>
     <module>kogito-build-parent</module>
     <module>kogito-bom</module>
     <module>kogito-test-utils</module>
     <module>api</module>
     <module>drools</module>
     <module>jbpm</module>
-    <module>kogito-cloud-services</module>
-    <module>kogito-codegen-modules</module>
     <module>kogito-springboot</module>
     <module>kogito-maven-plugin</module>
     <module>kogito-quarkus-parent</module>
     <module>archetypes</module>
     <module>grafana-api</module>
-    <module>addons</module>
-    <module>integration-tests</module>
-    <module>kogito-workitems</module>
+    <module>addons</module> 
+    <module>kogito-workitems</module>    
   </modules>
+  
+  <profiles>
+    <profile>
+      <id>default</id>
+      <activation>
+        <property>
+            <name>!productized</name>
+        </property>
+      </activation>
+      <modules>
+        <module>kogito-ide-config</module>       
+        <module>kogito-cloud-services</module>        
+        <module>kogito-codegen-modules</module>        
+        <module>integration-tests</module>
+      </modules>
+    </profile>
+  </profiles>
+
 
 </project>


### PR DESCRIPTION
This PR is trying to fix [issue](https://youtrack.jetbrains.com/issue/IDEA-266880) in Intellij IDEA where modules in profiles cannot be loaded even the profile is activated by default. The original jira where the profile(s) where created 

https://issues.redhat.com/browse/BXMSPROD-1208


- [X ] You have read the [contributors guide](CONTRIBUTING.md)
- [ ] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/master/kogito-ide-config)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [X] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [X ] Pull Request contains description of the issue
- [X] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>