### PR TITLE
KOGITO-4963 Refactor WorkItem APIs on processes

### DIFF
--- a/api/kogito-api/src/main/java/org/kie/kogito/process/ProcessInstance.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/process/ProcessInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/kogito-api/src/main/java/org/kie/kogito/process/ProcessInstance.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/process/ProcessInstance.java
@@ -177,14 +177,13 @@ public interface ProcessInstance<T> {
      * Returns list of currently active work items.
      *
      * <strong>this is an experimental API.</strong>
-     *  Will be renamed to <code>workItems</code> when
-     *  {@link #workItems(Policy[])} is removed
+     * Will be renamed to <code>workItems</code> when
+     * {@link #workItems(Policy[])} is removed
      *
      * @param policies optional list of policies to be enforced
      * @return non empty list of identifiers of currently active tasks.
      */
     WorkItemCatalog getWorkItems(Policy<?>... policies);
-
 
     /**
      * Returns identifier of this process instance

--- a/api/kogito-api/src/main/java/org/kie/kogito/process/ProcessInstance.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/process/ProcessInstance.java
@@ -30,6 +30,7 @@ import org.kie.kogito.process.flexible.AdHocFragment;
 import org.kie.kogito.process.flexible.Milestone;
 import org.kie.kogito.process.workitem.Policy;
 import org.kie.kogito.process.workitem.Transition;
+import org.kie.kogito.process.workitem.WorkItemCatalog;
 
 public interface ProcessInstance<T> {
 
@@ -113,6 +114,7 @@ public interface ProcessInstance<T> {
      * @param variables optional variables
      * @param policies optional list of policies to be enforced
      */
+    @Deprecated
     void completeWorkItem(String id, Map<String, Object> variables, Policy<?>... policies);
 
     /**
@@ -123,6 +125,7 @@ public interface ProcessInstance<T> {
      * @param policies optional security information
      * @return result of the operation performed by the updater
      */
+    @Deprecated
     <R> R updateWorkItem(String id, Function<KogitoWorkItem, R> updater, Policy<?>... policies);
 
     /**
@@ -131,6 +134,7 @@ public interface ProcessInstance<T> {
      * @param id id of the work item to complete
      * @param policies optional list of policies to be enforced
      */
+    @Deprecated
     void abortWorkItem(String id, Policy<?>... policies);
 
     /**
@@ -139,6 +143,7 @@ public interface ProcessInstance<T> {
      * @param id id of the work item to complete
      * @param transition target transition including phase, identity and data
      */
+    @Deprecated
     void transitionWorkItem(String id, Transition<?> transition);
 
     /**
@@ -148,6 +153,7 @@ public interface ProcessInstance<T> {
      * @param policies optional list of policies to be enforced
      * @return work item with its parameters if found
      */
+    @Deprecated
     WorkItem workItem(String workItemId, Policy<?>... policies);
 
     /**
@@ -164,7 +170,21 @@ public interface ProcessInstance<T> {
      * @param policies optional list of policies to be enforced
      * @return non empty list of identifiers of currently active tasks.
      */
+    @Deprecated
     List<WorkItem> workItems(Policy<?>... policies);
+
+    /**
+     * Returns list of currently active work items.
+     *
+     * <strong>this is an experimental API.</strong>
+     *  Will be renamed to <code>workItems</code> when
+     *  {@link #workItems(Policy[])} is removed
+     *
+     * @param policies optional list of policies to be enforced
+     * @return non empty list of identifiers of currently active tasks.
+     */
+    WorkItemCatalog getWorkItems(Policy<?>... policies);
+
 
     /**
      * Returns identifier of this process instance

--- a/api/kogito-api/src/main/java/org/kie/kogito/process/workitem/WorkItemCatalog.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/process/workitem/WorkItemCatalog.java
@@ -1,0 +1,62 @@
+package org.kie.kogito.process.workitem;
+
+import org.kie.kogito.internal.process.runtime.KogitoWorkItem;
+import org.kie.kogito.process.WorkItem;
+
+import java.util.Collection;
+import java.util.function.Function;
+
+public interface WorkItemCatalog {
+
+    /**
+     * Completes work item belonging to this process instance with given variables
+     *
+     * @param id id of the work item to complete
+     * @param variables optional variables
+     * @param policies optional list of policies to be enforced
+     */
+    void complete(String id, Object variables, Policy<?>... policies);
+
+    /**
+     * Updates work item according to provided consumer
+     *
+     * @param id the id of the work item that has been completed
+     * @param updater consumer implementation that contains the logic to update workitem
+     * @param policies optional security information
+     * @return result of the operation performed by the updater
+     */
+    <R> R update(String id, Function<KogitoWorkItem, R> updater, Policy<?>... policies);
+
+    /**
+     * Aborts work item belonging to this process instance
+     *
+     * @param id id of the work item to complete
+     * @param policies optional list of policies to be enforced
+     */
+    void abort(String id, Policy<?>... policies);
+
+    /**
+     * Transition work item belonging to this process instance not another life cycle phase
+     *
+     * @param id id of the work item to complete
+     * @param transition target transition including phase, identity and data
+     */
+    void transition(String id, Transition<?> transition);
+
+    /**
+     * Returns work item identified by given id if found
+     *
+     * @param workItemId id of the work item
+     * @param policies optional list of policies to be enforced
+     * @return work item with its parameters if found
+     */
+    WorkItem get(String workItemId, Policy<?>... policies);
+
+    /**
+     * Returns list of currently active work items.
+     *
+     * @param policies optional list of policies to be enforced
+     * @return non empty list of identifiers of currently active tasks.
+     */
+    Collection<WorkItem> get(Policy<?>... policies);
+}

--- a/api/kogito-api/src/main/java/org/kie/kogito/process/workitem/WorkItemCatalog.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/process/workitem/WorkItemCatalog.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.kie.kogito.process.workitem;
 
 import org.kie.kogito.internal.process.runtime.KogitoWorkItem;

--- a/api/kogito-api/src/main/java/org/kie/kogito/process/workitem/WorkItemCatalog.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/process/workitem/WorkItemCatalog.java
@@ -15,11 +15,11 @@
  */
 package org.kie.kogito.process.workitem;
 
-import org.kie.kogito.internal.process.runtime.KogitoWorkItem;
-import org.kie.kogito.process.WorkItem;
-
 import java.util.Collection;
 import java.util.function.Function;
+
+import org.kie.kogito.internal.process.runtime.KogitoWorkItem;
+import org.kie.kogito.process.WorkItem;
 
 public interface WorkItemCatalog {
 

--- a/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcess.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcessInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcessInstance.java
@@ -404,6 +404,11 @@ public abstract class AbstractProcessInstance<T extends Model> implements Proces
     }
 
     @Override
+    public WorkItemCatalog getWorkItems(Policy<?>... policies) {
+        return workItemCatalog;
+    }
+
+    @Override
     public WorkItem workItem(String workItemId, Policy<?>... policies) {
         return workItemCatalog.get(workItemId, policies);
     }

--- a/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcessInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcessInstance.java
@@ -128,7 +128,7 @@ public abstract class AbstractProcessInstance<T extends Model> implements Proces
 
     private WorkItemCatalogImpl<T> makeWorkItemCatalog() {
         return new WorkItemCatalogImpl<>(
-                (KogitoWorkItemManager) rt.getWorkItemManager(),
+                () -> (KogitoWorkItemManager) rt.getWorkItemManager(),
                 this::processInstance,
                 this::removeOnFinish,
                 this::notifyUpdate);

--- a/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/workitem/impl/WorkItemCatalogImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/workitem/impl/WorkItemCatalogImpl.java
@@ -15,6 +15,12 @@
  */
 package org.kie.kogito.process.workitem.impl;
 
+import java.util.Collection;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
 import org.jbpm.workflow.instance.WorkflowProcessInstance;
 import org.jbpm.workflow.instance.node.WorkItemNodeInstance;
 import org.kie.kogito.internal.process.runtime.KogitoWorkItem;
@@ -25,12 +31,6 @@ import org.kie.kogito.process.impl.BaseWorkItem;
 import org.kie.kogito.process.workitem.Policy;
 import org.kie.kogito.process.workitem.Transition;
 import org.kie.kogito.process.workitem.WorkItemCatalog;
-
-import java.util.Collection;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 public class WorkItemCatalogImpl<T> implements WorkItemCatalog {
 

--- a/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/workitem/impl/WorkItemCatalogImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/workitem/impl/WorkItemCatalogImpl.java
@@ -34,17 +34,17 @@ import org.kie.kogito.process.workitem.WorkItemCatalog;
 
 public class WorkItemCatalogImpl<T> implements WorkItemCatalog {
 
-    private final KogitoWorkItemManager workItemManager;
+    private final Supplier<KogitoWorkItemManager> workItemManagerSupplier;
     private final Supplier<WorkflowProcessInstance> processInstanceSupplier;
     private final Runnable removeOnFinish;
     private final Runnable updateNotifier;
 
     public WorkItemCatalogImpl(
-            KogitoWorkItemManager workItemManager,
+            Supplier<KogitoWorkItemManager> workItemManagerSupplier,
             Supplier<WorkflowProcessInstance> processInstanceSupplier,
             Runnable removeOnFinish,
             Runnable updateNotifier) {
-        this.workItemManager = workItemManager;
+        this.workItemManagerSupplier = workItemManagerSupplier;
         this.processInstanceSupplier = processInstanceSupplier;
         this.removeOnFinish = removeOnFinish;
         this.updateNotifier = updateNotifier;
@@ -52,13 +52,13 @@ public class WorkItemCatalogImpl<T> implements WorkItemCatalog {
 
     @Override
     public void complete(String id, Object variables, Policy<?>... policies) {
-        workItemManager.completeWorkItem(id, (Map<String, Object>) variables, policies);
+        workItemManagerSupplier.get().completeWorkItem(id, (Map<String, Object>) variables, policies);
         removeOnFinish.run();
     }
 
     @Override
     public <R> R update(String id, Function<KogitoWorkItem, R> updater, Policy<?>... policies) {
-        R result = workItemManager.updateWorkItem(id, updater,
+        R result = workItemManagerSupplier.get().updateWorkItem(id, updater,
                 policies);
         updateNotifier.run();
         return result;
@@ -66,13 +66,13 @@ public class WorkItemCatalogImpl<T> implements WorkItemCatalog {
 
     @Override
     public void abort(String id, Policy<?>... policies) {
-        workItemManager.abortWorkItem(id, policies);
+        workItemManagerSupplier.get().abortWorkItem(id, policies);
         removeOnFinish.run();
     }
 
     @Override
     public void transition(String id, Transition<?> transition) {
-        workItemManager.transitionWorkItem(id, transition);
+        workItemManagerSupplier.get().transitionWorkItem(id, transition);
         removeOnFinish.run();
     }
 

--- a/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/workitem/impl/WorkItemCatalogImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/workitem/impl/WorkItemCatalogImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.kie.kogito.process.workitem.impl;
 
 import org.jbpm.workflow.instance.WorkflowProcessInstance;

--- a/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/workitem/impl/WorkItemCatalogImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/workitem/impl/WorkItemCatalogImpl.java
@@ -1,0 +1,100 @@
+package org.kie.kogito.process.workitem.impl;
+
+import org.jbpm.workflow.instance.WorkflowProcessInstance;
+import org.jbpm.workflow.instance.node.WorkItemNodeInstance;
+import org.kie.kogito.internal.process.runtime.KogitoWorkItem;
+import org.kie.kogito.internal.process.runtime.KogitoWorkItemManager;
+import org.kie.kogito.internal.process.runtime.WorkItemNotFoundException;
+import org.kie.kogito.process.WorkItem;
+import org.kie.kogito.process.impl.BaseWorkItem;
+import org.kie.kogito.process.workitem.Policy;
+import org.kie.kogito.process.workitem.Transition;
+import org.kie.kogito.process.workitem.WorkItemCatalog;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+public class WorkItemCatalogImpl<T> implements WorkItemCatalog {
+
+    private final KogitoWorkItemManager workItemManager;
+    private final Supplier<WorkflowProcessInstance> processInstanceSupplier;
+    private final Runnable removeOnFinish;
+    private final Runnable updateNotifier;
+
+    public WorkItemCatalogImpl(
+            KogitoWorkItemManager workItemManager,
+            Supplier<WorkflowProcessInstance> processInstanceSupplier,
+            Runnable removeOnFinish,
+            Runnable updateNotifier) {
+        this.workItemManager = workItemManager;
+        this.processInstanceSupplier = processInstanceSupplier;
+        this.removeOnFinish = removeOnFinish;
+        this.updateNotifier = updateNotifier;
+    }
+
+
+    @Override
+    public void complete(String id, Object variables, Policy<?>... policies) {
+        workItemManager.completeWorkItem(id, (Map<String, Object>) variables, policies);
+        removeOnFinish.run();
+    }
+
+    @Override
+    public <R> R update(String id, Function<KogitoWorkItem, R> updater, Policy<?>... policies) {
+        R result = workItemManager.updateWorkItem(id, updater,
+                policies);
+        updateNotifier.run();
+        return result;
+    }
+
+    @Override
+    public void abort(String id, Policy<?>... policies) {
+        workItemManager.abortWorkItem(id, policies);
+        removeOnFinish.run();
+    }
+
+    @Override
+    public void transition(String id, Transition<?> transition) {
+        workItemManager.transitionWorkItem(id, transition);
+        removeOnFinish.run();
+    }
+
+    @Override
+    public WorkItem get(String workItemId, Policy<?>... policies) {
+        WorkItemNodeInstance workItemInstance = (WorkItemNodeInstance) processInstanceSupplier.get().getNodeInstances(true)
+                .stream()
+                .filter(ni -> ni instanceof WorkItemNodeInstance && ((WorkItemNodeInstance) ni).getWorkItemId().equals(workItemId) && ((WorkItemNodeInstance) ni).getWorkItem().enforce(policies))
+                .findFirst()
+                .orElseThrow(() -> new WorkItemNotFoundException("Work item with id " + workItemId + " was not found in current process instance", workItemId));
+        return new BaseWorkItem(workItemInstance.getStringId(),
+                workItemInstance.getWorkItem().getStringId(),
+                Long.toString(workItemInstance.getNode().getId()),
+                (String) workItemInstance.getWorkItem().getParameters().getOrDefault("TaskName", workItemInstance.getNodeName()),
+                workItemInstance.getWorkItem().getState(),
+                workItemInstance.getWorkItem().getPhaseId(),
+                workItemInstance.getWorkItem().getPhaseStatus(),
+                workItemInstance.getWorkItem().getParameters(),
+                workItemInstance.getWorkItem().getResults());
+    }
+
+    @Override
+    public Collection<WorkItem> get(Policy<?>... policies) {
+        return processInstanceSupplier.get().getNodeInstances(true)
+                .stream()
+                .filter(ni -> ni instanceof WorkItemNodeInstance && ((WorkItemNodeInstance) ni).getWorkItem().enforce(policies))
+                .map(ni -> new BaseWorkItem(ni.getStringId(),
+                        ((WorkItemNodeInstance) ni).getWorkItemId(),
+                        Long.toString(((WorkItemNodeInstance) ni).getNode().getId()),
+                        (String) ((WorkItemNodeInstance) ni).getWorkItem().getParameters().getOrDefault("TaskName", ni.getNodeName()),
+                        ((WorkItemNodeInstance) ni).getWorkItem().getState(),
+                        ((WorkItemNodeInstance) ni).getWorkItem().getPhaseId(),
+                        ((WorkItemNodeInstance) ni).getWorkItem().getPhaseStatus(),
+                        ((WorkItemNodeInstance) ni).getWorkItem().getParameters(),
+                        ((WorkItemNodeInstance) ni).getWorkItem().getResults()))
+                .collect(Collectors.toList());
+    }
+
+}

--- a/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/workitem/impl/WorkItemCatalogImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/workitem/impl/WorkItemCatalogImpl.java
@@ -50,7 +50,6 @@ public class WorkItemCatalogImpl<T> implements WorkItemCatalog {
         this.updateNotifier = updateNotifier;
     }
 
-
     @Override
     public void complete(String id, Object variables, Policy<?>... policies) {
         workItemManager.completeWorkItem(id, (Map<String, Object>) variables, policies);


### PR DESCRIPTION
🍼 This is a first baby step towards the brand-new awesome public API that will solve the energetic crisis, make you a better programmer, and feel a warm fuzzy feeling in your heart ❤️  

💡 General guiding principle: if you have a series of methods `getFoo()` `updateFoo()` `removeFoo()` etc, chances are you should want to create class `Foo` with methods `get()`, `update()`, `remove()` etc. 

So this PR moves all the work-item related methods to a `WorkItemCatalog` (*) object

- `@Deprecate` all methods `${verb}WorkItem$()`
- Delegate all deprecated methods to `this.workItems().${verb}()`

🟢  Next iteration(s) -- i.e. separate PRs: 
- update all usages (possibly one method at a time)
- remove all deprecated methods 

(*) I don't feel particularly attached to the name, I just wanted a synonym for Collection that was not Container. Not many options there.