### PR TITLE
Setup Drools pipeline as configurable

### DIFF
--- a/.jenkins/dsl/jobs.groovy
+++ b/.jenkins/dsl/jobs.groovy
@@ -105,6 +105,9 @@ void setupDroolsJob(String jobFolder) {
         parameters {
             stringParam('BUILD_BRANCH_NAME', "${GIT_BRANCH}", 'Set the Git branch to checkout')
             stringParam('GIT_AUTHOR', "${GIT_AUTHOR_NAME}", 'Set the Git author to checkout')
+
+            stringParam('DROOLS_VERSION', '', '(optional) If not set, then it will be guessed from drools repository')
+            stringParam('DROOLS_REPOSITORY', '', '(optional) In case Drools given version is in a specific repository')
         }
         environmentVariables {
             env('JENKINS_EMAIL_CREDS_ID', "${JENKINS_EMAIL_CREDS_ID}")

--- a/Jenkinsfile.drools
+++ b/Jenkinsfile.drools
@@ -36,10 +36,17 @@ pipeline {
                     checkoutRepo('kogito-examples')
                     checkoutRepo('kogito-examples', 'kogito-examples-persistence')
                     checkoutRepo('kogito-examples', 'kogito-examples-events')
+
+                    if (params.DROOLS_VERSION) {
+                        currentBuild.displayName = "Check against ${DROOLS_VERSION}"
+                    } else {
+                        currentBuild.displayName = "Check against Drools snapshot"
+                    }
                 }
             }
         }
         stage('Retrieve drools snapshot version') {
+            when { expression { return !params.DROOLS_VERSION } }
             steps {
                 script {
                     dir('drools') {
@@ -181,9 +188,12 @@ pipeline {
 }
 
 void sendNotification() {
-    emailext body: "Kogito daily Drools #${BUILD_NUMBER} was: ${currentBuild.currentResult}\nPlease look here: ${BUILD_URL}",
+    if (!params.DROOLS_VERSION) {
+        emailext body: "Kogito daily Drools #${BUILD_NUMBER} was: ${currentBuild.currentResult}\nPlease look here: ${BUILD_URL}",
              subject: "[${params.BUILD_BRANCH_NAME}][d] Runtimes Drools snapshot",
              to: env.KOGITO_CI_EMAIL_TO
+    }
+    // Do not send a notification in case DROOLS_VERSION was given
 }
 
 void checkoutRepo(String repoName, String dirName=repoName) {
@@ -215,10 +225,14 @@ void checkoutOptaplannerRepo() {
 }
 
 MavenCommand getMavenCommandWithDroolsVersion(String directory) {
-    return new MavenCommand(this, ['-fae'])
+    mvnCmd = new MavenCommand(this, ['-fae'])
                 .withSettingsXmlId('kogito_release_settings')
                 .inDirectory(directory)
                 .withProperty('version.org.kie7', "${DROOLS_VERSION}")
+    if (params.DROOLS_REPOSITORY) {
+        mvnCmd.withDependencyRepositoryInSettings('drools_repo', params.DROOLS_REPOSITORY)
+    }
+    return mvnCmd
 }
 
 void cleanContainers() {


### PR DESCRIPTION
This will allow to run sanity checks on Drools release

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/master/kogito-ide-config)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>