### PR TITLE
bump master quarkus 2.0.0.Alpha1

### DIFF
--- a/kogito-build-parent/pom.xml
+++ b/kogito-build-parent/pom.xml
@@ -186,7 +186,7 @@
     <version.org.confluent.kafka>5.4.3</version.org.confluent.kafka>
     <version.org.kie7>7.52.0.Final</version.org.kie7>
     <version.org.mockito>3.6.0</version.org.mockito>
-    <version.org.mongo>4.1.0</version.org.mongo>
+    <version.org.mongo>4.2.3</version.org.mongo>
     <version.org.mvel>2.4.12.Final</version.org.mvel>
     <version.org.reactivestreams>1.0.3</version.org.reactivestreams>
     <version.org.reflections>0.9.11</version.org.reflections>

--- a/kogito-build-parent/pom.xml
+++ b/kogito-build-parent/pom.xml
@@ -117,17 +117,17 @@
     <version.org.jsonschema2pojo-maven-plugin>1.0.1</version.org.jsonschema2pojo-maven-plugin>
 
     <!-- this version property is used in plugins but also in dependencies too -->
-    <version.io.quarkus>1.11.5.Final</version.io.quarkus>
+    <version.io.quarkus>1.13.2.Final</version.io.quarkus>
 
     <!-- dependencies versions -->
     <version.ch.obermuhlner>2.0.1</version.ch.obermuhlner>
-    <version.com.fasterxml.jackson>2.11.3</version.com.fasterxml.jackson>
+    <version.com.fasterxml.jackson>2.12.1</version.com.fasterxml.jackson>
     <version.com.github.haifengl.smile>1.5.2</version.com.github.haifengl.smile>
     <version.com.github.javaparser>3.13.10</version.com.github.javaparser>
     <version.com.github.java-json-tools>2.2.10</version.com.github.java-json-tools>
     <version.com.github.victools>4.12.1</version.com.github.victools>
     <version.com.github.tomakehurst.wiremock>2.27.2</version.com.github.tomakehurst.wiremock>
-    <version.com.github.ben-manes.caffeine>2.8.5</version.com.github.ben-manes.caffeine>
+    <version.com.github.ben-manes.caffeine>2.9.0</version.com.github.ben-manes.caffeine>
     <version.com.google.protobuf>3.14.0</version.com.google.protobuf>
     <version.com.google.guava>16.0.1</version.com.google.guava>
     <version.org.openapitools>5.0.1</version.org.openapitools>
@@ -148,25 +148,24 @@
     <version.io.cloudevents>2.0.0-milestone3</version.io.cloudevents>
     <version.io.jredisearch>2.0.0</version.io.jredisearch>
     <version.io.fabric8.kubernetes-client>5.0.0</version.io.fabric8.kubernetes-client>
-    <version.io.micrometer>1.6.1</version.io.micrometer>
+    <version.io.micrometer>1.6.5</version.io.micrometer>
     <version.io.rest-assured>4.3.0</version.io.rest-assured>
     <version.io.rest-assured.springboot>3.3.0</version.io.rest-assured.springboot>    <!-- Manually override to 3.3.0 because Spring boot uses rest-assured-common@3.3.0, otherwise error: The type io.restassured.common.mapper.TypeRef cannot be resolved. It is indirectly referenced from required .class files -->
     <version.io.serverlessworkflow>2.0.0.Final</version.io.serverlessworkflow>
-    <version.io.smallrye-open-api-core>2.0.22</version.io.smallrye-open-api-core>
-    <version.io.smallrye.reactive>2.7.1</version.io.smallrye.reactive>
-    <version.io.smallrye.reactive.mutiny-vertx-web-client>1.3.0</version.io.smallrye.reactive.mutiny-vertx-web-client>
+    <version.io.smallrye-open-api-core>2.0.26</version.io.smallrye-open-api-core>
+    <version.io.smallrye.reactive>2.9.0</version.io.smallrye.reactive>
+    <version.io.smallrye.reactive.mutiny-vertx-web-client>1.5.0</version.io.smallrye.reactive.mutiny-vertx-web-client>
     <version.io.swagger.core.v3>2.0.6</version.io.swagger.core.v3>
     <version.io.swagger.parser.v3>2.0.24</version.io.swagger.parser.v3>
 
     <version.org.antlr>3.5.2</version.org.antlr>
     <version.org.antlr4>4.8</version.org.antlr4>
     <version.org.apache.commons>3.8.1</version.org.apache.commons>
-    <!-- Quarkus on 2.5.0, but faced the following issue: https://issues.apache.org/jira/browse/KAFKA-9127 -->
-    <version.org.apache.kafka>2.5.1</version.org.apache.kafka>
+    <version.org.apache.kafka>2.7.0</version.org.apache.kafka>
     <version.org.apache.xmlgraphics.batik>1.13</version.org.apache.xmlgraphics.batik>
-    <version.org.assertj>3.16.1</version.org.assertj>
+    <version.org.assertj>3.19.0</version.org.assertj>
     <version.org.eclipse.jdt>3.19.0</version.org.eclipse.jdt>
-    <version.org.graalvm.nativeimage>20.3.1.2</version.org.graalvm.nativeimage>
+    <version.org.graalvm.nativeimage>21.0.0</version.org.graalvm.nativeimage>
     <version.org.hamcrest>1.3</version.org.hamcrest> <!-- else old version coming from Mockito wins and breaks tests -->
 
     <version.org.infinispan>11.0.4.Final</version.org.infinispan>
@@ -177,13 +176,13 @@
     <version.org.jboss.resteasy>4.5.9.Final</version.org.jboss.resteasy>
     <version.org.json>20200518</version.org.json>
     <version.org.json-unit-assertj>2.9.0</version.org.json-unit-assertj>
-    <version.org.junit.minor>7.0</version.org.junit.minor> <!-- so that org.junit.platform and org.junit can share the same minor version -->
+    <version.org.junit.minor>7.1</version.org.junit.minor> <!-- so that org.junit.platform and org.junit can share the same minor version -->
     <version.org.junit>5.${version.org.junit.minor}</version.org.junit>
     <version.org.junit.jupiter>${version.org.junit}</version.org.junit.jupiter>
     <version.org.junit.vintage>${version.org.junit}</version.org.junit.vintage>
     <version.org.junit.platform>1.${version.org.junit.minor}</version.org.junit.platform> <!-- otherwise Quarkus brings its own, silently disabling some tests -->
     <version.org.junit.pioneer>1.0.0</version.org.junit.pioneer>
-    <version.org.keycloak>11.0.3</version.org.keycloak>
+    <version.org.keycloak>12.0.4</version.org.keycloak>
     <version.org.confluent.kafka>5.4.3</version.org.confluent.kafka>
     <version.org.kie7>7.52.0.Final</version.org.kie7>
     <version.org.mockito>3.6.0</version.org.mockito>

--- a/kogito-build-parent/pom.xml
+++ b/kogito-build-parent/pom.xml
@@ -117,7 +117,7 @@
     <version.org.jsonschema2pojo-maven-plugin>1.0.1</version.org.jsonschema2pojo-maven-plugin>
 
     <!-- this version property is used in plugins but also in dependencies too -->
-    <version.io.quarkus>1.13.0.Final</version.io.quarkus>
+    <version.io.quarkus>1.13.1.Final</version.io.quarkus>
 
     <!-- dependencies versions -->
     <version.ch.obermuhlner>2.0.1</version.ch.obermuhlner>

--- a/kogito-build-parent/pom.xml
+++ b/kogito-build-parent/pom.xml
@@ -147,7 +147,7 @@
 
     <version.io.cloudevents>2.0.0-milestone3</version.io.cloudevents>
     <version.io.jredisearch>2.0.0</version.io.jredisearch>
-    <version.io.fabric8.kubernetes-client>5.3.0</version.io.fabric8.kubernetes-client>
+    <version.io.fabric8.kubernetes-client>5.0.0</version.io.fabric8.kubernetes-client>
     <version.io.micrometer>1.6.5</version.io.micrometer>
     <version.io.rest-assured>4.3.3</version.io.rest-assured>
     <version.io.rest-assured.springboot>3.3.0</version.io.rest-assured.springboot>    <!-- Manually override to 3.3.0 because Spring boot uses rest-assured-common@3.3.0, otherwise error: The type io.restassured.common.mapper.TypeRef cannot be resolved. It is indirectly referenced from required .class files -->

--- a/kogito-build-parent/pom.xml
+++ b/kogito-build-parent/pom.xml
@@ -95,7 +95,7 @@
     <version.license.plugin>4.0.rc2</version.license.plugin>
     <version.enforcer.plugin>3.0.0-M2</version.enforcer.plugin>
     <version.de.skuzzle.enforcer>1.1.0</version.de.skuzzle.enforcer>
-    <version.maven>3.6.3</version.maven>
+    <version.maven>3.6.2</version.maven>
     <version.maven.plugin>3.6.0</version.maven.plugin>
     <version.native2ascii.plugin>1.0-beta-1</version.native2ascii.plugin>
     <version.plexus>1.6</version.plexus>

--- a/kogito-build-parent/pom.xml
+++ b/kogito-build-parent/pom.xml
@@ -95,8 +95,8 @@
     <version.license.plugin>4.0.rc2</version.license.plugin>
     <version.enforcer.plugin>3.0.0-M2</version.enforcer.plugin>
     <version.de.skuzzle.enforcer>1.1.0</version.de.skuzzle.enforcer>
-    <version.maven>3.6.2</version.maven>
-    <version.maven.plugin>3.4</version.maven.plugin>
+    <version.maven>3.6.3</version.maven>
+    <version.maven.plugin>3.6.0</version.maven.plugin>
     <version.native2ascii.plugin>1.0-beta-1</version.native2ascii.plugin>
     <version.plexus>1.6</version.plexus>
     <version.plexus.classworld>2.5.2</version.plexus.classworld>
@@ -132,7 +132,7 @@
     <version.com.google.guava>16.0.1</version.com.google.guava>
     <version.org.openapitools>5.0.1</version.org.openapitools>
     <version.org.openapitools.jackson.databind.nullable>0.2.0</version.org.openapitools.jackson.databind.nullable>
-    <version.com.squareup.okhttp3>3.14.6</version.com.squareup.okhttp3>
+    <version.com.squareup.okhttp3>3.14.9</version.com.squareup.okhttp3>
     <version.com.sun.xml.bind>2.3.0</version.com.sun.xml.bind>
     <version.com.sun.activation>1.2.0</version.com.sun.activation>
     <version.com.thoughtworks.xstream>1.4.14</version.com.thoughtworks.xstream>
@@ -143,13 +143,13 @@
     <version.javax.json>1.1.4</version.javax.json>
     <version.javax.json.bind>1.0</version.javax.json.bind>
     <version.javax.validation>2.0.1.Final</version.javax.validation>
-    <version.javax.xml.bind>2.3.0</version.javax.xml.bind>
+    <version.javax.xml.bind>2.3.1</version.javax.xml.bind>
 
     <version.io.cloudevents>2.0.0-milestone3</version.io.cloudevents>
     <version.io.jredisearch>2.0.0</version.io.jredisearch>
-    <version.io.fabric8.kubernetes-client>5.0.0</version.io.fabric8.kubernetes-client>
+    <version.io.fabric8.kubernetes-client>5.3.0</version.io.fabric8.kubernetes-client>
     <version.io.micrometer>1.6.5</version.io.micrometer>
-    <version.io.rest-assured>4.3.0</version.io.rest-assured>
+    <version.io.rest-assured>4.3.3</version.io.rest-assured>
     <version.io.rest-assured.springboot>3.3.0</version.io.rest-assured.springboot>    <!-- Manually override to 3.3.0 because Spring boot uses rest-assured-common@3.3.0, otherwise error: The type io.restassured.common.mapper.TypeRef cannot be resolved. It is indirectly referenced from required .class files -->
     <version.io.serverlessworkflow>2.0.0.Final</version.io.serverlessworkflow>
     <version.io.smallrye-open-api-core>2.0.26</version.io.smallrye-open-api-core>
@@ -160,7 +160,7 @@
 
     <version.org.antlr>3.5.2</version.org.antlr>
     <version.org.antlr4>4.8</version.org.antlr4>
-    <version.org.apache.commons>3.8.1</version.org.apache.commons>
+    <version.org.apache.commons>3.12.0</version.org.apache.commons>
     <version.org.apache.kafka>2.7.0</version.org.apache.kafka>
     <version.org.apache.xmlgraphics.batik>1.13</version.org.apache.xmlgraphics.batik>
     <version.org.assertj>3.19.0</version.org.assertj>
@@ -172,7 +172,7 @@
     <version.org.redis>2.0.4</version.org.redis>
     <version.org.infinispan.protostream>4.3.4.Final</version.org.infinispan.protostream>
     <version.org.infinispan.starter>2.3.3.Final</version.org.infinispan.starter>
-    <version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>1.0.1.Final</version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>
+    <version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>2.0.1.Final</version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>
     <version.org.jboss.resteasy>4.5.9.Final</version.org.jboss.resteasy>
     <version.org.json>20200518</version.org.json>
     <version.org.json-unit-assertj>2.9.0</version.org.json-unit-assertj>
@@ -199,7 +199,7 @@
     <version.io.netty>4.1.52.Final</version.io.netty>
     <version.io.projectreactor>3.3.10.RELEASE</version.io.projectreactor>
     <version.io.projectreactor.kafka>1.2.2.RELEASE</version.io.projectreactor.kafka>
-    <version.io.vertx>3.9.2</version.io.vertx>
+    <version.io.vertx>3.9.6</version.io.vertx>
     <version.xerces>2.11.0</version.xerces>
   </properties>
 

--- a/kogito-build-parent/pom.xml
+++ b/kogito-build-parent/pom.xml
@@ -187,6 +187,7 @@
     <version.org.kie7>7.52.0.Final</version.org.kie7>
     <version.org.mockito>3.6.0</version.org.mockito>
     <version.org.mongo>4.2.3</version.org.mongo>
+    <version.org.mongo.springboot>4.1.0</version.org.mongo.springboot> <!-- https://issues.redhat.com/browse/KOGITO-5031 -->
     <version.org.mvel>2.4.12.Final</version.org.mvel>
     <version.org.reactivestreams>1.0.3</version.org.reactivestreams>
     <version.org.reflections>0.9.11</version.org.reflections>

--- a/kogito-build-parent/pom.xml
+++ b/kogito-build-parent/pom.xml
@@ -117,7 +117,7 @@
     <version.org.jsonschema2pojo-maven-plugin>1.0.1</version.org.jsonschema2pojo-maven-plugin>
 
     <!-- this version property is used in plugins but also in dependencies too -->
-    <version.io.quarkus>1.13.2.Final</version.io.quarkus>
+    <version.io.quarkus>1.13.0.Final</version.io.quarkus>
 
     <!-- dependencies versions -->
     <version.ch.obermuhlner>2.0.1</version.ch.obermuhlner>

--- a/kogito-build-parent/pom.xml
+++ b/kogito-build-parent/pom.xml
@@ -117,7 +117,7 @@
     <version.org.jsonschema2pojo-maven-plugin>1.0.1</version.org.jsonschema2pojo-maven-plugin>
 
     <!-- this version property is used in plugins but also in dependencies too -->
-    <version.io.quarkus>1.13.2.Final</version.io.quarkus>
+    <version.io.quarkus>1.13.3.Final</version.io.quarkus>
 
     <!-- dependencies versions -->
     <version.ch.obermuhlner>2.0.1</version.ch.obermuhlner>

--- a/kogito-build-parent/pom.xml
+++ b/kogito-build-parent/pom.xml
@@ -117,7 +117,7 @@
     <version.org.jsonschema2pojo-maven-plugin>1.0.1</version.org.jsonschema2pojo-maven-plugin>
 
     <!-- this version property is used in plugins but also in dependencies too -->
-    <version.io.quarkus>1.13.1.Final</version.io.quarkus>
+    <version.io.quarkus>1.13.2.Final</version.io.quarkus>
 
     <!-- dependencies versions -->
     <version.ch.obermuhlner>2.0.1</version.ch.obermuhlner>


### PR DESCRIPTION
- Quarkus 1.13
- missing versions
- revert maven version
- revert kubernetes client version
- try using Quarkus 1.13.0
- Quarkus 1.13.1
- Quarkus 1.13.2
- Quarkus 1.13.3
- <version.org.mongo>4.2.3</version.org.mongo>
- add     <version.org.mongo.springboot>4.1.0</version.org.mongo.springboot>
