### PR TITLE
KOGITO-5062 Use reflection in generated models

### DIFF
--- a/api/kogito-api/src/main/java/org/kie/kogito/MapInput.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/MapInput.java
@@ -28,5 +28,9 @@ public interface MapInput {
      * @param params Map containing keys which matches names of fields
      *        in the class
      */
-    MapInput fromMap(Map<String, Object> params);
+    default MapInput fromMap(Map<String, Object> params) {
+        Models.fromMap(this, params);
+        return this;
+    }
+
 }

--- a/api/kogito-api/src/main/java/org/kie/kogito/MapInputId.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/MapInputId.java
@@ -18,16 +18,19 @@ package org.kie.kogito;
 import java.util.Map;
 
 /**
- * To be implemented by classes which can express its internal information as a Map
+ * To be implemented by classes which can be populated from a Map
  */
-public interface MapOutput {
+public interface MapInputId {
 
     /**
-     * Returns class representation as map
+     * Fills the class with information retrieved from the map
      * 
-     * @return non null map of data extracted from the class
+     * @param params Map containing keys which matches names of fields
+     *        in the class
      */
-    default Map<String, Object> toMap() {
-        return Models.toMap(this);
+    default void fromMap(String id, Map<String, Object> params) {
+        Models.setId(this, id);
+        Models.fromMap(this, params);
     }
+
 }

--- a/api/kogito-api/src/main/java/org/kie/kogito/Model.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/Model.java
@@ -23,5 +23,7 @@ import java.util.Map;
  */
 public interface Model extends MapInput, MapOutput {
 
-    void update(Map<String, Object> params);
+    default void update(Map<String, Object> params) {
+        Models.fromMap(this, params);
+    }
 }

--- a/api/kogito-api/src/main/java/org/kie/kogito/Models.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/Models.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito;
+
+import java.beans.BeanInfo;
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class Models {
+    private Models() {
+    }
+
+    public static Map<String, Object> toMap(Object m) {
+        try {
+            Map<String, Object> map = new HashMap<>();
+            BeanInfo beanInfo = Introspector.getBeanInfo(m.getClass());
+            Map<String, PropertyDescriptor> descriptors = descriptorMap(beanInfo);
+
+            for (Map.Entry<String, PropertyDescriptor> e : descriptors.entrySet()) {
+                String k = e.getKey();
+                if (k.equals("class") || k.equals("id")) {
+                    continue;
+                }
+                if (e.getKey().startsWith("v$")) {
+                    k = k.substring(2);
+                }
+                map.put(k, e.getValue().getReadMethod().invoke(m));
+            }
+            return map;
+        } catch (IntrospectionException | IllegalAccessException | InvocationTargetException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    public static <T> T fromMap(T m, Map<String, Object> map) {
+        try {
+            BeanInfo beanInfo = Introspector.getBeanInfo(m.getClass());
+            Map<String, PropertyDescriptor> descriptors = descriptorMap(beanInfo);
+
+            for (Map.Entry<String, PropertyDescriptor> e : descriptors.entrySet()) {
+                String k = e.getKey();
+                if (e.getKey().startsWith("v$")) {
+                    k = k.substring(2);
+                }
+                if (map.containsKey(k)) {
+                    e.getValue().getWriteMethod().invoke(m, map.get(k));
+                }
+            }
+            return m;
+        } catch (IntrospectionException | IllegalAccessException | InvocationTargetException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    public static <T> T fromMap(Class<T> cls, Map<String, Object> map) {
+        try {
+            Constructor<T> constructor = cls.getConstructor();
+            T t = constructor.newInstance();
+            fromMap(t, map);
+            return t;
+        } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException | InstantiationException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    public static void setId(Object m, String id) {
+        try {
+            BeanInfo beanInfo = Introspector.getBeanInfo(m.getClass());
+            for (PropertyDescriptor pd : beanInfo.getPropertyDescriptors()) {
+                if (pd.getName().equals("id")) {
+                    pd.getWriteMethod().invoke(m, id);
+                }
+            }
+        } catch (IntrospectionException | IllegalAccessException | InvocationTargetException e) {
+            throw new IllegalArgumentException(e);
+        }
+
+    }
+
+    public static <I, O> O convert(I in, O out) {
+        fromMap(out, toMap(in));
+        return out;
+    }
+
+    private static Map<String, PropertyDescriptor> descriptorMap(BeanInfo beanInfo) {
+        return Arrays.stream(beanInfo.getPropertyDescriptors())
+                .filter(pd -> !pd.getName().equals("class"))
+                .collect(Collectors.toMap(
+                        PropertyDescriptor::getName,
+                        Function.identity()));
+    }
+}

--- a/api/kogito-api/src/main/java/org/kie/kogito/Models.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/Models.java
@@ -15,9 +15,6 @@
  */
 package org.kie.kogito;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.beans.BeanInfo;
 import java.beans.IntrospectionException;
 import java.beans.Introspector;
@@ -28,6 +25,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Models {
     private static final Logger LOGGER = LoggerFactory.getLogger(Models.class);

--- a/api/kogito-api/src/main/java/org/kie/kogito/ReflectiveModelAccessException.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/ReflectiveModelAccessException.java
@@ -17,7 +17,6 @@ package org.kie.kogito;
 
 public class ReflectiveModelAccessException extends IllegalArgumentException {
 
-
     public ReflectiveModelAccessException(Exception e) {
         super(e);
     }

--- a/api/kogito-api/src/main/java/org/kie/kogito/ReflectiveModelAccessException.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/ReflectiveModelAccessException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,21 +15,18 @@
  */
 package org.kie.kogito;
 
-import java.util.Map;
+public class ReflectiveModelAccessException extends IllegalArgumentException {
 
-/**
- * To be implemented by classes which can be populated from a Map
- */
-public interface MapInputId {
 
-    /**
-     * Fills the class with information retrieved from the map
-     * 
-     * @param params Map containing keys which matches names of fields
-     *        in the class
-     */
-    default void fromMap(String id, Map<String, Object> params) {
-        Models.fromMap(this, id, params);
+    public ReflectiveModelAccessException(Exception e) {
+        super(e);
     }
 
+    public ReflectiveModelAccessException(String msg, NoSuchMethodException e) {
+        super(msg, e);
+    }
+
+    public ReflectiveModelAccessException(String msg) {
+        super(msg);
+    }
 }

--- a/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-kafka-it/src/test/java/org/kie/kogito/integrationtests/springboot/PingPongMessageTest.java
+++ b/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-kafka-it/src/test/java/org/kie/kogito/integrationtests/springboot/PingPongMessageTest.java
@@ -49,7 +49,6 @@ public class PingPongMessageTest extends BaseRestTest {
 
     @Test
     void testPingPongBetweenProcessInstances() throws InterruptedException {
-        Thread.sleep(5_000); // arbitrary wait to avoid timeouts
         CountDownLatch latch = new CountDownLatch(1);
         Flux.from(publisher)
                 .map(x -> {

--- a/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-kafka-it/src/test/java/org/kie/kogito/integrationtests/springboot/PingPongMessageTest.java
+++ b/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-kafka-it/src/test/java/org/kie/kogito/integrationtests/springboot/PingPongMessageTest.java
@@ -49,6 +49,7 @@ public class PingPongMessageTest extends BaseRestTest {
 
     @Test
     void testPingPongBetweenProcessInstances() throws InterruptedException {
+        Thread.sleep(5_000); // arbitrary wait to avoid timeouts
         CountDownLatch latch = new CountDownLatch(1);
         Flux.from(publisher)
                 .map(x -> {

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ModelMetaData.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ModelMetaData.java
@@ -24,7 +24,6 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import com.github.javaparser.ast.stmt.ReturnStmt;
 import org.jbpm.process.core.context.variable.Variable;
 import org.kie.kogito.codegen.Generated;
 import org.kie.kogito.codegen.VariableInfo;
@@ -55,6 +54,7 @@ import com.github.javaparser.ast.expr.StringLiteralExpr;
 import com.github.javaparser.ast.expr.ThisExpr;
 import com.github.javaparser.ast.expr.VariableDeclarationExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.ReturnStmt;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 
 import static com.github.javaparser.StaticJavaParser.parse;
@@ -216,7 +216,6 @@ public class ModelMetaData {
 
         toMapBody.addStatement(new ReturnStmt(new NameExpr("params")));
         toMapMethod.ifPresent(methodDeclaration -> methodDeclaration.setBody(toMapBody));
-
 
         return compilationUnit;
     }

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ModelMetaData.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ModelMetaData.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import com.github.javaparser.ast.stmt.ReturnStmt;
 import org.jbpm.process.core.context.variable.Variable;
 import org.kie.kogito.codegen.Generated;
 import org.kie.kogito.codegen.VariableInfo;
@@ -54,11 +55,9 @@ import com.github.javaparser.ast.expr.StringLiteralExpr;
 import com.github.javaparser.ast.expr.ThisExpr;
 import com.github.javaparser.ast.expr.VariableDeclarationExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
-import com.github.javaparser.ast.stmt.ReturnStmt;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 
 import static com.github.javaparser.StaticJavaParser.parse;
-import static com.github.javaparser.StaticJavaParser.parseClassOrInterfaceType;
 import static org.drools.core.util.StringUtils.ucFirst;
 
 public class ModelMetaData {
@@ -211,23 +210,6 @@ public class ModelMetaData {
             fd.createGetter();
             fd.createSetter();
 
-            // toMap method body
-            MethodCallExpr putVariable = new MethodCallExpr(new NameExpr("params"), "put");
-            putVariable.addArgument(new StringLiteralExpr(varName));
-            putVariable.addArgument(new FieldAccessExpr(new ThisExpr(), sanitizedName));
-            toMapBody.addStatement(putVariable);
-
-            ClassOrInterfaceType type = parseClassOrInterfaceType(vtype);
-
-            // from map instance method body
-            FieldAccessExpr instanceField = new FieldAccessExpr(new ThisExpr(), sanitizedName);
-            staticFromMap.addStatement(new AssignExpr(instanceField, new CastExpr(
-                    type,
-                    new MethodCallExpr(
-                            new NameExpr("params"),
-                            "get")
-                                    .addArgument(new StringLiteralExpr(varName))),
-                    AssignExpr.Operator.ASSIGN));
         }
 
         Optional<MethodDeclaration> toMapMethod = modelClass.findFirst(MethodDeclaration.class, sl -> sl.getName().asString().equals("toMap"));
@@ -235,18 +217,6 @@ public class ModelMetaData {
         toMapBody.addStatement(new ReturnStmt(new NameExpr("params")));
         toMapMethod.ifPresent(methodDeclaration -> methodDeclaration.setBody(toMapBody));
 
-        //first setting return type for the fromMap with no id parameter
-        modelClass.findFirst(MethodDeclaration.class, sl -> sl.getName().asString().equals("fromMap") && sl.getParameters().size() == 1)
-                .ifPresent(m -> m.setType(modelClassSimpleName));
-
-        //second setting return type for the fromMap with id parameter
-        modelClass.findFirst(
-                // make sure to take only the method with two parameters (id, businessKey and params)
-                MethodDeclaration.class, sl -> sl.getName().asString().equals("fromMap") && sl.getParameters().size() == 2)
-                .ifPresent(m -> {
-                    m.setBody(staticFromMap.addStatement(new ReturnStmt(new ThisExpr())));
-                    m.setType(modelClassSimpleName);
-                });
 
         return compilationUnit;
     }

--- a/jbpm/jbpm-flow-builder/src/main/resources/class-templates/ModelNoIDTemplate.java
+++ b/jbpm/jbpm-flow-builder/src/main/resources/class-templates/ModelNoIDTemplate.java
@@ -15,31 +15,17 @@
  */
 package org.jbpm.process.codegen;
 
+import org.kie.kogito.MapInput;
+import org.kie.kogito.MapInputId;
+import org.kie.kogito.MapOutput;
+
 import java.util.Map;
 import java.util.HashMap;
 
 import org.kie.kogito.MappableToModel;
 import org.kie.kogito.Model;
 
-public class XXXModel implements Model,
+public class XXXModel implements Model, MapInput, MapInputId, MapOutput,
                                  MappableToModel<$modelClass$> {
-    
-    @Override
-    public Map<String, Object> toMap() {
-        
-    }
-    
-    @Override
-    public XXXModel fromMap(Map<String, Object> params) {
-        return fromMap(null, params);
-    }
 
-    @Override
-    public void update(Map<String, Object> params) {
-        fromMap(params);
-    }
-
-    public XXXModel fromMap(String id, Map<String, Object> params) {
-        
-    }
 }

--- a/jbpm/jbpm-flow-builder/src/main/resources/class-templates/ModelTemplate.java
+++ b/jbpm/jbpm-flow-builder/src/main/resources/class-templates/ModelTemplate.java
@@ -15,15 +15,18 @@
  */
 package org.jbpm.process.codegen;
 
+import org.kie.kogito.MapInput;
+import org.kie.kogito.MapInputId;
+import org.kie.kogito.MapOutput;
+
 import java.util.Map;
 import java.util.HashMap;
 
 import org.kie.kogito.MappableToModel;
 import org.kie.kogito.Model;
 
-public class XXXModel implements Model,
-                                 MappableToModel<$modelClass$> {
-    
+public class XXXModel implements org.kie.kogito.Model, MapInput, MapInputId, MapOutput, MappableToModel<$modelClass$> {
+
     private String id;
 
     public void setId(String id) {
@@ -34,22 +37,4 @@ public class XXXModel implements Model,
         return this.id;
     }
 
-    @Override
-    public Map<String, Object> toMap() {
-        
-    }
-
-    @Override
-    public XXXModel fromMap(Map<String, Object> params) {
-        return fromMap(null, params);
-    }
-
-    @Override
-    public void update(Map<String, Object> params) {
-        fromMap(getId(), params);
-    }
-
-    public XXXModel fromMap(String id, Map<String, Object> params) {
-        
-    }
 }


### PR DESCRIPTION
The idea is to remove useless codegen and align to a single strategy over the whole platform; i.e., replace it with reflection; then use Quarkus' opt-in mechanisms where necessary to allow reflection on our models. 

This will also make it possible for users to use their own models (otherwise user-provided models should explicitly provide toMap/fromMap methods, which is inconvenient).

- In further PRs we are going also to remove generics from `Process<T>` and `ProcessInstance<T>`; making them `Process` and `ProcessInstance`.
- Instead of the `T variables()` method, we will provide a `<T> T variables(Class<T>)` method
- users will be able to supply their choice of a class to such method, and retrieve the subset of fields that match the variables
- this in turn subsumes the requirement for different codegen for Model, InputModel and OutputModel!


Example:
- variables: `name`, `age`, `school`
- `class Person { String name; int age; }`
- `class Student extends Person { String name; int age; String school; }`
- `Person p = proc.variables(Person.class)`, `Student s = proc.variables(Student.class)`


Strategy:

- add default methods to interfaces (`toMap`, `fromMap`)
- delegate such methods to a static library `Models` (that for this PR is in the `api` module; should probably move to a `shared` kind of module). Notice that for convenience, and rapid prototyping this library is hand-rolled using Java's `Introspector`; I think Drools provides such utilities, we may choose to use those after careful refactoring to a stand-alone library 
- in a future PR, the `toMap`, `fromMap` can be removed entirely, substituted for explicit invocation to the static library

TODO: ensure native image works