### PR TITLE
KOGITO-5140 defer expansion of properties with versions in quarkus archetypes

### DIFF
--- a/archetypes/kogito-quarkus-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/kogito-quarkus-archetype/src/main/resources/archetype-resources/pom.xml
@@ -22,7 +22,7 @@
       <dependency>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-quarkus-bom</artifactId>
-        <version>${kogito.version}</version>
+        <version>\${kogito.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -72,15 +72,15 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>${compiler.version}</version>
+        <version>\${compiler.version}</version>
         <configuration>
-          <release>${maven.compiler.release}</release>
+          <release>\${maven.compiler.release}</release>
         </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire.version}</version>
+        <version>\${surefire.version}</version>
         <configuration>
           <systemPropertyVariables>
             <java.util.logging.manager>${quarkus.logging.manager}</java.util.logging.manager>
@@ -91,7 +91,7 @@
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
-        <version>${quarkus.version}</version>
+        <version>\${quarkus.version}</version>
         <executions>
           <execution>
             <goals>
@@ -116,7 +116,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>${surefire.version}</version>
+            <version>\${surefire.version}</version>
             <executions>
               <execution>
                 <goals>

--- a/archetypes/kogito-quarkus-dm-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/kogito-quarkus-dm-archetype/src/main/resources/archetype-resources/pom.xml
@@ -22,7 +22,7 @@
       <dependency>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-quarkus-bom</artifactId>
-        <version>${kogito.version}</version>
+        <version>\${kogito.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -80,15 +80,15 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>${compiler.version}</version>
+        <version>\${compiler.version}</version>
         <configuration>
-          <release>${maven.compiler.release}</release>
+          <release>\${maven.compiler.release}</release>
         </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire.version}</version>
+        <version>\${surefire.version}</version>
         <configuration>
           <systemPropertyVariables>
             <java.util.logging.manager>${quarkus.logging.manager}</java.util.logging.manager>
@@ -99,7 +99,7 @@
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
-        <version>${quarkus.version}</version>
+        <version>\${quarkus.version}</version>
         <executions>
           <execution>
             <goals>
@@ -124,7 +124,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>${surefire.version}</version>
+            <version>\${surefire.version}</version>
             <executions>
               <execution>
                 <goals>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/KOGITO-5140

Property expansion in archetype resources occur early if the referenced property is part of the maven build that builds the archetype itself. To prevent this, all property references that are supposed to be referencing a property in the generated project (i.e. keep in form `${kogito.version}` instead of expanding with the exact value during archetype project build) need to have the dollar sign escaped as `\${kogito.version}`.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>