### PR TITLE
Add Quarkus extension deployment artifacts to the kogito-bom

### DIFF
--- a/kogito-bom/pom.xml
+++ b/kogito-bom/pom.xml
@@ -1156,6 +1156,11 @@
       </dependency>
       <dependency>
         <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-quarkus-deployment</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-quarkus-decisions</artifactId>
         <version>${project.version}</version>
       </dependency>
@@ -1170,6 +1175,11 @@
         <artifactId>kogito-quarkus-decisions</artifactId>
         <version>${project.version}</version>
         <classifier>javadoc</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-quarkus-decisions-deployment</artifactId>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.kie.kogito</groupId>
@@ -1190,6 +1200,11 @@
       </dependency>
       <dependency>
         <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-quarkus-rules-deployment</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-quarkus-predictions</artifactId>
         <version>${project.version}</version>
       </dependency>
@@ -1204,6 +1219,11 @@
         <artifactId>kogito-quarkus-predictions</artifactId>
         <version>${project.version}</version>
         <classifier>javadoc</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-quarkus-predictions-deployment</artifactId>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.kie.kogito</groupId>
@@ -1238,6 +1258,11 @@
         <artifactId>kogito-quarkus-serverless-workflow</artifactId>
         <version>${project.version}</version>
         <classifier>javadoc</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-quarkus-serverless-workflow-deployment</artifactId>
+        <version>${project.version}</version>
       </dependency>
 
       <!-- Tracing -->


### PR DESCRIPTION
Given that the kogito-bom is imported into the quarkus-universe-bom, it is expected to include the extension deployment artifacts in addition to the runtime ones.