### PR TITLE
[KOGITO-5190] - Removing usage of deprecated getId from core process

### DIFF
--- a/api/kogito-api/src/main/java/org/kie/kogito/internal/process/runtime/KogitoProcessInstance.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/internal/process/runtime/KogitoProcessInstance.java
@@ -35,12 +35,18 @@ public interface KogitoProcessInstance extends ProcessInstance, KogitoEventListe
     int SLA_VIOLATED = 3;
     int SLA_ABORTED = 4;
 
+    /**
+     * @Deprecated use getStringId instead. Some implementations will throw {@link UnsupportedOperationException}
+     */
     @Deprecated
     @Override
     long getId();
 
     String getStringId();
 
+    /**
+     * @Deprecated use getParentProcessInstanceStringId instead. Some implementations will throw {@link UnsupportedOperationException}
+     */
     @Deprecated
     @Override
     long getParentProcessInstanceId();

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/context/variable/VariableScopeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/context/variable/VariableScopeInstance.java
@@ -54,9 +54,9 @@ public class VariableScopeInstance extends AbstractContextInstance {
 
         // support for processInstanceId and parentProcessInstanceId
         if ("processInstanceId".equals(name) && getProcessInstance() != null) {
-            return getProcessInstance().getId();
+            return getProcessInstance().getStringId();
         } else if ("parentProcessInstanceId".equals(name) && getProcessInstance() != null) {
-            return getProcessInstance().getParentProcessInstanceId();
+            return getProcessInstance().getParentProcessInstanceStringId();
         }
 
         if (getProcessInstance() != null && getProcessInstance().getKnowledgeRuntime() != null) {

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/ProcessInstanceImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/ProcessInstanceImpl.java
@@ -56,6 +56,11 @@ public abstract class ProcessInstanceImpl implements ProcessInstance,
     private String description;
     private String rootProcessId;
 
+    /**
+     * @Deprecated use getStringId instead.
+     * @throws UnsupportedOperationException if called
+     */
+    @Deprecated
     public long getId() {
         throw new UnsupportedOperationException();
     }
@@ -256,7 +261,7 @@ public abstract class ProcessInstanceImpl implements ProcessInstance,
 
     public String toString() {
         final StringBuilder b = new StringBuilder("ProcessInstance ");
-        b.append(getId());
+        b.append(getStringId());
         b.append(" [processId=");
         b.append(this.process.getId());
         b.append(",state=");
@@ -284,6 +289,10 @@ public abstract class ProcessInstanceImpl implements ProcessInstance,
         this.outcome = outcome;
     }
 
+    /**
+     * @Deprecated use getParentProcessInstanceStringId instead.
+     * @throws UnsupportedOperationException if called
+     */
     @Override
     public long getParentProcessInstanceId() {
         throw new UnsupportedOperationException();

--- a/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcessInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcessInstance.java
@@ -601,7 +601,7 @@ public abstract class AbstractProcessInstance<T extends Model> implements Proces
 
         @Override
         public String[] getEventTypes() {
-            return new String[] { "processInstanceCompleted:" + processInstance.getId() };
+            return new String[] { "processInstanceCompleted:" + processInstance.getStringId() };
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

See: https://issues.redhat.com/browse/KOGITO-5190

Context: https://kie.zulipchat.com/#narrow/stream/232676-kogito/topic/Get.20current.20process.20instance.20Id

After the unfork, we had to deprecate the `long getId()` method from the process instance since on Kogito we use a UUID instead. There were some leftovers in the code that we fixed in this PR. Although there are some usages that might also need to be removed in the future:
https://github.com/kiegroup/kogito-runtimes/blob/1.6.0.Final/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/StateBasedNodeInstance.java#L108-L109

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/master/kogito-build/kogito-ide-config)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>