### PR TITLE
KOGITO-5207 Remove Generics from Process/ProcessInstance

### DIFF
--- a/addons/jobs/jobs-management-quarkus-addon/src/main/java/org/kie/kogito/jobs/management/quarkus/CallbackJobsServiceResource.java
+++ b/addons/jobs/jobs-management-quarkus-addon/src/main/java/org/kie/kogito/jobs/management/quarkus/CallbackJobsServiceResource.java
@@ -57,15 +57,15 @@ public class CallbackJobsServiceResource {
             return Response.status(Status.BAD_REQUEST).entity("Process id and Process instance id must be given").build();
         }
 
-        Process<?> process = processes.processById(processId);
+        Process process = processes.processById(processId);
         if (process == null) {
             return Response.status(Status.NOT_FOUND).entity("Process with id " + processId + " not found").build();
         }
 
         return UnitOfWorkExecutor.executeInUnitOfWork(application.unitOfWorkManager(), () -> {
-            Optional<? extends ProcessInstance<?>> processInstanceFound = process.instances().findById(processInstanceId);
+            Optional<? extends ProcessInstance> processInstanceFound = process.instances().findById(processInstanceId);
             if (processInstanceFound.isPresent()) {
-                ProcessInstance<?> processInstance = processInstanceFound.get();
+                ProcessInstance processInstance = processInstanceFound.get();
                 String[] ids = timerId.split("_");
                 processInstance.send(Sig.of("timerTriggered", TimerInstance.with(Long.parseLong(ids[1]), timerId, limit)));
             } else {

--- a/addons/jobs/jobs-management-springboot-addon/src/main/java/org/kie/kogito/jobs/management/springboot/CallbackJobsServiceResource.java
+++ b/addons/jobs/jobs-management-springboot-addon/src/main/java/org/kie/kogito/jobs/management/springboot/CallbackJobsServiceResource.java
@@ -54,15 +54,15 @@ public class CallbackJobsServiceResource {
             return ResponseEntity.badRequest().body("Process id and Process instance id must be  given");
         }
 
-        Process<?> process = processes.processById(processId);
+        Process process = processes.processById(processId);
         if (process == null) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Process with id " + processId + " not found");
         }
 
         return UnitOfWorkExecutor.executeInUnitOfWork(application.unitOfWorkManager(), () -> {
-            Optional<? extends ProcessInstance<?>> processInstanceFound = process.instances().findById(processInstanceId);
+            Optional<? extends ProcessInstance> processInstanceFound = process.instances().findById(processInstanceId);
             if (processInstanceFound.isPresent()) {
-                ProcessInstance<?> processInstance = processInstanceFound.get();
+                ProcessInstance processInstance = processInstanceFound.get();
                 String[] ids = timerId.split("_");
                 processInstance.send(Sig.of("timerTriggered", TimerInstance.with(Long.parseLong(ids[1]), timerId, limit)));
             } else {

--- a/addons/persistence/filesystem-persistence-addon/src/main/java/org/kie/kogito/persistence/KogitoProcessInstancesFactory.java
+++ b/addons/persistence/filesystem-persistence-addon/src/main/java/org/kie/kogito/persistence/KogitoProcessInstancesFactory.java
@@ -27,7 +27,7 @@ import org.kie.kogito.process.ProcessInstancesFactory;
  */
 public abstract class KogitoProcessInstancesFactory implements ProcessInstancesFactory {
 
-    public FileSystemProcessInstances createProcessInstances(Process<?> process) {
+    public FileSystemProcessInstances createProcessInstances(Process process) {
         return new FileSystemProcessInstances(process, Paths.get(path()));
     }
 

--- a/addons/persistence/filesystem-persistence-addon/src/main/java/org/kie/kogito/persistence/filesystem/FileSystemProcessInstances.java
+++ b/addons/persistence/filesystem-persistence-addon/src/main/java/org/kie/kogito/persistence/filesystem/FileSystemProcessInstances.java
@@ -48,16 +48,16 @@ public class FileSystemProcessInstances implements MutableProcessInstances {
     public static final String PI_DESCRIPTION = "ProcessInstanceDescription";
     public static final String PI_STATUS = "ProcessInstanceStatus";
 
-    private Process<?> process;
+    private Process process;
     private Path storage;
 
     private ProcessInstanceMarshallerService marshaller;
 
-    public FileSystemProcessInstances(Process<?> process, Path storage) {
+    public FileSystemProcessInstances(Process process, Path storage) {
         this(process, storage, ProcessInstanceMarshallerService.newBuilder().withDefaultObjectMarshallerStrategies().build());
     }
 
-    public FileSystemProcessInstances(Process<?> process, Path storage, ProcessInstanceMarshallerService marshaller) {
+    public FileSystemProcessInstances(Process process, Path storage, ProcessInstanceMarshallerService marshaller) {
         this.process = process;
         this.storage = Paths.get(storage.toString(), process.id());
         this.marshaller = marshaller;
@@ -141,7 +141,7 @@ public class FileSystemProcessInstances implements MutableProcessInstances {
         }
     }
 
-    protected void storeProcessInstance(Path processInstanceStorage, ProcessInstance<?> instance) {
+    protected void storeProcessInstance(Path processInstanceStorage, ProcessInstance instance) {
         try {
             byte[] data = marshaller.marshallProcessInstance(instance);
             Files.write(processInstanceStorage, data);
@@ -164,7 +164,7 @@ public class FileSystemProcessInstances implements MutableProcessInstances {
 
     protected void disconnect(Path processInstanceStorage, ProcessInstance instance) {
         Supplier<byte[]> supplier = () -> readBytesFromFile(processInstanceStorage);
-        ((AbstractProcessInstance<?>) instance).internalRemoveProcessInstance(marshaller.createdReloadFunction(supplier));
+        ((AbstractProcessInstance) instance).internalRemoveProcessInstance(marshaller.createdReloadFunction(supplier));
     }
 
     public String getMetadata(Path file, String key) {

--- a/addons/persistence/filesystem-persistence-addon/src/test/java/org/kie/persistence/filesystem/FileSystemProcessInstancesTest.java
+++ b/addons/persistence/filesystem-persistence-addon/src/test/java/org/kie/persistence/filesystem/FileSystemProcessInstancesTest.java
@@ -34,6 +34,7 @@ import org.kie.kogito.process.ProcessInstanceReadMode;
 import org.kie.kogito.process.ProcessInstances;
 import org.kie.kogito.process.WorkItem;
 import org.kie.kogito.process.bpmn2.BpmnProcess;
+import org.kie.kogito.process.bpmn2.BpmnProcessInstance;
 import org.kie.kogito.process.bpmn2.BpmnVariables;
 import org.kie.kogito.process.impl.DefaultProcessEventListenerConfig;
 import org.kie.kogito.process.impl.DefaultWorkItemHandlerConfig;
@@ -82,7 +83,7 @@ class FileSystemProcessInstancesTest {
             }
         }
 
-        ProcessInstance<BpmnVariables> mutablePi = process.createInstance(BpmnVariables.create(Collections.singletonMap("var", "value")));
+        ProcessInstance mutablePi = process.createInstance(BpmnVariables.create(Collections.singletonMap("var", "value")));
 
         mutablePi.start();
         assertThat(mutablePi.status()).isEqualTo(STATE_ERROR);
@@ -92,12 +93,12 @@ class FileSystemProcessInstancesTest {
         });
         assertThat(mutablePi.variables().toMap()).containsExactly(entry("var", "value"));
 
-        ProcessInstances<BpmnVariables> instances = process.instances();
+        ProcessInstances instances = process.instances();
         assertThat(instances.size()).isOne();
-        ProcessInstance<BpmnVariables> pi = instances.findById(mutablePi.id(), ProcessInstanceReadMode.READ_ONLY).get();
+        ProcessInstance pi = instances.findById(mutablePi.id(), ProcessInstanceReadMode.READ_ONLY).get();
         assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> pi.abort());
 
-        ProcessInstance<BpmnVariables> readOnlyPi = instances.findById(mutablePi.id(), ProcessInstanceReadMode.READ_ONLY).get();
+        ProcessInstance readOnlyPi = instances.findById(mutablePi.id(), ProcessInstanceReadMode.READ_ONLY).get();
         assertThat(readOnlyPi.status()).isEqualTo(STATE_ERROR);
         assertThat(readOnlyPi.error()).hasValueSatisfying(error -> {
             assertThat(error.errorMessage()).contains("java.lang.NullPointerException");
@@ -113,12 +114,12 @@ class FileSystemProcessInstancesTest {
     @Test
     void testValuesReadMode() {
         BpmnProcess process = createProcess(null, "BPMN2-UserTask.bpmn2");
-        ProcessInstance<BpmnVariables> processInstance = process.createInstance(BpmnVariables.create(Collections.singletonMap("test", "test")));
+        ProcessInstance processInstance = process.createInstance(BpmnVariables.create(Collections.singletonMap("test", "test")));
         processInstance.start();
 
-        ProcessInstances<BpmnVariables> instances = process.instances();
+        ProcessInstances instances = process.instances();
         assertThat(instances.size()).isOne();
-        ProcessInstance<BpmnVariables> pi = instances.values().stream().findFirst().get();
+        ProcessInstance pi = instances.values().stream().findFirst().get();
         assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> pi.abort());
         instances.values(ProcessInstanceReadMode.MUTABLE).stream().findFirst().get().abort();
         assertThat(instances.size()).isZero();
@@ -127,7 +128,7 @@ class FileSystemProcessInstancesTest {
     @Test
     void testBasicFlow() {
         BpmnProcess process = createProcess(null, "BPMN2-UserTask.bpmn2");
-        ProcessInstance<BpmnVariables> processInstance = process.createInstance(BpmnVariables.create(Collections.singletonMap("test", "test")));
+        BpmnProcessInstance processInstance = process.createInstance(BpmnVariables.create(Collections.singletonMap("test", "test")));
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(STATE_ACTIVE);
@@ -161,7 +162,7 @@ class FileSystemProcessInstancesTest {
     @Test
     void testBasicFlowWithStartFrom() {
         BpmnProcess process = createProcess(null, "BPMN2-UserTask.bpmn2");
-        ProcessInstance<BpmnVariables> processInstance = process.createInstance(BpmnVariables.create(Collections.singletonMap("test", "test")));
+        BpmnProcessInstance processInstance = process.createInstance(BpmnVariables.create(Collections.singletonMap("test", "test")));
         processInstance.startFrom("_2");
 
         assertThat(processInstance.status()).isEqualTo(STATE_ACTIVE);
@@ -194,7 +195,7 @@ class FileSystemProcessInstancesTest {
         process.setProcessInstancesFactory(new FileSystemProcessInstancesFactory());
         process.configure();
 
-        ProcessInstance<BpmnVariables> processInstance = process.createInstance(BpmnVariables.create(Collections.singletonMap("test", "test")));
+        BpmnProcessInstance processInstance = process.createInstance(BpmnVariables.create(Collections.singletonMap("test", "test")));
 
         UnitOfWork uow = uowManager.newUnitOfWork();
         uow.start();
@@ -235,7 +236,7 @@ class FileSystemProcessInstancesTest {
     private class FileSystemProcessInstancesFactory extends KogitoProcessInstancesFactory {
 
         @Override
-        public FileSystemProcessInstances createProcessInstances(Process<?> process) {
+        public FileSystemProcessInstances createProcessInstances(Process process) {
             FileSystemProcessInstances instances = spy(super.createProcessInstances(process));
             return instances;
         }

--- a/addons/persistence/infinispan-persistence-addon/src/main/java/org/kie/kogito/infinispan/CacheProcessInstances.java
+++ b/addons/persistence/infinispan-persistence-addon/src/main/java/org/kie/kogito/infinispan/CacheProcessInstances.java
@@ -37,9 +37,9 @@ public class CacheProcessInstances implements MutableProcessInstances {
 
     private final RemoteCache<String, byte[]> cache;
     private ProcessInstanceMarshallerService marshaller;
-    private org.kie.kogito.process.Process<?> process;
+    private org.kie.kogito.process.Process process;
 
-    public CacheProcessInstances(Process<?> process, RemoteCacheManager cacheManager, String templateName) {
+    public CacheProcessInstances(Process process, RemoteCacheManager cacheManager, String templateName) {
         this.process = process;
         this.cache = cacheManager.administration().getOrCreateCache(process.id() + "_store", ignoreNullOrEmpty(templateName));
         this.marshaller = ProcessInstanceMarshallerService.newBuilder().withDefaultObjectMarshallerStrategies().build();
@@ -51,7 +51,7 @@ public class CacheProcessInstances implements MutableProcessInstances {
     }
 
     @Override
-    public Optional<? extends ProcessInstance> findById(String id, ProcessInstanceReadMode mode) {
+    public Optional<ProcessInstance> findById(String id, ProcessInstanceReadMode mode) {
         byte[] data = cache.get(id);
         if (data == null) {
             return Optional.empty();
@@ -61,7 +61,7 @@ public class CacheProcessInstances implements MutableProcessInstances {
     }
 
     @Override
-    public Collection<? extends ProcessInstance> values(ProcessInstanceReadMode mode) {
+    public Collection<ProcessInstance> values(ProcessInstanceReadMode mode) {
         return cache.values()
                 .parallelStream()
                 .map(data -> mode == MUTABLE ? marshaller.unmarshallProcessInstance(data, process) : marshaller.unmarshallReadOnlyProcessInstance(data, process))
@@ -105,7 +105,7 @@ public class CacheProcessInstances implements MutableProcessInstances {
                 cache.put(id, data);
             }
             Supplier<byte[]> supplier = () -> cache.get(id);
-            ((AbstractProcessInstance<?>) instance).internalRemoveProcessInstance(marshaller.createdReloadFunction(supplier));
+            ((AbstractProcessInstance) instance).internalRemoveProcessInstance(marshaller.createdReloadFunction(supplier));
         }
     }
 

--- a/addons/persistence/infinispan-persistence-addon/src/main/java/org/kie/kogito/persistence/KogitoProcessInstancesFactory.java
+++ b/addons/persistence/infinispan-persistence-addon/src/main/java/org/kie/kogito/persistence/KogitoProcessInstancesFactory.java
@@ -32,7 +32,7 @@ public abstract class KogitoProcessInstancesFactory implements ProcessInstancesF
         this.cacheManager = cacheManager;
     }
 
-    public CacheProcessInstances createProcessInstances(Process<?> process) {
+    public CacheProcessInstances createProcessInstances(Process process) {
         return new CacheProcessInstances(process, cacheManager, template());
     }
 

--- a/addons/persistence/infinispan-persistence-addon/src/test/java/org/kie/kogito/infinispan/CacheProcessInstancesIT.java
+++ b/addons/persistence/infinispan-persistence-addon/src/test/java/org/kie/kogito/infinispan/CacheProcessInstancesIT.java
@@ -100,7 +100,7 @@ class CacheProcessInstancesIT {
         process.setProcessInstancesFactory(new CacheProcessInstancesFactory(cacheManager));
         process.configure();
 
-        ProcessInstance<BpmnVariables> mutablePi = process.createInstance(BpmnVariables.create(Collections.singletonMap("var", "value")));
+        ProcessInstance mutablePi = process.createInstance(BpmnVariables.create(Collections.singletonMap("var", "value")));
 
         mutablePi.start();
         assertThat(mutablePi.status()).isEqualTo(STATE_ERROR);
@@ -110,12 +110,12 @@ class CacheProcessInstancesIT {
         });
         assertThat(mutablePi.variables().toMap()).containsExactly(entry("var", "value"));
 
-        ProcessInstances<BpmnVariables> instances = process.instances();
+        ProcessInstances instances = process.instances();
         assertThat(instances.size()).isOne();
-        ProcessInstance<BpmnVariables> pi = instances.findById(mutablePi.id(), ProcessInstanceReadMode.READ_ONLY).get();
+        ProcessInstance pi = instances.findById(mutablePi.id(), ProcessInstanceReadMode.READ_ONLY).get();
         assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> pi.abort());
 
-        ProcessInstance<BpmnVariables> readOnlyPi = instances.findById(mutablePi.id(), ProcessInstanceReadMode.READ_ONLY).get();
+        ProcessInstance readOnlyPi = instances.findById(mutablePi.id(), ProcessInstanceReadMode.READ_ONLY).get();
         assertThat(readOnlyPi.status()).isEqualTo(STATE_ERROR);
         assertThat(readOnlyPi.error()).hasValueSatisfying(error -> {
             assertThat(error.errorMessage()).contains("java.lang.NullPointerException");
@@ -134,13 +134,13 @@ class CacheProcessInstancesIT {
         process.setProcessInstancesFactory(new CacheProcessInstancesFactory(cacheManager));
         process.configure();
 
-        ProcessInstance<BpmnVariables> processInstance = process.createInstance(BpmnVariables.create(Collections.singletonMap("test", "test")));
+        ProcessInstance processInstance = process.createInstance(BpmnVariables.create(Collections.singletonMap("test", "test")));
 
         processInstance.start();
 
-        ProcessInstances<BpmnVariables> instances = process.instances();
+        ProcessInstances instances = process.instances();
         assertThat(instances.size()).isOne();
-        ProcessInstance<BpmnVariables> pi = instances.values().stream().findFirst().get();
+        ProcessInstance pi = instances.values().stream().findFirst().get();
         assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> pi.abort());
         instances.values(ProcessInstanceReadMode.MUTABLE).stream().findFirst().get().abort();
         assertThat(instances.size()).isZero();
@@ -152,7 +152,7 @@ class CacheProcessInstancesIT {
         process.setProcessInstancesFactory(new CacheProcessInstancesFactory(cacheManager));
         process.configure();
 
-        ProcessInstance<BpmnVariables> processInstance = process.createInstance(BpmnVariables.create(Collections.singletonMap("test", "test")));
+        ProcessInstance processInstance = process.createInstance(BpmnVariables.create(Collections.singletonMap("test", "test")));
 
         processInstance.start();
         assertEquals(STATE_ACTIVE, processInstance.status());

--- a/addons/persistence/infinispan-persistence-addon/src/test/java/org/kie/kogito/infinispan/KogitoProcessInstancesFactoryTest.java
+++ b/addons/persistence/infinispan-persistence-addon/src/test/java/org/kie/kogito/infinispan/KogitoProcessInstancesFactoryTest.java
@@ -45,20 +45,25 @@ class KogitoProcessInstancesFactoryTest {
         KogitoProcessInstancesFactory factory = new KogitoProcessInstancesFactory(cacheManager) {
 
         };
-        Process<?> myProcess = new MyProcessImpl();
+        Process myProcess = new MyProcessImpl();
         CacheProcessInstances instances = factory.createProcessInstances(myProcess);
         assertNotNull(instances);
     }
 
-    private static class MyProcessImpl extends AbstractProcess<Model> {
+    private static class MyProcessImpl extends AbstractProcess {
 
         @Override
-        public ProcessInstance<Model> createInstance(WorkflowProcessInstance wpi) {
+        public ProcessInstance createInstance(WorkflowProcessInstance wpi) {
             return null;
         }
 
         @Override
-        public ProcessInstance<Model> createReadOnlyInstance(WorkflowProcessInstance wpi) {
+        public ProcessInstance createInstance(String businessKey, Model workingMemory) {
+            return null;
+        }
+
+        @Override
+        public ProcessInstance createReadOnlyInstance(WorkflowProcessInstance wpi) {
             return null;
         }
 
@@ -68,9 +73,10 @@ class KogitoProcessInstancesFactoryTest {
         }
 
         @Override
-        public ProcessInstance<Model> createInstance(Model workingMemory) {
+        public ProcessInstance createInstance(Model workingMemory) {
             return null;
         }
+
     }
 
     List<BaseMarshaller<?>> getMarshallers() {

--- a/addons/persistence/infinispan-persistence-addon/src/test/java/org/kie/kogito/infinispan/MockCacheProcessInstancesTest.java
+++ b/addons/persistence/infinispan-persistence-addon/src/test/java/org/kie/kogito/infinispan/MockCacheProcessInstancesTest.java
@@ -107,7 +107,7 @@ public class MockCacheProcessInstancesTest {
         process.setProcessInstancesFactory(new CacheProcessInstancesFactory(cacheManager));
         process.configure();
 
-        ProcessInstance<BpmnVariables> mutablePi = process.createInstance(BpmnVariables.create(Collections.singletonMap("var", "value")));
+        ProcessInstance mutablePi = process.createInstance(BpmnVariables.create(Collections.singletonMap("var", "value")));
 
         mutablePi.start();
         assertThat(mutablePi.status()).isEqualTo(STATE_ERROR);
@@ -117,12 +117,12 @@ public class MockCacheProcessInstancesTest {
         });
         assertThat(mutablePi.variables().toMap()).containsExactly(entry("var", "value"));
 
-        ProcessInstances<BpmnVariables> instances = process.instances();
+        ProcessInstances instances = process.instances();
         assertThat(instances.size()).isOne();
-        ProcessInstance<BpmnVariables> pi = instances.findById(mutablePi.id(), ProcessInstanceReadMode.READ_ONLY).get();
+        ProcessInstance pi = instances.findById(mutablePi.id(), ProcessInstanceReadMode.READ_ONLY).get();
         assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> pi.abort());
 
-        ProcessInstance<BpmnVariables> readOnlyPi = instances.findById(mutablePi.id(), ProcessInstanceReadMode.READ_ONLY).get();
+        ProcessInstance readOnlyPi = instances.findById(mutablePi.id(), ProcessInstanceReadMode.READ_ONLY).get();
         assertThat(readOnlyPi.status()).isEqualTo(STATE_ERROR);
         assertThat(readOnlyPi.error()).hasValueSatisfying(error -> {
             assertThat(error.errorMessage()).contains("java.lang.NullPointerException");
@@ -141,7 +141,7 @@ public class MockCacheProcessInstancesTest {
         process.setProcessInstancesFactory(new CacheProcessInstancesFactory(cacheManager));
         process.configure();
 
-        ProcessInstance<BpmnVariables> processInstance = process.createInstance(BpmnVariables.create(Collections.singletonMap("test", "test")));
+        ProcessInstance processInstance = process.createInstance(BpmnVariables.create(Collections.singletonMap("test", "test")));
 
         processInstance.start();
         assertThat(processInstance.status()).isEqualTo(STATE_ACTIVE);
@@ -159,7 +159,7 @@ public class MockCacheProcessInstancesTest {
         process.setProcessInstancesFactory(new CacheProcessInstancesFactory(cacheManager));
         process.configure();
 
-        ProcessInstance<BpmnVariables> processInstance = process.createInstance(BpmnVariables.create(Collections.singletonMap("test", "test")));
+        ProcessInstance processInstance = process.createInstance(BpmnVariables.create(Collections.singletonMap("test", "test")));
 
         processInstance.start();
         assertThat(processInstance.status()).isEqualTo(STATE_ACTIVE);
@@ -181,7 +181,7 @@ public class MockCacheProcessInstancesTest {
         process.setProcessInstancesFactory(new CacheProcessInstancesFactory(cacheManager));
         process.configure();
 
-        ProcessInstance<BpmnVariables> processInstance = process.createInstance(BpmnVariables.create(Collections.singletonMap("test", "test")));
+        ProcessInstance processInstance = process.createInstance(BpmnVariables.create(Collections.singletonMap("test", "test")));
 
         processInstance.start();
         assertThat(processInstance.status()).isEqualTo(STATE_ACTIVE);
@@ -189,7 +189,7 @@ public class MockCacheProcessInstancesTest {
 
         assertThatThrownBy(() -> processInstance.workItems().get(0)).isInstanceOf(ProcessInstanceNotFoundException.class);
 
-        Optional<? extends ProcessInstance<BpmnVariables>> loaded = process.instances().findById(processInstance.id());
+        Optional<? extends ProcessInstance> loaded = process.instances().findById(processInstance.id());
         assertThat(loaded).isNotPresent();
     }
 
@@ -209,7 +209,7 @@ public class MockCacheProcessInstancesTest {
         });
     }
 
-    private void testBasicFlowWithError(Consumer<ProcessInstance<BpmnVariables>> op) {
+    private void testBasicFlowWithError(Consumer<ProcessInstance> op) {
         BpmnProcess process = BpmnProcess.from(new ClassPathResource("BPMN2-UserTask-Script.bpmn2")).get(0);
         // workaround as BpmnProcess does not compile the scripts but just reads the xml
         for (Node node : ((WorkflowProcess) process.process()).getNodes()) {
@@ -225,7 +225,7 @@ public class MockCacheProcessInstancesTest {
         process.setProcessInstancesFactory(new CacheProcessInstancesFactory(cacheManager));
         process.configure();
 
-        ProcessInstance<BpmnVariables> processInstance = process.createInstance(BpmnVariables.create());
+        ProcessInstance processInstance = process.createInstance(BpmnVariables.create());
 
         processInstance.start();
         assertThat(processInstance.status()).isEqualTo(STATE_ERROR);

--- a/addons/persistence/kafka-persistence-addon/src/main/java/org/kie/kogito/persistence/KogitoProcessInstancesFactory.java
+++ b/addons/persistence/kafka-persistence-addon/src/main/java/org/kie/kogito/persistence/KogitoProcessInstancesFactory.java
@@ -59,7 +59,7 @@ public abstract class KogitoProcessInstancesFactory implements ProcessInstancesF
         }
     }
 
-    public KafkaProcessInstances createProcessInstances(Process<?> process) {
+    public KafkaProcessInstances createProcessInstances(Process process) {
         try {
             LOGGER.info("Creating KafkaProcessInstances for process: {}", process.id());
             KafkaProcessInstances pi = new KafkaProcessInstances(process, producer);

--- a/addons/persistence/kafka-persistence-addon/src/main/java/org/kie/kogito/persistence/kafka/KafkaProcessInstances.java
+++ b/addons/persistence/kafka-persistence-addon/src/main/java/org/kie/kogito/persistence/kafka/KafkaProcessInstances.java
@@ -44,21 +44,21 @@ public class KafkaProcessInstances implements MutableProcessInstances {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaProcessInstances.class);
 
-    private Process<?> process;
+    private Process process;
     private KafkaProducer<String, byte[]> producer;
     private String topic;
     private ReadOnlyKeyValueStore<String, byte[]> store;
     private ProcessInstanceMarshallerService marshaller;
     private CountDownLatch latch = new CountDownLatch(1);
 
-    public KafkaProcessInstances(Process<?> process, KafkaProducer<String, byte[]> producer) {
+    public KafkaProcessInstances(Process process, KafkaProducer<String, byte[]> producer) {
         this.process = process;
         this.topic = topicName(process.id());
         this.producer = producer;
         setMarshaller(ProcessInstanceMarshallerService.newBuilder().withDefaultObjectMarshallerStrategies().build());
     }
 
-    protected Process<?> getProcess() {
+    protected Process getProcess() {
         return process;
     }
 
@@ -168,6 +168,6 @@ public class KafkaProcessInstances implements MutableProcessInstances {
 
     protected void disconnect(ProcessInstance instance) {
         Supplier<byte[]> supplier = () -> getStore().get(instance.id());
-        ((AbstractProcessInstance<?>) instance).internalRemoveProcessInstance(marshaller.createdReloadFunction(supplier));
+        ((AbstractProcessInstance) instance).internalRemoveProcessInstance(marshaller.createdReloadFunction(supplier));
     }
 }

--- a/addons/persistence/kafka-persistence-addon/src/test/java/org/kie/kogito/persistence/kafka/KafkaProcessInstancesIT.java
+++ b/addons/persistence/kafka-persistence-addon/src/test/java/org/kie/kogito/persistence/kafka/KafkaProcessInstancesIT.java
@@ -93,10 +93,10 @@ public class KafkaProcessInstancesIT {
         process.configure();
         listener.getKafkaStreams().start();
 
-        ProcessInstances<BpmnVariables> instances = process.instances();
+        ProcessInstances instances = process.instances();
         assertThat(instances.size()).isZero();
 
-        ProcessInstance<BpmnVariables> mutablePi = process.createInstance(BpmnVariables.create(singletonMap("var", "value")));
+        ProcessInstance mutablePi = process.createInstance(BpmnVariables.create(singletonMap("var", "value")));
 
         mutablePi.start();
         assertThat(mutablePi.status()).isEqualTo(STATE_ERROR);
@@ -108,10 +108,10 @@ public class KafkaProcessInstancesIT {
 
         await().until(() -> instances.values().size() == 1);
 
-        ProcessInstance<BpmnVariables> pi = instances.findById(mutablePi.id(), ProcessInstanceReadMode.READ_ONLY).get();
+        ProcessInstance pi = instances.findById(mutablePi.id(), ProcessInstanceReadMode.READ_ONLY).get();
         assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> pi.abort());
 
-        ProcessInstance<BpmnVariables> readOnlyPi = instances.findById(mutablePi.id(), ProcessInstanceReadMode.READ_ONLY).get();
+        ProcessInstance readOnlyPi = instances.findById(mutablePi.id(), ProcessInstanceReadMode.READ_ONLY).get();
         assertThat(readOnlyPi.status()).isEqualTo(STATE_ERROR);
         assertThat(readOnlyPi.error()).hasValueSatisfying(error -> {
             assertThat(error.errorMessage()).endsWith("java.lang.NullPointerException - null");
@@ -132,16 +132,16 @@ public class KafkaProcessInstancesIT {
         process.configure();
         listener.getKafkaStreams().start();
 
-        ProcessInstances<BpmnVariables> instances = process.instances();
+        ProcessInstances instances = process.instances();
         assertThat(instances.size()).isZero();
 
-        ProcessInstance<BpmnVariables> processInstance = process.createInstance(BpmnVariables.create(singletonMap("test", "test")));
+        ProcessInstance processInstance = process.createInstance(BpmnVariables.create(singletonMap("test", "test")));
 
         processInstance.start();
 
         await().until(() -> instances.values().size() == 1);
 
-        ProcessInstance<BpmnVariables> pi = instances.values().stream().findFirst().get();
+        ProcessInstance pi = instances.values().stream().findFirst().get();
         assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> pi.abort());
         instances.values(ProcessInstanceReadMode.MUTABLE).stream().findFirst().get().abort();
         assertThat(instances.size()).isZero();
@@ -155,10 +155,10 @@ public class KafkaProcessInstancesIT {
         process.configure();
         listener.getKafkaStreams().start();
 
-        ProcessInstances<BpmnVariables> instances = process.instances();
+        ProcessInstances instances = process.instances();
         assertThat(instances.size()).isZero();
 
-        ProcessInstance<BpmnVariables> processInstance = process.createInstance(BpmnVariables.create(singletonMap("test", "test")));
+        ProcessInstance processInstance = process.createInstance(BpmnVariables.create(singletonMap("test", "test")));
 
         processInstance.start();
         assertEquals(STATE_ACTIVE, processInstance.status());

--- a/addons/persistence/mongodb-persistence-addon/src/main/java/org/kie/kogito/persistence/KogitoProcessInstancesFactory.java
+++ b/addons/persistence/mongodb-persistence-addon/src/main/java/org/kie/kogito/persistence/KogitoProcessInstancesFactory.java
@@ -37,7 +37,7 @@ public abstract class KogitoProcessInstancesFactory implements ProcessInstancesF
     public abstract String dbName();
 
     @Override
-    public MongoDBProcessInstances<?> createProcessInstances(Process<?> process) {
-        return new MongoDBProcessInstances<>(mongoClient, process, dbName());
+    public MongoDBProcessInstances createProcessInstances(Process process) {
+        return new MongoDBProcessInstances(mongoClient, process, dbName());
     }
 }

--- a/addons/persistence/mongodb-persistence-addon/src/test/java/org/kie/kogito/mongodb/DocumentProcessInstanceMarshallerTest.java
+++ b/addons/persistence/mongodb-persistence-addon/src/test/java/org/kie/kogito/mongodb/DocumentProcessInstanceMarshallerTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.kie.kogito.process.ProcessInstance;
 import org.kie.kogito.process.bpmn2.BpmnProcess;
+import org.kie.kogito.process.bpmn2.BpmnProcessInstance;
 import org.kie.kogito.process.bpmn2.BpmnVariables;
 import org.kie.kogito.serialization.process.MarshallerContextName;
 import org.kie.kogito.serialization.process.ProcessInstanceMarshallerService;
@@ -52,7 +53,7 @@ class DocumentProcessInstanceMarshallerTest {
 
     @Test
     void testMarshalProcessInstance() {
-        ProcessInstance<BpmnVariables> processInstance = process.createInstance(BpmnVariables.create(Collections.singletonMap("test", "testValue")));
+        ProcessInstance processInstance = process.createInstance(BpmnVariables.create(Collections.singletonMap("test", "testValue")));
         processInstance.start();
         doc = Document.parse(new String(marshaller.marshallProcessInstance(processInstance)));
         assertNotNull(doc, "Marshalled value should not be null");
@@ -66,12 +67,12 @@ class DocumentProcessInstanceMarshallerTest {
 
     @Test
     void testUnmarshalProcessInstance() {
-        ProcessInstance<BpmnVariables> processInstance = (ProcessInstance<BpmnVariables>) marshaller.unmarshallProcessInstance(doc.toJson().getBytes(), process);
+        BpmnProcessInstance processInstance = (BpmnProcessInstance) marshaller.unmarshallProcessInstance(doc.toJson().getBytes(), process);
         assertNotNull(processInstance, "Unmarshalled value should not be null");
         assertThat(processInstance.id()).isEqualTo(doc.get("id"));
         assertThat(processInstance.description()).isEqualTo(doc.get("description"));
         assertThat(processInstance.description()).isEqualTo("User Task");
-        Collection<? extends ProcessInstance<BpmnVariables>> values = process.instances().values();
+        Collection<? extends ProcessInstance> values = process.instances().values();
         assertThat(values).isNotEmpty();
         BpmnVariables variables = processInstance.variables();
         String testVar = (String) variables.get("test");
@@ -80,18 +81,18 @@ class DocumentProcessInstanceMarshallerTest {
 
     @Test
     void testProcessInstanceReadOnly() {
-        ProcessInstance<BpmnVariables> processInstance = process.createInstance(BpmnVariables.create(Collections.singletonMap("test", "testValue")));
+        ProcessInstance processInstance = process.createInstance(BpmnVariables.create(Collections.singletonMap("test", "testValue")));
         processInstance.start();
         doc = Document.parse(new String(marshaller.marshallProcessInstance(processInstance)));
-        ProcessInstance<BpmnVariables> processInstanceReadOnly = (ProcessInstance<BpmnVariables>) marshaller.unmarshallProcessInstance(doc.toJson().getBytes(), process);
+        ProcessInstance processInstanceReadOnly = marshaller.unmarshallProcessInstance(doc.toJson().getBytes(), process);
         assertNotNull(processInstanceReadOnly, "Unmarshalled value should not be null");
-        ProcessInstance<BpmnVariables> pi = (ProcessInstance<BpmnVariables>) marshaller.unmarshallReadOnlyProcessInstance(doc.toJson().getBytes(), process);
+        ProcessInstance pi = marshaller.unmarshallReadOnlyProcessInstance(doc.toJson().getBytes(), process);
         assertNotNull(pi, "Unmarshalled value should not be null");
     }
 
     @Test
     void testDocumentMarshallingException() {
-        ProcessInstance<BpmnVariables> processInstance = process.createInstance(BpmnVariables.create(Collections.singletonMap("test", "testValue")));
+        ProcessInstance processInstance = process.createInstance(BpmnVariables.create(Collections.singletonMap("test", "testValue")));
         assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> marshaller.marshallProcessInstance(processInstance));
     }
 

--- a/addons/persistence/mongodb-persistence-addon/src/test/java/org/kie/kogito/mongodb/KogitoProcessInstancesFactoryIT.java
+++ b/addons/persistence/mongodb-persistence-addon/src/test/java/org/kie/kogito/mongodb/KogitoProcessInstancesFactoryIT.java
@@ -37,10 +37,10 @@ class KogitoProcessInstancesFactoryIT extends TestHelper {
         };
         assertNotNull(factory);
         assertThat(factory.dbName()).isEqualTo(DB_NAME);
-        Process<?> process = mock(Process.class);
+        Process process = mock(Process.class);
         lenient().when(process.id()).thenReturn(PROCESS_NAME);
         lenient().when(process.name()).thenReturn(PROCESS_NAME);
-        MongoDBProcessInstances<?> instance = factory.createProcessInstances(process);
+        MongoDBProcessInstances instance = factory.createProcessInstances(process);
         assertNotNull(instance);
     }
 }

--- a/addons/persistence/mongodb-persistence-addon/src/test/java/org/kie/kogito/mongodb/PersistentProcessInstancesIT.java
+++ b/addons/persistence/mongodb-persistence-addon/src/test/java/org/kie/kogito/mongodb/PersistentProcessInstancesIT.java
@@ -43,12 +43,12 @@ class PersistentProcessInstancesIT extends TestHelper {
         process.setProcessInstancesFactory(new MongoDBProcessInstancesFactory(getMongoClient()));
         process.configure();
 
-        ProcessInstance<BpmnVariables> processInstance = process.createInstance(BpmnVariables.create(Collections.singletonMap("test", "test")));
+        ProcessInstance processInstance = process.createInstance(BpmnVariables.create(Collections.singletonMap("test", "test")));
 
         processInstance.start();
         assertEquals(STATE_ACTIVE, processInstance.status());
 
-        MongoDBProcessInstances<?> mongodbInstance = new MongoDBProcessInstances<>(getMongoClient(), process, DB_NAME);
+        MongoDBProcessInstances mongodbInstance = new MongoDBProcessInstances(getMongoClient(), process, DB_NAME);
 
         assertThat(mongodbInstance.size()).isOne();
         assertThat(mongodbInstance.size()).isEqualTo(process.instances().size());
@@ -62,7 +62,7 @@ class PersistentProcessInstancesIT extends TestHelper {
         assertThat(mongodbInstance.exists(processInstance.id())).isTrue();
         assertThat(mongodbInstance.values().size()).isOne();
 
-        ProcessInstance<?> readOnlyPI = mongodbInstance.findById(processInstance.id(), ProcessInstanceReadMode.READ_ONLY).get();
+        ProcessInstance readOnlyPI = mongodbInstance.findById(processInstance.id(), ProcessInstanceReadMode.READ_ONLY).get();
         assertNotNull(readOnlyPI, "ProcessInstanceDocument cannot be null");
         assertThat(mongodbInstance.values(ProcessInstanceReadMode.READ_ONLY).size()).isOne();
 

--- a/addons/persistence/postgresql-persistence-addon/src/main/java/org/kie/kogito/persistence/KogitoProcessInstancesFactory.java
+++ b/addons/persistence/postgresql-persistence-addon/src/main/java/org/kie/kogito/persistence/KogitoProcessInstancesFactory.java
@@ -46,7 +46,7 @@ public abstract class KogitoProcessInstancesFactory implements ProcessInstancesF
     }
 
     @Override
-    public PostgreProcessInstances createProcessInstances(Process<?> process) {
+    public PostgreProcessInstances createProcessInstances(Process process) {
         return new PostgreProcessInstances(process, client(), autoDDL, queryTimeout);
     }
 }

--- a/addons/persistence/postgresql-persistence-addon/src/main/java/org/kie/kogito/persistence/postgresql/PostgreProcessInstances.java
+++ b/addons/persistence/postgresql-persistence-addon/src/main/java/org/kie/kogito/persistence/postgresql/PostgreProcessInstances.java
@@ -54,13 +54,13 @@ public class PostgreProcessInstances implements MutableProcessInstances {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PostgreProcessInstances.class);
 
-    private final Process<?> process;
+    private final Process process;
     private final PgPool client;
     private final ProcessInstanceMarshallerService marshaller;
     private final boolean autoDDL;
     private final Long queryTimeoutMillis;
 
-    public PostgreProcessInstances(Process<?> process, PgPool client, boolean autoDDL, Long queryTimeoutMillis) {
+    public PostgreProcessInstances(Process process, PgPool client, boolean autoDDL, Long queryTimeoutMillis) {
         this.process = process;
         this.client = client;
         this.autoDDL = autoDDL;
@@ -108,7 +108,7 @@ public class PostgreProcessInstances implements MutableProcessInstances {
 
     private void disconnect(ProcessInstance instance) {
         Supplier<byte[]> supplier = () -> findByIdInternal(UUID.fromString(instance.id())).get();
-        ((AbstractProcessInstance<?>) instance).internalRemoveProcessInstance(marshaller.createdReloadFunction(supplier));
+        ((AbstractProcessInstance) instance).internalRemoveProcessInstance(marshaller.createdReloadFunction(supplier));
     }
 
     private boolean insertInternal(UUID id, byte[] payload) {

--- a/addons/persistence/postgresql-persistence-addon/src/test/java/org/kie/persistence/postgresql/PostgreProcessInstancesIT.java
+++ b/addons/persistence/postgresql-persistence-addon/src/test/java/org/kie/persistence/postgresql/PostgreProcessInstancesIT.java
@@ -27,10 +27,10 @@ import org.kie.kogito.persistence.KogitoProcessInstancesFactory;
 import org.kie.kogito.persistence.postgresql.PostgreProcessInstances;
 import org.kie.kogito.process.Process;
 import org.kie.kogito.process.ProcessConfig;
-import org.kie.kogito.process.ProcessInstance;
 import org.kie.kogito.process.ProcessInstanceReadMode;
 import org.kie.kogito.process.WorkItem;
 import org.kie.kogito.process.bpmn2.BpmnProcess;
+import org.kie.kogito.process.bpmn2.BpmnProcessInstance;
 import org.kie.kogito.process.bpmn2.BpmnVariables;
 import org.kie.kogito.testcontainers.KogitoPostgreSqlContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -82,7 +82,7 @@ class PostgreProcessInstancesIT {
     @Test
     void testBasicFlow() {
         BpmnProcess process = createProcess(null, "BPMN2-UserTask.bpmn2");
-        ProcessInstance<BpmnVariables> processInstance = process.createInstance(BpmnVariables.create(Collections.singletonMap("test", "test")));
+        BpmnProcessInstance processInstance = process.createInstance(BpmnVariables.create(Collections.singletonMap("test", "test")));
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(STATE_ACTIVE);
@@ -93,7 +93,8 @@ class PostgreProcessInstancesIT {
         assertThat(processInstances.exists(processInstance.id())).isTrue();
         verify(processInstances).create(any(), any());
 
-        String testVar = (String) processInstance.variables().get("test");
+        BpmnVariables variables = processInstance.variables();
+        String testVar = (String) variables.get("test");
         assertThat(testVar).isEqualTo("test");
 
         assertThat(processInstance.description()).isEqualTo("User Task");
@@ -120,7 +121,7 @@ class PostgreProcessInstancesIT {
         }
 
         @Override
-        public PostgreProcessInstances createProcessInstances(Process<?> process) {
+        public PostgreProcessInstances createProcessInstances(Process process) {
             PostgreProcessInstances instances = spy(super.createProcessInstances(process));
             return instances;
         }

--- a/addons/predictions/kogito-predictions-api/src/test/java/org/kie/kogito/prediction/api/PredictionAwareHumanTaskLifeCycleTest.java
+++ b/addons/predictions/kogito-predictions-api/src/test/java/org/kie/kogito/prediction/api/PredictionAwareHumanTaskLifeCycleTest.java
@@ -97,7 +97,7 @@ public class PredictionAwareHumanTaskLifeCycleTest {
         BpmnProcess process = BpmnProcess.from(config, new ClassPathResource("BPMN2-UserTask.bpmn2")).get(0);
         process.configure();
 
-        ProcessInstance<BpmnVariables> processInstance = process.createInstance(BpmnVariables.create(Collections.singletonMap("test", "test")));
+        ProcessInstance processInstance = process.createInstance(BpmnVariables.create(Collections.singletonMap("test", "test")));
 
         processInstance.start();
         assertEquals(STATE_COMPLETED, processInstance.status());
@@ -116,7 +116,7 @@ public class PredictionAwareHumanTaskLifeCycleTest {
         BpmnProcess process = BpmnProcess.from(config, new ClassPathResource("BPMN2-UserTask.bpmn2")).get(0);
         process.configure();
 
-        ProcessInstance<BpmnVariables> processInstance = process.createInstance(BpmnVariables.create(Collections.singletonMap("test", "test")));
+        ProcessInstance processInstance = process.createInstance(BpmnVariables.create(Collections.singletonMap("test", "test")));
 
         processInstance.start();
         assertEquals(STATE_ACTIVE, processInstance.status());

--- a/addons/predictions/kogito-predictions-smile-addon/src/test/java/org/kie/kogito/predictions/smile/SmileRandomForestPredictionTest.java
+++ b/addons/predictions/kogito-predictions-smile-addon/src/test/java/org/kie/kogito/predictions/smile/SmileRandomForestPredictionTest.java
@@ -78,7 +78,7 @@ public class SmileRandomForestPredictionTest {
         BpmnProcess process = (BpmnProcess) BpmnProcess.from(config, new ClassPathResource("BPMN2-UserTask.bpmn2")).get(0);
         process.configure();
 
-        ProcessInstance<BpmnVariables> processInstance = process.createInstance(BpmnVariables.create(Collections.singletonMap("test", "test")));
+        ProcessInstance processInstance = process.createInstance(BpmnVariables.create(Collections.singletonMap("test", "test")));
 
         processInstance.start();
         assertEquals(STATE_COMPLETED, processInstance.status());

--- a/addons/process-management/process-management-common/src/main/java/org/kie/kogito/process/management/BaseProcessInstanceManagementResource.java
+++ b/addons/process-management/process-management-common/src/main/java/org/kie/kogito/process/management/BaseProcessInstanceManagementResource.java
@@ -56,7 +56,7 @@ public abstract class BaseProcessInstanceManagementResource<T> implements Proces
 
     public T doGetProcessNodes(String processId) {
         return executeOnProcess(processId, process -> {
-            List<org.kie.api.definition.process.Node> nodes = ((KogitoWorkflowProcess) ((AbstractProcess<?>) process).process()).getNodesRecursively();
+            List<org.kie.api.definition.process.Node> nodes = ((KogitoWorkflowProcess) ((AbstractProcess) process).process()).getNodesRecursively();
             List<Map<String, Object>> list = nodes.stream().map(n -> {
                 Map<String, Object> data = new HashMap<>();
                 data.put("id", n.getId());
@@ -176,20 +176,20 @@ public abstract class BaseProcessInstanceManagementResource<T> implements Proces
     /*
      * Helper methods
      */
-    private T executeOnInstanceInError(String processId, String processInstanceId, Function<ProcessInstance<?>, T> supplier) {
+    private T executeOnInstanceInError(String processId, String processInstanceId, Function<ProcessInstance, T> supplier) {
         if (processId == null || processInstanceId == null) {
             return badRequestResponse(PROCESS_AND_INSTANCE_REQUIRED);
         }
 
-        Process<?> process = processes.processById(processId);
+        Process process = processes.processById(processId);
         if (process == null) {
             return notFoundResponse(String.format(PROCESS_NOT_FOUND, processId));
         }
 
         return UnitOfWorkExecutor.executeInUnitOfWork(application.unitOfWorkManager(), () -> {
-            Optional<? extends ProcessInstance<?>> processInstanceFound = process.instances().findById(processInstanceId);
+            Optional<? extends ProcessInstance> processInstanceFound = process.instances().findById(processInstanceId);
             if (processInstanceFound.isPresent()) {
-                ProcessInstance<?> processInstance = processInstanceFound.get();
+                ProcessInstance processInstance = processInstanceFound.get();
 
                 if (processInstance.error().isPresent()) {
                     return supplier.apply(processInstance);
@@ -202,19 +202,19 @@ public abstract class BaseProcessInstanceManagementResource<T> implements Proces
         });
     }
 
-    private T executeOnProcessInstance(String processId, String processInstanceId, Function<ProcessInstance<?>, T> supplier) {
+    private T executeOnProcessInstance(String processId, String processInstanceId, Function<ProcessInstance, T> supplier) {
         if (processId == null || processInstanceId == null) {
             return badRequestResponse(PROCESS_AND_INSTANCE_REQUIRED);
         }
 
-        Process<?> process = processes.processById(processId);
+        Process process = processes.processById(processId);
         if (process == null) {
             return notFoundResponse(String.format(PROCESS_NOT_FOUND, processId));
         }
         return UnitOfWorkExecutor.executeInUnitOfWork(application.unitOfWorkManager(), () -> {
-            Optional<? extends ProcessInstance<?>> processInstanceFound = process.instances().findById(processInstanceId);
+            Optional<? extends ProcessInstance> processInstanceFound = process.instances().findById(processInstanceId);
             if (processInstanceFound.isPresent()) {
-                ProcessInstance<?> processInstance = processInstanceFound.get();
+                ProcessInstance processInstance = processInstanceFound.get();
 
                 return supplier.apply(processInstance);
             } else {
@@ -223,12 +223,12 @@ public abstract class BaseProcessInstanceManagementResource<T> implements Proces
         });
     }
 
-    private T executeOnProcess(String processId, Function<Process<?>, T> supplier) {
+    private T executeOnProcess(String processId, Function<Process, T> supplier) {
         if (processId == null) {
             return badRequestResponse(PROCESS_REQUIRED);
         }
 
-        Process<?> process = processes.processById(processId);
+        Process process = processes.processById(processId);
         if (process == null) {
             return notFoundResponse(String.format(PROCESS_NOT_FOUND, processId));
         }

--- a/addons/process-management/process-management-common/src/test/java/org/kie/kogito/process/management/BaseProcessInstanceManagementResourceTest.java
+++ b/addons/process-management/process-management-common/src/test/java/org/kie/kogito/process/management/BaseProcessInstanceManagementResourceTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.kie.kogito.Application;
+import org.kie.kogito.Model;
 import org.kie.kogito.auth.SecurityPolicy;
 import org.kie.kogito.internal.process.runtime.KogitoWorkflowProcess;
 import org.kie.kogito.process.ProcessError;
@@ -86,7 +87,7 @@ class BaseProcessInstanceManagementResourceTest {
     private Node node;
 
     @Mock
-    private Object variables;
+    private Model variables;
 
     @BeforeEach
     void setUp() {

--- a/addons/task-management/task-management-common/src/main/java/org/kie/kogito/task/management/service/TaskManagementService.java
+++ b/addons/task-management/task-management-common/src/main/java/org/kie/kogito/task/management/service/TaskManagementService.java
@@ -50,7 +50,7 @@ public class TaskManagementService implements TaskManagementOperations {
             TaskInfo taskInfo,
             boolean shouldReplace,
             Policy<?>... policies) {
-        ProcessInstance<?> pi = getProcessInstance(processId, processInstanceId, taskId);
+        ProcessInstance pi = getProcessInstance(processId, processInstanceId, taskId);
         KogitoWorkItem workItem = UnitOfWorkExecutor.executeInUnitOfWork(processConfig.unitOfWorkManager(),
                 () -> pi.updateWorkItem(taskId,
                         wi -> {
@@ -105,7 +105,7 @@ public class TaskManagementService implements TaskManagementOperations {
                 humanTask.getAdminGroups(), humanTask.getParameters());
     }
 
-    private ProcessInstance<?> getProcessInstance(String processId, String processInstanceId, String taskId) {
+    private ProcessInstance getProcessInstance(String processId, String processInstanceId, String taskId) {
         if (processId == null) {
             throw new IllegalArgumentException("Process id must be given");
         }
@@ -115,7 +115,7 @@ public class TaskManagementService implements TaskManagementOperations {
         if (taskId == null) {
             throw new IllegalArgumentException("Task id must be given");
         }
-        Process<?> process = processes.processById(processId);
+        Process process = processes.processById(processId);
         if (process == null) {
             throw new IllegalArgumentException(String.format("Process with id %s not found", processId));
         }

--- a/api/kogito-api/src/main/java/org/kie/kogito/MappableToModel.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/MappableToModel.java
@@ -15,7 +15,7 @@
  */
 package org.kie.kogito;
 
-public interface MappableToModel<T> extends Model {
+public interface MappableToModel extends Model {
 
-    T toModel();
+    Model toModel();
 }

--- a/api/kogito-api/src/main/java/org/kie/kogito/internal/process/runtime/KogitoProcessRuntime.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/internal/process/runtime/KogitoProcessRuntime.java
@@ -42,7 +42,7 @@ public interface KogitoProcessRuntime {
      * be used is referenced by the given process id.
      *
      * @param processId The id of the process that should be started
-     * @return the <code>ProcessInstance</code> that represents the instance of the process that was started
+     * @return the <code>ProcessInstance that represents the instance of the process that was started
      */
     KogitoProcessInstance startProcess(String processId);
 
@@ -54,7 +54,7 @@ public interface KogitoProcessRuntime {
      *
      * @param processId the id of the process that should be started
      * @param parameters the process variables that should be set when starting the process instance
-     * @return the <code>ProcessInstance</code> that represents the instance of the process that was started
+     * @return the <code>ProcessInstance that represents the instance of the process that was started
      */
     KogitoProcessInstance startProcess(String processId, Map<String, Object> parameters);
 
@@ -68,7 +68,7 @@ public interface KogitoProcessRuntime {
      *
      * @param processId the id of the process that should be started
      * @param parameters the process variables that should be set when creating the process instance
-     * @return the <code>ProcessInstance</code> that represents the instance of the process that was created (but not yet started)
+     * @return the <code>ProcessInstance that represents the instance of the process that was created (but not yet started)
      */
     KogitoProcessInstance createProcessInstance(String processId, Map<String, Object> parameters);
 
@@ -78,7 +78,7 @@ public interface KogitoProcessRuntime {
      *
      * @param processId The id of the process that should be started
      * @param agendaFilter filters the Matches that may fire
-     * @return the <code>ProcessInstance</code> that represents the instance of the process that was started
+     * @return the <code>ProcessInstance that represents the instance of the process that was started
      */
     KogitoProcessInstance startProcess(String processId, AgendaFilter agendaFilter);
 
@@ -91,7 +91,7 @@ public interface KogitoProcessRuntime {
      * @param processId the id of the process that should be started
      * @param parameters the process variables that should be set when starting the process instance
      * @param agendaFilter filters the Matches that may fire
-     * @return the <code>ProcessInstance</code> that represents the instance of the process that was started
+     * @return the <code>ProcessInstance that represents the instance of the process that was started
      */
     KogitoProcessInstance startProcess(String processId, Map<String, Object> parameters, AgendaFilter agendaFilter);
 
@@ -102,7 +102,7 @@ public interface KogitoProcessRuntime {
      * process instance before actually starting it. Otherwise, use startProcess.
      *
      * @param processInstanceId the id of the process instance that needs to be started
-     * @return the <code>ProcessInstance</code> that represents the instance of the process that was started
+     * @return the <code>ProcessInstance that represents the instance of the process that was started
      */
     KogitoProcessInstance startProcessInstance(String processInstanceId);
 
@@ -114,7 +114,7 @@ public interface KogitoProcessRuntime {
      *
      * @param processInstanceId the id of the process instance that needs to be started
      * @param trigger - type of trigger to locate proper start event, can be null
-     * @return the <code>ProcessInstance</code> that represents the instance of the process that was started
+     * @return the <code>ProcessInstance that represents the instance of the process that was started
      */
     KogitoProcessInstance startProcessInstance(String processInstanceId, String trigger);
 

--- a/api/kogito-api/src/main/java/org/kie/kogito/jobs/ProcessJobDescription.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/jobs/ProcessJobDescription.java
@@ -33,7 +33,7 @@ public class ProcessJobDescription implements JobDescription {
 
     private String processId;
 
-    private Process<?> process;
+    private Process process;
 
     private ProcessJobDescription(ExpirationTime expirationTime, Integer priority, String processId) {
         this.id = UUID.randomUUID().toString();
@@ -42,14 +42,14 @@ public class ProcessJobDescription implements JobDescription {
         this.processId = requireNonNull(processId);
     }
 
-    public ProcessJobDescription(ExpirationTime expirationTime, Integer priority, Process<?> process) {
+    public ProcessJobDescription(ExpirationTime expirationTime, Integer priority, Process process) {
         this.id = UUID.randomUUID().toString();
         this.expirationTime = requireNonNull(expirationTime);
         this.priority = requireNonNull(priority);
         this.process = requireNonNull(process);
     }
 
-    public static ProcessJobDescription of(ExpirationTime expirationTime, Process<?> process) {
+    public static ProcessJobDescription of(ExpirationTime expirationTime, Process process) {
         return new ProcessJobDescription(expirationTime, DEFAULT_PRIORITY, process);
     }
 
@@ -81,7 +81,7 @@ public class ProcessJobDescription implements JobDescription {
         return processId;
     }
 
-    public Process<?> process() {
+    public Process process() {
         return process;
     }
 }

--- a/api/kogito-api/src/main/java/org/kie/kogito/process/MutableProcessInstances.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/process/MutableProcessInstances.java
@@ -15,17 +15,17 @@
  */
 package org.kie.kogito.process;
 
-public interface MutableProcessInstances<T> extends ProcessInstances<T> {
+public interface MutableProcessInstances extends ProcessInstances {
 
     boolean exists(String id);
 
-    void create(String id, ProcessInstance<T> instance);
+    void create(String id, ProcessInstance instance);
 
-    void update(String id, ProcessInstance<T> instance);
+    void update(String id, ProcessInstance instance);
 
     void remove(String id);
 
-    default boolean isActive(ProcessInstance<T> instance) {
+    default boolean isActive(ProcessInstance instance) {
         return instance.status() == ProcessInstance.STATE_ACTIVE || instance.status() == ProcessInstance.STATE_ERROR;
     }
 

--- a/api/kogito-api/src/main/java/org/kie/kogito/process/Process.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/process/Process.java
@@ -17,21 +17,17 @@ package org.kie.kogito.process;
 
 import org.kie.kogito.Model;
 
-public interface Process<T> {
+public interface Process {
 
-    ProcessInstance<T> createInstance(T workingMemory);
+    ProcessInstance createInstance(Model workingMemory);
 
-    ProcessInstance<T> createInstance(String businessKey, T workingMemory);
+    ProcessInstance createInstance(String businessKey, Model workingMemory);
 
-    ProcessInstances<T> instances();
+    ProcessInstances instances();
 
     <S> void send(Signal<S> sig);
 
-    T createModel();
-
-    ProcessInstance<? extends Model> createInstance(Model m);
-
-    ProcessInstance<? extends Model> createInstance(String businessKey, Model m);
+    Model createModel();
 
     String id();
 

--- a/api/kogito-api/src/main/java/org/kie/kogito/process/ProcessInstance.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/process/ProcessInstance.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.kie.kogito.Model;
 import org.kie.kogito.internal.process.runtime.KogitoNodeInstance;
 import org.kie.kogito.internal.process.runtime.KogitoWorkItem;
 import org.kie.kogito.process.flexible.AdHocFragment;
@@ -31,7 +32,7 @@ import org.kie.kogito.process.flexible.Milestone;
 import org.kie.kogito.process.workitem.Policy;
 import org.kie.kogito.process.workitem.Transition;
 
-public interface ProcessInstance<T> {
+public interface ProcessInstance {
 
     int STATE_PENDING = 0;
     int STATE_ACTIVE = 1;
@@ -45,7 +46,7 @@ public interface ProcessInstance<T> {
      *
      * @return process definition of this process instance
      */
-    Process<T> process();
+    Process process();
 
     /**
      * Starts process instance
@@ -92,12 +93,12 @@ public interface ProcessInstance<T> {
      *
      * @return variables of the process instance
      */
-    T variables();
+    Model variables();
 
     /**
      * Updates process variables of this process instance
      */
-    T updateVariables(T updates);
+    Model updateVariables(Model updates);
 
     /**
      * Returns current status of this process instance
@@ -201,7 +202,7 @@ public interface ProcessInstance<T> {
      */
     Optional<ProcessError> error();
 
-    default ProcessInstance<T> checkError() {
+    default ProcessInstance checkError() {
         Optional<ProcessError> error = error();
         if (error.isPresent()) {
             throw new ProcessInstanceExecutionException(id(), error.get().failedNodeId(), error.get().errorMessage());

--- a/api/kogito-api/src/main/java/org/kie/kogito/process/ProcessInstances.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/process/ProcessInstances.java
@@ -18,19 +18,19 @@ package org.kie.kogito.process;
 import java.util.Collection;
 import java.util.Optional;
 
-public interface ProcessInstances<T> {
+public interface ProcessInstances {
 
-    default Optional<ProcessInstance<T>> findById(String id) {
+    default Optional<ProcessInstance> findById(String id) {
         return findById(id, ProcessInstanceReadMode.MUTABLE);
     }
 
-    Optional<ProcessInstance<T>> findById(String id, ProcessInstanceReadMode mode);
+    Optional<ProcessInstance> findById(String id, ProcessInstanceReadMode mode);
 
-    default Collection<ProcessInstance<T>> values() {
+    default Collection<ProcessInstance> values() {
         return values(ProcessInstanceReadMode.READ_ONLY);
     }
 
-    Collection<ProcessInstance<T>> values(ProcessInstanceReadMode mode);
+    Collection<ProcessInstance> values(ProcessInstanceReadMode mode);
 
     Integer size();
 }

--- a/api/kogito-api/src/main/java/org/kie/kogito/process/ProcessInstancesFactory.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/process/ProcessInstancesFactory.java
@@ -17,5 +17,5 @@ package org.kie.kogito.process;
 
 public interface ProcessInstancesFactory {
 
-    MutableProcessInstances<?> createProcessInstances(Process<?> process);
+    MutableProcessInstances createProcessInstances(Process process);
 }

--- a/api/kogito-api/src/main/java/org/kie/kogito/process/ProcessService.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/process/ProcessService.java
@@ -22,7 +22,6 @@ import java.util.Optional;
 import java.util.function.Function;
 
 import org.kie.kogito.MapOutput;
-import org.kie.kogito.MappableToModel;
 import org.kie.kogito.Model;
 import org.kie.kogito.process.workitem.Attachment;
 import org.kie.kogito.process.workitem.AttachmentInfo;
@@ -30,25 +29,25 @@ import org.kie.kogito.process.workitem.Comment;
 
 public interface ProcessService {
 
-    <T extends Model> ProcessInstance<T> createProcessInstance(Process<T> process, String businessKey,
-            T model,
+    ProcessInstance createProcessInstance(Process process, String businessKey,
+            Model model,
             String startFromNodeId);
 
-    <T extends MappableToModel<R>, R> List<R> getProcessInstanceOutput(Process<T> process);
+    List<Model> getProcessInstanceOutput(Process process);
 
-    <T extends MappableToModel<R>, R> Optional<R> findById(Process<T> process, String id);
+    Optional<Model> findById(Process process, String id);
 
-    <T extends MappableToModel<R>, R> Optional<R> delete(Process<T> process, String id);
+    Optional<Model> delete(Process process, String id);
 
-    <T extends MappableToModel<R>, R> Optional<R> update(Process<T> process, String id, T resource);
+    Optional<Model> update(Process process, String id, Model resource);
 
-    <T extends Model> Optional<List<WorkItem>> getTasks(Process<T> process, String id, String user, List<String> groups);
+    Optional<List<WorkItem>> getTasks(Process process, String id, String user, List<String> groups);
 
-    <T extends Model> Optional<WorkItem> signalTask(Process<T> process, String id, String taskNodeName, String taskName);
+    Optional<WorkItem> signalTask(Process process, String id, String taskNodeName, String taskName);
 
-    <T extends Model> Optional<WorkItem> getTaskByName(ProcessInstance<T> pi, String taskName);
+    Optional<WorkItem> getTaskByName(ProcessInstance pi, String taskName);
 
-    <T extends MappableToModel<R>, R> Optional<R> completeTask(Process<T> process,
+    Optional<Model> completeTask(Process process,
             String id,
             String taskId,
             String phase,
@@ -56,16 +55,16 @@ public interface ProcessService {
             List<String> groups,
             MapOutput taskModel);
 
-    <T extends Model, R extends MapOutput> Optional<R> saveTask(Process<T> process,
+    Optional<MapOutput> saveTask(Process process,
             String id,
             String taskId,
             String user,
             List<String> groups,
             MapOutput model,
-            Function<Map<String, Object>, R> mapper);
+            Function<Map<String, Object>, MapOutput> mapper);
 
-    <T extends MappableToModel<R>, R> Optional<R> taskTransition(
-            Process<T> process,
+    Optional<Model> taskTransition(
+            Process process,
             String id,
             String taskId,
             String phase,
@@ -73,28 +72,28 @@ public interface ProcessService {
             List<String> groups,
             MapOutput model);
 
-    <T extends MappableToModel<?>, R> Optional<R> getTask(Process<T> process,
+    Optional<Model> getTask(Process process,
             String id,
             String taskId,
             String user,
             List<String> groups,
-            Function<WorkItem, R> mapper);
+            Function<WorkItem, Model> mapper);
 
-    <T extends MappableToModel<R>, R> Optional<R> abortTask(Process<T> process,
+    Optional<Model> abortTask(Process process,
             String id,
             String taskId,
             String phase,
             String user,
             List<String> groups);
 
-    <T extends Model> Optional<Comment> addComment(Process<T> process,
+    Optional<Comment> addComment(Process process,
             String id,
             String taskId,
             String user,
             List<String> groups,
             String commentInfo);
 
-    <T extends Model> Optional<Comment> updateComment(Process<T> process,
+    Optional<Comment> updateComment(Process process,
             String id,
             String taskId,
             String commentId,
@@ -102,21 +101,21 @@ public interface ProcessService {
             List<String> groups,
             String commentInfo);
 
-    <T extends Model> Optional<Boolean> deleteComment(Process<T> process,
+    Optional<Boolean> deleteComment(Process process,
             String id,
             String taskId,
             String commentId,
             String user,
             List<String> groups);
 
-    <T extends Model> Optional<Attachment> addAttachment(Process<T> process,
+    Optional<Attachment> addAttachment(Process process,
             String id,
             String taskId,
             String user,
             List<String> groups,
             AttachmentInfo attachmentInfo);
 
-    <T extends Model> Optional<Attachment> updateAttachment(Process<T> process,
+    Optional<Attachment> updateAttachment(Process process,
             String id,
             String taskId,
             String attachmentId,
@@ -124,43 +123,43 @@ public interface ProcessService {
             List<String> groups,
             AttachmentInfo attachment);
 
-    <T extends Model> Optional<Boolean> deleteAttachment(Process<T> process,
+    Optional<Boolean> deleteAttachment(Process process,
             String id,
             String taskId,
             String attachmentId,
             String user,
             List<String> groups);
 
-    <T extends Model> Optional<Attachment> getAttachment(Process<T> process,
+    Optional<Attachment> getAttachment(Process process,
             String id,
             String taskId,
             String attachmentId,
             String user,
             List<String> groups);
 
-    <T extends Model> Optional<Collection<Attachment>> getAttachments(Process<T> process,
+    Optional<Collection<Attachment>> getAttachments(Process process,
             String id,
             String taskId,
             String user,
             List<String> groups);
 
-    <T extends Model> Optional<Comment> getComment(Process<T> process,
+    Optional<Comment> getComment(Process process,
             String id,
             String taskId,
             String commentId,
             String user,
             List<String> groups);
 
-    <T extends Model> Optional<Collection<Comment>> getComments(Process<T> process,
+    Optional<Collection<Comment>> getComments(Process process,
             String id,
             String taskId,
             String user,
             List<String> groups);
 
-    <T extends MappableToModel<R>, R> Optional<R> signalProcessInstance(Process<T> process, String id, Object data, String signalName);
+    Optional<Model> signalProcessInstance(Process process, String id, Object data, String signalName);
 
     //Schema
-    <T extends Model> Map<String, Object> getSchemaAndPhases(Process<T> process,
+    Map<String, Object> getSchemaAndPhases(Process process,
             String id,
             String taskId,
             String user,

--- a/api/kogito-api/src/main/java/org/kie/kogito/process/ProcessService.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/process/ProcessService.java
@@ -26,6 +26,7 @@ import org.kie.kogito.Model;
 import org.kie.kogito.process.workitem.Attachment;
 import org.kie.kogito.process.workitem.AttachmentInfo;
 import org.kie.kogito.process.workitem.Comment;
+import org.kie.kogito.process.workitem.TaskModel;
 
 public interface ProcessService {
 
@@ -33,13 +34,13 @@ public interface ProcessService {
             Model model,
             String startFromNodeId);
 
-    List<Model> getProcessInstanceOutput(Process process);
+    <T extends Model> List<T> getProcessInstanceOutput(Process process, Class<T> modelType);
 
-    Optional<Model> findById(Process process, String id);
+    <T extends Model> Optional<T> findById(Process process, String id, Class<T> modelType);
 
-    Optional<Model> delete(Process process, String id);
+    <T extends Model> Optional<T> delete(Process process, String id, Class<T> modelType);
 
-    Optional<Model> update(Process process, String id, Model resource);
+    <T extends Model> Optional<T> update(Process process, String id, Model resource, Class<T> modelType);
 
     Optional<List<WorkItem>> getTasks(Process process, String id, String user, List<String> groups);
 
@@ -47,44 +48,47 @@ public interface ProcessService {
 
     Optional<WorkItem> getTaskByName(ProcessInstance pi, String taskName);
 
-    Optional<Model> completeTask(Process process,
+    <T extends Model> Optional<T> completeTask(Process process,
             String id,
             String taskId,
             String phase,
             String user,
             List<String> groups,
-            MapOutput taskModel);
+            MapOutput taskModel,
+            Class<T> modelType);
 
-    Optional<MapOutput> saveTask(Process process,
+    <T extends MapOutput> Optional<T> saveTask(Process process,
             String id,
             String taskId,
             String user,
             List<String> groups,
-            MapOutput model,
-            Function<Map<String, Object>, MapOutput> mapper);
+            T model,
+            Function<Map<String, Object>, T> mapper);
 
-    Optional<Model> taskTransition(
+    <T extends Model> Optional<T> taskTransition(
             Process process,
             String id,
             String taskId,
             String phase,
             String user,
             List<String> groups,
-            MapOutput model);
+            MapOutput model,
+            Class<T> modelType);
 
-    Optional<Model> getTask(Process process,
+    <T extends TaskModel<?, ?>> Optional<T> getTask(Process process,
             String id,
             String taskId,
             String user,
             List<String> groups,
-            Function<WorkItem, Model> mapper);
+            Function<WorkItem, T> mapper);
 
-    Optional<Model> abortTask(Process process,
+    <T extends Model> Optional<T> abortTask(Process process,
             String id,
             String taskId,
             String phase,
             String user,
-            List<String> groups);
+            List<String> groups,
+            Class<T> modelType);
 
     Optional<Comment> addComment(Process process,
             String id,
@@ -156,7 +160,7 @@ public interface ProcessService {
             String user,
             List<String> groups);
 
-    Optional<Model> signalProcessInstance(Process process, String id, Object data, String signalName);
+    <T extends Model> Optional<T> signalProcessInstance(Process process, String id, Object data, String signalName, Class<T> modelType);
 
     //Schema
     Map<String, Object> getSchemaAndPhases(Process process,

--- a/api/kogito-api/src/main/java/org/kie/kogito/process/Processes.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/process/Processes.java
@@ -18,11 +18,10 @@ package org.kie.kogito.process;
 import java.util.Collection;
 
 import org.kie.kogito.KogitoEngine;
-import org.kie.kogito.Model;
 
 public interface Processes extends KogitoEngine {
 
-    Process<? extends Model> processById(String processId);
+    Process processById(String processId);
 
     Collection<String> processIds();
 

--- a/api/kogito-services/src/main/java/org/kie/kogito/services/event/EventConsumer.java
+++ b/api/kogito-services/src/main/java/org/kie/kogito/services/event/EventConsumer.java
@@ -21,6 +21,6 @@ import org.kie.kogito.process.Process;
 
 public interface EventConsumer<T extends Model> {
 
-    void consume(Application application, Process<T> process, Object payload, String trigger);
+    void consume(Application application, Process process, Object payload, String trigger);
 
 }

--- a/api/kogito-services/src/main/java/org/kie/kogito/services/event/impl/AbstractMessageConsumer.java
+++ b/api/kogito-services/src/main/java/org/kie/kogito/services/event/impl/AbstractMessageConsumer.java
@@ -33,7 +33,7 @@ public abstract class AbstractMessageConsumer<M extends Model, D, T extends Abst
 
     private static final Logger logger = LoggerFactory.getLogger(AbstractMessageConsumer.class);
 
-    private Process<M> process;
+    private Process process;
     private Application application;
     private String trigger;
     private EventConsumer<M> eventConsumer;
@@ -45,7 +45,7 @@ public abstract class AbstractMessageConsumer<M extends Model, D, T extends Abst
     }
 
     public AbstractMessageConsumer(Application application,
-            Process<M> process,
+            Process process,
             String trigger,
             EventConsumerFactory eventConsumerFactory,
             EventReceiver eventReceiver,
@@ -56,7 +56,7 @@ public abstract class AbstractMessageConsumer<M extends Model, D, T extends Abst
     }
 
     public void init(Application application,
-            Process<M> process,
+            Process process,
             String trigger,
             EventConsumerFactory eventConsumerFactory,
             EventReceiver eventReceiver,

--- a/api/kogito-services/src/main/java/org/kie/kogito/services/uow/ProcessInstanceWorkUnit.java
+++ b/api/kogito-services/src/main/java/org/kie/kogito/services/uow/ProcessInstanceWorkUnit.java
@@ -20,25 +20,25 @@ import java.util.function.Consumer;
 import org.kie.kogito.process.ProcessInstance;
 import org.kie.kogito.uow.WorkUnit;
 
-public class ProcessInstanceWorkUnit<T> implements WorkUnit<ProcessInstance<T>> {
+public class ProcessInstanceWorkUnit<T> implements WorkUnit<ProcessInstance> {
 
-    private ProcessInstance<T> data;
+    private ProcessInstance data;
     private Consumer<Object> action;
     private Consumer<Object> compensation;
 
-    public ProcessInstanceWorkUnit(ProcessInstance<T> data, Consumer<Object> action) {
+    public ProcessInstanceWorkUnit(ProcessInstance data, Consumer<Object> action) {
         this.data = data;
         this.action = action;
     }
 
-    public ProcessInstanceWorkUnit(ProcessInstance<T> data, Consumer<Object> action, Consumer<Object> compensation) {
+    public ProcessInstanceWorkUnit(ProcessInstance data, Consumer<Object> action, Consumer<Object> compensation) {
         this.data = data;
         this.action = action;
         this.compensation = compensation;
     }
 
     @Override
-    public ProcessInstance<T> data() {
+    public ProcessInstance data() {
         return data;
     }
 

--- a/api/kogito-services/src/main/java/org/kie/services/jobs/impl/InMemoryJobService.java
+++ b/api/kogito-services/src/main/java/org/kie/services/jobs/impl/InMemoryJobService.java
@@ -187,7 +187,7 @@ public class InMemoryJobService implements JobsService {
 
         private Integer limit;
 
-        private StartProcessOnExpiredTimer(String id, org.kie.kogito.process.Process<?> process, boolean removeAtExecution, Integer limit) {
+        private StartProcessOnExpiredTimer(String id, org.kie.kogito.process.Process process, boolean removeAtExecution, Integer limit) {
             this.id = id;
             this.process = process;
             this.removeAtExecution = removeAtExecution;
@@ -200,7 +200,7 @@ public class InMemoryJobService implements JobsService {
             try {
                 LOGGER.debug("Job {} started", id);
                 UnitOfWorkExecutor.executeInUnitOfWork(unitOfWorkManager, () -> {
-                    org.kie.kogito.process.ProcessInstance<?> pi = process.createInstance(process.createModel());
+                    org.kie.kogito.process.ProcessInstance pi = process.createInstance(process.createModel());
                     if (pi != null) {
                         pi.start(TRIGGER, null);
                     }

--- a/integration-tests/integration-tests-kogito-plugin/src/it/integration-tests-kogito-plugin-it/src/test/java/org/acme/travels/PersonProcessTest.java
+++ b/integration-tests/integration-tests-kogito-plugin/src/it/integration-tests-kogito-plugin-it/src/test/java/org/acme/travels/PersonProcessTest.java
@@ -39,7 +39,7 @@ public class PersonProcessTest {
 
     @Inject
     @Named("persons")
-    Process<? extends Model> personProcess;
+    Process personProcess;
 
     @Test
     public void testAdult() {
@@ -49,7 +49,7 @@ public class PersonProcessTest {
         parameters.put("person", new Person("John Doe", 20));
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = personProcess.createInstance(m);
+        ProcessInstance processInstance = personProcess.createInstance(m);
         processInstance.start();
 
         assertEquals(ProcessInstance.STATE_COMPLETED, processInstance.status());
@@ -65,7 +65,7 @@ public class PersonProcessTest {
         parameters.put("person", new Person("Jenny Quark", 14));
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = personProcess.createInstance(m);
+        ProcessInstance processInstance = personProcess.createInstance(m);
         processInstance.start();
 
         assertEquals(ProcessInstance.STATE_ACTIVE, processInstance.status());

--- a/integration-tests/integration-tests-quarkus-norest/src/test/java/org/kie/kogito/quarkus/jbpm/ProcessTest.java
+++ b/integration-tests/integration-tests-quarkus-norest/src/test/java/org/kie/kogito/quarkus/jbpm/ProcessTest.java
@@ -36,7 +36,7 @@ public class ProcessTest {
 
     @Inject
     @Named("tests")
-    Process<? extends Model> process;
+    Process process;
 
     @Test
     public void testProcess() {
@@ -44,7 +44,7 @@ public class ProcessTest {
         Map<String, Object> parameters = new HashMap<>();
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = process.createInstance(m);
+        ProcessInstance processInstance = process.createInstance(m);
         processInstance.start();
         assertEquals(KogitoProcessInstance.STATE_COMPLETED, processInstance.status());
     }

--- a/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-norest-it/src/test/java/org/kie/kogito/spring/jbpm/ProcessTest.java
+++ b/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-norest-it/src/test/java/org/kie/kogito/spring/jbpm/ProcessTest.java
@@ -40,7 +40,7 @@ public class ProcessTest {
 
     @Autowired
     @Qualifier("tests")
-    Process<? extends Model> process;
+    Process process;
 
     @Test
     public void testProcess() {
@@ -48,7 +48,7 @@ public class ProcessTest {
         Map<String, Object> parameters = new HashMap<>();
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = process.createInstance(m);
+        ProcessInstance processInstance = process.createInstance(m);
         processInstance.start();
         assertEquals(KogitoProcessInstance.STATE_COMPLETED, processInstance.status());
     }

--- a/jbpm/jbpm-bpmn2/src/main/java/org/kie/kogito/process/bpmn2/BpmnProcess.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/kie/kogito/process/bpmn2/BpmnProcess.java
@@ -26,10 +26,9 @@ import org.kie.api.io.Resource;
 import org.kie.api.runtime.process.WorkflowProcessInstance;
 import org.kie.kogito.Model;
 import org.kie.kogito.process.ProcessConfig;
-import org.kie.kogito.process.ProcessInstance;
 import org.kie.kogito.process.impl.AbstractProcess;
 
-public class BpmnProcess extends AbstractProcess<BpmnVariables> {
+public class BpmnProcess extends AbstractProcess {
 
     private static BpmnProcessCompiler COMPILER = new BpmnProcessCompiler();
 
@@ -45,37 +44,30 @@ public class BpmnProcess extends AbstractProcess<BpmnVariables> {
     }
 
     @Override
-    public ProcessInstance<BpmnVariables> createInstance(Model m) {
+    public BpmnProcessInstance createInstance(Model m) {
         BpmnVariables variables = createModel();
         variables.fromMap(m.toMap());
         return new BpmnProcessInstance(this, variables, this.createProcessRuntime());
     }
 
-    public ProcessInstance<BpmnVariables> createInstance() {
+    public BpmnProcessInstance createInstance() {
         return new BpmnProcessInstance(this, createModel(), this.createProcessRuntime());
     }
 
     @Override
-    public ProcessInstance<BpmnVariables> createInstance(String businessKey, BpmnVariables variables) {
+    public BpmnProcessInstance createInstance(String businessKey, Model variables) {
         BpmnVariables variablesModel = createModel();
         variablesModel.fromMap(variables.toMap());
         return new BpmnProcessInstance(this, variablesModel, businessKey, this.createProcessRuntime());
     }
 
     @Override
-    public ProcessInstance<BpmnVariables> createInstance(BpmnVariables variables) {
-        BpmnVariables variablesModel = createModel();
-        variablesModel.fromMap(variables.toMap());
-        return new BpmnProcessInstance(this, variablesModel, this.createProcessRuntime());
-    }
-
-    @Override
-    public ProcessInstance<BpmnVariables> createInstance(WorkflowProcessInstance wpi) {
+    public BpmnProcessInstance createInstance(WorkflowProcessInstance wpi) {
         return new BpmnProcessInstance(this, createModel(), this.createProcessRuntime(), wpi);
     }
 
     @Override
-    public ProcessInstance<BpmnVariables> createReadOnlyInstance(WorkflowProcessInstance wpi) {
+    public BpmnProcessInstance createReadOnlyInstance(WorkflowProcessInstance wpi) {
         return new BpmnProcessInstance(this, createModel(), wpi);
     }
 

--- a/jbpm/jbpm-bpmn2/src/main/java/org/kie/kogito/process/bpmn2/BpmnProcessInstance.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/kie/kogito/process/bpmn2/BpmnProcessInstance.java
@@ -19,29 +19,35 @@ import java.util.Map;
 
 import org.jbpm.process.instance.InternalProcessRuntime;
 import org.kie.api.runtime.process.WorkflowProcessInstance;
+import org.kie.kogito.Model;
 import org.kie.kogito.process.impl.AbstractProcess;
 import org.kie.kogito.process.impl.AbstractProcessInstance;
 
-public class BpmnProcessInstance extends AbstractProcessInstance<BpmnVariables> {
+public class BpmnProcessInstance extends AbstractProcessInstance {
 
-    public BpmnProcessInstance(AbstractProcess<BpmnVariables> process, BpmnVariables variables, InternalProcessRuntime rt) {
+    public BpmnProcessInstance(AbstractProcess process, BpmnVariables variables, InternalProcessRuntime rt) {
         super(process, variables, rt);
     }
 
-    public BpmnProcessInstance(AbstractProcess<BpmnVariables> process, BpmnVariables variables, WorkflowProcessInstance wpi) {
+    public BpmnProcessInstance(AbstractProcess process, BpmnVariables variables, WorkflowProcessInstance wpi) {
         super(process, variables, wpi);
     }
 
-    public BpmnProcessInstance(AbstractProcess<BpmnVariables> process, BpmnVariables variables, InternalProcessRuntime rt, WorkflowProcessInstance wpi) {
+    public BpmnProcessInstance(AbstractProcess process, BpmnVariables variables, InternalProcessRuntime rt, WorkflowProcessInstance wpi) {
         super(process, variables, rt, wpi);
     }
 
-    public BpmnProcessInstance(AbstractProcess<BpmnVariables> process, BpmnVariables variables, String businessKey, InternalProcessRuntime rt) {
+    public BpmnProcessInstance(AbstractProcess process, BpmnVariables variables, String businessKey, InternalProcessRuntime rt) {
         super(process, variables, businessKey, rt);
     }
 
     @Override
-    protected Map<String, Object> bind(BpmnVariables variables) {
+    public BpmnVariables variables() {
+        return (BpmnVariables) super.variables();
+    }
+
+    @Override
+    protected Map<String, Object> bind(Model variables) {
         if (variables == null) {
             return null;
         }
@@ -49,7 +55,7 @@ public class BpmnProcessInstance extends AbstractProcessInstance<BpmnVariables> 
     }
 
     @Override
-    protected void unbind(BpmnVariables variables, Map<String, Object> vmap) {
+    protected void unbind(Model variables, Map<String, Object> vmap) {
         if (variables == null || vmap == null) {
             return;
         }

--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/VariableTagsTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/VariableTagsTest.java
@@ -118,16 +118,17 @@ public class VariableTagsTest extends JbpmBpmn2TestCase {
         Map<String, Object> params = new HashMap<>();
         params.put("approver", "john");
 
-        org.kie.kogito.process.ProcessInstance<BpmnVariables> instance = process.createInstance(BpmnVariables.create(params));
+        org.kie.kogito.process.ProcessInstance instance = process.createInstance(BpmnVariables.create(params));
         instance.start();
 
         assertEquals(STATE_ACTIVE, instance.status());
 
-        assertThat(instance.variables().toMap()).hasSize(1);
-        assertThat(instance.variables().toMap(BpmnVariables.OUTPUTS_ONLY)).hasSize(0);
-        assertThat(instance.variables().toMap(BpmnVariables.INPUTS_ONLY)).hasSize(0);
-        assertThat(instance.variables().toMap(BpmnVariables.INTERNAL_ONLY)).hasSize(0);
-        assertThat(instance.variables().toMap(v -> v.hasTag("onlyAdmin"))).hasSize(1).containsEntry("approver", "john");
+        BpmnVariables variables = (BpmnVariables) instance.variables();
+        assertThat(variables.toMap()).hasSize(1);
+        assertThat(variables.toMap(BpmnVariables.OUTPUTS_ONLY)).hasSize(0);
+        assertThat(variables.toMap(BpmnVariables.INPUTS_ONLY)).hasSize(0);
+        assertThat(variables.toMap(BpmnVariables.INTERNAL_ONLY)).hasSize(0);
+        assertThat(variables.toMap(v -> v.hasTag("onlyAdmin"))).hasSize(1).containsEntry("approver", "john");
 
         instance.abort();
 

--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/canonical/ActivityGenerationModelTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/canonical/ActivityGenerationModelTest.java
@@ -82,7 +82,7 @@ public class ActivityGenerationModelTest extends JbpmBpmn2TestCase {
         classData.put("com.sample.MinimalProcess", content);
 
         Map<String, BpmnProcess> processes = createProcesses(classData, Collections.emptyMap());
-        ProcessInstance<BpmnVariables> processInstance = processes.get("Minimal").createInstance();
+        ProcessInstance processInstance = processes.get("Minimal").createInstance();
 
         processInstance.start();
 
@@ -128,7 +128,7 @@ public class ActivityGenerationModelTest extends JbpmBpmn2TestCase {
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
 
         Map<String, BpmnProcess> processes = createProcesses(classData, Collections.singletonMap("Human Task", workItemHandler));
-        ProcessInstance<BpmnVariables> processInstance = processes.get("UserTask").createInstance();
+        ProcessInstance processInstance = processes.get("UserTask").createInstance();
 
         processInstance.start();
         assertEquals(STATE_ACTIVE, processInstance.status());
@@ -155,7 +155,7 @@ public class ActivityGenerationModelTest extends JbpmBpmn2TestCase {
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
 
         Map<String, BpmnProcess> processes = createProcesses(classData, Collections.singletonMap("Human Task", workItemHandler));
-        ProcessInstance<BpmnVariables> processInstance = processes.get("UserTask").createInstance();
+        ProcessInstance processInstance = processes.get("UserTask").createInstance();
 
         processInstance.start();
         assertEquals(STATE_ACTIVE, processInstance.status());
@@ -180,7 +180,7 @@ public class ActivityGenerationModelTest extends JbpmBpmn2TestCase {
         classData.put("org.drools.bpmn2.SubProcessProcess", content);
 
         Map<String, BpmnProcess> processes = createProcesses(classData, Collections.emptyMap());
-        ProcessInstance<BpmnVariables> processInstance = processes.get("SubProcess").createInstance();
+        ProcessInstance processInstance = processes.get("SubProcess").createInstance();
 
         processInstance.start();
 
@@ -205,7 +205,7 @@ public class ActivityGenerationModelTest extends JbpmBpmn2TestCase {
         Map<String, Object> params = new HashMap<String, Object>();
         params.put("x", "First");
         params.put("y", "Second");
-        ProcessInstance<BpmnVariables> processInstance = processes.get("com.sample.test").createInstance(BpmnVariables.create(params));
+        ProcessInstance processInstance = processes.get("com.sample.test").createInstance(BpmnVariables.create(params));
 
         processInstance.start();
 
@@ -231,7 +231,7 @@ public class ActivityGenerationModelTest extends JbpmBpmn2TestCase {
         Map<String, Object> params = new HashMap<String, Object>();
         params.put("x", "First1");
         params.put("y", "Second1");
-        ProcessInstance<BpmnVariables> processInstance = processes.get("com.sample.test").createInstance(BpmnVariables.create(params));
+        ProcessInstance processInstance = processes.get("com.sample.test").createInstance(BpmnVariables.create(params));
 
         processInstance.start();
 
@@ -266,7 +266,7 @@ public class ActivityGenerationModelTest extends JbpmBpmn2TestCase {
         Map<String, BpmnProcess> processes = createProcesses(classData, Collections.emptyMap());
         Map<String, Object> params = new HashMap<String, Object>();
         params.put("x", 15);
-        ProcessInstance<BpmnVariables> processInstance = processes.get("com.sample.test").createInstance(BpmnVariables.create(params));
+        ProcessInstance processInstance = processes.get("com.sample.test").createInstance(BpmnVariables.create(params));
 
         processInstance.start();
 
@@ -289,7 +289,7 @@ public class ActivityGenerationModelTest extends JbpmBpmn2TestCase {
         Map<String, BpmnProcess> processes = createProcesses(classData, Collections.emptyMap());
         Map<String, Object> params = new HashMap<String, Object>();
         params.put("test", "c");
-        ProcessInstance<BpmnVariables> processInstance = processes.get("InclusiveGatewayWithDefault").createInstance(BpmnVariables.create(params));
+        ProcessInstance processInstance = processes.get("InclusiveGatewayWithDefault").createInstance(BpmnVariables.create(params));
 
         processInstance.start();
 
@@ -311,7 +311,7 @@ public class ActivityGenerationModelTest extends JbpmBpmn2TestCase {
 
         Map<String, BpmnProcess> processes = createProcesses(classData, Collections.emptyMap());
         Map<String, Object> params = new HashMap<String, Object>();
-        ProcessInstance<BpmnVariables> processInstance = processes.get("com.sample.test").createInstance(BpmnVariables.create(params));
+        ProcessInstance processInstance = processes.get("com.sample.test").createInstance(BpmnVariables.create(params));
 
         processInstance.start();
 
@@ -334,7 +334,7 @@ public class ActivityGenerationModelTest extends JbpmBpmn2TestCase {
         Map<String, Object> params = new HashMap<String, Object>();
         params.put("x", 15);
         Map<String, BpmnProcess> processes = createProcesses(classData, Collections.singletonMap("Human Task", workItemHandler));
-        ProcessInstance<BpmnVariables> processInstance = processes.get("com.sample.test").createInstance(BpmnVariables.create(params));
+        ProcessInstance processInstance = processes.get("com.sample.test").createInstance(BpmnVariables.create(params));
 
         processInstance.start();
         assertEquals(STATE_ACTIVE, processInstance.status());
@@ -374,12 +374,12 @@ public class ActivityGenerationModelTest extends JbpmBpmn2TestCase {
         Map<String, Object> params = new HashMap<String, Object>();
         params.put("x", 15);
         Map<String, BpmnProcess> processes = createProcesses(classData, Collections.singletonMap("Human Task", workItemHandler));
-        ProcessInstance<BpmnVariables> processInstance = processes.get("com.sample.test").createInstance(businessKey, BpmnVariables.create(params));
+        ProcessInstance processInstance = processes.get("com.sample.test").createInstance(businessKey, BpmnVariables.create(params));
 
         processInstance.start();
         assertEquals(STATE_ACTIVE, processInstance.status());
 
-        ProcessInstance<BpmnVariables> loadedProcessInstance = processes.get("com.sample.test").instances().findById(processInstance.id()).orElse(null);
+        ProcessInstance loadedProcessInstance = processes.get("com.sample.test").instances().findById(processInstance.id()).orElse(null);
         assertThat(loadedProcessInstance).isNotNull();
         assertThat(loadedProcessInstance.businessKey()).isEqualTo(businessKey);
 
@@ -405,7 +405,7 @@ public class ActivityGenerationModelTest extends JbpmBpmn2TestCase {
         Map<String, Object> params = new HashMap<String, Object>();
         params.put("s", "john");
         Map<String, BpmnProcess> processes = createProcesses(classData, Collections.singletonMap("org.jbpm.bpmn2.objects.HelloService_hello_2_Handler", workItemHandler));
-        ProcessInstance<BpmnVariables> processInstance = processes.get("ServiceProcess").createInstance(BpmnVariables.create(params));
+        ProcessInstance processInstance = processes.get("ServiceProcess").createInstance(BpmnVariables.create(params));
 
         processInstance.start();
         assertEquals(STATE_ACTIVE, processInstance.status());
@@ -459,7 +459,7 @@ public class ActivityGenerationModelTest extends JbpmBpmn2TestCase {
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
 
         Map<String, BpmnProcess> processes = createProcesses(classData, Collections.singletonMap("Human Task", workItemHandler));
-        ProcessInstance<BpmnVariables> processInstance = processes.get("UserTask").createInstance(BpmnVariables.create(Collections.singletonMap("s", "test")));
+        ProcessInstance processInstance = processes.get("UserTask").createInstance(BpmnVariables.create(Collections.singletonMap("s", "test")));
 
         processInstance.start();
         assertEquals(STATE_ACTIVE, processInstance.status());
@@ -469,7 +469,7 @@ public class ActivityGenerationModelTest extends JbpmBpmn2TestCase {
         byte[] data = marshaller.marshallProcessInstance(processInstance);
         assertNotNull(data);
 
-        processInstance = (ProcessInstance<BpmnVariables>) marshaller.unmarshallProcessInstance(data, process);
+        processInstance = (ProcessInstance) marshaller.unmarshallProcessInstance(data, process);
 
         KogitoWorkItem workItem = workItemHandler.getWorkItem();
         assertNotNull(workItem);

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/XmlProcessReader.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/XmlProcessReader.java
@@ -79,7 +79,7 @@ public class XmlProcessReader {
     }
 
     /**
-     * Read a <code>Process</code> from a <code>Reader</code>.
+     * Read a <code>Process from a <code>Reader</code>.
      *
      * @param reader
      *        The reader containing the rule-set.
@@ -93,7 +93,7 @@ public class XmlProcessReader {
     }
 
     /**
-     * Read a <code>Process</code> from an <code>InputStream</code>.
+     * Read a <code>Process from an <code>InputStream</code>.
      *
      * @param inputStream
      *        The input-stream containing the rule-set.
@@ -107,7 +107,7 @@ public class XmlProcessReader {
     }
 
     /**
-     * Read a <code>Process</code> from an <code>InputSource</code>.
+     * Read a <code>Process from an <code>InputSource</code>.
      *
      * @param in
      *        The rule-set input-source.

--- a/jbpm/jbpm-flow-builder/src/main/resources/class-templates/ModelNoIDTemplate.java
+++ b/jbpm/jbpm-flow-builder/src/main/resources/class-templates/ModelNoIDTemplate.java
@@ -22,7 +22,7 @@ import org.kie.kogito.MappableToModel;
 import org.kie.kogito.Model;
 
 public class XXXModel implements Model,
-                                 MappableToModel<$modelClass$> {
+                                 MappableToModel {
     
     @Override
     public Map<String, Object> toMap() {

--- a/jbpm/jbpm-flow-builder/src/main/resources/class-templates/ModelTemplate.java
+++ b/jbpm/jbpm-flow-builder/src/main/resources/class-templates/ModelTemplate.java
@@ -22,7 +22,7 @@ import org.kie.kogito.MappableToModel;
 import org.kie.kogito.Model;
 
 public class XXXModel implements Model,
-                                 MappableToModel<$modelClass$> {
+                                 MappableToModel {
     
     private String id;
 

--- a/jbpm/jbpm-flow-builder/src/main/resources/class-templates/SubProcessFactoryTemplate.java
+++ b/jbpm/jbpm-flow-builder/src/main/resources/class-templates/SubProcessFactoryTemplate.java
@@ -18,7 +18,7 @@ class Template {
         public $Type$ bind(org.kie.api.runtime.process.ProcessContext kcontext) {
             return null;
         }
-        public org.kie.kogito.process.ProcessInstance<$Type$> createInstance($Type$ model) {
+        public org.kie.kogito.process.ProcessInstance createInstance($Type$ model) {
             return null;
         }
         public void unbind(org.kie.api.runtime.process.ProcessContext kcontext, $Type$ model) {

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/humantask/HumanTaskHelper.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/humantask/HumanTaskHelper.java
@@ -112,7 +112,7 @@ public class HumanTaskHelper {
         return attachments.remove(id) != null;
     }
 
-    public static HumanTaskWorkItem findTask(ProcessInstance<?> pi, String taskId, Policy<?>... policies) {
+    public static HumanTaskWorkItem findTask(ProcessInstance pi, String taskId, Policy<?>... policies) {
         return pi.findNodes(ni -> isSearchWorkItem(ni, taskId,
                 policies)).stream().findFirst().map(wi -> (HumanTaskWorkItem) ((WorkItemNodeInstance) wi).getWorkItem())
                 .orElseThrow(() -> new WorkItemNotFoundException(taskId));

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/util/JsonSchemaUtil.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/util/JsonSchemaUtil.java
@@ -72,7 +72,7 @@ public class JsonSchemaUtil {
         });
     }
 
-    public static <T> Map<String, Object> addPhases(Process<T> process,
+    public static <T> Map<String, Object> addPhases(Process process,
             KogitoWorkItemHandler workItemHandler,
             String processInstanceId,
             String workItemId,

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/SubProcessFactory.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/SubProcessFactory.java
@@ -21,7 +21,7 @@ import org.kie.kogito.process.ProcessInstance;
 public interface SubProcessFactory<T> {
     T bind(ProcessContext ctx);
 
-    ProcessInstance<T> createInstance(T model);
+    ProcessInstance createInstance(T model);
 
     void unbind(ProcessContext ctx, T model);
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/LambdaSubProcessNodeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/LambdaSubProcessNodeInstance.java
@@ -81,9 +81,9 @@ public class LambdaSubProcessNodeInstance extends StateBasedNodeInstance impleme
         context.setNodeInstance(this);
         SubProcessFactory subProcessFactory = getSubProcessNode().getSubProcessFactory();
         Object o = subProcessFactory.bind(context);
-        org.kie.kogito.process.ProcessInstance<?> processInstance = subProcessFactory.createInstance(o);
+        org.kie.kogito.process.ProcessInstance processInstance = subProcessFactory.createInstance(o);
 
-        org.kie.api.runtime.process.ProcessInstance pi = ((AbstractProcessInstance<?>) processInstance).internalGetProcessInstance();
+        org.kie.api.runtime.process.ProcessInstance pi = ((AbstractProcessInstance) processInstance).internalGetProcessInstance();
         ((ProcessInstanceImpl) pi).setMetaData("ParentProcessInstanceId", getProcessInstance().getStringId());
         ((ProcessInstanceImpl) pi).setMetaData("ParentNodeInstanceId", getUniqueId());
         ((ProcessInstanceImpl) pi).setMetaData("ParentNodeId", getSubProcessNode().getUniqueId());
@@ -193,7 +193,7 @@ public class LambdaSubProcessNodeInstance extends StateBasedNodeInstance impleme
         SubProcessFactory subProcessFactory = getSubProcessNode().getSubProcessFactory();
         KogitoProcessContextImpl context = new KogitoProcessContextImpl(getProcessInstance().getKnowledgeRuntime());
         context.setNodeInstance(this);
-        org.kie.kogito.process.ProcessInstance<?> pi = ((org.kie.kogito.process.ProcessInstance<?>) processInstance.getMetaData().get("KogitoProcessInstance"));
+        org.kie.kogito.process.ProcessInstance pi = ((org.kie.kogito.process.ProcessInstance) processInstance.getMetaData().get("KogitoProcessInstance"));
         if (pi != null) {
             subProcessFactory.unbind(context, pi.variables());
         }

--- a/jbpm/jbpm-flow/src/main/java/org/kie/kogito/event/impl/CloudEventConsumer.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/kogito/event/impl/CloudEventConsumer.java
@@ -40,7 +40,7 @@ public class CloudEventConsumer<D, M extends Model, T extends AbstractProcessDat
     }
 
     @Override
-    public void consume(Application application, Process<M> process, Object object, String trigger) {
+    public void consume(Application application, Process process, Object object, String trigger) {
         T cloudEvent = (T) object;
         M model = function.apply(cloudEvent.getData());
         String simpleName = cloudEvent.getClass().getSimpleName();
@@ -58,7 +58,7 @@ public class CloudEventConsumer<D, M extends Model, T extends AbstractProcessDat
                 logger.debug("Received message with reference id '{}' going to use it to send signal '{}'",
                         cloudEvent.getKogitoReferenceId(),
                         trigger);
-                Optional<ProcessInstance<M>> instance = process.instances().findById(cloudEvent.getKogitoReferenceId());
+                Optional<ProcessInstance> instance = process.instances().findById(cloudEvent.getKogitoReferenceId());
                 if (instance.isPresent()) {
                     instance.get().send(Sig.of("Message-" + trigger,
                             cloudEvent.getData(),
@@ -71,7 +71,7 @@ public class CloudEventConsumer<D, M extends Model, T extends AbstractProcessDat
             } else {
                 logger.debug("Received message without reference id, starting new process instance with trigger '{}'",
                         trigger);
-                ProcessInstance<M> pi = process.createInstance(model);
+                ProcessInstance pi = process.createInstance(model);
                 if (cloudEvent.getKogitoStartFromNode() != null && !cloudEvent.getKogitoStartFromNode().isEmpty()) {
                     pi.startFrom(cloudEvent.getKogitoStartFromNode(), cloudEvent.getKogitoProcessinstanceId());
                 } else {

--- a/jbpm/jbpm-flow/src/main/java/org/kie/kogito/event/impl/DataEventConsumer.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/kogito/event/impl/DataEventConsumer.java
@@ -37,13 +37,13 @@ public class DataEventConsumer<D, M extends Model> implements EventConsumer<M> {
     }
 
     @Override
-    public void consume(Application application, Process<M> process, Object eventData, String trigger) {
+    public void consume(Application application, Process process, Object eventData, String trigger) {
         M model = function.apply((D) eventData);
         UnitOfWorkExecutor.executeInUnitOfWork(application.unitOfWorkManager(), () -> {
             logger.debug(
                     "Received message without reference id, staring new process instance with trigger '{}'",
                     trigger);
-            ProcessInstance<M> pi = process.createInstance(model);
+            ProcessInstance pi = process.createInstance(model);
             pi.start(trigger, null);
             return null;
         });

--- a/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/MapProcessInstances.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/MapProcessInstances.java
@@ -24,9 +24,9 @@ import org.kie.kogito.process.ProcessInstance;
 import org.kie.kogito.process.ProcessInstanceDuplicatedException;
 import org.kie.kogito.process.ProcessInstanceReadMode;
 
-class MapProcessInstances<T> implements MutableProcessInstances<T> {
+class MapProcessInstances implements MutableProcessInstances {
 
-    private final ConcurrentHashMap<String, ProcessInstance<T>> instances = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, ProcessInstance> instances = new ConcurrentHashMap<>();
 
     @Override
     public Integer size() {
@@ -34,19 +34,19 @@ class MapProcessInstances<T> implements MutableProcessInstances<T> {
     }
 
     @Override
-    public Optional<ProcessInstance<T>> findById(String id, ProcessInstanceReadMode mode) {
+    public Optional<ProcessInstance> findById(String id, ProcessInstanceReadMode mode) {
         return Optional.ofNullable(instances.get(id));
     }
 
     @Override
-    public Collection<ProcessInstance<T>> values(ProcessInstanceReadMode mode) {
+    public Collection<ProcessInstance> values(ProcessInstanceReadMode mode) {
         return instances.values();
     }
 
     @Override
-    public void create(String id, ProcessInstance<T> instance) {
+    public void create(String id, ProcessInstance instance) {
         if (isActive(instance)) {
-            ProcessInstance<T> existing = instances.putIfAbsent(id, instance);
+            ProcessInstance existing = instances.putIfAbsent(id, instance);
             if (existing != null) {
                 throw new ProcessInstanceDuplicatedException(id);
             }
@@ -54,7 +54,7 @@ class MapProcessInstances<T> implements MutableProcessInstances<T> {
     }
 
     @Override
-    public void update(String id, ProcessInstance<T> instance) {
+    public void update(String id, ProcessInstance instance) {
         if (isActive(instance)) {
             instances.put(id, instance);
         }

--- a/jbpm/jbpm-flow/src/test/java/org/jbpm/util/JsonSchemaUtilTest.java
+++ b/jbpm/jbpm-flow/src/test/java/org/jbpm/util/JsonSchemaUtilTest.java
@@ -106,10 +106,10 @@ public class JsonSchemaUtilTest {
         Policy<T>[] policies = new Policy[0];
         Map<String, Object> schemaMap = JsonSchemaUtil.load(in);
         in.close();
-        Process<T> process = mock(Process.class);
-        ProcessInstances<T> processInstances = mock(ProcessInstances.class);
+        Process process = mock(Process.class);
+        ProcessInstances processInstances = mock(ProcessInstances.class);
         when(process.instances()).thenReturn(processInstances);
-        ProcessInstance<T> processInstance = mock(ProcessInstance.class);
+        ProcessInstance processInstance = mock(ProcessInstance.class);
         when(processInstances.findById("pepe", ProcessInstanceReadMode.READ_ONLY)).thenReturn((Optional) Optional.of(processInstance));
         WorkItem task = mock(WorkItem.class);
         when(processInstance.workItem("task", policies)).thenReturn(task);

--- a/jbpm/jbpm-flow/src/test/java/org/kie/kogito/event/impl/EventImplTest.java
+++ b/jbpm/jbpm-flow/src/test/java/org/kie/kogito/event/impl/EventImplTest.java
@@ -113,9 +113,9 @@ public class EventImplTest {
         marshaller = new DefaultEventMarshaller();
     }
 
-    private Process<DummyModel> process;
-    private ProcessInstance<DummyModel> processInstance;
-    private ProcessInstances<DummyModel> processInstances;
+    private Process process;
+    private ProcessInstance processInstance;
+    private ProcessInstances processInstances;
     private Application application;
 
     @BeforeEach

--- a/jbpm/jbpm-flow/src/test/java/org/kie/kogito/process/impl/AbstractProcessInstanceTest.java
+++ b/jbpm/jbpm-flow/src/test/java/org/kie/kogito/process/impl/AbstractProcessInstanceTest.java
@@ -57,14 +57,14 @@ public class AbstractProcessInstanceTest {
     @Mock
     private UnitOfWork unitOfWork;
 
-    private AbstractProcessInstance<TestModel> processInstance;
+    private AbstractProcessInstance processInstance;
 
     @SuppressWarnings("unchecked")
     @BeforeEach
     private void setup() {
         MockitoAnnotations.initMocks(this);
 
-        AbstractProcess<TestModel> process = mock(AbstractProcess.class);
+        AbstractProcess process = mock(AbstractProcess.class);
         when(process.process()).thenReturn(mock(Process.class));
         InternalProcessRuntime pr = mock(InternalProcessRuntime.class);
         when(pr.createProcessInstance(any(), any(), any())).thenReturn(wpi);
@@ -120,9 +120,9 @@ public class AbstractProcessInstanceTest {
         return nodeInstance;
     }
 
-    static class TestProcessInstance extends AbstractProcessInstance<TestModel> {
+    static class TestProcessInstance extends AbstractProcessInstance {
 
-        public TestProcessInstance(AbstractProcess<TestModel> process, TestModel variables, InternalProcessRuntime rt) {
+        public TestProcessInstance(AbstractProcess process, TestModel variables, InternalProcessRuntime rt) {
             super(process, variables, rt);
         }
     }

--- a/jbpm/process-serialization-protobuf/src/main/java/org/kie/kogito/serialization/process/MarshallerContextName.java
+++ b/jbpm/process-serialization-protobuf/src/main/java/org/kie/kogito/serialization/process/MarshallerContextName.java
@@ -21,7 +21,7 @@ public final class MarshallerContextName<T> {
 
     public static final MarshallerContextName<ObjectMarshallerStrategy[]> OBJECT_MARSHALLING_STRATEGIES = new MarshallerContextName<>("OBJECT_MARSHALLING_STRATEGIES");
     public static final MarshallerContextName<String> MARSHALLER_FORMAT = new MarshallerContextName<>("FORMAT");
-    public static final MarshallerContextName<Process<?>> MARSHALLER_PROCESS = new MarshallerContextName<>("PROCESS");
+    public static final MarshallerContextName<Process> MARSHALLER_PROCESS = new MarshallerContextName<>("PROCESS");
     public static final MarshallerContextName<Boolean> MARSHALLER_INSTANCE_READ_ONLY = new MarshallerContextName<>("READ_ONLY");
 
     private String name;

--- a/jbpm/process-serialization-protobuf/src/main/java/org/kie/kogito/serialization/process/ProcessInstanceMarshaller.java
+++ b/jbpm/process-serialization-protobuf/src/main/java/org/kie/kogito/serialization/process/ProcessInstanceMarshaller.java
@@ -31,10 +31,10 @@ import org.kie.kogito.process.ProcessInstance;
 
 public interface ProcessInstanceMarshaller {
 
-    void writeProcessInstance(MarshallerWriterContext context, ProcessInstance<?> processInstance) throws IOException;
+    void writeProcessInstance(MarshallerWriterContext context, ProcessInstance processInstance) throws IOException;
 
-    ProcessInstance<?> readProcessInstance(MarshallerReaderContext context) throws IOException;
+    ProcessInstance readProcessInstance(MarshallerReaderContext context) throws IOException;
 
-    void reloadProcessInstance(MarshallerReaderContext context, ProcessInstance<?> processInstance) throws IOException;
+    void reloadProcessInstance(MarshallerReaderContext context, ProcessInstance processInstance) throws IOException;
 
 }

--- a/jbpm/process-serialization-protobuf/src/main/java/org/kie/kogito/serialization/process/ProcessInstanceMarshallerService.java
+++ b/jbpm/process-serialization-protobuf/src/main/java/org/kie/kogito/serialization/process/ProcessInstanceMarshallerService.java
@@ -100,7 +100,7 @@ public class ProcessInstanceMarshallerService {
         }
     }
 
-    public byte[] marshallProcessInstance(ProcessInstance<?> processInstance) {
+    public byte[] marshallProcessInstance(ProcessInstance processInstance) {
         try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
             MarshallerWriterContext context = processInstanceMarshallerFactory.newWriterContext(baos);
             setupEnvironment(context);
@@ -112,28 +112,28 @@ public class ProcessInstanceMarshallerService {
         }
     }
 
-    public ProcessInstance<?> unmarshallProcessInstance(byte[] data, Process<?> process, boolean readOnly) {
+    public ProcessInstance unmarshallProcessInstance(byte[] data, Process process, boolean readOnly) {
         try (ByteArrayInputStream bais = new ByteArrayInputStream(data)) {
             MarshallerReaderContext context = processInstanceMarshallerFactory.newReaderContext(bais);
             context.set(MarshallerContextName.MARSHALLER_PROCESS, process);
             context.set(MarshallerContextName.MARSHALLER_INSTANCE_READ_ONLY, readOnly);
             setupEnvironment(context);
             org.kie.kogito.serialization.process.ProcessInstanceMarshaller marshaller = processInstanceMarshallerFactory.newKogitoProcessInstanceMarshaller();
-            return (ProcessInstance<?>) marshaller.readProcessInstance(context);
+            return (ProcessInstance) marshaller.readProcessInstance(context);
         } catch (Exception e) {
             throw new ProcessInstanceMarshallerException("Error while unmarshalling process instance", e);
         }
     }
 
-    public ProcessInstance<?> unmarshallProcessInstance(byte[] data, Process<?> process) {
+    public ProcessInstance unmarshallProcessInstance(byte[] data, Process process) {
         return unmarshallProcessInstance(data, process, false);
     }
 
-    public ProcessInstance<?> unmarshallReadOnlyProcessInstance(byte[] data, Process<?> process) {
+    public ProcessInstance unmarshallReadOnlyProcessInstance(byte[] data, Process process) {
         return unmarshallProcessInstance(data, process, true);
     }
 
-    public Consumer<AbstractProcessInstance<?>> createdReloadFunction(Supplier<byte[]> dataSupplier) {
+    public Consumer<AbstractProcessInstance> createdReloadFunction(Supplier<byte[]> dataSupplier) {
         return (processInstance) -> {
             byte[] data = dataSupplier.get();
             if (data == null) {

--- a/jbpm/process-serialization-protobuf/src/main/java/org/kie/kogito/serialization/process/impl/ProtobufProcessInstanceMarshaller.java
+++ b/jbpm/process-serialization-protobuf/src/main/java/org/kie/kogito/serialization/process/impl/ProtobufProcessInstanceMarshaller.java
@@ -33,25 +33,25 @@ import org.kie.kogito.serialization.process.ProcessInstanceMarshaller;
 public class ProtobufProcessInstanceMarshaller implements ProcessInstanceMarshaller {
 
     @Override
-    public void writeProcessInstance(MarshallerWriterContext context, ProcessInstance<?> processInstance) throws IOException {
-        RuleFlowProcessInstance pi = (RuleFlowProcessInstance) ((AbstractProcessInstance<?>) processInstance).internalGetProcessInstance();
+    public void writeProcessInstance(MarshallerWriterContext context, ProcessInstance processInstance) throws IOException {
+        RuleFlowProcessInstance pi = (RuleFlowProcessInstance) ((AbstractProcessInstance) processInstance).internalGetProcessInstance();
         ProtobufProcessInstanceWriter writer = new ProtobufProcessInstanceWriter(context);
         writer.writeProcessInstance(pi, context.output());
         pi.disconnect();
     }
 
     @Override
-    public ProcessInstance<?> readProcessInstance(MarshallerReaderContext context) throws IOException {
+    public ProcessInstance readProcessInstance(MarshallerReaderContext context) throws IOException {
         ProtobufProcessInstanceReader reader = new ProtobufProcessInstanceReader(context);
         boolean readOnly = context.get(MarshallerContextName.MARSHALLER_INSTANCE_READ_ONLY);
-        AbstractProcess<?> process = (AbstractProcess<?>) context.get(MarshallerContextName.MARSHALLER_PROCESS);
+        AbstractProcess process = (AbstractProcess) context.get(MarshallerContextName.MARSHALLER_PROCESS);
         return readOnly ? process.createReadOnlyInstance(reader.read(context.input())) : process.createInstance(reader.read(context.input()));
     }
 
     @Override
-    public void reloadProcessInstance(MarshallerReaderContext context, ProcessInstance<?> processInstance) throws IOException {
+    public void reloadProcessInstance(MarshallerReaderContext context, ProcessInstance processInstance) throws IOException {
         ProtobufProcessInstanceReader reader = new ProtobufProcessInstanceReader(context);
-        ((AbstractProcessInstance<?>) processInstance).internalSetProcessInstance(reader.read(context.input()));
+        ((AbstractProcessInstance) processInstance).internalSetProcessInstance(reader.read(context.input()));
     }
 
 }

--- a/jbpm/process-serialization-protobuf/src/main/java/org/kie/kogito/serialization/process/impl/ProtobufProcessInstanceReader.java
+++ b/jbpm/process-serialization-protobuf/src/main/java/org/kie/kogito/serialization/process/impl/ProtobufProcessInstanceReader.java
@@ -115,7 +115,7 @@ public class ProtobufProcessInstanceReader {
     private RuleFlowProcessInstance buildWorkflow(KogitoProcessInstanceProtobuf.ProcessInstance processInstanceProtobuf) {
 
         RuleFlowProcessInstance processInstance = ruleFlowProcessInstance;
-        processInstance.setProcess(((AbstractProcess<?>) context.get(MarshallerContextName.MARSHALLER_PROCESS)).process());
+        processInstance.setProcess(((AbstractProcess) context.get(MarshallerContextName.MARSHALLER_PROCESS)).process());
 
         processInstance.setId(processInstanceProtobuf.getId());
         processInstance.setProcessId(processInstanceProtobuf.getProcessId());

--- a/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/process/ProcessGenerationIT.java
+++ b/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/process/ProcessGenerationIT.java
@@ -64,7 +64,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.definition.process.Connection;
 import org.kie.api.definition.process.Node;
 import org.kie.kogito.Application;
-import org.kie.kogito.Model;
 import org.kie.kogito.codegen.AbstractCodegenIT;
 import org.kie.kogito.process.Processes;
 import org.kie.kogito.process.impl.AbstractProcess;
@@ -129,7 +128,7 @@ public class ProcessGenerationIT extends AbstractCodegenIT {
         RuleFlowProcess expected = (RuleFlowProcess) processes.get(0);
 
         Application app = generateCodeProcessesOnly(processFile);
-        AbstractProcess<? extends Model> process = (AbstractProcess<? extends Model>) app.get(Processes.class).processById(expected.getId());
+        AbstractProcess process = (AbstractProcess) app.get(Processes.class).processById(expected.getId());
         assertThat(process).isNotNull().isSameAs(app.get(Processes.class).processById(expected.getId()));
 
         RuleFlowProcess current = (RuleFlowProcess) process.process();

--- a/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/tests/BusinessRuleTaskIT.java
+++ b/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/tests/BusinessRuleTaskIT.java
@@ -53,12 +53,12 @@ public class BusinessRuleTaskIT extends AbstractCodegenIT {
         Application app = generateCode(resourcesTypeMap);
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("BusinessRuleTask");
+        Process p = app.get(Processes.class).processById("BusinessRuleTask");
 
         Model m = p.createModel();
         m.fromMap(Collections.singletonMap("person", new Person("john", 25)));
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
@@ -83,12 +83,12 @@ public class BusinessRuleTaskIT extends AbstractCodegenIT {
             }
 
         });
-        Process<? extends Model> p = app.get(Processes.class).processById("BusinessRuleTask");
+        Process p = app.get(Processes.class).processById("BusinessRuleTask");
 
         Model m = p.createModel();
         m.fromMap(Collections.singletonMap("person", new Person("john", 25)));
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
@@ -119,12 +119,12 @@ public class BusinessRuleTaskIT extends AbstractCodegenIT {
         UnitOfWork uow = app.unitOfWorkManager().newUnitOfWork();
         uow.start();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("BusinessRuleTask");
+        Process p = app.get(Processes.class).processById("BusinessRuleTask");
 
         Model m = p.createModel();
         m.fromMap(Collections.singletonMap("person", new Person("john", 25)));
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
@@ -145,7 +145,7 @@ public class BusinessRuleTaskIT extends AbstractCodegenIT {
         resourcesTypeMap.put(TYPE.PROCESS, Collections.singletonList("decision/models/dmnprocess.bpmn2"));
         resourcesTypeMap.put(TYPE.DECISION, Collections.singletonList("decision/models/vacationDaysAlt/vacationDaysAlt.dmn"));
         Application app = generateCode(resourcesTypeMap);
-        Process<? extends Model> p =
+        Process p =
                 app.get(Processes.class)
                         .processById("DmnProcess");
 
@@ -157,7 +157,7 @@ public class BusinessRuleTaskIT extends AbstractCodegenIT {
             vars.put("yearsOfService", 1);
             m.fromMap(vars);
 
-            ProcessInstance<? extends Model> processInstance = p.createInstance(m);
+            ProcessInstance processInstance = p.createInstance(m);
             processInstance.start();
 
             assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
@@ -176,7 +176,7 @@ public class BusinessRuleTaskIT extends AbstractCodegenIT {
             vars.put("yearsOfService", 20);
             m.fromMap(vars);
 
-            ProcessInstance<? extends Model> processInstance = p.createInstance(m);
+            ProcessInstance processInstance = p.createInstance(m);
             processInstance.start();
 
             assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
@@ -195,7 +195,7 @@ public class BusinessRuleTaskIT extends AbstractCodegenIT {
             vars.put("yearsOfService", 30);
             m.fromMap(vars);
 
-            ProcessInstance<? extends Model> processInstance = p.createInstance(m);
+            ProcessInstance processInstance = p.createInstance(m);
             processInstance.start();
 
             assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
@@ -215,7 +215,7 @@ public class BusinessRuleTaskIT extends AbstractCodegenIT {
         Application app = generateCode(resourcesTypeMap);
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("BusinessRuleTask");
+        Process p = app.get(Processes.class).processById("BusinessRuleTask");
 
         Model m = p.createModel();
         Map<String, Object> params = new HashMap<>();
@@ -223,7 +223,7 @@ public class BusinessRuleTaskIT extends AbstractCodegenIT {
         params.put("account", new Account());
         m.fromMap(params);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);

--- a/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/tests/BusinessRuleUnitIT.java
+++ b/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/tests/BusinessRuleUnitIT.java
@@ -70,12 +70,12 @@ public class BusinessRuleUnitIT extends AbstractCodegenIT {
         Application app = generateCode(resourcesTypeMap);
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("BusinessRuleUnit");
+        Process p = app.get(Processes.class).processById("BusinessRuleUnit");
 
         Model m = p.createModel();
         m.fromMap(Collections.singletonMap("person", new Person("john", 25)));
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
@@ -101,12 +101,12 @@ public class BusinessRuleUnitIT extends AbstractCodegenIT {
             }
 
         });
-        Process<? extends Model> p = app.get(Processes.class).processById("BusinessRuleUnit");
+        Process p = app.get(Processes.class).processById("BusinessRuleUnit");
 
         Model m = p.createModel();
         m.fromMap(Collections.singletonMap("person", new Person("john", 25)));
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
@@ -138,12 +138,12 @@ public class BusinessRuleUnitIT extends AbstractCodegenIT {
         UnitOfWork uow = app.unitOfWorkManager().newUnitOfWork();
         uow.start();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("BusinessRuleUnit");
+        Process p = app.get(Processes.class).processById("BusinessRuleUnit");
 
         Model m = p.createModel();
         m.fromMap(Collections.singletonMap("person", new Person("john", 25)));
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
@@ -164,7 +164,7 @@ public class BusinessRuleUnitIT extends AbstractCodegenIT {
         resourcesTypeMap.put(TYPE.PROCESS, Collections.singletonList("ruletask/ExampleP.bpmn"));
         resourcesTypeMap.put(TYPE.RULES, Collections.singletonList("ruletask/Example.drl"));
         Application app = generateCode(resourcesTypeMap);
-        Process<? extends Model> process = app.get(Processes.class).processById("ruletask.ExampleP");
+        Process process = app.get(Processes.class).processById("ruletask.ExampleP");
 
         HashMap<String, Object> map = new HashMap<>();
         map.put("singleString", "hello");
@@ -174,7 +174,7 @@ public class BusinessRuleUnitIT extends AbstractCodegenIT {
 
         Model model = process.createModel();
         model.fromMap(map);
-        ProcessInstance<? extends Model> instance = process.createInstance(model);
+        ProcessInstance instance = process.createInstance(model);
         Model variables = instance.variables();
         Map<String, Object> result = variables.toMap();
 
@@ -205,7 +205,7 @@ public class BusinessRuleUnitIT extends AbstractCodegenIT {
         resourcesTypeMap.put(TYPE.PROCESS, Collections.singletonList("ruletask/ExampleGenerated.bpmn"));
         resourcesTypeMap.put(TYPE.RULES, Collections.singletonList("ruletask/Generated.drl"));
         Application app = generateCode(resourcesTypeMap);
-        Process<? extends Model> process = app.get(Processes.class).processById("ruletask.ExampleGenerated");
+        Process process = app.get(Processes.class).processById("ruletask.ExampleGenerated");
 
         HashMap<String, Object> map = new HashMap<>();
         map.put("singleString", "hello");
@@ -215,7 +215,7 @@ public class BusinessRuleUnitIT extends AbstractCodegenIT {
 
         Model model = process.createModel();
         model.fromMap(map);
-        ProcessInstance<? extends Model> instance = process.createInstance(model);
+        ProcessInstance instance = process.createInstance(model);
         Model variables = instance.variables();
         Map<String, Object> result = variables.toMap();
 
@@ -238,7 +238,7 @@ public class BusinessRuleUnitIT extends AbstractCodegenIT {
         resourcesTypeMap.put(TYPE.PROCESS, Collections.singletonList("ruletask/ExampleGenerated.bpmn"));
         resourcesTypeMap.put(TYPE.RULES, Collections.singletonList("ruletask/Generated.drl"));
         Application app = generateCode(resourcesTypeMap);
-        Process<? extends Model> process = app.get(Processes.class).processById("ruletask.ExampleGenerated");
+        Process process = app.get(Processes.class).processById("ruletask.ExampleGenerated");
 
         HashMap<String, Object> map = new HashMap<>();
         map.put("singleString", "hello");
@@ -246,7 +246,7 @@ public class BusinessRuleUnitIT extends AbstractCodegenIT {
 
         Model model = process.createModel();
         model.fromMap(map);
-        ProcessInstance<? extends Model> instance = process.createInstance(model);
+        ProcessInstance instance = process.createInstance(model);
         Model variables = instance.variables();
         Map<String, Object> result = variables.toMap();
 
@@ -270,7 +270,7 @@ public class BusinessRuleUnitIT extends AbstractCodegenIT {
         resourcesTypeMap.put(TYPE.PROCESS, Collections.singletonList("ruletask/ExampleGenerated.bpmn"));
         resourcesTypeMap.put(TYPE.RULES, Collections.singletonList("ruletask/Generated.drl"));
         Application app = generateCode(resourcesTypeMap);
-        Process<? extends Model> process = app.get(Processes.class).processById("ruletask.ExampleGenerated");
+        Process process = app.get(Processes.class).processById("ruletask.ExampleGenerated");
 
         HashMap<String, Object> map = new HashMap<>();
         map.put("singleString", "hello");
@@ -278,7 +278,7 @@ public class BusinessRuleUnitIT extends AbstractCodegenIT {
 
         Model model = process.createModel();
         model.fromMap(map);
-        ProcessInstance<? extends Model> instance = process.createInstance(model);
+        ProcessInstance instance = process.createInstance(model);
         Model variables = instance.variables();
         Map<String, Object> result = variables.toMap();
 
@@ -313,7 +313,7 @@ public class BusinessRuleUnitIT extends AbstractCodegenIT {
         resourcesTypeMap.put(TYPE.PROCESS, Collections.singletonList("ruletask/ExampleP.bpmn"));
         resourcesTypeMap.put(TYPE.RULES, Collections.singletonList("ruletask/Example.drl"));
         Application app = generateCode(resourcesTypeMap);
-        Process<? extends Model> process = app.get(Processes.class).processById("ruletask.ExampleP");
+        Process process = app.get(Processes.class).processById("ruletask.ExampleP");
 
         HashMap<String, Object> map = new HashMap<>();
         map.put("singleString", "hello");
@@ -322,7 +322,7 @@ public class BusinessRuleUnitIT extends AbstractCodegenIT {
 
         Model model = process.createModel();
         model.fromMap(map);
-        ProcessInstance<? extends Model> instance = process.createInstance(model);
+        ProcessInstance instance = process.createInstance(model);
         Model variables = instance.variables();
         Map<String, Object> result = variables.toMap();
 
@@ -343,7 +343,7 @@ public class BusinessRuleUnitIT extends AbstractCodegenIT {
         resourcesTypeMap.put(TYPE.PROCESS, Collections.singletonList("ruletask/ExampleP.bpmn"));
         resourcesTypeMap.put(TYPE.RULES, Collections.singletonList("ruletask/Example.drl"));
         Application app = generateCode(resourcesTypeMap);
-        Process<? extends Model> process = app.get(Processes.class).processById("ruletask.ExampleP");
+        Process process = app.get(Processes.class).processById("ruletask.ExampleP");
 
         HashMap<String, Object> map = new HashMap<>();
         map.put("singleString", "hello");
@@ -352,7 +352,7 @@ public class BusinessRuleUnitIT extends AbstractCodegenIT {
 
         Model model = process.createModel();
         model.fromMap(map);
-        ProcessInstance<? extends Model> instance = process.createInstance(model);
+        ProcessInstance instance = process.createInstance(model);
         Model variables = instance.variables();
         Map<String, Object> result = variables.toMap();
 

--- a/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/tests/CallActivityTaskIT.java
+++ b/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/tests/CallActivityTaskIT.java
@@ -51,7 +51,7 @@ public class CallActivityTaskIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("subprocess/CallActivity.bpmn2", "subprocess/CallActivitySubProcess.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("ParentProcess");
+        Process p = app.get(Processes.class).processById("ParentProcess");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
@@ -59,7 +59,7 @@ public class CallActivityTaskIT extends AbstractCodegenIT {
         parameters.put("y", "b");
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
@@ -75,7 +75,7 @@ public class CallActivityTaskIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("subprocess/CallActivityWithTypeInfo.bpmn2", "subprocess/CallActivitySubProcess.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("ParentProcess");
+        Process p = app.get(Processes.class).processById("ParentProcess");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
@@ -83,7 +83,7 @@ public class CallActivityTaskIT extends AbstractCodegenIT {
         parameters.put("y", "b");
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
@@ -99,7 +99,7 @@ public class CallActivityTaskIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("subprocess/CallActivityMI.bpmn2", "subprocess/CallActivitySubProcess.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("ParentProcess");
+        Process p = app.get(Processes.class).processById("ParentProcess");
 
         List<String> list = new ArrayList<String>();
         list.add("first");
@@ -112,7 +112,7 @@ public class CallActivityTaskIT extends AbstractCodegenIT {
         parameters.put("listOut", listOut);
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
@@ -128,14 +128,14 @@ public class CallActivityTaskIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("subprocess/CallActivityWithIOexpression.bpmn2", "subprocess/CallActivitySubProcess.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("ParentProcess");
+        Process p = app.get(Processes.class).processById("ParentProcess");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("person", new Person("john", 0));
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_ACTIVE);
@@ -163,7 +163,7 @@ public class CallActivityTaskIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("subprocess/CallActivityWithIOexpressionNested.bpmn2", "subprocess/CallActivitySubProcess.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("ParentProcess");
+        Process p = app.get(Processes.class).processById("ParentProcess");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
@@ -172,7 +172,7 @@ public class CallActivityTaskIT extends AbstractCodegenIT {
         parameters.put("person", pa);
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_ACTIVE);
@@ -202,7 +202,7 @@ public class CallActivityTaskIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("subprocess/CallActivityVarIOExpression.bpmn2", "subprocess/CallActivitySubProcess.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("ParentProcess");
+        Process p = app.get(Processes.class).processById("ParentProcess");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
@@ -210,7 +210,7 @@ public class CallActivityTaskIT extends AbstractCodegenIT {
         parameters.put("y", "b");
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);

--- a/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/tests/CompensationIT.java
+++ b/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/tests/CompensationIT.java
@@ -35,8 +35,8 @@ class CompensationIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("compensation/compensateFirst.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("compensateFirst");
-        ProcessInstance<?> processInstance = p.createInstance(p.createModel());
+        Process p = app.get(Processes.class).processById("compensateFirst");
+        ProcessInstance processInstance = p.createInstance(p.createModel());
         processInstance.start();
         assertState(processInstance, ProcessInstance.STATE_COMPLETED);
 
@@ -50,8 +50,8 @@ class CompensationIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("compensation/compensateSecond.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("compensateSecond");
-        ProcessInstance<?> processInstance = p.createInstance(p.createModel());
+        Process p = app.get(Processes.class).processById("compensateSecond");
+        ProcessInstance processInstance = p.createInstance(p.createModel());
         processInstance.start();
         assertState(processInstance, ProcessInstance.STATE_COMPLETED);
 
@@ -65,8 +65,8 @@ class CompensationIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("compensation/compensateAll.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("compensateAll");
-        ProcessInstance<?> processInstance = p.createInstance(p.createModel());
+        Process p = app.get(Processes.class).processById("compensateAll");
+        ProcessInstance processInstance = p.createInstance(p.createModel());
         processInstance.start();
         assertState(processInstance, ProcessInstance.STATE_COMPLETED);
 
@@ -80,8 +80,8 @@ class CompensationIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("compensation/BPMN2-Compensation-ThrowSpecificForSubProcess.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("CompensationSpecificSubProcess");
-        ProcessInstance<?> processInstance = p.createInstance(p.createModel());
+        Process p = app.get(Processes.class).processById("CompensationSpecificSubProcess");
+        ProcessInstance processInstance = p.createInstance(p.createModel());
         processInstance.start();
 
         Model model = (Model) processInstance.variables();

--- a/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/tests/EmbeddedSubProcessIT.java
+++ b/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/tests/EmbeddedSubProcessIT.java
@@ -40,13 +40,13 @@ public class EmbeddedSubProcessIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("subprocess/EmbeddedSubProcess.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("SubProcess");
+        Process p = app.get(Processes.class).processById("SubProcess");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
@@ -58,14 +58,14 @@ public class EmbeddedSubProcessIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("subprocess/EmbeddedSubProcessWithUserTask.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("embeddedWithUserTask");
+        Process p = app.get(Processes.class).processById("embeddedWithUserTask");
         Person person = new Person("john", 25);
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("person", person);
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_ACTIVE);

--- a/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/tests/ErrorIT.java
+++ b/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/tests/ErrorIT.java
@@ -22,7 +22,6 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.kie.api.event.process.ProcessNodeLeftEvent;
 import org.kie.kogito.Application;
-import org.kie.kogito.Model;
 import org.kie.kogito.codegen.AbstractCodegenIT;
 import org.kie.kogito.internal.process.event.DefaultKogitoProcessEventListener;
 import org.kie.kogito.internal.process.event.KogitoProcessEventListener;
@@ -44,8 +43,8 @@ public class ErrorIT extends AbstractCodegenIT {
 
         List<String> completedNodesNames = completedNodesListener(app);
 
-        Process<? extends Model> p = app.get(Processes.class).processById("EndError");
-        ProcessInstance<?> processInstance = p.createInstance(p.createModel());
+        Process p = app.get(Processes.class).processById("EndError");
+        ProcessInstance processInstance = p.createInstance(p.createModel());
         assertState(processInstance, ProcessInstance.STATE_PENDING);
 
         processInstance.start();
@@ -83,8 +82,8 @@ public class ErrorIT extends AbstractCodegenIT {
 
         List<String> completedNames = completedNodesListener(app);
 
-        Process<? extends Model> p = app.get(Processes.class).processById(processId);
-        ProcessInstance<?> processInstance = p.createInstance(p.createModel());
+        Process p = app.get(Processes.class).processById(processId);
+        ProcessInstance processInstance = p.createInstance(p.createModel());
 
         assertState(processInstance, ProcessInstance.STATE_PENDING);
 

--- a/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/tests/EventSubProcessIT.java
+++ b/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/tests/EventSubProcessIT.java
@@ -38,13 +38,13 @@ public class EventSubProcessIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("event-subprocess/EventSubprocessSignal.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("EventSubprocessSignal");
+        Process p = app.get(Processes.class).processById("EventSubprocessSignal");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_ACTIVE);
@@ -60,13 +60,13 @@ public class EventSubProcessIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("event-subprocess/EventSubprocessSignalWithData.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("EventSubprocessSignal");
+        Process p = app.get(Processes.class).processById("EventSubprocessSignal");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_ACTIVE);

--- a/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/tests/GatewayIT.java
+++ b/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/tests/GatewayIT.java
@@ -41,11 +41,11 @@ public class GatewayIT extends AbstractCodegenIT {
         Application app = generateCode(resourcesTypeMap);
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("EventBasedSplit");
+        Process p = app.get(Processes.class).processById("EventBasedSplit");
 
         Model m = p.createModel();
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_ACTIVE);

--- a/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/tests/MessageIntermediateEventIT.java
+++ b/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/tests/MessageIntermediateEventIT.java
@@ -46,10 +46,10 @@ public class MessageIntermediateEventIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("messageevent/MessageEndEvent.bpmn2");
         ProcessEventListener listener = mock(KogitoProcessEventListener.class);
         app.config().get(ProcessConfig.class).processEventListeners().listeners().add(listener);
-        Process<? extends Model> p = app.get(Processes.class).processById("MessageEndEvent");
+        Process p = app.get(Processes.class).processById("MessageEndEvent");
         Model m = p.createModel();
         m.update(Collections.singletonMap("x", "Javierito"));
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
         ArgumentCaptor<MessageEvent> messageEvent = ArgumentCaptor.forClass(MessageEvent.class);
@@ -63,10 +63,10 @@ public class MessageIntermediateEventIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("messageevent/IntermediateThrowEventMessage.bpmn2");
         ProcessEventListener listener = mock(KogitoProcessEventListener.class);
         app.config().get(ProcessConfig.class).processEventListeners().listeners().add(listener);
-        Process<? extends Model> p = app.get(Processes.class).processById("MessageIntermediateEvent");
+        Process p = app.get(Processes.class).processById("MessageIntermediateEvent");
         Model m = p.createModel();
         m.update(Collections.singletonMap("customerId", "Javierito"));
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
         ArgumentCaptor<MessageEvent> messageEvent = ArgumentCaptor.forClass(MessageEvent.class);
@@ -81,13 +81,13 @@ public class MessageIntermediateEventIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("messageevent/IntermediateCatchEventMessage.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("IntermediateCatchEvent");
+        Process p = app.get(Processes.class).processById("IntermediateCatchEvent");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_ACTIVE);
@@ -106,13 +106,13 @@ public class MessageIntermediateEventIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("messageevent/BoundaryMessageEventOnTask.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("BoundaryMessageOnTask");
+        Process p = app.get(Processes.class).processById("BoundaryMessageOnTask");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_ACTIVE);

--- a/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/tests/MessageStartEventIT.java
+++ b/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/tests/MessageStartEventIT.java
@@ -36,14 +36,14 @@ public class MessageStartEventIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("messagestartevent/MessageStartEvent.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("MessageStartEvent");
+        Process p = app.get(Processes.class).processById("MessageStartEvent");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("customerId", "CUS-00998877");
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start("customers", null);
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
@@ -58,14 +58,14 @@ public class MessageStartEventIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("messagestartevent/MessageStartAndEndEvent.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("MessageStartEvent");
+        Process p = app.get(Processes.class).processById("MessageStartEvent");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("customerId", "CUS-00998877");
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start("customers", null);
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
@@ -80,14 +80,14 @@ public class MessageStartEventIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("messagestartevent/NoneAndMessageStartEvent.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("MessageStartEvent");
+        Process p = app.get(Processes.class).processById("MessageStartEvent");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("customerId", "CUS-00998877");
         m.fromMap(parameters);
         // first start it via none start event
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);

--- a/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/tests/PublishEventIT.java
+++ b/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/tests/PublishEventIT.java
@@ -65,9 +65,9 @@ public class PublishEventIT extends AbstractCodegenIT {
         UnitOfWork uow = app.unitOfWorkManager().newUnitOfWork();
         uow.start();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("TestCase.SimpleMilestone");
+        Process p = app.get(Processes.class).processById("TestCase.SimpleMilestone");
 
-        ProcessInstance<?> processInstance = p.createInstance(p.createModel());
+        ProcessInstance processInstance = p.createInstance(p.createModel());
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
@@ -109,12 +109,12 @@ public class PublishEventIT extends AbstractCodegenIT {
         UnitOfWork uow = app.unitOfWorkManager().newUnitOfWork();
         uow.start();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("BusinessRuleTask");
+        Process p = app.get(Processes.class).processById("BusinessRuleTask");
 
         Model m = p.createModel();
         m.fromMap(Collections.singletonMap("person", new Person("john", 25)));
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
@@ -160,9 +160,9 @@ public class PublishEventIT extends AbstractCodegenIT {
         UnitOfWork uow = app.unitOfWorkManager().newUnitOfWork();
         uow.start();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("compensateAll");
+        Process p = app.get(Processes.class).processById("compensateAll");
 
-        ProcessInstance<?> processInstance = p.createInstance(p.createModel());
+        ProcessInstance processInstance = p.createInstance(p.createModel());
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
@@ -201,7 +201,7 @@ public class PublishEventIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("usertask/UserTasksProcess.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("UserTasksProcess");
+        Process p = app.get(Processes.class).processById("UserTasksProcess");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
@@ -214,7 +214,7 @@ public class PublishEventIT extends AbstractCodegenIT {
         UnitOfWork uow = app.unitOfWorkManager().newUnitOfWork();
         uow.start();
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
         uow.end();
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_ACTIVE);
@@ -271,7 +271,7 @@ public class PublishEventIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("usertask/UserTasksProcessWithSecurityRoles.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("UserTasksProcess");
+        Process p = app.get(Processes.class).processById("UserTasksProcess");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
@@ -284,7 +284,7 @@ public class PublishEventIT extends AbstractCodegenIT {
         UnitOfWork uow = app.unitOfWorkManager().newUnitOfWork();
         uow.start();
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
         uow.end();
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_ACTIVE);
@@ -305,7 +305,7 @@ public class PublishEventIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("subprocess/CallActivity.bpmn2", "subprocess/CallActivitySubProcess.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("ParentProcess");
+        Process p = app.get(Processes.class).processById("ParentProcess");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
@@ -320,7 +320,7 @@ public class PublishEventIT extends AbstractCodegenIT {
         UnitOfWork uow = app.unitOfWorkManager().newUnitOfWork();
         uow.start();
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         uow.end();
@@ -382,12 +382,12 @@ public class PublishEventIT extends AbstractCodegenIT {
         UnitOfWork uow = app.unitOfWorkManager().newUnitOfWork();
         uow.start();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("BusinessRuleTask");
+        Process p = app.get(Processes.class).processById("BusinessRuleTask");
 
         Model m = p.createModel();
         m.fromMap(Collections.singletonMap("person", new Person("john", 25)));
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
@@ -412,7 +412,7 @@ public class PublishEventIT extends AbstractCodegenIT {
         UnitOfWork uow = app.unitOfWorkManager().newUnitOfWork();
         uow.start();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("ExclusiveSplit");
+        Process p = app.get(Processes.class).processById("ExclusiveSplit");
 
         Map<String, Object> params = new HashMap<>();
         params.put("x", "First");
@@ -420,7 +420,7 @@ public class PublishEventIT extends AbstractCodegenIT {
         Model m = p.createModel();
         m.fromMap(params);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
@@ -461,7 +461,7 @@ public class PublishEventIT extends AbstractCodegenIT {
         UnitOfWork uow = app.unitOfWorkManager().newUnitOfWork();
         uow.start();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("ServiceProcessDifferentOperations");
+        Process p = app.get(Processes.class).processById("ServiceProcessDifferentOperations");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
@@ -532,12 +532,12 @@ public class PublishEventIT extends AbstractCodegenIT {
         UnitOfWork uow = app.unitOfWorkManager().newUnitOfWork();
         uow.start();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("BusinessRuleTask");
+        Process p = app.get(Processes.class).processById("BusinessRuleTask");
 
         Model m = p.createModel();
         m.fromMap(Collections.singletonMap("person", new Person("john", 25)));
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);

--- a/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/tests/ServerlessWorkflowIT.java
+++ b/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/tests/ServerlessWorkflowIT.java
@@ -44,13 +44,13 @@ public class ServerlessWorkflowIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly(processLocation);
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("function");
+        Process p = app.get(Processes.class).processById("function");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
@@ -66,13 +66,13 @@ public class ServerlessWorkflowIT extends AbstractCodegenIT {
         NodeLeftCountDownProcessEventListener listener = new NodeLeftCountDownProcessEventListener("SmallDelay", 1);
         app.config().get(ProcessConfig.class).processEventListeners().listeners().add(listener);
 
-        Process<? extends Model> p = app.get(Processes.class).processById("function");
+        Process p = app.get(Processes.class).processById("function");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         boolean completed = listener.waitTillCompleted(5000);
@@ -88,13 +88,13 @@ public class ServerlessWorkflowIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly(processLocation);
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("function");
+        Process p = app.get(Processes.class).processById("function");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
@@ -107,13 +107,13 @@ public class ServerlessWorkflowIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly(processLocation);
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("noactions");
+        Process p = app.get(Processes.class).processById("noactions");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
@@ -126,13 +126,13 @@ public class ServerlessWorkflowIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly(processLocation);
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("function");
+        Process p = app.get(Processes.class).processById("function");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
@@ -145,7 +145,7 @@ public class ServerlessWorkflowIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly(processLocation);
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("singleservice");
+        Process p = app.get(Processes.class).processById("singleservice");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
@@ -160,7 +160,7 @@ public class ServerlessWorkflowIT extends AbstractCodegenIT {
         parameters.put("workflowdata", jsonParamObj);
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
@@ -181,7 +181,7 @@ public class ServerlessWorkflowIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly(processLocation);
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("singleinject");
+        Process p = app.get(Processes.class).processById("singleinject");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
@@ -194,7 +194,7 @@ public class ServerlessWorkflowIT extends AbstractCodegenIT {
         parameters.put("workflowdata", jsonParamObj);
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
@@ -215,7 +215,7 @@ public class ServerlessWorkflowIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly(processLocation);
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("switchworkflow");
+        Process p = app.get(Processes.class).processById("switchworkflow");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
@@ -228,7 +228,7 @@ public class ServerlessWorkflowIT extends AbstractCodegenIT {
         parameters.put("workflowdata", jsonParamObj);
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
@@ -249,7 +249,7 @@ public class ServerlessWorkflowIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly(processLocation);
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("switchworkflow");
+        Process p = app.get(Processes.class).processById("switchworkflow");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
@@ -262,7 +262,7 @@ public class ServerlessWorkflowIT extends AbstractCodegenIT {
         parameters.put("workflowdata", jsonParamObj);
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
@@ -283,7 +283,7 @@ public class ServerlessWorkflowIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly(processLocation);
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("switchworkflow");
+        Process p = app.get(Processes.class).processById("switchworkflow");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
@@ -296,7 +296,7 @@ public class ServerlessWorkflowIT extends AbstractCodegenIT {
         parameters.put("workflowdata", jsonParamObj);
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
@@ -308,7 +308,7 @@ public class ServerlessWorkflowIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("serverless/single-subflow.sw.json", "serverless/called-subflow.sw.json");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("singlesubflow");
+        Process p = app.get(Processes.class).processById("singlesubflow");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
@@ -321,7 +321,7 @@ public class ServerlessWorkflowIT extends AbstractCodegenIT {
         parameters.put("workflowdata", jsonParamObj);
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
@@ -344,7 +344,7 @@ public class ServerlessWorkflowIT extends AbstractCodegenIT {
             Application app = generateCodeProcessesOnly("serverless/parallel-state.sw.json", "serverless/parallel-state-branch1.sw.json", "serverless/parallel-state-branch2.sw.json");
             assertThat(app).isNotNull();
 
-            Process<? extends Model> p = app.get(Processes.class).processById("parallelworkflow");
+            Process p = app.get(Processes.class).processById("parallelworkflow");
 
             Model m = p.createModel();
             Map<String, Object> parameters = new HashMap<>();
@@ -357,7 +357,7 @@ public class ServerlessWorkflowIT extends AbstractCodegenIT {
             parameters.put("workflowdata", jsonParamObj);
             m.fromMap(parameters);
 
-            ProcessInstance<?> processInstance = p.createInstance(m);
+            ProcessInstance processInstance = p.createInstance(m);
             processInstance.start();
 
             assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
@@ -384,7 +384,7 @@ public class ServerlessWorkflowIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly(processLocation);
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("prchecker");
+        Process p = app.get(Processes.class).processById("prchecker");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
@@ -397,7 +397,7 @@ public class ServerlessWorkflowIT extends AbstractCodegenIT {
         parameters.put("workflowdata", jsonParamObj);
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);

--- a/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/tests/ServiceTaskIT.java
+++ b/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/tests/ServiceTaskIT.java
@@ -41,14 +41,14 @@ public class ServiceTaskIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("servicetask/ServiceProcess.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("ServiceProcess");
+        Process p = app.get(Processes.class).processById("ServiceProcess");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("s", "john");
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.startDate()).isNotNull();
@@ -64,14 +64,14 @@ public class ServiceTaskIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("servicetask/ServiceProcessDifferentOperations.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("ServiceProcessDifferentOperations");
+        Process p = app.get(Processes.class).processById("ServiceProcessDifferentOperations");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("s", "john");
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.startDate()).isNotNull();
@@ -87,14 +87,14 @@ public class ServiceTaskIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("servicetask/ServiceProcessDifferentOperations.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("ServiceProcessDifferentOperations");
+        Process p = app.get(Processes.class).processById("ServiceProcessDifferentOperations");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("s", "john");
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.startFrom("_A1EE8114-BF7B-4DAF-ABD7-62EEDCFAEFD4");
 
         assertThat(processInstance.startDate()).isNotNull();
@@ -110,14 +110,14 @@ public class ServiceTaskIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("servicetask/ServiceProcessSameOperations.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("ServiceProcessSameOperations");
+        Process p = app.get(Processes.class).processById("ServiceProcessSameOperations");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("s", "john");
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
@@ -132,7 +132,7 @@ public class ServiceTaskIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("servicetask/ServiceProcessMI.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("ServiceProcess");
+        Process p = app.get(Processes.class).processById("ServiceProcess");
 
         List<String> list = new ArrayList<String>();
         list.add("first");
@@ -145,7 +145,7 @@ public class ServiceTaskIT extends AbstractCodegenIT {
         parameters.put("listOut", listOut);
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
@@ -173,7 +173,7 @@ public class ServiceTaskIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("servicetask/MultiParamServiceProcess.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("ServiceProcess");
+        Process p = app.get(Processes.class).processById("ServiceProcess");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
@@ -181,7 +181,7 @@ public class ServiceTaskIT extends AbstractCodegenIT {
         parameters.put("x", "doe");
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
@@ -196,7 +196,7 @@ public class ServiceTaskIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("servicetask/MultiParamServiceProcessConstant.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("ServiceProcess");
+        Process p = app.get(Processes.class).processById("ServiceProcess");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
@@ -204,7 +204,7 @@ public class ServiceTaskIT extends AbstractCodegenIT {
         parameters.put("x", "doe");
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
@@ -219,7 +219,7 @@ public class ServiceTaskIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("servicetask/MultiParamServiceProcessNoOutput.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("MultiParamServiceProcessNoOutput");
+        Process p = app.get(Processes.class).processById("MultiParamServiceProcessNoOutput");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
@@ -227,7 +227,7 @@ public class ServiceTaskIT extends AbstractCodegenIT {
         parameters.put("age", 35);
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
@@ -242,7 +242,7 @@ public class ServiceTaskIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("servicetask/MultiParamCustomResultServiceTask.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("services");
+        Process p = app.get(Processes.class).processById("services");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
@@ -250,7 +250,7 @@ public class ServiceTaskIT extends AbstractCodegenIT {
         parameters.put("age", 35);
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
@@ -267,8 +267,8 @@ public class ServiceTaskIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("servicetask/ServiceProcessOverloaded.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("ServiceProcessOverloaded");
-        ProcessInstance<?> processInstance = p.createInstance(p.createModel());
+        Process p = app.get(Processes.class).processById("ServiceProcessOverloaded");
+        ProcessInstance processInstance = p.createInstance(p.createModel());
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);

--- a/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/tests/SignalEventIT.java
+++ b/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/tests/SignalEventIT.java
@@ -50,10 +50,10 @@ public class SignalEventIT extends AbstractCodegenIT {
         KogitoProcessEventListener listener = mock(KogitoProcessEventListener.class);
         app.config().get(ProcessConfig.class).processEventListeners().listeners().add(listener);
         assertThat(app).isNotNull();
-        Process<? extends Model> p = app.get(Processes.class).processById("SignalIntermediateEvent");
+        Process p = app.get(Processes.class).processById("SignalIntermediateEvent");
         Model m = p.createModel();
         m.update(Collections.singletonMap("x", "Javierito"));
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
         ArgumentCaptor<SignalEvent> signalEvent = ArgumentCaptor.forClass(SignalEvent.class);
@@ -69,8 +69,8 @@ public class SignalEventIT extends AbstractCodegenIT {
         KogitoProcessEventListener listener = mock(KogitoProcessEventListener.class);
         app.config().get(ProcessConfig.class).processEventListeners().listeners().add(listener);
         assertThat(app).isNotNull();
-        Process<? extends Model> p = app.get(Processes.class).processById("src.simpleEndSignal");
-        ProcessInstance<?> processInstance = p.createInstance(p.createModel());
+        Process p = app.get(Processes.class).processById("src.simpleEndSignal");
+        ProcessInstance processInstance = p.createInstance(p.createModel());
         processInstance.start();
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);
         ArgumentCaptor<SignalEvent> signalEvent = ArgumentCaptor.forClass(SignalEvent.class);
@@ -87,11 +87,11 @@ public class SignalEventIT extends AbstractCodegenIT {
         Application app = generateCode(resourcesTypeMap);
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("IntermediateCatchEvent");
+        Process p = app.get(Processes.class).processById("IntermediateCatchEvent");
 
         Model m = p.createModel();
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_ACTIVE);
@@ -139,11 +139,11 @@ public class SignalEventIT extends AbstractCodegenIT {
         Application app = generateCode(resourcesTypeMap);
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("BoundarySignalOnTask");
+        Process p = app.get(Processes.class).processById("BoundarySignalOnTask");
 
         Model m = p.createModel();
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_ACTIVE);
@@ -178,11 +178,11 @@ public class SignalEventIT extends AbstractCodegenIT {
         Application app = generateCode(resourcesTypeMap);
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("BoundarySignalOnTask");
+        Process p = app.get(Processes.class).processById("BoundarySignalOnTask");
 
         Model m = p.createModel();
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_ACTIVE);
@@ -209,11 +209,11 @@ public class SignalEventIT extends AbstractCodegenIT {
         UnitOfWork uow = app.unitOfWorkManager().newUnitOfWork();
         uow.start();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("IntermediateCatchEvent");
+        Process p = app.get(Processes.class).processById("IntermediateCatchEvent");
 
         Model m = p.createModel();
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_ACTIVE);

--- a/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/tests/SplitGatewayIT.java
+++ b/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/tests/SplitGatewayIT.java
@@ -40,12 +40,12 @@ public class SplitGatewayIT extends AbstractCodegenIT {
         Application app = generateCode(resourcesTypeMap);
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("SplitMultilineExpression");
+        Process p = app.get(Processes.class).processById("SplitMultilineExpression");
 
         Model m = p.createModel();
         m.fromMap(singletonMap("valid", false));
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);

--- a/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/tests/SubProcessIT.java
+++ b/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/tests/SubProcessIT.java
@@ -37,21 +37,21 @@ public class SubProcessIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("subprocess/SubProcess.bpmn", "subprocess/ParentProcess.bpmn");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> parent = app.get(Processes.class).processById("parent");
-        Process<? extends Model> subProcess = app.get(Processes.class).processById("subprocess");
+        Process parent = app.get(Processes.class).processById("parent");
+        Process subProcess = app.get(Processes.class).processById("subprocess");
 
         Model m = parent.createModel();
         m.fromMap(Collections.singletonMap("name", "test"));
 
-        ProcessInstance<? extends Model> processInstance = parent.createInstance(m);
+        ProcessInstance processInstance = parent.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_ACTIVE);
 
-        Collection<? extends ProcessInstance<? extends Model>> instances = subProcess.instances().values();
+        Collection<? extends ProcessInstance> instances = subProcess.instances().values();
         assertThat(instances).hasSize(1);
 
-        ProcessInstance<? extends Model> subProcessInstance = instances.iterator().next();
+        ProcessInstance subProcessInstance = instances.iterator().next();
         assertThat(subProcessInstance.variables().toMap()).hasSize(3).contains(
                 entry("constant", "aString"), entry("name", "test"), entry("review", null));
 

--- a/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/tests/TimerEventIT.java
+++ b/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/tests/TimerEventIT.java
@@ -45,13 +45,13 @@ public class TimerEventIT extends AbstractCodegenIT {
         NodeLeftCountDownProcessEventListener listener = new NodeLeftCountDownProcessEventListener("timer", 3);
         app.config().get(ProcessConfig.class).processEventListeners().listeners().add(listener);
 
-        Process<? extends Model> p = app.get(Processes.class).processById("IntermediateCatchEvent");
+        Process p = app.get(Processes.class).processById("IntermediateCatchEvent");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         boolean completed = listener.waitTillCompleted(5000);
@@ -72,13 +72,13 @@ public class TimerEventIT extends AbstractCodegenIT {
         NodeLeftCountDownProcessEventListener listener = new NodeLeftCountDownProcessEventListener("timer", 1);
         app.config().get(ProcessConfig.class).processEventListeners().listeners().add(listener);
 
-        Process<? extends Model> p = app.get(Processes.class).processById("IntermediateCatchEvent");
+        Process p = app.get(Processes.class).processById("IntermediateCatchEvent");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         boolean completed = listener.waitTillCompleted(5000);
@@ -96,7 +96,7 @@ public class TimerEventIT extends AbstractCodegenIT {
         NodeLeftCountDownProcessEventListener listener = new NodeLeftCountDownProcessEventListener("timer", 1);
         app.config().get(ProcessConfig.class).processEventListeners().listeners().add(listener);
 
-        Process<? extends Model> p = app.get(Processes.class).processById("IntermediateCatchEvent");
+        Process p = app.get(Processes.class).processById("IntermediateCatchEvent");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
@@ -104,7 +104,7 @@ public class TimerEventIT extends AbstractCodegenIT {
         parameters.put("date", plusTwoSeconds.toString());
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         boolean completed = listener.waitTillCompleted(5000);
@@ -122,13 +122,13 @@ public class TimerEventIT extends AbstractCodegenIT {
         NodeLeftCountDownProcessEventListener listener = new NodeLeftCountDownProcessEventListener("TimerEvent", 1);
         app.config().get(ProcessConfig.class).processEventListeners().listeners().add(listener);
 
-        Process<? extends Model> p = app.get(Processes.class).processById("TimerBoundaryEvent");
+        Process p = app.get(Processes.class).processById("TimerBoundaryEvent");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         boolean completed = listener.waitTillCompleted(5000);
@@ -146,13 +146,13 @@ public class TimerEventIT extends AbstractCodegenIT {
         NodeLeftCountDownProcessEventListener listener = new NodeLeftCountDownProcessEventListener("TimerEvent", 1);
         app.config().get(ProcessConfig.class).processEventListeners().listeners().add(listener);
 
-        Process<? extends Model> p = app.get(Processes.class).processById("TimerBoundaryEvent");
+        Process p = app.get(Processes.class).processById("TimerBoundaryEvent");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         boolean completed = listener.waitTillCompleted(5000);
@@ -170,7 +170,7 @@ public class TimerEventIT extends AbstractCodegenIT {
         NodeLeftCountDownProcessEventListener listener = new NodeLeftCountDownProcessEventListener("TimerEvent", 1);
         app.config().get(ProcessConfig.class).processEventListeners().listeners().add(listener);
 
-        Process<? extends Model> p = app.get(Processes.class).processById("TimerBoundaryEvent");
+        Process p = app.get(Processes.class).processById("TimerBoundaryEvent");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
@@ -178,7 +178,7 @@ public class TimerEventIT extends AbstractCodegenIT {
         parameters.put("date", plusTwoSeconds.toString());
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         boolean completed = listener.waitTillCompleted(5000);
@@ -196,13 +196,13 @@ public class TimerEventIT extends AbstractCodegenIT {
         NodeLeftCountDownProcessEventListener listener = new NodeLeftCountDownProcessEventListener("TimerEvent", 1);
         app.config().get(ProcessConfig.class).processEventListeners().listeners().add(listener);
 
-        Process<? extends Model> p = app.get(Processes.class).processById("TimerBoundaryEvent");
+        Process p = app.get(Processes.class).processById("TimerBoundaryEvent");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         boolean completed = listener.waitTillCompleted(5000);
@@ -220,7 +220,7 @@ public class TimerEventIT extends AbstractCodegenIT {
         NodeLeftCountDownProcessEventListener listener = new NodeLeftCountDownProcessEventListener("timer fired", 1);
         app.config().get(ProcessConfig.class).processEventListeners().listeners().add(listener);
 
-        Process<? extends Model> p = app.get(Processes.class).processById("defaultPackage.TimerProcess");
+        Process p = app.get(Processes.class).processById("defaultPackage.TimerProcess");
         // activate to schedule timers
         p.activate();
 
@@ -230,7 +230,7 @@ public class TimerEventIT extends AbstractCodegenIT {
         Collection<?> instances = p.instances().values(ProcessInstanceReadMode.MUTABLE);
         assertThat(instances).hasSize(1);
 
-        ProcessInstance<?> processInstance = (ProcessInstance<?>) instances.iterator().next();
+        ProcessInstance processInstance = (ProcessInstance) instances.iterator().next();
         assertThat(processInstance).isNotNull();
 
         assertThat(processInstance.status()).isEqualTo(KogitoProcessInstance.STATE_ACTIVE);
@@ -249,7 +249,7 @@ public class TimerEventIT extends AbstractCodegenIT {
         NodeLeftCountDownProcessEventListener listener = new NodeLeftCountDownProcessEventListener("timer fired", 2);
         app.config().get(ProcessConfig.class).processEventListeners().listeners().add(listener);
 
-        Process<? extends Model> p = app.get(Processes.class).processById("defaultPackage.TimerProcess");
+        Process p = app.get(Processes.class).processById("defaultPackage.TimerProcess");
         // activate to schedule timers
         p.activate();
 
@@ -259,7 +259,7 @@ public class TimerEventIT extends AbstractCodegenIT {
         Collection<?> instances = p.instances().values(ProcessInstanceReadMode.MUTABLE);
         assertThat(instances).hasSize(2);
 
-        ProcessInstance<?> processInstance = (ProcessInstance<?>) instances.iterator().next();
+        ProcessInstance processInstance = (ProcessInstance) instances.iterator().next();
         assertThat(processInstance).isNotNull();
 
         assertThat(processInstance.status()).isEqualTo(KogitoProcessInstance.STATE_ACTIVE);
@@ -274,7 +274,7 @@ public class TimerEventIT extends AbstractCodegenIT {
         instances = p.instances().values(ProcessInstanceReadMode.MUTABLE);
         assertThat(instances).hasSize(2);
         // clean up by aborting all instances
-        instances.forEach(i -> ((ProcessInstance<?>) i).abort());
+        instances.forEach(i -> ((ProcessInstance) i).abort());
         assertThat(p.instances().size()).isZero();
     }
 }

--- a/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/tests/UserTaskIT.java
+++ b/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/tests/UserTaskIT.java
@@ -79,13 +79,13 @@ public class UserTaskIT extends AbstractCodegenIT {
             }
         });
 
-        Process<? extends Model> p = app.get(Processes.class).processById("UserTasksProcess");
+        Process p = app.get(Processes.class).processById("UserTasksProcess");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(KogitoProcessInstance.STATE_ACTIVE);
@@ -113,13 +113,13 @@ public class UserTaskIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("usertask/UserTasksProcess.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("UserTasksProcess");
+        Process p = app.get(Processes.class).processById("UserTasksProcess");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_ACTIVE);
@@ -152,13 +152,13 @@ public class UserTaskIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("usertask/UserTasksProcess.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("UserTasksProcess");
+        Process p = app.get(Processes.class).processById("UserTasksProcess");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_ACTIVE);
@@ -205,13 +205,13 @@ public class UserTaskIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("usertask/UserTasksProcess.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("UserTasksProcess");
+        Process p = app.get(Processes.class).processById("UserTasksProcess");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_ACTIVE);
@@ -272,13 +272,13 @@ public class UserTaskIT extends AbstractCodegenIT {
             }
         });
 
-        Process<? extends Model> p = app.get(Processes.class).processById("UserTasksProcess");
+        Process p = app.get(Processes.class).processById("UserTasksProcess");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_ACTIVE);
@@ -327,13 +327,13 @@ public class UserTaskIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("usertask/UserTasksProcess.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("UserTasksProcess");
+        Process p = app.get(Processes.class).processById("UserTasksProcess");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_ACTIVE);
@@ -391,13 +391,13 @@ public class UserTaskIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("usertask/approval.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("approvals");
+        Process p = app.get(Processes.class).processById("approvals");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
         assertEquals(KogitoProcessInstance.STATE_ACTIVE, processInstance.status());
 
@@ -432,13 +432,13 @@ public class UserTaskIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("usertask/approval.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("approvals");
+        Process p = app.get(Processes.class).processById("approvals");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
         assertEquals(KogitoProcessInstance.STATE_ACTIVE, processInstance.status());
 
@@ -472,13 +472,13 @@ public class UserTaskIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("usertask/UserTasksProcess.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("UserTasksProcess");
+        Process p = app.get(Processes.class).processById("UserTasksProcess");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_ACTIVE);
@@ -525,13 +525,13 @@ public class UserTaskIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("usertask/UserTasksProcess.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("UserTasksProcess");
+        Process p = app.get(Processes.class).processById("UserTasksProcess");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_ACTIVE);
@@ -577,13 +577,13 @@ public class UserTaskIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("usertask/UserTasksProcess.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("UserTasksProcess");
+        Process p = app.get(Processes.class).processById("UserTasksProcess");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_ACTIVE);
@@ -663,7 +663,7 @@ public class UserTaskIT extends AbstractCodegenIT {
         assertThat(approverField).isNotNull();
         assertThat(approverField.getType().getCanonicalName()).isEqualTo(String.class.getCanonicalName());
 
-        Process<? extends Model> p = app.get(Processes.class).processById("approvals");
+        Process p = app.get(Processes.class).processById("approvals");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
@@ -697,13 +697,13 @@ public class UserTaskIT extends AbstractCodegenIT {
         // internal variables are not exposed on the model
         assertThrows(NoSuchFieldException.class, () -> resourceClazz.getDeclaredField("approver"));
 
-        Process<? extends Model> p = app.get(Processes.class).processById("approvals");
+        Process p = app.get(Processes.class).processById("approvals");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
         assertEquals(KogitoProcessInstance.STATE_ACTIVE, processInstance.status());
 
@@ -718,14 +718,14 @@ public class UserTaskIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("usertask/approval-with-required-variable-tags.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("approvals");
+        Process p = app.get(Processes.class).processById("approvals");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
         m.fromMap(parameters);
 
         assertThrows(VariableViolationException.class, () -> {
-            ProcessInstance<?> processInstance = p.createInstance(m);
+            ProcessInstance processInstance = p.createInstance(m);
             processInstance.start();
         });
     }
@@ -753,14 +753,14 @@ public class UserTaskIT extends AbstractCodegenIT {
         assertNotNull(outputModelClazz.getDeclaredField("id"));
         assertThrows(NoSuchFieldException.class, () -> outputModelClazz.getDeclaredField("approver"));
 
-        Process<? extends Model> p = app.get(Processes.class).processById("approvals");
+        Process p = app.get(Processes.class).processById("approvals");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("approver", "mary");
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
         assertEquals(KogitoProcessInstance.STATE_ACTIVE, processInstance.status());
 
@@ -775,14 +775,14 @@ public class UserTaskIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("usertask/UserTaskWithIOexpression.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("UserTask");
+        Process p = app.get(Processes.class).processById("UserTask");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("person", new Person("john", 0));
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_ACTIVE);
@@ -806,7 +806,7 @@ public class UserTaskIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("usertask/UserTasksProcess.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("UserTasksProcess");
+        Process p = app.get(Processes.class).processById("UserTasksProcess");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
@@ -814,7 +814,7 @@ public class UserTaskIT extends AbstractCodegenIT {
 
         // assign custom business key for process instance
         String businessKey = "business key";
-        ProcessInstance<?> processInstance = p.createInstance(businessKey, m);
+        ProcessInstance processInstance = p.createInstance(businessKey, m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_ACTIVE);
@@ -822,7 +822,7 @@ public class UserTaskIT extends AbstractCodegenIT {
         assertThat(processInstance.businessKey()).isEqualTo(businessKey);
 
         // find the process instance by ID and verify business key
-        Optional<? extends ProcessInstance<? extends Model>> processInstanceByBussinesKey = p.instances().findById(processInstance.id());
+        Optional<? extends ProcessInstance> processInstanceByBussinesKey = p.instances().findById(processInstance.id());
         assertThat(processInstanceByBussinesKey.isPresent()).isTrue();
         assertThat(processInstanceByBussinesKey.get().businessKey()).isEqualTo(businessKey);
 
@@ -847,7 +847,7 @@ public class UserTaskIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("usertask/UserTasksProcess.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("UserTasksProcess");
+        Process p = app.get(Processes.class).processById("UserTasksProcess");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
@@ -855,7 +855,7 @@ public class UserTaskIT extends AbstractCodegenIT {
 
         // assign custom business key for process instance
         String businessKey = "business key";
-        ProcessInstance<?> processInstance = p.createInstance(businessKey, m);
+        ProcessInstance processInstance = p.createInstance(businessKey, m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_ACTIVE);
@@ -863,7 +863,7 @@ public class UserTaskIT extends AbstractCodegenIT {
         assertThat(processInstance.businessKey()).isEqualTo(businessKey);
 
         // start another process instance with assigned duplicated business key of already active instance
-        ProcessInstance<? extends Model> otherProcessInstance = p.createInstance(businessKey, m);
+        ProcessInstance otherProcessInstance = p.createInstance(businessKey, m);
         assertThat(otherProcessInstance.id()).isNotEqualTo(processInstance.id());
         assertThat(otherProcessInstance.businessKey()).isEqualTo(processInstance.businessKey()).isEqualTo(businessKey);
     }

--- a/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/tests/VariableIT.java
+++ b/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/tests/VariableIT.java
@@ -35,14 +35,14 @@ public class VariableIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("servicetask/ServiceTaskWithReservedNameVariable.bpmn2");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("test");
+        Process p = app.get(Processes.class).processById("test");
 
         Model m = p.createModel();
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("package", "john");
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = p.createInstance(m);
+        ProcessInstance processInstance = p.createInstance(m);
         processInstance.start();
 
         assertThat(processInstance.status()).isEqualTo(ProcessInstance.STATE_COMPLETED);

--- a/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/tests/WorkItemParamsIT.java
+++ b/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/tests/WorkItemParamsIT.java
@@ -34,9 +34,9 @@ class WorkItemParamsIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("servicetask/WorkItemParams.bpmn");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("WorkItemParamsTest");
+        Process p = app.get(Processes.class).processById("WorkItemParamsTest");
 
-        ProcessInstance<?> processInstance = p.createInstance(p.createModel());
+        ProcessInstance processInstance = p.createInstance(p.createModel());
         processInstance.start();
 
         assertThat(processInstance.startDate()).isNotNull();

--- a/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/process/impl/AdHocFragmentsIT.java
+++ b/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/process/impl/AdHocFragmentsIT.java
@@ -47,8 +47,8 @@ class AdHocFragmentsIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("cases/AdHocFragments.bpmn");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("TestCase.AdHocFragments");
-        ProcessInstance<?> processInstance = p.createInstance(p.createModel());
+        Process p = app.get(Processes.class).processById("TestCase.AdHocFragments");
+        ProcessInstance processInstance = p.createInstance(p.createModel());
         Collection<AdHocFragment> adHocFragments = processInstance.adHocFragments();
         List<AdHocFragment> expected = new ArrayList<>();
         expected.add(new AdHocFragment.Builder(MilestoneNode.class).withName("AdHoc Milestone").withAutoStart(true).build());
@@ -64,8 +64,8 @@ class AdHocFragmentsIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("cases/AdHocFragments.bpmn");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("TestCase.AdHocFragments");
-        ProcessInstance<? extends Model> processInstance = p.createInstance(p.createModel());
+        Process p = app.get(Processes.class).processById("TestCase.AdHocFragments");
+        ProcessInstance processInstance = p.createInstance(p.createModel());
         processInstance.start();
 
         Optional<WorkItem> workItem = processInstance.workItems().stream().filter(wi -> wi.getParameters().get("NodeName").equals(taskName)).findFirst();
@@ -85,8 +85,8 @@ class AdHocFragmentsIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("cases/AdHocFragments.bpmn");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("TestCase.AdHocFragments");
-        ProcessInstance<? extends Model> processInstance = p.createInstance(p.createModel());
+        Process p = app.get(Processes.class).processById("TestCase.AdHocFragments");
+        ProcessInstance processInstance = p.createInstance(p.createModel());
         processInstance.start();
         Map<String, Object> params = new HashMap<>();
         params.put("user", "Juan");
@@ -103,13 +103,13 @@ class AdHocFragmentsIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("cases/AdHocProcess.bpmn");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("AdHocProcess");
+        Process p = app.get(Processes.class).processById("AdHocProcess");
         Model model = p.createModel();
         Map<String, Object> params = new HashMap<>();
         params.put("var1", "Pablo");
         params.put("var2", "Luis");
         model.fromMap(params);
-        ProcessInstance<? extends Model> processInstance = p.createInstance(model);
+        ProcessInstance processInstance = p.createInstance(model);
 
         processInstance.start();
 

--- a/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/process/impl/AdHocSubProcessIT.java
+++ b/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/process/impl/AdHocSubProcessIT.java
@@ -38,12 +38,12 @@ class AdHocSubProcessIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("cases/ActivationAdHoc.bpmn");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("TestCase.ActivationAdHoc");
+        Process p = app.get(Processes.class).processById("TestCase.ActivationAdHoc");
         Model model = p.createModel();
         Map<String, Object> params = new HashMap<>();
         params.put("favouriteColour", "yellow");
         model.fromMap(params);
-        ProcessInstance<?> processInstance = p.createInstance(model);
+        ProcessInstance processInstance = p.createInstance(model);
         assertState(processInstance, ProcessInstance.STATE_PENDING);
         processInstance.start();
 
@@ -64,12 +64,12 @@ class AdHocSubProcessIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("cases/CompletionAdHoc.bpmn");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("TestCase.CompletionAdHoc");
+        Process p = app.get(Processes.class).processById("TestCase.CompletionAdHoc");
         Model model = p.createModel();
         Map<String, Object> params = new HashMap<>();
         params.put("favouriteColour", "yellow");
         model.fromMap(params);
-        ProcessInstance<?> processInstance = p.createInstance(model);
+        ProcessInstance processInstance = p.createInstance(model);
         assertState(processInstance, ProcessInstance.STATE_PENDING);
         processInstance.start();
 

--- a/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/process/impl/BusinessKeyIT.java
+++ b/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/process/impl/BusinessKeyIT.java
@@ -17,7 +17,6 @@ package org.kie.kogito.process.impl;
 
 import org.junit.jupiter.api.Test;
 import org.kie.kogito.Application;
-import org.kie.kogito.Model;
 import org.kie.kogito.codegen.AbstractCodegenIT;
 import org.kie.kogito.process.Process;
 import org.kie.kogito.process.ProcessInstance;
@@ -35,8 +34,8 @@ class BusinessKeyIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("cases/ActivationAdHoc.bpmn");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("TestCase.ActivationAdHoc");
-        ProcessInstance<?> processInstance = p.createInstance(businessKey, p.createModel());
+        Process p = app.get(Processes.class).processById("TestCase.ActivationAdHoc");
+        ProcessInstance processInstance = p.createInstance(businessKey, p.createModel());
         assertState(processInstance, ProcessInstance.STATE_PENDING);
         assertEquals(businessKey, processInstance.businessKey());
     }

--- a/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/process/impl/MilestoneIT.java
+++ b/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/process/impl/MilestoneIT.java
@@ -52,8 +52,8 @@ class MilestoneIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("cases/milestones/SimpleMilestone.bpmn");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("TestCase.SimpleMilestone");
-        ProcessInstance<?> processInstance = p.createInstance(p.createModel());
+        Process p = app.get(Processes.class).processById("TestCase.SimpleMilestone");
+        ProcessInstance processInstance = p.createInstance(p.createModel());
         assertState(processInstance, ProcessInstance.STATE_PENDING);
 
         Collection<Milestone> expected = new ArrayList<>();
@@ -67,7 +67,7 @@ class MilestoneIT extends AbstractCodegenIT {
         expected = expected.stream().map(m -> Milestone.builder().withId(m.getId()).withName(m.getName()).withStatus(COMPLETED).build()).collect(Collectors.toList());
         assertMilestones(expected, processInstance.milestones());
 
-        RuleFlowProcessInstance legacyProcessInstance = (RuleFlowProcessInstance) ((AbstractProcessInstance<?>) processInstance).processInstance;
+        RuleFlowProcessInstance legacyProcessInstance = (RuleFlowProcessInstance) ((AbstractProcessInstance) processInstance).processInstance;
         assertThat(legacyProcessInstance.getNodeInstances()).isEmpty();
         assertThat(legacyProcessInstance.getNodeIdInError()).isNullOrEmpty();
         Optional<String> milestoneId = Stream.of(legacyProcessInstance.getNodeContainer().getNodes())
@@ -83,12 +83,12 @@ class MilestoneIT extends AbstractCodegenIT {
         Application app = generateCodeProcessesOnly("cases/milestones/ConditionalMilestone.bpmn");
         assertThat(app).isNotNull();
 
-        Process<? extends Model> p = app.get(Processes.class).processById("TestCase.ConditionalMilestone");
+        Process p = app.get(Processes.class).processById("TestCase.ConditionalMilestone");
         Model model = p.createModel();
         Map<String, Object> params = new HashMap<>();
         params.put("favouriteColour", "orange");
         model.fromMap(params);
-        ProcessInstance<?> processInstance = p.createInstance(model);
+        ProcessInstance processInstance = p.createInstance(model);
         assertState(processInstance, ProcessInstance.STATE_PENDING);
 
         Collection<Milestone> expected = new ArrayList<>();

--- a/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/process/impl/ProcessTestUtils.java
+++ b/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/process/impl/ProcessTestUtils.java
@@ -21,16 +21,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class ProcessTestUtils {
 
-    public static void assertState(ProcessInstance<?> processInstance, int state) {
+    public static void assertState(ProcessInstance processInstance, int state) {
         assertThat(processInstance).isInstanceOf(AbstractProcessInstance.class);
-        AbstractProcessInstance<?> abstractProcessInstance = (AbstractProcessInstance<?>) processInstance;
+        AbstractProcessInstance abstractProcessInstance = (AbstractProcessInstance) processInstance;
         assertThat(abstractProcessInstance.status)
                 .withFailMessage("ProcessInstance [%s] Status - Expected: %s - Got: %s", processInstance.id(), state, processInstance.status())
                 .isEqualTo(state);
         assertThat(abstractProcessInstance.processInstance.getState())
                 .withFailMessage(
                         "LegacyProcessInstance [%s] Status - Expected: %s - Got: %s",
-                        processInstance.id(), state, ((AbstractProcessInstance<?>) processInstance).processInstance.getState())
+                        processInstance.id(), state, ((AbstractProcessInstance) processInstance).processInstance.getState())
                 .isEqualTo(state);
     }
 

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/ProcessResourceGenerator.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/ProcessResourceGenerator.java
@@ -263,8 +263,8 @@ public class ProcessResourceGenerator {
         template.findAll(MethodDeclaration.class).forEach(this::interpolateMethods);
 
         if (context.hasDI()) {
-            template.findAll(FieldDeclaration.class,
-                    CodegenUtils::isProcessField).forEach(fd -> context.getDependencyInjectionAnnotator().withNamedInjection(fd, processId));
+            //            template.findAll(FieldDeclaration.class,
+            //                    CodegenUtils::isProcessField).forEach(fd -> context.getDependencyInjectionAnnotator().withNamedInjection(fd, processId));
         } else {
             template.findAll(FieldDeclaration.class,
                     CodegenUtils::isProcessField).forEach(this::initializeProcessField);

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/MessageConsumerJavaTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/MessageConsumerJavaTemplate.java
@@ -25,7 +25,7 @@ import org.kie.kogito.event.impl.DefaultEventConsumerFactory;
 
 public class $Type$MessageConsumer {
 
-    Process<$Type$> process;
+    Process process;
 
     Application application;
 

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/MessageConsumerQuarkusTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/MessageConsumerQuarkusTemplate.java
@@ -29,7 +29,7 @@ public class $Type$MessageConsumer extends AbstractMessageConsumer<$Type$, $Data
     Application application;
 
     @javax.inject.Inject
-    @javax.inject.Named("$ProcessName$") Process<$Type$> process;
+    @javax.inject.Named("$ProcessName$") Process process;
 
     @javax.inject.Inject
     ConfigBean configBean;

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/MessageConsumerSpringTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/MessageConsumerSpringTemplate.java
@@ -28,7 +28,7 @@ public class $Type$MessageConsumer extends AbstractMessageConsumer<$Type$, $Data
     @org.springframework.beans.factory.annotation.Autowired()
     $Type$MessageConsumer(
             Application application,
-            @org.springframework.beans.factory.annotation.Qualifier("$ProcessName$") Process<$Type$> process,
+            @org.springframework.beans.factory.annotation.Qualifier("$ProcessName$") Process process,
             ConfigBean configBean,
             EventReceiver eventReceiver) {
         super(application,

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/ProcessContainerJavaTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/ProcessContainerJavaTemplate.java
@@ -18,13 +18,13 @@ package $Package$;
 public class Processes implements org.kie.kogito.process.Processes {
 
     private final Application application;
-    private java.util.Map<String, org.kie.kogito.process.Process<? extends org.kie.kogito.Model>> mappedProcesses = new java.util.concurrent.ConcurrentHashMap<>();
+    private java.util.Map<String, org.kie.kogito.process.Process> mappedProcesses = new java.util.concurrent.ConcurrentHashMap<>();
 
     public Processes(Application application) {
         this.application = application;
     }
 
-    public org.kie.kogito.process.Process<? extends org.kie.kogito.Model> processById(String processId) {
+    public org.kie.kogito.process.Process processById(String processId) {
         if ("$ProcessId".equals(processId)) {
             return mappedProcesses.computeIfAbsent("$ProcessId", k -> new $ProcessClassName$(application).configure());
         }

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/ProcessContainerQuarkusTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/ProcessContainerQuarkusTemplate.java
@@ -19,18 +19,18 @@ package $Package$;
 public class Processes implements org.kie.kogito.process.Processes {
 
     @javax.inject.Inject
-    javax.enterprise.inject.Instance<org.kie.kogito.process.Process<? extends org.kie.kogito.Model>> processes;
+    javax.enterprise.inject.Instance<org.kie.kogito.process.Process> processes;
 
-    private java.util.Map<String, org.kie.kogito.process.Process<? extends org.kie.kogito.Model>> mappedProcesses = new java.util.HashMap<>();
+    private java.util.Map<String, org.kie.kogito.process.Process> mappedProcesses = new java.util.HashMap<>();
 
     @javax.annotation.PostConstruct
     public void setup() {
-        for (org.kie.kogito.process.Process<? extends org.kie.kogito.Model> process : processes) {
+        for (org.kie.kogito.process.Process process : processes) {
             mappedProcesses.put(process.id(), process);
         }
     }
 
-    public org.kie.kogito.process.Process<? extends org.kie.kogito.Model> processById(String processId) {
+    public org.kie.kogito.process.Process processById(String processId) {
         return mappedProcesses.get(processId);
     }
 

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/ProcessContainerSpringTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/ProcessContainerSpringTemplate.java
@@ -20,18 +20,18 @@ package $Package$;
 public class Processes implements org.kie.kogito.process.Processes {
 
     @org.springframework.beans.factory.annotation.Autowired
-    java.util.Collection<org.kie.kogito.process.Process<? extends org.kie.kogito.Model>> processes;
+    java.util.Collection<org.kie.kogito.process.Process> processes;
 
-    private java.util.Map<String, org.kie.kogito.process.Process<? extends org.kie.kogito.Model>> mappedProcesses = new java.util.HashMap<>();
+    private java.util.Map<String, org.kie.kogito.process.Process> mappedProcesses = new java.util.HashMap<>();
 
     @javax.annotation.PostConstruct
     public void setup() {
-        for (org.kie.kogito.process.Process<? extends org.kie.kogito.Model> process : processes) {
+        for (org.kie.kogito.process.Process process : processes) {
             mappedProcesses.put(process.id(), process);
         }
     }
 
-    public org.kie.kogito.process.Process<? extends org.kie.kogito.Model> processById(String processId) {
+    public org.kie.kogito.process.Process processById(String processId) {
         return mappedProcesses.get(processId);
     }
 

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/ReactiveRestResourceQuarkusTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/ReactiveRestResourceQuarkusTemplate.java
@@ -52,7 +52,7 @@ import org.kie.kogito.auth.IdentityProvider;
 @Path("/$name$")
 public class $Type$ReactiveResource {
 
-    Process<$Type$> process;
+    Process process;
 
     Application application;
 
@@ -65,7 +65,7 @@ public class $Type$ReactiveResource {
         return CompletableFuture
                 .supplyAsync(
                         () -> {
-                            ProcessInstance<$Type$> pi = processService.createProcessInstance(process,
+                            ProcessInstance pi = processService.createProcessInstance(process,
                                                                                               businessKey,
                                                                                               Optional.ofNullable(resource).orElse(new $Type$Input()).toModel(),
                                                                                               httpHeaders.getHeaderString("X-KOGITO-StartFromNode"));

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/ReactiveRestResourceQuarkusTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/ReactiveRestResourceQuarkusTemplate.java
@@ -70,7 +70,7 @@ public class $Type$ReactiveResource {
                                                                                               Optional.ofNullable(resource).orElse(new $Type$Input()).toModel(),
                                                                                               httpHeaders.getHeaderString("X-KOGITO-StartFromNode"));
                             return Response.created(uriInfo.getAbsolutePathBuilder().path(pi.id()).build())
-                                    .entity(pi.checkError().variables().toModel())
+                                    .entity(($Type$Output) (($Type$)pi.checkError().variables()).toModel())
                                     .build();
                         });
     }

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/RestResourceQuarkusTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/RestResourceQuarkusTemplate.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -58,6 +59,8 @@ import org.kie.kogito.auth.IdentityProvider;
 @Path("/$name$")
 public class $Type$Resource {
 
+    @Inject
+    @Named("$id$")
     Process process;
 
     @Inject
@@ -75,28 +78,28 @@ public class $Type$Resource {
                                                                           Optional.ofNullable(resource).orElse(new $Type$Input()).toModel(),
                                                                           httpHeaders.getHeaderString("X-KOGITO-StartFromNode"));
         return Response.created(uriInfo.getAbsolutePathBuilder().path(pi.id()).build())
-                .entity(pi.checkError().variables().toModel())
+                .entity( (($Type$) pi.checkError().variables() ).toModel() )
                 .build();
     }
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public List<$Type$Output> getResources_$name$() {
-        return processService.getProcessInstanceOutput(process);
+        return processService.getProcessInstanceOutput(process, $Type$Output.class);
     }
 
     @GET
     @Path("/{id}")
     @Produces(MediaType.APPLICATION_JSON)
     public $Type$Output getResource_$name$(@PathParam("id") String id) {
-        return processService.findById(process, id).orElseThrow(NotFoundException::new);
+        return processService.findById(process, id, $Type$Output.class).orElseThrow(NotFoundException::new);
     }
 
     @DELETE
     @Path("/{id}")
     @Produces(MediaType.APPLICATION_JSON)
     public $Type$Output deleteResource_$name$(@PathParam("id") final String id) {
-        return processService.delete(process, id).orElseThrow(NotFoundException::new);
+        return processService.delete(process, id, $Type$Output.class).orElseThrow(NotFoundException::new);
     }
 
     @PUT
@@ -104,7 +107,7 @@ public class $Type$Resource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public $Type$Output updateModel_$name$(@PathParam("id") String id, $Type$ resource) {
-        return processService.update(process, id, resource).orElseThrow(NotFoundException::new);
+        return processService.update(process, id, resource, $Type$Output.class).orElseThrow(NotFoundException::new);
     }
 
     @GET

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/RestResourceQuarkusTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/RestResourceQuarkusTemplate.java
@@ -58,7 +58,7 @@ import org.kie.kogito.auth.IdentityProvider;
 @Path("/$name$")
 public class $Type$Resource {
 
-    Process<$Type$> process;
+    Process process;
 
     @Inject
     ProcessService processService;
@@ -70,7 +70,7 @@ public class $Type$Resource {
                                           @Context UriInfo uriInfo,
                                           @QueryParam("businessKey") String businessKey,
                                           $Type$Input resource) {
-        ProcessInstance<$Type$> pi = processService.createProcessInstance(process,
+        ProcessInstance pi = processService.createProcessInstance(process,
                                                                           businessKey,
                                                                           Optional.ofNullable(resource).orElse(new $Type$Input()).toModel(),
                                                                           httpHeaders.getHeaderString("X-KOGITO-StartFromNode"));

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/RestResourceSignalQuarkusTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/RestResourceSignalQuarkusTemplate.java
@@ -26,7 +26,7 @@ public class $Type$Resource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public $Type$Output signal(@PathParam("id") final String id, final $signalType$ data) {
-        return processService.signalProcessInstance(process, id, data, "$signalName$")
+        return processService.signalProcessInstance(process, id, data, "$signalName$", $Type$Output.class)
                 .orElseThrow(() -> new NotFoundException());
     }
 }

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/RestResourceSignalQuarkusTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/RestResourceSignalQuarkusTemplate.java
@@ -19,7 +19,7 @@ import org.kie.kogito.process.Process;
 
 public class $Type$Resource {
 
-    Process<$Type$> process;
+    Process process;
 
     @POST
     @Path("/{id}/$signalPath$")

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/RestResourceSignalSpringTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/RestResourceSignalSpringTemplate.java
@@ -31,7 +31,7 @@ public class $Type$Resource {
 
     @PostMapping(value = "/{id}/$signalPath$", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
     public $Type$Output signal(@PathVariable("id") final String id, final @RequestBody(required = false) $signalType$ data) {
-        return processService.signalProcessInstance(process, id, data, "$signalName$")
+        return processService.signalProcessInstance(process, id, data, "$signalName$", $Type$Output.class)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 }

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/RestResourceSignalSpringTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/RestResourceSignalSpringTemplate.java
@@ -27,7 +27,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 
 public class $Type$Resource {
 
-    Process<$Type$> process;
+    Process process;
 
     @PostMapping(value = "/{id}/$signalPath$", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
     public $Type$Output signal(@PathVariable("id") final String id, final @RequestBody(required = false) $signalType$ data) {

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/RestResourceSpringTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/RestResourceSpringTemplate.java
@@ -59,7 +59,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 @RequestMapping("/$name$")
 public class $Type$Resource {
 
-    Process<$Type$> process;
+    Process process;
 
     @Autowired
     ProcessService processService;
@@ -69,7 +69,7 @@ public class $Type$Resource {
                                                               @RequestParam(value = "businessKey", required = false) String businessKey,
                                                               @RequestBody(required = false) $Type$Input resource,
                                                               UriComponentsBuilder uriComponentsBuilder) {
-        ProcessInstance<$Type$> pi = processService.createProcessInstance(process,
+        ProcessInstance pi = processService.createProcessInstance(process,
                                                                           businessKey,
                                                                           Optional.ofNullable(resource).orElse(new $Type$Input()).toModel(),
                                                                           httpHeaders.getOrEmpty("X-KOGITO-StartFromNode").stream().findFirst().orElse(null));

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/RestResourceSpringTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/RestResourceSpringTemplate.java
@@ -35,6 +35,7 @@ import org.kie.kogito.process.workitem.TaskModel;
 import org.kie.kogito.auth.IdentityProvider;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -59,6 +60,8 @@ import org.springframework.web.util.UriComponentsBuilder;
 @RequestMapping("/$name$")
 public class $Type$Resource {
 
+    @Autowired
+    @Qualifier("$id$")
     Process process;
 
     @Autowired
@@ -74,28 +77,28 @@ public class $Type$Resource {
                                                                           Optional.ofNullable(resource).orElse(new $Type$Input()).toModel(),
                                                                           httpHeaders.getOrEmpty("X-KOGITO-StartFromNode").stream().findFirst().orElse(null));
         return ResponseEntity.created(uriComponentsBuilder.path("/$name$/{id}").buildAndExpand(pi.id()).toUri())
-                .body(pi.checkError().variables().toModel());
+                .body(($Type$Output) (($Type$)pi.checkError().variables()).toModel());
     }
 
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     public List<$Type$Output> getResources_$name$() {
-        return processService.getProcessInstanceOutput(process);
+        return processService.getProcessInstanceOutput(process, $Type$Output.class);
     }
 
     @GetMapping(value = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
     public $Type$Output getResource_$name$(@PathVariable("id") String id) {
-        return processService.findById(process, id).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+        return processService.findById(process, id, $Type$Output.class).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @DeleteMapping(value = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
     public $Type$Output deleteResource_$name$(@PathVariable("id") final String id) {
-        return processService.delete(process, id).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+        return processService.delete(process, id, $Type$Output.class).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @PutMapping(value = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE,
             consumes = MediaType.APPLICATION_JSON_VALUE)
     public $Type$Output updateModel_$name$(@PathVariable("id") String id, @RequestBody(required = false) $Type$ resource) {
-        return processService.update(process, id, resource).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+        return processService.update(process, id, resource, $Type$Output.class).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
     @GetMapping(value = "/{id}/tasks", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/RestResourceUserTaskQuarkusTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/RestResourceUserTaskQuarkusTemplate.java
@@ -54,7 +54,7 @@ public class $Type$Resource {
                                      @QueryParam("user") final String user,
                                      @QueryParam("group") final List<String> groups,
                                      final $TaskOutput$ model) {
-        return processService.completeTask(process, id, taskId, phase, user, groups, model)
+        return processService.completeTask(process, id, taskId, phase, user, groups, model, $Type$Output.class)
                 .orElseThrow(NotFoundException::new);
     }
 
@@ -81,7 +81,7 @@ public class $Type$Resource {
             @QueryParam("user") final String user,
             @QueryParam("group") final List<String> groups,
             final $TaskOutput$ model) {
-        return processService.taskTransition(process, id, taskId, phase, user, groups, model)
+        return processService.taskTransition(process, id, taskId, phase, user, groups, model, $Type$Output.class)
                 .orElseThrow(NotFoundException::new);
     }
 
@@ -92,7 +92,7 @@ public class $Type$Resource {
                                @PathParam("taskId") String taskId,
                                @QueryParam("user") final String user,
                                @QueryParam("group") final List<String> groups) {
-        return processService.getTask(process, id, taskId, user, groups, $TaskModel$::from)
+        return processService.getTask(process, id, taskId, user, groups, wi-> ($TaskModel$) $TaskModel$.from(wi))
                 .orElseThrow(NotFoundException::new);
     }
 
@@ -104,7 +104,7 @@ public class $Type$Resource {
                                   @QueryParam("phase") @DefaultValue("abort") final String phase,
                                   @QueryParam("user") final String user,
                                   @QueryParam("group") final List<String> groups) {
-        return processService.abortTask(process, id, taskId, phase, user, groups)
+        return processService.abortTask(process, id, taskId, phase, user, groups, $Type$Output.class)
                 .orElseThrow(() -> new NotFoundException());
     }
 

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/RestResourceUserTaskSpringTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/RestResourceUserTaskSpringTemplate.java
@@ -62,7 +62,7 @@ public class $Type$Resource {
                                      @RequestParam("user") final String user,
                                      @RequestParam("group") final List<String> groups,
                                      @RequestBody(required = false) final $TaskOutput$ model) {
-        return processService.completeTask(process, id, taskId, phase, user, groups, model)
+        return processService.completeTask(process, id, taskId, phase, user, groups, model, $Type$Output.class)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
@@ -87,7 +87,7 @@ public class $Type$Resource {
                                        @RequestParam(value = "group",
                                                required = false) final List<String> groups,
                                        @RequestBody(required = false) final $TaskOutput$ model) {
-        return processService.taskTransition(process, id, taskId, phase, user, groups, model)
+        return processService.taskTransition(process, id, taskId, phase, user, groups, model, $Type$Output.class)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
@@ -97,7 +97,7 @@ public class $Type$Resource {
                                @RequestParam(value = "user", required = false) final String user,
                                @RequestParam(value = "group",
                                        required = false) final List<String> groups) {
-        return processService.getTask(process, id, taskId, user, groups, $TaskModel$::from)
+        return processService.<$TaskModel$>getTask(process, id, taskId, user, groups, wi-> ($TaskModel$) $TaskModel$.from(wi))
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
@@ -109,7 +109,7 @@ public class $Type$Resource {
                                   @RequestParam(value = "user", required = false) final String user,
                                   @RequestParam(value = "group",
                                           required = false) final List<String> groups) {
-        return processService.abortTask(process, id, taskId, phase, user, groups)
+        return processService.abortTask(process, id, taskId, phase, user, groups, $Type$Output.class)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 

--- a/kogito-quarkus-parent/kogito-quarkus-extension/kogito-quarkus-integration-test/src/test/java/org/kie/kogito/quarkus/jbpm/ProcessIT.java
+++ b/kogito-quarkus-parent/kogito-quarkus-extension/kogito-quarkus-integration-test/src/test/java/org/kie/kogito/quarkus/jbpm/ProcessIT.java
@@ -36,7 +36,7 @@ public class ProcessIT {
 
     @Inject
     @Named("tests")
-    Process<? extends Model> process;
+    Process process;
 
     @Test
     public void testProcess() throws Exception {
@@ -45,7 +45,7 @@ public class ProcessIT {
         Map<String, Object> parameters = new HashMap<>();
         m.fromMap(parameters);
 
-        ProcessInstance<?> processInstance = process.createInstance(m);
+        ProcessInstance processInstance = process.createInstance(m);
         processInstance.start();
         assertEquals(KogitoProcessInstance.STATE_COMPLETED, processInstance.status());
     }


### PR DESCRIPTION
The generic `T` in `Process<T>`, `ProcessInstance<T>` has never really been used for its intended purpose; instead there are a lot of casts and conversions at various places.

This PR:

- Removes generic type from `Process<T>`, `ProcessInstance<T>`, `ProcessInstances<T>`
- Inserts casts where relevant (very few places in fact, and only temporarily)

Future PR(s):

- will introduce a new API `T variables(Class<T>)` returning an instance of Class<T> with fields set to the variable values. This supersedes also toModel/ToOutputModel
- this API will use reflection, thus reflection will be opted-in for such classes in the Quarkus extension

Disclaimer:

- This PR attempts a "big-bang" change everywhere (in kogito-runtimes). It may not work; if it doesn't work, it will be closed and substituted with a set of smaller changes.
- This PR is intended to be followed up by further refinements;
- This PR is intended to address only kogito-runtimes
- Usages outside of kogito-runtimes should be backwards compatible (for now)
- If necessary an (unused) generic type may-be re-introduced for the sole purposes of making apps/examples compile for the time being
- Follow-up PR will address apps/examples if necessary!
