### PR TITLE
[KOGITO-5244] Error in process instance marshalling persisting in mongodb.

### DIFF
--- a/jbpm/process-serialization-protobuf/src/main/java/org/kie/kogito/serialization/process/protobuf/ProtostreamProtobufAdapterTypeProvider.java
+++ b/jbpm/process-serialization-protobuf/src/main/java/org/kie/kogito/serialization/process/protobuf/ProtostreamProtobufAdapterTypeProvider.java
@@ -79,7 +79,7 @@ public class ProtostreamProtobufAdapterTypeProvider implements ProtobufTypeProvi
     private SerializationContextImpl buildSerializationContext() throws IOException, DescriptorValidationException {
         SerializationContextImpl context = new SerializationContextImpl(Configuration.builder().build());
         for (String protoFile : protostreamDescriptors()) {
-            try (InputStream is = ProtostreamProtobufAdapterTypeProvider.class.getClassLoader().getResourceAsStream(protoFile)) {
+            try (InputStream is = getInputStream(protoFile)) {
                 if (is == null) {
                     continue;
                 }
@@ -90,6 +90,14 @@ public class ProtostreamProtobufAdapterTypeProvider implements ProtobufTypeProvi
             }
         }
         return context;
+    }
+
+    private InputStream getInputStream(String protoFile) {
+        InputStream is = ProtostreamProtobufAdapterTypeProvider.class.getClassLoader().getResourceAsStream(protoFile);
+        if(is == null && Thread.currentThread().getContextClassLoader() != null) {
+            is = Thread.currentThread().getContextClassLoader().getResourceAsStream(protoFile);
+        }
+        return is;
     }
 
     private FileDescriptorProto buildEnumTypes(FileDescriptor descriptor) {


### PR DESCRIPTION
During dev the context class loader in quarkus has the right class loader for reading resources.