### PR TITLE
[KOGITO-5282] Fix warning in Quarkus related to ConfigProperty usage with Provider

### DIFF
--- a/addons/monitoring/monitoring-core/monitoring-core-quarkus-addon/src/test/java/org/kie/kogito/monitoring/core/quarkus/QuarkusMetricsFilterRegisterTest.java
+++ b/addons/monitoring/monitoring-core/monitoring-core-quarkus-addon/src/test/java/org/kie/kogito/monitoring/core/quarkus/QuarkusMetricsFilterRegisterTest.java
@@ -17,6 +17,7 @@ package org.kie.kogito.monitoring.core.quarkus;
 
 import java.util.List;
 
+import javax.enterprise.inject.Instance;
 import javax.ws.rs.core.FeatureContext;
 
 import org.junit.jupiter.api.Test;
@@ -27,6 +28,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class QuarkusMetricsFilterRegisterTest {
 
@@ -40,7 +42,12 @@ class QuarkusMetricsFilterRegisterTest {
         FeatureContext contextMock = mock(FeatureContext.class);
         QuarkusMetricsFilterRegister filterRegister = new QuarkusMetricsFilterRegister(new MockedConfigBean());
 
-        filterRegister.setHttpInterceptorUseDefault(httpInterceptorUseDefault);
+        @SuppressWarnings("unchecked")
+        Instance<Boolean> instanceHttpInterceptorUseDefault = mock(Instance.class);
+        when(instanceHttpInterceptorUseDefault.isResolvable()).thenReturn(true);
+        when(instanceHttpInterceptorUseDefault.get()).thenReturn(httpInterceptorUseDefault);
+
+        filterRegister.setHttpInterceptorUseDefault(instanceHttpInterceptorUseDefault);
         filterRegister.configure(null, contextMock);
 
         final ArgumentCaptor<Object> registerCaptor = ArgumentCaptor.forClass(Object.class);


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-5282

Before: performing `mvn clean package` on `dmn-drools-quarkus-metrics` project

> [INFO] --- quarkus-maven-plugin:1.13.3.Final:build (default) @ dmn-drools-quarkus-metrics ---
> [INFO] [org.jboss.threads] JBoss Threads version 3.2.0.Final
> [INFO] Performed addonsConfig discovery, found: AddonsConfig{usePersistence=false, useTracing=false, useMonitoring=true, usePrometheusMonitoring=true, useCloudEvents=false, useExplainability=false, useProcessSVG=false}
> [INFO] Generator discovery performed, found [openapispecs, rules, decisions]
> ...
> **[WARNING] [io.quarkus.resteasy.common.deployment.ResteasyCommonProcessor] Directly injecting a @ConfigProperty into a JAX-RS provider may lead to unexpected results. To ensure proper results, please change the type of the field to javax.enterprise.inject.Instance<boolean>. Offending field is 'httpInterceptorUseDefaultWrong' of class** 'org.kie.kogito.monitoring.core.quarkus.QuarkusMetricsFilterRegister'
> [INFO] [io.quarkus.deployment.QuarkusAugmentor] Quarkus augmentation completed in 6297ms
> [INFO] ------------------------------------------------------------------------
> [INFO] BUILD SUCCESS
> [INFO] ------------------------------------------------------------------------
> [INFO] Total time:  01:08 min
> [INFO] Finished at: 2021-06-07T19:05:28+02:00
> [INFO] ------------------------------------------------------------------------

After 
> [INFO] --- quarkus-maven-plugin:1.13.3.Final:build (default) @ dmn-drools-quarkus-metrics ---
> [INFO] [org.jboss.threads] JBoss Threads version 3.2.0.Final
> [INFO] Performed addonsConfig discovery, found: AddonsConfig{usePersistence=false, useTracing=false, useMonitoring=true, usePrometheusMonitoring=true, useCloudEvents=false, useExplainability=false, useProcessSVG=false}
> [INFO] Generator discovery performed, found [openapispecs, rules, decisions]
> ...
> [INFO] [io.quarkus.deployment.QuarkusAugmentor] Quarkus augmentation completed in 5014ms
> [INFO] ------------------------------------------------------------------------
> [INFO] BUILD SUCCESS
> [INFO] ------------------------------------------------------------------------
> [INFO] Total time:  30.243 s
> [INFO] Finished at: 2021-06-07T19:01:24+02:00
> [INFO] ------------------------------------------------------------------------


- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/master/kogito-build/kogito-ide-config)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>