### PR TITLE
[KOGITO-5273] - Disabling Kubernetes API Mock tests until refactoring

### DIFF
--- a/kogito-cloud-services/kogito-cloud-kubernetes-client/src/test/java/org/kie/kogito/cloud/kubernetes/client/KubeClientConfigTest.java
+++ b/kogito-cloud-services/kogito-cloud-kubernetes-client/src/test/java/org/kie/kogito/cloud/kubernetes/client/KubeClientConfigTest.java
@@ -22,12 +22,14 @@ import java.nio.file.Paths;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+@Disabled("Disabled in favor of the refactoring: https://issues.redhat.com/browse/KOGITO-5284")
 public class KubeClientConfigTest {
 
     public static final Path KUBE_CONFIG_PATH = Paths.get(System.getProperty("user.home") + "/.kube/config");
@@ -65,5 +67,4 @@ public class KubeClientConfigTest {
         final KogitoKubeConfig config = new KogitoKubeConfig();
         assertThat(config.getMasterUrl().toString(), containsString("localhost"));
     }
-
 }

--- a/kogito-cloud-services/kogito-cloud-kubernetes-client/src/test/java/org/kie/kogito/cloud/kubernetes/client/operations/ServiceOperationsStatusCodeHandlingTest.java
+++ b/kogito-cloud-services/kogito-cloud-kubernetes-client/src/test/java/org/kie/kogito/cloud/kubernetes/client/operations/ServiceOperationsStatusCodeHandlingTest.java
@@ -33,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * Service Operations test cases that integrates with a mock Kubernetes server to validate HTTP Rest API handling.
  */
+@Disabled("Disabled in favor of the refactoring: https://issues.redhat.com/browse/KOGITO-5284")
 public class ServiceOperationsStatusCodeHandlingTest extends MockKubernetesServerSupport {
 
     public ServiceOperationsStatusCodeHandlingTest() {

--- a/kogito-cloud-services/kogito-cloud-kubernetes-client/src/test/java/org/kie/kogito/cloud/kubernetes/client/operations/ServiceOperationsTest.java
+++ b/kogito-cloud-services/kogito-cloud-kubernetes-client/src/test/java/org/kie/kogito/cloud/kubernetes/client/operations/ServiceOperationsTest.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.kie.kogito.cloud.kubernetes.client.MockKubernetesServerSupport;
 
@@ -35,6 +36,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+@Disabled("Disabled in favor of the refactoring: https://issues.redhat.com/browse/KOGITO-5284")
 public class ServiceOperationsTest extends MockKubernetesServerSupport {
 
     private void assertDefaultServiceCreated(final String services) throws JsonParseException, JsonMappingException, IOException {
@@ -110,5 +112,4 @@ public class ServiceOperationsTest extends MockKubernetesServerSupport {
         String services = this.getKubeClient().services().list(null).asJson();
         this.assertDefaultServiceCreated(services);
     }
-
 }

--- a/kogito-cloud-services/kogito-cloud-workitems/src/test/java/org/kie/kogito/cloud/workitems/BaseTestKubernetesDiscoveredService.java
+++ b/kogito-cloud-services/kogito-cloud-workitems/src/test/java/org/kie/kogito/cloud/workitems/BaseTestKubernetesDiscoveredService.java
@@ -33,7 +33,7 @@ import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 /**
  * Base class for tests with Kubernetes API. In this scenario, nor Istio or KNative is available.
  */
-public abstract class BaseKubernetesDiscoveredServiceTest {
+public abstract class BaseTestKubernetesDiscoveredService {
 
     public static final int SERVICE_PORT = 65200;
     public KubernetesServer server = new KubernetesServer(false, true, InetAddress.getLoopbackAddress(), SERVICE_PORT, Collections.emptyList());
@@ -43,11 +43,11 @@ public abstract class BaseKubernetesDiscoveredServiceTest {
     private boolean enableIstio;
     private boolean istioEnabled;
 
-    public BaseKubernetesDiscoveredServiceTest() {
+    public BaseTestKubernetesDiscoveredService() {
         this.enableIstio = false;
     }
 
-    public BaseKubernetesDiscoveredServiceTest(final boolean enableIstio) {
+    public BaseTestKubernetesDiscoveredService(final boolean enableIstio) {
         this.enableIstio = enableIstio;
     }
 
@@ -89,7 +89,7 @@ public abstract class BaseKubernetesDiscoveredServiceTest {
 
     protected static class TestDiscoveredServiceWorkItemHandler extends DiscoveredServiceWorkItemHandler {
 
-        public TestDiscoveredServiceWorkItemHandler(BaseKubernetesDiscoveredServiceTest testCase) {
+        public TestDiscoveredServiceWorkItemHandler(BaseTestKubernetesDiscoveredService testCase) {
             super(new DefaultKogitoKubeClient().withConfig(new KogitoKubeConfig(testCase.getClient())));
         }
 

--- a/kogito-cloud-services/kogito-cloud-workitems/src/test/java/org/kie/kogito/cloud/workitems/DiscoveredServiceWorkItemHandlerTest.java
+++ b/kogito-cloud-services/kogito-cloud-workitems/src/test/java/org/kie/kogito/cloud/workitems/DiscoveredServiceWorkItemHandlerTest.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.kie.api.runtime.process.WorkItem;
 import org.kie.kogito.cloud.kubernetes.client.KogitoKubeClient;
@@ -43,6 +44,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@Disabled("Disabled in favor of the refactoring: https://issues.redhat.com/browse/KOGITO-5284")
 public class DiscoveredServiceWorkItemHandlerTest {
 
     private OkHttpClient httpClient;

--- a/kogito-cloud-services/kogito-cloud-workitems/src/test/java/org/kie/kogito/cloud/workitems/KNativeDiscoveredServiceWorkItemHandlerTest.java
+++ b/kogito-cloud-services/kogito-cloud-workitems/src/test/java/org/kie/kogito/cloud/workitems/KNativeDiscoveredServiceWorkItemHandlerTest.java
@@ -15,6 +15,7 @@
  */
 package org.kie.kogito.cloud.workitems;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.fabric8.kubernetes.api.model.KubernetesList;
@@ -24,8 +25,8 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-@org.junit.jupiter.api.Disabled
-public class KNativeDiscoveredServiceWorkItemHandlerTest extends BaseKubernetesDiscoveredServiceTest {
+@Disabled("Disabled in favor of the refactoring: https://issues.redhat.com/browse/KOGITO-5284")
+public class KNativeDiscoveredServiceWorkItemHandlerTest extends BaseTestKubernetesDiscoveredService {
 
     public KNativeDiscoveredServiceWorkItemHandlerTest() {
         super(true);
@@ -43,5 +44,4 @@ public class KNativeDiscoveredServiceWorkItemHandlerTest extends BaseKubernetesD
         assertThat(serviceInfo.getUrl(), is("http://172.30.101.218:80/employeeValidation"));
         assertThat(serviceInfo.getHeaders().get("HOST"), is("onboarding-hr.test.apps.example.com"));
     }
-
 }

--- a/kogito-cloud-services/kogito-cloud-workitems/src/test/java/org/kie/kogito/cloud/workitems/KubernetesDiscoveredServiceWorkItemHandlerTest.java
+++ b/kogito-cloud-services/kogito-cloud-workitems/src/test/java/org/kie/kogito/cloud/workitems/KubernetesDiscoveredServiceWorkItemHandlerTest.java
@@ -18,6 +18,7 @@ package org.kie.kogito.cloud.workitems;
 import java.io.IOException;
 import java.util.Collections;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.fabric8.kubernetes.api.model.IntOrString;
@@ -34,8 +35,8 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
-@org.junit.jupiter.api.Disabled
-public class KubernetesDiscoveredServiceWorkItemHandlerTest extends BaseKubernetesDiscoveredServiceTest {
+@Disabled("Disabled in favor of the refactoring: https://issues.redhat.com/browse/KOGITO-5284")
+public class KubernetesDiscoveredServiceWorkItemHandlerTest extends BaseTestKubernetesDiscoveredService {
 
     @Test
     public void testGivenServiceExists() {

--- a/kogito-cloud-services/kogito-cloud-workitems/src/test/java/org/kie/kogito/cloud/workitems/service/discovery/KubernetesServiceDiscoveryTest.java
+++ b/kogito-cloud-services/kogito-cloud-workitems/src/test/java/org/kie/kogito/cloud/workitems/service/discovery/KubernetesServiceDiscoveryTest.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.kie.kogito.cloud.kubernetes.client.DefaultKogitoKubeClient;
 import org.kie.kogito.cloud.kubernetes.client.KogitoKubeConfig;
@@ -35,7 +36,7 @@ import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@org.junit.jupiter.api.Disabled
+@Disabled("Disabled in favor of the refactoring: https://issues.redhat.com/browse/KOGITO-5284")
 public class KubernetesServiceDiscoveryTest {
 
     public static final String NAMESPACE = "mockns";


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

See origin issue: https://issues.redhat.com/browse/KOGITO-5273
See refactor issue: https://issues.redhat.com/browse/KOGITO-5284

KOGITO-5284 will be part of the Addon API refactoring effort. These "cloud services" needed to be re-engineered to be an addon instead of a loose couple library in the runtimes ecosystem.

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/master/kogito-build/kogito-ide-config)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>