### PR TITLE
[KOGITO-3919] - Using CE type instead of Source on SW builders

### DIFF
--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/ServerlessWorkflowParser.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/ServerlessWorkflowParser.java
@@ -120,7 +120,7 @@ public class ServerlessWorkflowParser {
                 .name(eventDefinition.getName())
                 .metaData(Metadata.TRIGGER_MAPPING, DEFAULT_WORKFLOW_VAR)
                 .metaData(Metadata.TRIGGER_TYPE, "ConsumeMessage")
-                .metaData(Metadata.TRIGGER_REF, eventDefinition.getSource())
+                .metaData(Metadata.TRIGGER_REF, eventDefinition.getType())
                 .metaData(Metadata.MESSAGE_TYPE, JSON_NODE)
                 .trigger(JSON_NODE, DEFAULT_WORKFLOW_VAR);
     }
@@ -144,7 +144,7 @@ public class ServerlessWorkflowParser {
                 .name(eventDefinition.getName())
                 .metaData(Metadata.TRIGGER_TYPE, "ProduceMessage")
                 .metaData(Metadata.MAPPING_VARIABLE, DEFAULT_WORKFLOW_VAR)
-                .metaData(Metadata.TRIGGER_REF, eventDefinition.getSource())
+                .metaData(Metadata.TRIGGER_REF, eventDefinition.getType())
                 .metaData(Metadata.MESSAGE_TYPE, JSON_NODE);
     }
 
@@ -154,9 +154,9 @@ public class ServerlessWorkflowParser {
                 .name(eventDefinition.getName())
                 .variableName(DEFAULT_WORKFLOW_VAR)
                 .metaData(Metadata.EVENT_TYPE, "message")
-                .metaData(Metadata.TRIGGER_REF, eventDefinition.getSource())
+                .metaData(Metadata.TRIGGER_REF, eventDefinition.getType())
                 .metaData(Metadata.MESSAGE_TYPE, JSON_NODE)
                 .metaData(Metadata.TRIGGER_TYPE, "ConsumeMessage")
-                .eventType("Message-" + eventDefinition.getSource());
+                .eventType("Message-" + eventDefinition.getType());
     }
 }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/java/org/kie/kogito/serverless/workflow/ServerlessWorkflowParsingTest.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/java/org/kie/kogito/serverless/workflow/ServerlessWorkflowParsingTest.java
@@ -18,6 +18,7 @@ package org.kie.kogito.serverless.workflow;
 import java.io.InputStreamReader;
 import java.util.Collections;
 
+import org.jbpm.ruleflow.core.Metadata;
 import org.jbpm.ruleflow.core.RuleFlowProcess;
 import org.jbpm.workflow.core.Constraint;
 import org.jbpm.workflow.core.node.ActionNode;
@@ -211,6 +212,8 @@ public class ServerlessWorkflowParsingTest {
 
         Node node = process.getNodes()[2];
         assertTrue(node instanceof StartNode);
+        assertEquals(((StartNode) node).getTriggers().size(), 1);
+        assertEquals(((StartNode) node).getMetaData(Metadata.TRIGGER_REF), "kafka");
         node = process.getNodes()[0];
         assertTrue(node instanceof EndNode);
         node = process.getNodes()[1];
@@ -510,7 +513,7 @@ public class ServerlessWorkflowParsingTest {
         assertEquals("TestKafkaEvent", actionNode.getName());
         assertEquals("ProduceMessage", actionNode.getMetaData("TriggerType"));
         assertEquals("workflowdata", actionNode.getMetaData("MappingVariable"));
-        assertEquals("testtopic", actionNode.getMetaData("TriggerRef"));
+        assertEquals("kafka", actionNode.getMetaData("TriggerRef"));
         assertEquals("com.fasterxml.jackson.databind.JsonNode", actionNode.getMetaData("MessageType"));
     }
 


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

See: https://issues.redhat.com/browse/KOGITO-3919

Small change in order to use CE `type` on SW Event definitions.

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/master/kogito-build/kogito-ide-config)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run all builds</b>  
  Please add comment: <b>Jenkins retest this</b>

* <b>Run (or rerun) specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] tests</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Run (or rerun) LTS specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Run (or rerun) native specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
