### PR TITLE
[RHPAM-3706] Use BOM managed version for non-productized quarkus-juni… [1.5.x]

### DIFF
--- a/kogito-build-parent/pom.xml
+++ b/kogito-build-parent/pom.xml
@@ -117,6 +117,8 @@
 
     <!-- this version property is used in plugins but also in dependencies too -->
     <version.io.quarkus>1.11.6.Final</version.io.quarkus>
+    <!-- non-productized non-bom managed dependency keep in sync with version.io.quarkus -->
+    <version.io.quarkus.test-maven>1.11.6.Final</version.io.quarkus.test-maven>
 
     <!-- dependencies versions -->
     <version.ch.obermuhlner>2.0.1</version.ch.obermuhlner>
@@ -1260,7 +1262,7 @@ limitations under the License.
                 </excludes>
                 <useDefaultExcludes>false</useDefaultExcludes>
                 <properties>
-                  <license.git.copyrightLastYearMaxCommitsLookup>100</license.git.copyrightLastYearMaxCommitsLookup> 
+                  <license.git.copyrightLastYearMaxCommitsLookup>100</license.git.copyrightLastYearMaxCommitsLookup>
                 </properties>
               </licenseSet>
             </licenseSets>

--- a/kogito-quarkus-parent/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test-hot-reload/pom.xml
+++ b/kogito-quarkus-parent/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test-hot-reload/pom.xml
@@ -41,7 +41,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
-            <version>${version.io.quarkus}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kogito-quarkus-parent/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test/pom.xml
+++ b/kogito-quarkus-parent/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test/pom.xml
@@ -26,7 +26,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
-            <version>${version.io.quarkus}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kogito-quarkus-parent/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/pom.xml
+++ b/kogito-quarkus-parent/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/pom.xml
@@ -84,7 +84,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
-            <version>${version.io.quarkus}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kogito-quarkus-parent/kogito-quarkus-extension/kogito-quarkus-deployment/pom.xml
+++ b/kogito-quarkus-parent/kogito-quarkus-extension/kogito-quarkus-deployment/pom.xml
@@ -55,7 +55,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
-            <version>${version.io.quarkus}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kogito-quarkus-parent/kogito-quarkus-extension/kogito-quarkus-integration-test-hot-reload/pom.xml
+++ b/kogito-quarkus-parent/kogito-quarkus-extension/kogito-quarkus-integration-test-hot-reload/pom.xml
@@ -47,7 +47,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
-            <version>${version.io.quarkus}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kogito-quarkus-parent/kogito-quarkus-extension/kogito-quarkus-integration-test-maven-devmode/pom.xml
+++ b/kogito-quarkus-parent/kogito-quarkus-extension/kogito-quarkus-integration-test-maven-devmode/pom.xml
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-test-maven</artifactId>
-      <version>${version.io.quarkus}</version>
+      <version>${version.io.quarkus.test-maven}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-quarkus-parent/kogito-quarkus-extension/kogito-quarkus-integration-test/pom.xml
+++ b/kogito-quarkus-parent/kogito-quarkus-extension/kogito-quarkus-integration-test/pom.xml
@@ -28,7 +28,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
-            <version>${version.io.quarkus}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kogito-quarkus-parent/kogito-quarkus-predictions-extension/kogito-quarkus-predictions-integration-test/pom.xml
+++ b/kogito-quarkus-parent/kogito-quarkus-predictions-extension/kogito-quarkus-predictions-integration-test/pom.xml
@@ -26,7 +26,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
-            <version>${version.io.quarkus}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kogito-quarkus-parent/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test-hot-reload/pom.xml
+++ b/kogito-quarkus-parent/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test-hot-reload/pom.xml
@@ -46,7 +46,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
-            <version>${version.io.quarkus}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kogito-quarkus-parent/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test/pom.xml
+++ b/kogito-quarkus-parent/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test/pom.xml
@@ -30,7 +30,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
-            <version>${version.io.quarkus}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kogito-quarkus-parent/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/pom.xml
+++ b/kogito-quarkus-parent/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/pom.xml
@@ -26,7 +26,6 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5-internal</artifactId>
-      <version>${version.io.quarkus}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
…t5-internal and add new prop for non-bom managed dep.

When aligning internally to a productized version of Quarkus in [RHPAM-3706](https://issues.redhat.com/browse/RHPAM-3706) we realised there are some deps that aren't part of the runtime and therefore aren't productized, we use `quarkus-junit5-internal` which is defined in the quarkus-bom so this change uses the BOM managed version (as is done in other places).

There is also quarkus-test-maven being used that is not BOM managed, as a temporary solution to keep it at the community version I'm introducing a version property to be kept in sync with version.io.quarkus that would not be touched by PME when aligning the version in the productized build.

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](CONTRIBUTING.md)
- [ ] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/master/kogito-build/kogito-ide-config)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run all builds</b>  
  Please add comment: <b>Jenkins retest this</b>

* <b>Run (or rerun) specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] tests</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Run (or rerun) LTS specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Run (or rerun) native specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
