### PR TITLE
KOGITO-5361 Native Image tests are not configured correctly on persistence addons

### DIFF
--- a/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-infinispan/src/test/java/org/kie/kogito/it/NativeInfinispanPersistenceIT.java
+++ b/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-infinispan/src/test/java/org/kie/kogito/it/NativeInfinispanPersistenceIT.java
@@ -15,8 +15,9 @@
  */
 package org.kie.kogito.it;
 
-import io.quarkus.test.junit.NativeImageTest;
 import org.junit.jupiter.api.Disabled;
+
+import io.quarkus.test.junit.NativeImageTest;
 
 @Disabled("KOGITO-5358 Native Image tests are broken in Infinispan persistence")
 @NativeImageTest

--- a/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-infinispan/src/test/java/org/kie/kogito/it/NativeInfinispanPersistenceIT.java
+++ b/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-infinispan/src/test/java/org/kie/kogito/it/NativeInfinispanPersistenceIT.java
@@ -16,7 +16,9 @@
 package org.kie.kogito.it;
 
 import io.quarkus.test.junit.NativeImageTest;
+import org.junit.jupiter.api.Disabled;
 
+@Disabled("KOGITO-5358 Native Image tests are broken in Infinispan persistence")
 @NativeImageTest
 class NativeInfinispanPersistenceIT extends InfinispanPersistenceIT {
 

--- a/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-kafka-persistence/src/test/java/org/kie/kogito/it/NativeKafkaPersistenceIT.java
+++ b/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-kafka-persistence/src/test/java/org/kie/kogito/it/NativeKafkaPersistenceIT.java
@@ -15,9 +15,12 @@
  */
 package org.kie.kogito.it;
 
+import org.junit.jupiter.api.Disabled;
+
 import io.quarkus.test.junit.NativeImageTest;
 
 @NativeImageTest
+@Disabled("Inject not supported in native test")
 public class NativeKafkaPersistenceIT extends KafkaPersistenceIT {
 
 }

--- a/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-kafka-persistence/src/test/java/org/kie/kogito/it/NativeKafkaPersistenceIT.java
+++ b/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-kafka-persistence/src/test/java/org/kie/kogito/it/NativeKafkaPersistenceIT.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Disabled;
 import io.quarkus.test.junit.NativeImageTest;
 
 @NativeImageTest
-@Disabled("Inject not supported in native test")
+@Disabled("KOGITO-5362 Native Image tests are broken in Kafka persistence")
 public class NativeKafkaPersistenceIT extends KafkaPersistenceIT {
 
 }

--- a/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-mongodb/src/test/java/org/kie/kogito/it/NativeMongoDBPersistenceIT.java
+++ b/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-mongodb/src/test/java/org/kie/kogito/it/NativeMongoDBPersistenceIT.java
@@ -16,7 +16,9 @@
 package org.kie.kogito.it;
 
 import io.quarkus.test.junit.NativeImageTest;
+import org.junit.jupiter.api.Disabled;
 
+@Disabled("KOGITO-5359 Native Image tests are broken in MongoDB persistence")
 @NativeImageTest
 class NativeMongoDBPersistenceIT extends MongoDBPersistenceIT {
 }

--- a/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-mongodb/src/test/java/org/kie/kogito/it/NativeMongoDBPersistenceIT.java
+++ b/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-mongodb/src/test/java/org/kie/kogito/it/NativeMongoDBPersistenceIT.java
@@ -15,8 +15,9 @@
  */
 package org.kie.kogito.it;
 
-import io.quarkus.test.junit.NativeImageTest;
 import org.junit.jupiter.api.Disabled;
+
+import io.quarkus.test.junit.NativeImageTest;
 
 @Disabled("KOGITO-5359 Native Image tests are broken in MongoDB persistence")
 @NativeImageTest

--- a/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-postgresql/src/test/java/org/kie/kogito/it/NativePostgreSQLPersistenceIT.java
+++ b/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-postgresql/src/test/java/org/kie/kogito/it/NativePostgreSQLPersistenceIT.java
@@ -15,8 +15,9 @@
  */
 package org.kie.kogito.it;
 
-import io.quarkus.test.junit.NativeImageTest;
 import org.junit.jupiter.api.Disabled;
+
+import io.quarkus.test.junit.NativeImageTest;
 
 @Disabled("KOGITO-5360 Native Image tests are broken in PostgreSQL Persistence")
 @NativeImageTest

--- a/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-postgresql/src/test/java/org/kie/kogito/it/NativePostgreSQLPersistenceIT.java
+++ b/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-postgresql/src/test/java/org/kie/kogito/it/NativePostgreSQLPersistenceIT.java
@@ -16,7 +16,9 @@
 package org.kie.kogito.it;
 
 import io.quarkus.test.junit.NativeImageTest;
+import org.junit.jupiter.api.Disabled;
 
+@Disabled("KOGITO-5360 Native Image tests are broken in PostgreSQL Persistence")
 @NativeImageTest
 class NativePostgreSQLPersistenceIT extends PostgreSQLPersistenceIT {
 

--- a/integration-tests/integration-tests-quarkus-processes-persistence/pom.xml
+++ b/integration-tests/integration-tests-quarkus-processes-persistence/pom.xml
@@ -88,6 +88,7 @@
                   <goal>verify</goal>
                 </goals>
                 <configuration combine.self="override">
+                  <useModulePath>false</useModulePath>
                   <includes>
                     <include>**/Native*IT.java</include>
                   </includes>


### PR DESCRIPTION
- This PR fixes native image tests for persistence which weren't running 🚀  
- However when they run, they are all broken 😢 

  - PostgreSQL: serialization issue
  - Infinispan: serialization issue
  - MongoDB: serialization issue
  - Kafka: field is being injected (not supported with NativeImageTest)