### PR TITLE
Configure Quarkus extension capabilities in extension descriptors

### DIFF
--- a/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-deployment/src/main/java/org/kie/kogito/quarkus/decisions/deployment/DecisionsAssetsProcessor.java
+++ b/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-deployment/src/main/java/org/kie/kogito/quarkus/decisions/deployment/DecisionsAssetsProcessor.java
@@ -21,7 +21,6 @@ import java.util.List;
 import org.jboss.jandex.DotName;
 
 import io.quarkus.deployment.annotations.BuildStep;
-import io.quarkus.deployment.builditem.CapabilityBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyIgnoreWarningBuildItem;
@@ -30,11 +29,6 @@ import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyIgnoreWarn
  * Main class of the Kogito decisions extension
  */
 public class DecisionsAssetsProcessor {
-
-    @BuildStep
-    CapabilityBuildItem capability() {
-        return new CapabilityBuildItem("kogito-decisions");
-    }
 
     @BuildStep
     FeatureBuildItem featureBuildItem() {

--- a/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions/pom.xml
@@ -49,8 +49,10 @@
                         </goals>
                         <phase>compile</phase>
                         <configuration>
-                            <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}
-                            </deployment>
+                            <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}</deployment>
+                            <capabilities>
+                                <provides>kogito-decisions</provides>
+                            </capabilities>
                         </configuration>
                     </execution>
                 </executions>

--- a/quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions-deployment/src/main/java/org/kie/kogito/quarkus/predictions/deployment/PredictionsAssetsProcessor.java
+++ b/quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions-deployment/src/main/java/org/kie/kogito/quarkus/predictions/deployment/PredictionsAssetsProcessor.java
@@ -26,7 +26,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.quarkus.deployment.annotations.BuildStep;
-import io.quarkus.deployment.builditem.CapabilityBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
@@ -37,11 +36,6 @@ import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 public class PredictionsAssetsProcessor {
 
     private static final Logger logger = LoggerFactory.getLogger(PredictionsAssetsProcessor.class);
-
-    @BuildStep
-    CapabilityBuildItem capability() {
-        return new CapabilityBuildItem("kogito-predictions");
-    }
 
     @BuildStep
     FeatureBuildItem featureBuildItem() {

--- a/quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions/pom.xml
@@ -47,8 +47,10 @@
                         </goals>
                         <phase>compile</phase>
                         <configuration>
-                            <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}
-                            </deployment>
+                            <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}</deployment>
+                            <capabilities>
+                                <provides>kogito-predictions</provides>
+                            </capabilities>
                         </configuration>
                     </execution>
                 </executions>

--- a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-deployment/src/main/java/org/kie/kogito/quarkus/processes/deployment/ProcessesAssetsProcessor.java
+++ b/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-deployment/src/main/java/org/kie/kogito/quarkus/processes/deployment/ProcessesAssetsProcessor.java
@@ -56,7 +56,6 @@ import io.quarkus.bootstrap.model.AppDependency;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.ArchiveRootBuildItem;
-import io.quarkus.deployment.builditem.CapabilityBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
@@ -98,11 +97,6 @@ public class ProcessesAssetsProcessor {
     LiveReloadBuildItem liveReload;
     @Inject
     CurateOutcomeBuildItem curateOutcomeBuildItem;
-
-    @BuildStep
-    CapabilityBuildItem capability() {
-        return new CapabilityBuildItem("kogito-processes");
-    }
 
     @BuildStep
     FeatureBuildItem featureBuildItem() {

--- a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes/pom.xml
@@ -49,8 +49,10 @@
             </goals>
             <phase>compile</phase>
             <configuration>
-              <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}
-              </deployment>
+              <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}</deployment>
+              <capabilities>
+                <provides>kogito-processes</provides>
+              </capabilities>
             </configuration>
           </execution>
         </executions>

--- a/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-deployment/src/main/java/org/kie/kogito/quarkus/rules/deployment/RulesAssetsProcessor.java
+++ b/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-deployment/src/main/java/org/kie/kogito/quarkus/rules/deployment/RulesAssetsProcessor.java
@@ -16,18 +16,12 @@
 package org.kie.kogito.quarkus.rules.deployment;
 
 import io.quarkus.deployment.annotations.BuildStep;
-import io.quarkus.deployment.builditem.CapabilityBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 
 /**
  * Main class of the Kogito rules extension
  */
 public class RulesAssetsProcessor {
-
-    @BuildStep
-    CapabilityBuildItem capability() {
-        return new CapabilityBuildItem("kogito-rules");
-    }
 
     @BuildStep
     FeatureBuildItem featureBuildItem() {

--- a/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules/pom.xml
@@ -48,8 +48,10 @@
                         </goals>
                         <phase>compile</phase>
                         <configuration>
-                            <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}
-                            </deployment>
+                            <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}</deployment>
+                            <capabilities>
+                                <provides>kogito-rules</provides>
+                            </capabilities>
                         </configuration>
                     </execution>
                 </executions>

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/src/main/java/org/kie/kogito/quarkus/serverless/workflow/deployment/ServerlessWorkflowAssetsProcessor.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/src/main/java/org/kie/kogito/quarkus/serverless/workflow/deployment/ServerlessWorkflowAssetsProcessor.java
@@ -16,18 +16,12 @@
 package org.kie.kogito.quarkus.serverless.workflow.deployment;
 
 import io.quarkus.deployment.annotations.BuildStep;
-import io.quarkus.deployment.builditem.CapabilityBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 
 /**
  * Main class of the Kogito Serverless Workflow extension
  */
 public class ServerlessWorkflowAssetsProcessor {
-
-    @BuildStep
-    CapabilityBuildItem capability() {
-        return new CapabilityBuildItem("kogito-serverless-workflow");
-    }
 
     @BuildStep
     FeatureBuildItem featureBuildItem() {

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/pom.xml
@@ -84,8 +84,10 @@
             </goals>
             <phase>compile</phase>
             <configuration>
-              <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}
-              </deployment>
+              <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}</deployment>
+              <capabilities>
+                <provides>kogito-serverless-workflow</provides>
+              </capabilities>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
In Quarkus 2.x capabilities should be configured in the extension descriptors. While creating instances of `CapabilityBuildItem` still works, moving them to descriptors will make the dev tools aware of the provided capabilities and so they will be taken into account when checking compatibility of selected extensions for a Quarkus app.