### PR TITLE
BXMSPROD-1390 github actions flows concurrency

### DIFF
--- a/.github/workflows/apps-pr.yml
+++ b/.github/workflows/apps-pr.yml
@@ -4,6 +4,9 @@ on: [pull_request]
 
 jobs:
   apps-build:
+    concurrency:
+      group: apps_pr-${{ github.head_ref }}
+      cancel-in-progress: true
     timeout-minutes: 120
     strategy:
       matrix:

--- a/.github/workflows/examples-pr.yml
+++ b/.github/workflows/examples-pr.yml
@@ -4,6 +4,9 @@ on: [pull_request]
 
 jobs:
   example-build:
+    concurrency:
+      group: examples_pr-${{ github.head_ref }}
+      cancel-in-progress: true
     timeout-minutes: 120
     strategy:
       matrix:

--- a/.github/workflows/optaplanner-pr.yml
+++ b/.github/workflows/optaplanner-pr.yml
@@ -4,6 +4,9 @@ on: [pull_request]
 
 jobs:
   optaplanner-build:
+    concurrency:
+      group: optaplanner_pr-${{ github.head_ref }}
+      cancel-in-progress: true
     timeout-minutes: 120
     strategy:
       matrix:

--- a/.github/workflows/runtimes-pr.yml
+++ b/.github/workflows/runtimes-pr.yml
@@ -4,6 +4,9 @@ on: [pull_request]
 
 jobs:
   runtime-build:
+    concurrency:
+      group: runtimes_pr-${{ github.head_ref }}
+      cancel-in-progress: true
     timeout-minutes: 120
     strategy:
       matrix:


### PR DESCRIPTION
https://issues.redhat.com/browse/BXMSPROD-1390

related PRs:

- https://github.com/kiegroup/kogito-runtimes/pull/1384
- https://github.com/kiegroup/kogito-examples/pull/736



Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](CONTRIBUTING.md)
- [ ] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/master/kogito-build/kogito-ide-config)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run all builds</b>  
  Please add comment: <b>Jenkins retest this</b>

* <b>Run (or rerun) specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] tests</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Run (or rerun) LTS specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Run (or rerun) native specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
