### PR TITLE
KOGITO-5445 upgrade rpkgtests-maven-plugin version

### DIFF
--- a/kogito-build/kogito-build-parent/pom.xml
+++ b/kogito-build/kogito-build-parent/pom.xml
@@ -108,7 +108,7 @@
     <version.plexus.classworld>2.5.2</version.plexus.classworld>
     <version.plugin.plugin>3.6.0</version.plugin.plugin>
     <version.project.sources.plugin>0.3</version.project.sources.plugin>
-    <version.rpkgtests.maven.plugin>0.8.0</version.rpkgtests.maven.plugin>
+    <version.rpkgtests.maven.plugin>0.10.0</version.rpkgtests.maven.plugin>
     <version.resources.plugin>3.1.0</version.resources.plugin>
     <version.site.plugin>3.7.1</version.site.plugin>
     <version.shade.plugin>3.0.0</version.shade.plugin>


### PR DESCRIPTION
[KOGITO-5445](https://issues.redhat.com/browse/KOGITO-5445)

Upgrading version of rpkgtests-maven-plugin due to build issue in kogito-quarkus-test-list on OpenJDK 16.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run all builds</b>  
  Please add comment: <b>Jenkins retest this</b>

* <b>Run (or rerun) specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] tests</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Run (or rerun) LTS specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Run (or rerun) native specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
