### PR TITLE
[KOGITO-5223] add kogito legacy-api to jbpm-flow

### DIFF
--- a/jbpm/jbpm-flow/pom.xml
+++ b/jbpm/jbpm-flow/pom.xml
@@ -39,6 +39,10 @@
     </dependency>
     <dependency>
       <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-legacy-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-events-api</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
@tiagodolphine @cristianonicolai I moved the `KieRuntimeBuilder`, which is an adapter to use kie v7 API into the module `kogito-legacy-api`. This means that now jbpm-flow has to depend on it, for the (also legacy) case when a `ruleflow-group` is used. We still have a few examples doing this and without this dependency now they're broken. 

I consider adding this dependency only a temporary fix. Kogito's jbpm shouldn't need the legacy api anymore or, in case we still need it to keep supporting the ruleflow-groups, we need to make the users aware that they need `kogito-legacy-api` and make the import it directly in their projects. 