### PR TITLE
Quarkus Ecosystem CI: Update dependencies using Quarkus BOM

### DIFF
--- a/.github/quarkus-ecosystem-test
+++ b/.github/quarkus-ecosystem-test
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
 set -e
 
-# update the version
+# update Quarkus dependencies
+mvn versions:compare-dependencies \
+    -pl :kogito-build-parent \
+    -DremotePom=io.quarkus:quarkus-bom:${QUARKUS_VERSION} \
+    -DupdatePropertyVersions=true \
+    -DupdateDependencies=true \
+    -DgenerateBackupPoms=false
+
+# update Quarkus version
 mvn versions:set-property -pl :kogito-build-parent -Dproperty=version.io.quarkus -DnewVersion=${QUARKUS_VERSION} -DgenerateBackupPoms=false
 
 # run the tests


### PR DESCRIPTION
`quarkus-ecosystem-test` is bumping only the Quarkus version, without the 3rd party dependencies, this is a recipe for breakage: add 3rd party dependency bump to the CI.

Note: in our script we also [pin the Maven version](https://github.com/kiegroup/kogito-pipelines/blob/master/tools/update-quarkus-versions.sh#L141-L146) to the one running in our repo -- so that Maven plugins are kept aligned to our Maven executable. This may not be required for this CI.