### PR TITLE
[1.5.x] ModelBuilderImpl arguments length

### DIFF
--- a/kogito-codegen-modules/kogito-codegen-rules/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
+++ b/kogito-codegen-modules/kogito-codegen-rules/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
@@ -154,7 +154,7 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
         KnowledgeBuilderConfigurationImpl configuration =
                 new KogitoKnowledgeBuilderConfigurationImpl(context().getClassLoader());
 
-        ModelBuilderImpl<KogitoPackageSources> modelBuilder = new ModelBuilderImpl<>(KogitoPackageSources::dumpSources, configuration, dummyReleaseId, true, hotReloadMode);
+        ModelBuilderImpl<KogitoPackageSources> modelBuilder = new ModelBuilderImpl<>(KogitoPackageSources::dumpSources, configuration, dummyReleaseId, hotReloadMode);
 
         CompositeKnowledgeBuilder batch = modelBuilder.batch();
         resources.forEach(f -> addResource(batch, f));


### PR DESCRIPTION
This refactoring https://github.com/kiegroup/drools/commit/24d30ee77bfdd8bc5a958b6873ef0b5bdad1a792#diff-1edc23cad73ee1cb81406436cbdc8e1b656a6e08c793f32c9b0d591131669370 produces an error on prod process.
```
[ERROR] /tmp/org.kie.kogito-kogito-runtimes-1.5.0.Final-CR2/kogito-codegen-modules/kogito-codegen-rules/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java:[157,63] cannot infer type arguments for org.drools.modelcompiler.builder.ModelBuilderImpl<>
  reason: cannot infer type-variable(s) T
    (actual and formal argument lists differ in length)
[INFO] 1 error
```

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run all builds</b>  
  Please add comment: <b>Jenkins retest this</b>

* <b>Run (or rerun) specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] tests</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Run (or rerun) LTS specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Run (or rerun) native specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
