### PR TITLE
Revert "PLANNER-2467 Jenkinsfiles moved to .ci/jenkins"

### DIFF
--- a/.jenkins/dsl/jobs.groovy
+++ b/.jenkins/dsl/jobs.groovy
@@ -28,10 +28,7 @@ Map getMultijobPRConfig() {
             ], [
                 id: 'Optaplanner',
                 dependsOn: 'Runtimes',
-                repository: 'optaplanner',
-                // TODO remove once https://issues.redhat.com/browse/KOGITO-4113 is done 
-                // as it will become the default path
-                jenkinsfile: '.ci/jenkins/Jenkinsfile',
+                repository: 'optaplanner'
             ], [
                 id: 'Apps',
                 dependsOn: 'Optaplanner',


### PR DESCRIPTION
Reverts kiegroup/kogito-runtimes#1423

Revert until https://github.com/kiegroup/optaplanner/pull/1414 and related are merged