### PR TITLE
KOGITO-5580 adapt kogito-quarkus-test-list after refactoring

### DIFF
--- a/quarkus/extensions/kogito-quarkus-test-list/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-test-list/pom.xml
@@ -47,7 +47,7 @@
               <testJarsPath>${test.list.file.location}</testJarsPath>
               <fileSets>
                 <fileSet>
-                  <directory>${basedir}/../../integration-tests</directory>
+                  <directory>${project.root.dir}/integration-tests/</directory>
                   <includes>
                     <include>*quarkus*/pom.xml</include>
                     <include>integration-tests-quarkus-processes-persistence/*/pom.xml</include>
@@ -61,7 +61,7 @@
                   </excludes>
                 </fileSet>
                 <fileSet>
-                  <directory>${basedir}/../</directory>
+                  <directory>${project.root.dir}/quarkus/extensions/</directory>
                   <includes>
                     <include>kogito-quarkus-decisions-extension/*-integration-test*/pom.xml</include>
                     <include>kogito-quarkus-extension/*-integration-test*/pom.xml</include>


### PR DESCRIPTION
[KOGITO-5580](https://issues.redhat.com/browse/KOGITO-5580)

Use absolute paths starting at project root in kogito-quarkust-test-list module configuration.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run all builds</b>  
  Please add comment: <b>Jenkins retest this</b>

* <b>Run (or rerun) specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] tests</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Run (or rerun) LTS specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Run (or rerun) native specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
