### PR TITLE
KOGITO-5585 Add `skip-ci` label on created PRs

### DIFF
--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -233,7 +233,7 @@ void commitAndCreatePR() {
 
     githubscm.commitChanges(commitMsg, { githubscm.findAndStageNotIgnoredFiles('pom.xml') })
     githubscm.pushObject('origin', getBotBranch(), getBotAuthorCredsID())
-    deployProperties["${getRepoName()}.pr.link"] = githubscm.createPR(commitMsg, prBody, getBuildBranch(), getBotAuthorCredsID())
+    deployProperties["${getRepoName()}.pr.link"] = githubscm.createPRWithLabels(commitMsg, prBody, getBuildBranch(), [ 'skip-ci' ] as String[], getBotAuthorCredsID())
 }
 
 void sendNotification() {

--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -247,7 +247,7 @@ void commitAndCreatePR() {
 
     githubscm.commitChanges(commitMsg, { githubscm.findAndStageNotIgnoredFiles('pom.xml') })
     githubscm.pushObject('origin', getSnapshotBranch(), getBotAuthorCredsID())
-    setPipelinePrLink(githubscm.createPR(commitMsg, prBody, getBuildBranch(), getBotAuthorCredsID()))
+    setPipelinePrLink(githubscm.createPRWithLabels(commitMsg, prBody, getBuildBranch(), [ 'skip-ci' ] as String[], getBotAuthorCredsID()))
 }
 
 MavenCommand getMavenCommand() {


### PR DESCRIPTION
Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](CONTRIBUTING.md)
- [ ] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run all builds</b>  
  Please add comment: <b>Jenkins retest this</b>

* <b>Run (or rerun) specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] tests</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Run (or rerun) LTS specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Run (or rerun) native specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
