### PR TITLE
[KOGITO-5622] Implement Generator.isEmpty() to skip generation when no resources are available

### DIFF
--- a/kogito-codegen-modules/kogito-codegen-api/src/main/java/org/kie/kogito/codegen/api/Generator.java
+++ b/kogito-codegen-modules/kogito-codegen-api/src/main/java/org/kie/kogito/codegen/api/Generator.java
@@ -49,6 +49,8 @@ public interface Generator {
 
     String name();
 
+    boolean isEmpty();
+
     /**
      * Override this method to specify an order of execution
      * 
@@ -59,7 +61,7 @@ public interface Generator {
     }
 
     default boolean isEnabled() {
-        return context().getApplicationProperty(CONFIG_PREFIX + name())
+        return !isEmpty() && context().getApplicationProperty(CONFIG_PREFIX + name())
                 .map("true"::equalsIgnoreCase)
                 .orElse(true);
     }

--- a/kogito-codegen-modules/kogito-codegen-core/src/main/java/org/kie/kogito/codegen/core/AbstractGenerator.java
+++ b/kogito-codegen-modules/kogito-codegen-core/src/main/java/org/kie/kogito/codegen/core/AbstractGenerator.java
@@ -15,10 +15,13 @@
  */
 package org.kie.kogito.codegen.core;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Objects;
 import java.util.Optional;
 
 import org.kie.kogito.codegen.api.ConfigGenerator;
+import org.kie.kogito.codegen.api.GeneratedFile;
 import org.kie.kogito.codegen.api.Generator;
 import org.kie.kogito.codegen.api.context.KogitoBuildContext;
 
@@ -57,4 +60,14 @@ public abstract class AbstractGenerator implements Generator {
     public Optional<ConfigGenerator> configGenerator() {
         return Optional.ofNullable(configGenerator);
     }
+
+    @Override
+    public final Collection<GeneratedFile> generate() {
+        if (isEmpty()) {
+            return Collections.emptySet();
+        }
+        return internalGenerate();
+    }
+
+    protected abstract Collection<GeneratedFile> internalGenerate();
 }

--- a/kogito-codegen-modules/kogito-codegen-core/src/test/java/org/kie/kogito/codegen/core/ApplicationGeneratorTest.java
+++ b/kogito-codegen-modules/kogito-codegen-core/src/test/java/org/kie/kogito/codegen/core/ApplicationGeneratorTest.java
@@ -228,7 +228,7 @@ public class ApplicationGeneratorTest {
         }
 
         @Override
-        public Collection<GeneratedFile> generate() {
+        protected Collection<GeneratedFile> internalGenerate() {
             if (context.hasRESTForGenerator(this)) {
                 return Collections.singleton(new GeneratedFile(REST_TYPE, "my/path", ""));
             } else {
@@ -239,6 +239,11 @@ public class ApplicationGeneratorTest {
         @Override
         public boolean isEnabled() {
             return enabled;
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return !isEnabled();
         }
     }
 }

--- a/kogito-codegen-modules/kogito-codegen-decisions/src/main/java/org/kie/kogito/codegen/decision/DecisionCodegen.java
+++ b/kogito-codegen-modules/kogito-codegen-decisions/src/main/java/org/kie/kogito/codegen/decision/DecisionCodegen.java
@@ -18,7 +18,6 @@ package org.kie.kogito.codegen.decision;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -110,15 +109,17 @@ public class DecisionCodegen extends AbstractGenerator {
     }
 
     @Override
-    public List<GeneratedFile> generate() {
-        if (cResources.isEmpty()) {
-            return Collections.emptyList();
-        }
+    protected Collection<GeneratedFile> internalGenerate() {
         loadModelsAndValidate();
         generateAndStoreRestResources();
         generateAndStoreDecisionModelResourcesProvider();
 
         return generatedFiles;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return cResources.isEmpty();
     }
 
     private void generateAndStoreRestResources() {

--- a/kogito-codegen-modules/kogito-codegen-decisions/src/test/java/org/kie/kogito/codegen/decision/DecisionCodegenTest.java
+++ b/kogito-codegen-modules/kogito-codegen-decisions/src/test/java/org/kie/kogito/codegen/decision/DecisionCodegenTest.java
@@ -19,6 +19,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
@@ -48,10 +49,31 @@ public class DecisionCodegenTest {
 
     @ParameterizedTest
     @MethodSource("org.kie.kogito.codegen.api.utils.KogitoContextTestUtils#contextBuilders")
+    public void isEmpty(KogitoBuildContext.Builder contextBuilder) {
+        KogitoBuildContext context = contextBuilder.build();
+        DecisionCodegen emptyCodeGenerator = DecisionCodegen.ofCollectedResources(context, Collections.emptyList());
+
+        assertThat(emptyCodeGenerator.isEmpty()).isTrue();
+        assertThat(emptyCodeGenerator.isEnabled()).isFalse();
+
+        Collection<GeneratedFile> emptyGeneratedFiles = emptyCodeGenerator.generate();
+        assertThat(emptyGeneratedFiles.size()).isEqualTo(0);
+
+        DecisionCodegen codeGenerator = getDecisionCodegen("src/test/resources/decision/models/vacationDays", contextBuilder);
+
+        assertThat(codeGenerator.isEmpty()).isFalse();
+        assertThat(codeGenerator.isEnabled()).isTrue();
+
+        Collection<GeneratedFile> generatedFiles = codeGenerator.generate();
+        assertThat(generatedFiles.size()).isGreaterThanOrEqualTo(1);
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.kie.kogito.codegen.api.utils.KogitoContextTestUtils#contextBuilders")
     public void generateAllFiles(KogitoBuildContext.Builder contextBuilder) {
         DecisionCodegen codeGenerator = getDecisionCodegen("src/test/resources/decision/models/vacationDays", contextBuilder);
 
-        List<GeneratedFile> generatedFiles = codeGenerator.generate();
+        Collection<GeneratedFile> generatedFiles = codeGenerator.generate();
         assertThat(generatedFiles.size()).isGreaterThanOrEqualTo(6);
 
         Collection<String> expectedResources = new ArrayList<>(Arrays.asList("decision/InputSet.java",
@@ -75,7 +97,7 @@ public class DecisionCodegenTest {
     public void doNotGenerateTypesafeInfo(KogitoBuildContext.Builder contextBuilder) {
         DecisionCodegen codeGenerator = getDecisionCodegen("src/test/resources/decision/alltypes/", contextBuilder);
 
-        List<GeneratedFile> generatedFiles = codeGenerator.generate();
+        Collection<GeneratedFile> generatedFiles = codeGenerator.generate();
         assertThat(generatedFiles.size()).isGreaterThanOrEqualTo(3);
 
         Collection<String> expectedResources = new ArrayList<>(Arrays.asList("http_58_47_47www_46trisotech_46com_47definitions_47__4f5608e9_454d74_454c22_45a47e_45ab657257fc9c/InputSet.java",
@@ -139,7 +161,7 @@ public class DecisionCodegenTest {
     public void resilientToDuplicateDMNIDs(KogitoBuildContext.Builder contextBuilder) {
         DecisionCodegen codeGenerator = getDecisionCodegen("src/test/resources/decision-test20200507", contextBuilder);
 
-        List<GeneratedFile> generatedFiles = codeGenerator.generate();
+        Collection<GeneratedFile> generatedFiles = codeGenerator.generate();
         assertThat(generatedFiles.size()).isGreaterThanOrEqualTo(3);
 
         assertNotEmptySectionCompilationUnit(codeGenerator);
@@ -161,7 +183,7 @@ public class DecisionCodegenTest {
         // This test is meant to check that IFF Eclipse MP OpenAPI annotations are available on Build/CP of Kogito application, annotation is used with codegen
         DecisionCodegen codeGenerator = getDecisionCodegen("src/test/resources/decision-NSEW", contextBuilder);
 
-        List<GeneratedFile> generatedFiles = codeGenerator.generate();
+        Collection<GeneratedFile> generatedFiles = codeGenerator.generate();
         assertThat(generatedFiles).anyMatch(x -> x.relativePath().endsWith("InputSet.java"));
         GeneratedFile inputSetFile = generatedFiles.stream().filter(x -> x.relativePath().endsWith("InputSet.java")).findFirst().get();
         assertThat(new String(inputSetFile.contents())).containsPattern("@org\\.eclipse\\.microprofile\\.openapi\\.annotations\\.media\\.Schema\\(.*enumeration");
@@ -174,7 +196,7 @@ public class DecisionCodegenTest {
                 .withClassAvailabilityResolver(mockClassAvailabilityResolver(emptyList(), singleton("org.eclipse.microprofile.openapi.models.OpenAPI")));
         DecisionCodegen codeGenerator = getDecisionCodegen("src/test/resources/decision-NSEW", contextBuilder);
 
-        List<GeneratedFile> generatedFiles = codeGenerator.generate();
+        Collection<GeneratedFile> generatedFiles = codeGenerator.generate();
         assertThat(generatedFiles).anyMatch(x -> x.relativePath().endsWith("InputSet.java"));
         GeneratedFile inputSetFile = generatedFiles.stream().filter(x -> x.relativePath().endsWith("InputSet.java")).findFirst().get();
         assertThat(new String(inputSetFile.contents())).doesNotContain("@org.eclipse.microprofile.openapi.annotations.media.Schema");
@@ -230,13 +252,13 @@ public class DecisionCodegenTest {
         return DecisionCodegen.ofCollectedResources(context, CollectedResourceProducer.fromPaths(Paths.get(sourcePath).toAbsolutePath()));
     }
 
-    private List<String> fileNames(List<GeneratedFile> generatedFiles) {
+    private Collection<String> fileNames(Collection<GeneratedFile> generatedFiles) {
         return generatedFiles.stream().map(GeneratedFile::relativePath).collect(Collectors.toList());
     }
 
     private List<GeneratedFile> generateTestDashboards(KogitoBuildContext.Builder contextBuilder, DecisionCodegen codeGenerator) {
 
-        List<GeneratedFile> generatedFiles = codeGenerator.generate();
+        Collection<GeneratedFile> generatedFiles = codeGenerator.generate();
 
         List<GeneratedFile> dashboards = generatedFiles.stream()
                 .filter(x -> x.type().equals(DashboardGeneratedFileUtils.DASHBOARD_TYPE))

--- a/kogito-codegen-modules/kogito-codegen-decisions/src/test/java/org/kie/kogito/codegen/decision/DecisionModelResourcesProviderGeneratorTest.java
+++ b/kogito-codegen-modules/kogito-codegen-decisions/src/test/java/org/kie/kogito/codegen/decision/DecisionModelResourcesProviderGeneratorTest.java
@@ -73,7 +73,7 @@ public class DecisionModelResourcesProviderGeneratorTest {
         final DecisionCodegen codeGenerator = DecisionCodegen
                 .ofCollectedResources(context, collectedResources);
 
-        final List<GeneratedFile> generatedFiles = codeGenerator.generate();
+        final Collection<GeneratedFile> generatedFiles = codeGenerator.generate();
         assertThat(generatedFiles.size()).isGreaterThanOrEqualTo(2); // the two resources below, see https://github.com/kiegroup/kogito-runtimes/commit/18ec525f530b1ff1bddcf18c0083f14f86aff171#diff-edd3a09d62dc627ee10fe37925944217R53
 
         // Align this FAI-215 test (#621) with unknown order of generated files (ie.: additional generated files might be present)

--- a/kogito-codegen-modules/kogito-codegen-decisions/src/test/java/org/kie/kogito/codegen/decision/DecisionValidationTest.java
+++ b/kogito-codegen-modules/kogito-codegen-decisions/src/test/java/org/kie/kogito/codegen/decision/DecisionValidationTest.java
@@ -16,7 +16,7 @@
 package org.kie.kogito.codegen.decision;
 
 import java.nio.file.Paths;
-import java.util.List;
+import java.util.Collection;
 import java.util.Properties;
 import java.util.function.Consumer;
 
@@ -57,7 +57,7 @@ public class DecisionValidationTest {
     public void testIgnore() throws Exception {
         DecisionCodegen codeGenerator = codeGenerator("src/test/resources/decision-validation-duplicateName",
                 p -> p.setProperty(DecisionCodegen.VALIDATION_CONFIGURATION_KEY, "IGNORE"));
-        List<GeneratedFile> files = codeGenerator.generate();
+        Collection<GeneratedFile> files = codeGenerator.generate();
         Assertions.assertThat(files).hasSizeGreaterThanOrEqualTo(1);
     }
 
@@ -65,7 +65,7 @@ public class DecisionValidationTest {
     public void testDisabled() throws Exception {
         DecisionCodegen codeGenerator = codeGenerator("src/test/resources/decision-validation-duplicateName",
                 p -> p.setProperty(DecisionCodegen.VALIDATION_CONFIGURATION_KEY, "DISABLED"));
-        List<GeneratedFile> files = codeGenerator.generate();
+        Collection<GeneratedFile> files = codeGenerator.generate();
         Assertions.assertThat(files).hasSizeGreaterThanOrEqualTo(1);
     }
 
@@ -85,7 +85,7 @@ public class DecisionValidationTest {
     public void testDTAnalysisIgnore() throws Exception {
         DecisionCodegen codeGenerator = codeGenerator("src/test/resources/decision-validation-DTsemanticError",
                 p -> p.setProperty(DecisionCodegen.VALIDATION_CONFIGURATION_KEY, "IGNORE"));
-        List<GeneratedFile> files = codeGenerator.generate();
+        Collection<GeneratedFile> files = codeGenerator.generate();
         Assertions.assertThat(files).hasSizeGreaterThanOrEqualTo(1);
     }
 
@@ -93,7 +93,7 @@ public class DecisionValidationTest {
     public void testDTAnalysisDisabled() throws Exception {
         DecisionCodegen codeGenerator = codeGenerator("src/test/resources/decision-validation-DTsemanticError",
                 p -> p.setProperty(DecisionCodegen.VALIDATION_CONFIGURATION_KEY, "DISABLED"));
-        List<GeneratedFile> files = codeGenerator.generate();
+        Collection<GeneratedFile> files = codeGenerator.generate();
         Assertions.assertThat(files).hasSizeGreaterThanOrEqualTo(1);
     }
 }

--- a/kogito-codegen-modules/kogito-codegen-openapi/src/main/java/org/kie/kogito/codegen/openapi/client/OpenApiClientCodegen.java
+++ b/kogito-codegen-modules/kogito-codegen-openapi/src/main/java/org/kie/kogito/codegen/openapi/client/OpenApiClientCodegen.java
@@ -104,7 +104,7 @@ public class OpenApiClientCodegen extends AbstractGenerator {
     }
 
     @Override
-    public Collection<GeneratedFile> generate() {
+    protected Collection<GeneratedFile> internalGenerate() {
         final List<GeneratedFile> generatedFiles = new ArrayList<>();
         this.openApiSpecDescriptors.forEach(descriptor -> {
             LOGGER.debug("Generating OpenApi classes based on {}", descriptor.getResourceName());
@@ -129,6 +129,11 @@ public class OpenApiClientCodegen extends AbstractGenerator {
         });
         this.context().addContextAttribute(ContextAttributesConstants.OPENAPI_DESCRIPTORS, this.openApiSpecDescriptors);
         return generatedFiles;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return openApiSpecDescriptors.isEmpty();
     }
 
     /**

--- a/kogito-codegen-modules/kogito-codegen-openapi/src/test/java/org/kie/kogito/codegen/openapi/client/OpenApiClientCodegenTest.java
+++ b/kogito-codegen-modules/kogito-codegen-openapi/src/test/java/org/kie/kogito/codegen/openapi/client/OpenApiClientCodegenTest.java
@@ -17,6 +17,7 @@ package org.kie.kogito.codegen.openapi.client;
 
 import java.nio.file.Paths;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -29,6 +30,30 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.kogito.codegen.api.utils.CollectedResourcesTestUtils.toCollectedResources;
 
 class OpenApiClientCodegenTest {
+
+    @ParameterizedTest
+    @MethodSource("org.kie.kogito.codegen.api.utils.KogitoContextTestUtils#contextBuilders")
+    public void isEmpty(KogitoBuildContext.Builder contextBuilder) {
+        final String workflowDefinitionFile = "/sendcloudeventonprovision.sw.json";
+
+        KogitoBuildContext context = contextBuilder.build();
+        OpenApiClientCodegen emptyCodeGenerator = OpenApiClientCodegen.ofCollectedResources(context, Collections.emptyList());
+
+        assertThat(emptyCodeGenerator.isEmpty()).isTrue();
+        assertThat(emptyCodeGenerator.isEnabled()).isFalse();
+
+        Collection<GeneratedFile> emptyGeneratedFiles = emptyCodeGenerator.generate();
+        assertThat(emptyGeneratedFiles.size()).isEqualTo(0);
+
+        final OpenApiClientCodegen codeGenerator =
+                OpenApiClientCodegen.ofCollectedResources(context,
+                        toCollectedResources(workflowDefinitionFile));
+
+        assertThat(codeGenerator.isEmpty()).isFalse();
+        assertThat(codeGenerator.isEnabled()).isTrue();
+
+        assertThat(codeGenerator.getOpenAPISpecResources()).hasSizeGreaterThanOrEqualTo(1);
+    }
 
     @ParameterizedTest
     @MethodSource("org.kie.kogito.codegen.api.utils.KogitoContextTestUtils#contextBuilders")

--- a/kogito-codegen-modules/kogito-codegen-predictions/src/main/java/org/kie/kogito/codegen/prediction/PredictionCodegen.java
+++ b/kogito-codegen-modules/kogito-codegen-predictions/src/main/java/org/kie/kogito/codegen/prediction/PredictionCodegen.java
@@ -103,12 +103,17 @@ public class PredictionCodegen extends AbstractGenerator {
     }
 
     @Override
-    public List<GeneratedFile> generate() {
+    protected Collection<GeneratedFile> internalGenerate() {
         List<GeneratedFile> files = new ArrayList<>();
         for (PMMLResource resource : resources) {
             generateModelsFromResource(files, resource);
         }
         return files;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return resources.isEmpty();
     }
 
     @Override

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/ProcessCodegen.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/ProcessCodegen.java
@@ -266,19 +266,8 @@ public class ProcessCodegen extends AbstractGenerator {
         }
     }
 
-    public static String defaultWorkItemHandlerConfigClass(String packageName) {
-        return packageName + ".WorkItemHandlerConfig";
-    }
-
-    public static String defaultProcessListenerConfigClass(String packageName) {
-        return packageName + ".ProcessEventListenerConfig";
-    }
-
     @Override
-    public Collection<GeneratedFile> generate() {
-        if (processes.isEmpty()) {
-            return Collections.emptySet();
-        }
+    protected Collection<GeneratedFile> internalGenerate() {
 
         List<ProcessGenerator> ps = new ArrayList<>();
         List<ProcessInstanceGenerator> pis = new ArrayList<>();
@@ -536,6 +525,11 @@ public class ProcessCodegen extends AbstractGenerator {
         } else {
             generatedFiles.add(new GeneratedFile(type, path, source));
         }
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return processes.isEmpty();
     }
 
     @Override

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/persistence/PersistenceGenerator.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/persistence/PersistenceGenerator.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -122,11 +121,7 @@ public class PersistenceGenerator extends AbstractGenerator {
     }
 
     @Override
-    public Collection<GeneratedFile> generate() {
-        if (!context().getAddonsConfig().usePersistence()) {
-            return Collections.emptyList();
-        }
-
+    protected Collection<GeneratedFile> internalGenerate() {
         Collection<GeneratedFile> generatedFiles = new ArrayList<>();
 
         switch (persistenceType()) {
@@ -153,6 +148,12 @@ public class PersistenceGenerator extends AbstractGenerator {
         }
 
         return generatedFiles;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        // PersistenceGenerator is a different type of generator without specific resources
+        return !context().getAddonsConfig().usePersistence();
     }
 
     public String persistenceType() {

--- a/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/process/ProcessCodegenTest.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/process/ProcessCodegenTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.codegen.process;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.Collections;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.kie.kogito.codegen.api.GeneratedFile;
+import org.kie.kogito.codegen.api.context.KogitoBuildContext;
+import org.kie.kogito.codegen.core.io.CollectedResourceProducer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProcessCodegenTest {
+
+    private static final Path BASE_PATH = Paths.get("src/test/resources/").toAbsolutePath();
+    private static final String MESSAGE_USERTASK_SOURCE = "usertask/UserTasksProcess.bpmn2";
+    private static final Path MESSAGE_USERTASK_SOURCE_FULL_SOURCE = BASE_PATH.resolve(MESSAGE_USERTASK_SOURCE);
+
+    @ParameterizedTest
+    @MethodSource("org.kie.kogito.codegen.api.utils.KogitoContextTestUtils#contextBuilders")
+    public void isEmpty(KogitoBuildContext.Builder contextBuilder) {
+        KogitoBuildContext context = contextBuilder.build();
+
+        ProcessCodegen emptyCodeGenerator = ProcessCodegen.ofCollectedResources(context, Collections.emptyList());
+
+        assertThat(emptyCodeGenerator.isEmpty()).isTrue();
+        assertThat(emptyCodeGenerator.isEnabled()).isFalse();
+
+        Collection<GeneratedFile> emptyGeneratedFiles = emptyCodeGenerator.generate();
+        assertThat(emptyGeneratedFiles.size()).isEqualTo(0);
+
+        ProcessCodegen codeGenerator = ProcessCodegen.ofCollectedResources(
+                context,
+                CollectedResourceProducer.fromFiles(BASE_PATH, MESSAGE_USERTASK_SOURCE_FULL_SOURCE.toFile()));
+
+        assertThat(codeGenerator.isEmpty()).isFalse();
+        assertThat(codeGenerator.isEnabled()).isTrue();
+
+        Collection<GeneratedFile> generatedFiles = codeGenerator.generate();
+        assertThat(generatedFiles).hasSizeGreaterThanOrEqualTo(10);
+    }
+}

--- a/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/process/persistence/FileSystemPersistenceGeneratorTest.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/process/persistence/FileSystemPersistenceGeneratorTest.java
@@ -67,7 +67,7 @@ class FileSystemPersistenceGeneratorTest {
         int expectedNumberOfFiles = context.hasRESTForGenerator(persistenceGenerator) ? 15 : 14;
         assertThat(generatedFiles).hasSize(expectedNumberOfFiles);
 
-        if (context.hasRESTForGenerator(persistenceGenerator)) {
+        if (context.hasDI()) {
             Optional<GeneratedFile> persistenceFactoryImpl = generatedFiles.stream()
                     .filter(gf -> gf.relativePath().equals("org/kie/kogito/persistence/KogitoProcessInstancesFactoryImpl.java"))
                     .findFirst();

--- a/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/process/persistence/InfinispanPersistenceGeneratorTest.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/process/persistence/InfinispanPersistenceGeneratorTest.java
@@ -24,11 +24,11 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.kogito.codegen.api.AddonsConfig;
 import org.kie.kogito.codegen.api.GeneratedFile;
 import org.kie.kogito.codegen.api.context.KogitoBuildContext;
-import org.kie.kogito.codegen.api.context.impl.QuarkusKogitoBuildContext;
 import org.kie.kogito.codegen.data.GeneratedPOJO;
 import org.kie.kogito.codegen.process.persistence.proto.ProtoGenerator;
 import org.kie.kogito.codegen.process.persistence.proto.ReflectionProtoGenerator;
@@ -43,14 +43,15 @@ import static org.kie.kogito.codegen.process.persistence.PersistenceGenerator.IN
 class InfinispanPersistenceGeneratorTest {
 
     private static final String TEST_RESOURCES = "src/test/resources";
-    KogitoBuildContext context = QuarkusKogitoBuildContext.builder()
-            .withApplicationProperties(new File(TEST_RESOURCES))
-            .withPackageName(this.getClass().getPackage().getName())
-            .withAddonsConfig(AddonsConfig.builder().withPersistence(true).build())
-            .build();
 
-    @Test
-    void test() {
+    @ParameterizedTest
+    @MethodSource("org.kie.kogito.codegen.api.utils.KogitoContextTestUtils#contextBuilders")
+    void test(KogitoBuildContext.Builder contextBuilder) {
+        KogitoBuildContext context = contextBuilder
+                .withApplicationProperties(new File(TEST_RESOURCES))
+                .withPackageName(this.getClass().getPackage().getName())
+                .withAddonsConfig(AddonsConfig.builder().withPersistence(true).build())
+                .build();
         context.setApplicationProperty("kogito.persistence.type", INFINISPAN_PERSISTENCE_TYPE);
 
         ReflectionProtoGenerator protoGenerator = ReflectionProtoGenerator.builder().build(Collections.singleton(GeneratedPOJO.class));
@@ -62,21 +63,23 @@ class InfinispanPersistenceGeneratorTest {
         assertThat(generatedFiles.stream().filter(gf -> gf.type().equals(ProtoGenerator.PROTO_TYPE)).count()).isEqualTo(2);
         assertThat(generatedFiles.stream().filter(gf -> gf.type().equals(ProtoGenerator.PROTO_TYPE) && gf.relativePath().endsWith(".json")).count()).isEqualTo(1);
 
-        Optional<GeneratedFile> persistenceFactoryImpl = generatedFiles.stream()
-                .filter(gf -> gf.relativePath().equals("org/kie/kogito/persistence/KogitoProcessInstancesFactoryImpl.java"))
-                .findFirst();
-        List<GeneratedFile> marshallerFiles = generatedFiles.stream().filter(gf -> gf.relativePath().endsWith("MessageMarshaller.java")).collect(Collectors.toList());
+        if (context.hasRESTForGenerator(persistenceGenerator)) {
+            Optional<GeneratedFile> persistenceFactoryImpl = generatedFiles.stream()
+                    .filter(gf -> gf.relativePath().equals("org/kie/kogito/persistence/KogitoProcessInstancesFactoryImpl.java"))
+                    .findFirst();
+            List<GeneratedFile> marshallerFiles = generatedFiles.stream().filter(gf -> gf.relativePath().endsWith("MessageMarshaller.java")).collect(Collectors.toList());
 
-        String expectedMarshaller = "PersonMessageMarshaller";
-        assertThat(persistenceFactoryImpl).isNotEmpty();
-        assertThat(marshallerFiles.size()).isEqualTo(1);
-        assertThat(marshallerFiles.get(0).relativePath()).endsWith(expectedMarshaller + ".java");
+            String expectedMarshaller = "PersonMessageMarshaller";
+            assertThat(persistenceFactoryImpl).isNotEmpty();
+            assertThat(marshallerFiles.size()).isEqualTo(1);
+            assertThat(marshallerFiles.get(0).relativePath()).endsWith(expectedMarshaller + ".java");
 
-        final CompilationUnit compilationUnit = parse(new ByteArrayInputStream(persistenceFactoryImpl.get().contents()));
+            final CompilationUnit compilationUnit = parse(new ByteArrayInputStream(persistenceFactoryImpl.get().contents()));
 
-        compilationUnit
-                .findFirst(ClassOrInterfaceDeclaration.class)
-                .orElseThrow(() -> new NoSuchElementException("Compilation unit doesn't contain a class or interface declaration!"));
+            compilationUnit
+                    .findFirst(ClassOrInterfaceDeclaration.class)
+                    .orElseThrow(() -> new NoSuchElementException("Compilation unit doesn't contain a class or interface declaration!"));
+        }
 
     }
 }

--- a/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/process/persistence/InfinispanPersistenceGeneratorTest.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/process/persistence/InfinispanPersistenceGeneratorTest.java
@@ -63,7 +63,7 @@ class InfinispanPersistenceGeneratorTest {
         assertThat(generatedFiles.stream().filter(gf -> gf.type().equals(ProtoGenerator.PROTO_TYPE)).count()).isEqualTo(2);
         assertThat(generatedFiles.stream().filter(gf -> gf.type().equals(ProtoGenerator.PROTO_TYPE) && gf.relativePath().endsWith(".json")).count()).isEqualTo(1);
 
-        if (context.hasRESTForGenerator(persistenceGenerator)) {
+        if (context.hasDI()) {
             Optional<GeneratedFile> persistenceFactoryImpl = generatedFiles.stream()
                     .filter(gf -> gf.relativePath().equals("org/kie/kogito/persistence/KogitoProcessInstancesFactoryImpl.java"))
                     .findFirst();

--- a/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/process/persistence/JDBCPersistenceGeneratorTest.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/process/persistence/JDBCPersistenceGeneratorTest.java
@@ -66,7 +66,7 @@ class JDBCPersistenceGeneratorTest {
         assertThat(generatedFiles.stream().filter(gf -> gf.type().equals(ProtoGenerator.PROTO_TYPE)).count()).isEqualTo(2);
         assertThat(generatedFiles.stream().filter(gf -> gf.type().equals(ProtoGenerator.PROTO_TYPE) && gf.relativePath().endsWith(".json")).count()).isEqualTo(1);
 
-        if (context.hasRESTForGenerator(persistenceGenerator)) {
+        if (context.hasDI()) {
             Optional<GeneratedFile> persistenceFactoryImpl = generatedFiles.stream()
                     .filter(gf -> gf.relativePath().equals("org/kie/kogito/persistence/KogitoProcessInstancesFactoryImpl.java"))
                     .findFirst();

--- a/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/process/persistence/KafkaPersistenceGeneratorTest.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/process/persistence/KafkaPersistenceGeneratorTest.java
@@ -24,11 +24,11 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.kogito.codegen.api.AddonsConfig;
 import org.kie.kogito.codegen.api.GeneratedFile;
 import org.kie.kogito.codegen.api.context.KogitoBuildContext;
-import org.kie.kogito.codegen.api.context.impl.QuarkusKogitoBuildContext;
 import org.kie.kogito.codegen.data.GeneratedPOJO;
 import org.kie.kogito.codegen.process.persistence.proto.ProtoGenerator;
 import org.kie.kogito.codegen.process.persistence.proto.ReflectionProtoGenerator;
@@ -43,14 +43,16 @@ import static org.kie.kogito.codegen.process.persistence.PersistenceGenerator.KA
 class KafkaPersistenceGeneratorTest {
 
     private static final String TEST_RESOURCES = "src/test/resources";
-    KogitoBuildContext context = QuarkusKogitoBuildContext.builder()
-            .withApplicationProperties(new File(TEST_RESOURCES))
-            .withPackageName(this.getClass().getPackage().getName())
-            .withAddonsConfig(AddonsConfig.builder().withPersistence(true).build())
-            .build();
 
-    @Test
-    void test() {
+    @ParameterizedTest
+    @MethodSource("org.kie.kogito.codegen.api.utils.KogitoContextTestUtils#contextBuilders")
+    void test(KogitoBuildContext.Builder contextBuilder) {
+        KogitoBuildContext context = contextBuilder
+                .withApplicationProperties(new File(TEST_RESOURCES))
+                .withPackageName(this.getClass().getPackage().getName())
+                .withAddonsConfig(AddonsConfig.builder().withPersistence(true).build())
+                .build();
+
         context.setApplicationProperty("kogito.persistence.type", KAFKA_PERSISTENCE_TYPE);
 
         ReflectionProtoGenerator protoGenerator = ReflectionProtoGenerator.builder().build(Collections.singleton(GeneratedPOJO.class));
@@ -62,21 +64,22 @@ class KafkaPersistenceGeneratorTest {
         assertThat(generatedFiles.stream().filter(gf -> gf.type().equals(ProtoGenerator.PROTO_TYPE)).count()).isEqualTo(2);
         assertThat(generatedFiles.stream().filter(gf -> gf.type().equals(ProtoGenerator.PROTO_TYPE) && gf.relativePath().endsWith(".json")).count()).isEqualTo(1);
 
-        Optional<GeneratedFile> persistenceFactoryImpl = generatedFiles.stream()
-                .filter(gf -> gf.relativePath().equals("org/kie/kogito/persistence/KogitoProcessInstancesFactoryImpl.java"))
-                .findFirst();
-        List<GeneratedFile> marshallerFiles = generatedFiles.stream().filter(gf -> gf.relativePath().endsWith("MessageMarshaller.java")).collect(Collectors.toList());
+        if (context.hasRESTForGenerator(persistenceGenerator)) {
+            Optional<GeneratedFile> persistenceFactoryImpl = generatedFiles.stream()
+                    .filter(gf -> gf.relativePath().equals("org/kie/kogito/persistence/KogitoProcessInstancesFactoryImpl.java"))
+                    .findFirst();
+            List<GeneratedFile> marshallerFiles = generatedFiles.stream().filter(gf -> gf.relativePath().endsWith("MessageMarshaller.java")).collect(Collectors.toList());
 
-        String expectedMarshaller = "PersonMessageMarshaller";
-        assertThat(persistenceFactoryImpl).isNotEmpty();
-        assertThat(marshallerFiles.size()).isEqualTo(1);
-        assertThat(marshallerFiles.get(0).relativePath()).endsWith(expectedMarshaller + ".java");
+            String expectedMarshaller = "PersonMessageMarshaller";
+            assertThat(persistenceFactoryImpl).isNotEmpty();
+            assertThat(marshallerFiles.size()).isEqualTo(1);
+            assertThat(marshallerFiles.get(0).relativePath()).endsWith(expectedMarshaller + ".java");
 
-        final CompilationUnit compilationUnit = parse(new ByteArrayInputStream(persistenceFactoryImpl.get().contents()));
+            final CompilationUnit compilationUnit = parse(new ByteArrayInputStream(persistenceFactoryImpl.get().contents()));
 
-        compilationUnit
-                .findFirst(ClassOrInterfaceDeclaration.class)
-                .orElseThrow(() -> new NoSuchElementException("Compilation unit doesn't contain a class or interface declaration!"));
-
+            compilationUnit
+                    .findFirst(ClassOrInterfaceDeclaration.class)
+                    .orElseThrow(() -> new NoSuchElementException("Compilation unit doesn't contain a class or interface declaration!"));
+        }
     }
 }

--- a/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/process/persistence/KafkaPersistenceGeneratorTest.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/process/persistence/KafkaPersistenceGeneratorTest.java
@@ -64,7 +64,7 @@ class KafkaPersistenceGeneratorTest {
         assertThat(generatedFiles.stream().filter(gf -> gf.type().equals(ProtoGenerator.PROTO_TYPE)).count()).isEqualTo(2);
         assertThat(generatedFiles.stream().filter(gf -> gf.type().equals(ProtoGenerator.PROTO_TYPE) && gf.relativePath().endsWith(".json")).count()).isEqualTo(1);
 
-        if (context.hasRESTForGenerator(persistenceGenerator)) {
+        if (context.hasDI()) {
             Optional<GeneratedFile> persistenceFactoryImpl = generatedFiles.stream()
                     .filter(gf -> gf.relativePath().equals("org/kie/kogito/persistence/KogitoProcessInstancesFactoryImpl.java"))
                     .findFirst();

--- a/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/process/persistence/MongoDBPersistenceGeneratorTest.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/process/persistence/MongoDBPersistenceGeneratorTest.java
@@ -23,13 +23,16 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.kogito.codegen.api.AddonsConfig;
 import org.kie.kogito.codegen.api.GeneratedFile;
 import org.kie.kogito.codegen.api.GeneratedFileType;
 import org.kie.kogito.codegen.api.context.KogitoBuildContext;
 import org.kie.kogito.codegen.api.context.impl.QuarkusKogitoBuildContext;
-import org.kie.kogito.codegen.data.Person;
+import org.kie.kogito.codegen.api.context.impl.SpringBootKogitoBuildContext;
+import org.kie.kogito.codegen.data.GeneratedPOJO;
+import org.kie.kogito.codegen.process.persistence.proto.ProtoGenerator;
 import org.kie.kogito.codegen.process.persistence.proto.ReflectionProtoGenerator;
 
 import com.github.javaparser.ast.CompilationUnit;
@@ -37,9 +40,8 @@ import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.ConstructorDeclaration;
 import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.expr.Name;
-import com.github.javaparser.ast.expr.NormalAnnotationExpr;
-import com.github.javaparser.ast.expr.StringLiteralExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.ReturnStmt;
 
@@ -57,94 +59,122 @@ class MongoDBPersistenceGeneratorTest {
     private static final String PERSISTENCE_FILE_PATH = "org/kie/kogito/persistence/KogitoProcessInstancesFactoryImpl.java";
     private static final String TRANSACTION_FILE_PATH = "org/kie/kogito/mongodb/transaction/MongoDBTransactionManagerImpl.java";
 
-    KogitoBuildContext context = QuarkusKogitoBuildContext.builder()
-            .withApplicationProperties(new File(TEST_RESOURCES))
-            .withPackageName(this.getClass().getPackage().getName())
-            .withAddonsConfig(AddonsConfig.builder().withPersistence(true).build())
-            .build();
+    @ParameterizedTest
+    @MethodSource("org.kie.kogito.codegen.api.utils.KogitoContextTestUtils#contextBuilders")
+    void test(KogitoBuildContext.Builder contextBuilder) {
+        KogitoBuildContext context = contextBuilder
+                .withApplicationProperties(new File(TEST_RESOURCES))
+                .withPackageName(this.getClass().getPackage().getName())
+                .withAddonsConfig(AddonsConfig.builder().withPersistence(true).build())
+                .build();
 
-    @Test
-    void test() {
         context.setApplicationProperty("kogito.persistence.type", MONGODB_PERSISTENCE_TYPE);
 
-        ReflectionProtoGenerator protoGenerator = ReflectionProtoGenerator.builder().build(Collections.singleton(Person.class));
+        ReflectionProtoGenerator protoGenerator = ReflectionProtoGenerator.builder().build(Collections.singleton(GeneratedPOJO.class));
         PersistenceGenerator persistenceGenerator = new PersistenceGenerator(
                 context,
                 protoGenerator);
         Collection<GeneratedFile> generatedFiles = persistenceGenerator.generate();
 
-        Optional<GeneratedFile> generatedCLASSFile = generatedFiles.stream().filter(gf -> gf.category() == GeneratedFileType.SOURCE.category())
-                .filter(f -> PERSISTENCE_FILE_PATH.equals(f.relativePath())).findAny();
-        assertTrue(generatedCLASSFile.isPresent());
-        GeneratedFile classFile = generatedCLASSFile.get();
-        assertEquals(PERSISTENCE_FILE_PATH, classFile.relativePath());
+        assertThat(generatedFiles.stream().filter(gf -> gf.type().equals(ProtoGenerator.PROTO_TYPE)).count()).isEqualTo(2);
+        assertThat(generatedFiles.stream().filter(gf -> gf.type().equals(ProtoGenerator.PROTO_TYPE) && gf.relativePath().endsWith(".json")).count()).isEqualTo(1);
 
-        final CompilationUnit compilationUnit = parse(new ByteArrayInputStream(classFile.contents()));
+        if (context.hasRESTForGenerator(persistenceGenerator)) {
+            Optional<GeneratedFile> generatedCLASSFile = generatedFiles.stream().filter(gf -> gf.category() == GeneratedFileType.SOURCE.category())
+                    .filter(f -> PERSISTENCE_FILE_PATH.equals(f.relativePath())).findAny();
+            assertTrue(generatedCLASSFile.isPresent());
+            GeneratedFile classFile = generatedCLASSFile.get();
+            assertEquals(PERSISTENCE_FILE_PATH, classFile.relativePath());
 
-        final ClassOrInterfaceDeclaration classDeclaration =
-                compilationUnit.findFirst(ClassOrInterfaceDeclaration.class).orElseThrow(() -> new NoSuchElementException("Compilation unit doesn't contain a class or interface declaration!"));
+            final CompilationUnit compilationUnit = parse(new ByteArrayInputStream(classFile.contents()));
 
-        assertNotNull(classDeclaration);
+            final ClassOrInterfaceDeclaration classDeclaration =
+                    compilationUnit.findFirst(ClassOrInterfaceDeclaration.class).orElseThrow(() -> new NoSuchElementException("Compilation unit doesn't contain a class or interface declaration!"));
 
-        final MethodDeclaration methodDeclaration = classDeclaration.findFirst(MethodDeclaration.class, d -> d.getName().getIdentifier().equals("dbName"))
-                .orElseThrow(() -> new NoSuchElementException("Class declaration doesn't contain a method named \"dbName\"!"));
-        assertNotNull(methodDeclaration);
-        assertTrue(methodDeclaration.getBody().isPresent());
+            assertNotNull(classDeclaration);
 
-        final BlockStmt body = methodDeclaration.getBody().get();
-        assertThat(body.getStatements().size()).isOne();
-        assertTrue(body.getStatements().get(0).isReturnStmt());
+            final MethodDeclaration methodDeclaration = classDeclaration.findFirst(MethodDeclaration.class, d -> d.getName().getIdentifier().equals("dbName"))
+                    .orElseThrow(() -> new NoSuchElementException("Class declaration doesn't contain a method named \"dbName\"!"));
+            assertNotNull(methodDeclaration);
+            assertTrue(methodDeclaration.getBody().isPresent());
 
-        final ReturnStmt returnStmt = (ReturnStmt) body.getStatements().get(0);
-        assertThat(returnStmt.toString()).contains("kogito");
+            final BlockStmt body = methodDeclaration.getBody().get();
+            assertThat(body.getStatements().size()).isOne();
+            assertTrue(body.getStatements().get(0).isReturnStmt());
 
-        final MethodDeclaration transactionMethodDeclaration = classDeclaration.findFirst(MethodDeclaration.class, d -> "transactionManager".equals(d.getName().getIdentifier()))
-                .orElseThrow(() -> new NoSuchElementException("Class declaration doesn't contain a method named \"transactionManager\"!"));
-        assertNotNull(transactionMethodDeclaration);
-        assertTrue(transactionMethodDeclaration.getBody().isPresent());
+            final ReturnStmt returnStmt = (ReturnStmt) body.getStatements().get(0);
+            assertThat(returnStmt.toString()).contains("kogito");
 
-        final BlockStmt transactionMethodBody = transactionMethodDeclaration.getBody().get();
-        assertThat(transactionMethodBody.getStatements().size()).isOne();
-        assertTrue(transactionMethodBody.getStatements().get(0).isReturnStmt());
+            final MethodDeclaration transactionMethodDeclaration = classDeclaration.findFirst(MethodDeclaration.class, d -> "transactionManager".equals(d.getName().getIdentifier()))
+                    .orElseThrow(() -> new NoSuchElementException("Class declaration doesn't contain a method named \"transactionManager\"!"));
+            assertNotNull(transactionMethodDeclaration);
+            assertTrue(transactionMethodDeclaration.getBody().isPresent());
 
-        final ReturnStmt transactionReturnStmt = (ReturnStmt) transactionMethodBody.getStatements().get(0);
-        assertThat(transactionReturnStmt.toString()).contains("transactionManager");
+            final BlockStmt transactionMethodBody = transactionMethodDeclaration.getBody().get();
+            assertThat(transactionMethodBody.getStatements().size()).isOne();
+            assertTrue(transactionMethodBody.getStatements().get(0).isReturnStmt());
 
-        Optional<GeneratedFile> generatedTransactionCLASSFile = generatedFiles.stream().filter(gf -> gf.category() == GeneratedFileType.SOURCE.category())
-                .filter(f -> TRANSACTION_FILE_PATH.equals(f.relativePath())).findAny();
-        assertTrue(generatedTransactionCLASSFile.isPresent());
+            final ReturnStmt transactionReturnStmt = (ReturnStmt) transactionMethodBody.getStatements().get(0);
+            assertThat(transactionReturnStmt.toString()).contains("transactionManager");
 
-        final CompilationUnit transactionCompilationUnit = parse(new ByteArrayInputStream(generatedTransactionCLASSFile.get().contents()));
-        final ClassOrInterfaceDeclaration transactionClassDeclaration = transactionCompilationUnit.findFirst(ClassOrInterfaceDeclaration.class)
-                .orElseThrow(() -> new NoSuchElementException("Compilation unit doesn't contain a class or interface declaration!"));
-        assertNotNull(transactionClassDeclaration);
+            Optional<GeneratedFile> generatedTransactionCLASSFile = generatedFiles.stream().filter(gf -> gf.category() == GeneratedFileType.SOURCE.category())
+                    .filter(f -> TRANSACTION_FILE_PATH.equals(f.relativePath())).findAny();
+            assertTrue(generatedTransactionCLASSFile.isPresent());
 
-        final List<ConstructorDeclaration> constructorDeclarations = transactionCompilationUnit.findAll(ConstructorDeclaration.class);
-        assertEquals(2, constructorDeclarations.size());
+            final CompilationUnit transactionCompilationUnit = parse(new ByteArrayInputStream(generatedTransactionCLASSFile.get().contents()));
+            final ClassOrInterfaceDeclaration transactionClassDeclaration = transactionCompilationUnit.findFirst(ClassOrInterfaceDeclaration.class)
+                    .orElseThrow(() -> new NoSuchElementException("Compilation unit doesn't contain a class or interface declaration!"));
+            assertNotNull(transactionClassDeclaration);
 
-        Optional<ConstructorDeclaration> annotatedConstructorDeclaration = constructorDeclarations.stream()
-                .filter(c -> c.isAnnotationPresent("Inject")).findAny();
-        assertTrue(annotatedConstructorDeclaration.isPresent());
+            final List<ConstructorDeclaration> constructorDeclarations = transactionCompilationUnit.findAll(ConstructorDeclaration.class);
+            assertEquals(2, constructorDeclarations.size());
 
-        final MethodDeclaration transactionEnabledMethodDeclaration = transactionClassDeclaration.findFirst(MethodDeclaration.class, d -> d.getName().getIdentifier().equals("enabled"))
-                .orElseThrow(() -> new NoSuchElementException("Class declaration doesn't contain a method named \"enabled\"!"));
-        assertNotNull(transactionEnabledMethodDeclaration);
-        assertTrue(transactionEnabledMethodDeclaration.getBody().isPresent());
+            Optional<ConstructorDeclaration> annotatedConstructorDeclaration = constructorDeclarations.stream()
+                    .filter(c -> c.isAnnotationPresent(injectionAnnotation(context))).findAny();
+            assertTrue(annotatedConstructorDeclaration.isPresent());
 
-        final BlockStmt enabledMethodBody = transactionEnabledMethodDeclaration.getBody().get();
-        assertThat(enabledMethodBody.getStatements().size()).isOne();
-        assertTrue(enabledMethodBody.getStatements().get(0).isReturnStmt());
+            final MethodDeclaration transactionEnabledMethodDeclaration = transactionClassDeclaration.findFirst(MethodDeclaration.class, d -> d.getName().getIdentifier().equals("enabled"))
+                    .orElseThrow(() -> new NoSuchElementException("Class declaration doesn't contain a method named \"enabled\"!"));
+            assertNotNull(transactionEnabledMethodDeclaration);
+            assertTrue(transactionEnabledMethodDeclaration.getBody().isPresent());
 
-        final ReturnStmt enabledReturnStmt = (ReturnStmt) enabledMethodBody.getStatements().get(0);
-        assertThat(enabledReturnStmt.toString()).contains("enabled");
+            final BlockStmt enabledMethodBody = transactionEnabledMethodDeclaration.getBody().get();
+            assertThat(enabledMethodBody.getStatements().size()).isOne();
+            assertTrue(enabledMethodBody.getStatements().get(0).isReturnStmt());
 
-        final FieldDeclaration transactionEnabledFieldDeclaration = transactionClassDeclaration.findFirst(FieldDeclaration.class, f -> f.getVariable(0).getName().getIdentifier().equals("enabled"))
-                .orElseThrow(() -> new NoSuchElementException("Class declaration doesn't contain a field named \"enabled\"!"));
-        assertNotNull(transactionEnabledFieldDeclaration);
-        final NormalAnnotationExpr transactionEnabledAnnotationDeclaration =
-                transactionEnabledFieldDeclaration.findFirst(NormalAnnotationExpr.class, a -> ((Name) a.getChildNodes().get(0)).getIdentifier().equals("ConfigProperty"))
-                        .orElseThrow(() -> new NoSuchElementException("Field declaration doesn't contain an annotation  named \"ConfigProperty\"!"));
-        assertNotNull(transactionEnabledAnnotationDeclaration);
-        assertEquals("kogito.persistence.transaction.enabled", ((StringLiteralExpr) transactionEnabledAnnotationDeclaration.getChildNodes().get(1).getChildNodes().get(1)).getValue());
+            final ReturnStmt enabledReturnStmt = (ReturnStmt) enabledMethodBody.getStatements().get(0);
+            assertThat(enabledReturnStmt.toString()).contains("enabled");
+
+            final FieldDeclaration transactionEnabledFieldDeclaration = transactionClassDeclaration.findFirst(FieldDeclaration.class, f -> f.getVariable(0).getName().getIdentifier().equals("enabled"))
+                    .orElseThrow(() -> new NoSuchElementException("Class declaration doesn't contain a field named \"enabled\"!"));
+            assertNotNull(transactionEnabledFieldDeclaration);
+            final AnnotationExpr transactionEnabledAnnotationDeclaration =
+                    transactionEnabledFieldDeclaration.findFirst(AnnotationExpr.class, a -> ((Name) a.getChildNodes().get(0)).getIdentifier().equals(configInjectionAnnotation(context)))
+                            .orElseThrow(() -> new NoSuchElementException("Field declaration doesn't contain an annotation  named \"" + configInjectionAnnotation(context) + "\"!"));
+            assertNotNull(transactionEnabledAnnotationDeclaration);
+            assertThat(transactionEnabledAnnotationDeclaration.getChildNodes().get(1).toString()).contains("kogito.persistence.transaction.enabled");
+        }
+    }
+
+    private String injectionAnnotation(KogitoBuildContext context) {
+        switch (context.name()) {
+            case QuarkusKogitoBuildContext.CONTEXT_NAME:
+                return "Inject";
+            case SpringBootKogitoBuildContext.CONTEXT_NAME:
+                return "Autowired";
+            default:
+                throw new RuntimeException("No injection annotation found");
+        }
+    }
+
+    private String configInjectionAnnotation(KogitoBuildContext context) {
+        switch (context.name()) {
+            case QuarkusKogitoBuildContext.CONTEXT_NAME:
+                return "ConfigProperty";
+            case SpringBootKogitoBuildContext.CONTEXT_NAME:
+                return "Value";
+            default:
+                throw new RuntimeException("No config injection annotation found");
+        }
     }
 }

--- a/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/process/persistence/MongoDBPersistenceGeneratorTest.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/process/persistence/MongoDBPersistenceGeneratorTest.java
@@ -79,7 +79,7 @@ class MongoDBPersistenceGeneratorTest {
         assertThat(generatedFiles.stream().filter(gf -> gf.type().equals(ProtoGenerator.PROTO_TYPE)).count()).isEqualTo(2);
         assertThat(generatedFiles.stream().filter(gf -> gf.type().equals(ProtoGenerator.PROTO_TYPE) && gf.relativePath().endsWith(".json")).count()).isEqualTo(1);
 
-        if (context.hasRESTForGenerator(persistenceGenerator)) {
+        if (context.hasDI()) {
             Optional<GeneratedFile> generatedCLASSFile = generatedFiles.stream().filter(gf -> gf.category() == GeneratedFileType.SOURCE.category())
                     .filter(f -> PERSISTENCE_FILE_PATH.equals(f.relativePath())).findAny();
             assertTrue(generatedCLASSFile.isPresent());

--- a/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/process/persistence/PersistenceGeneratorTest.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/process/persistence/PersistenceGeneratorTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.codegen.process.persistence;
+
+import java.util.Collection;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.kie.kogito.codegen.api.AddonsConfig;
+import org.kie.kogito.codegen.api.GeneratedFile;
+import org.kie.kogito.codegen.api.context.KogitoBuildContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PersistenceGeneratorTest {
+
+    @ParameterizedTest
+    @MethodSource("org.kie.kogito.codegen.api.utils.KogitoContextTestUtils#contextBuilders")
+    public void isEmpty(KogitoBuildContext.Builder contextBuilder) {
+        KogitoBuildContext noPersistenceContext = contextBuilder
+                .withAddonsConfig(AddonsConfig.builder()
+                        .withPersistence(false)
+                        .build())
+                .build();
+
+        PersistenceGenerator emptyCodeGenerator = new PersistenceGenerator(noPersistenceContext, null);
+
+        assertThat(emptyCodeGenerator.isEmpty()).isTrue();
+        assertThat(emptyCodeGenerator.isEnabled()).isFalse();
+
+        Collection<GeneratedFile> emptyGeneratedFiles = emptyCodeGenerator.generate();
+        assertThat(emptyGeneratedFiles.size()).isEqualTo(0);
+
+        KogitoBuildContext persistenceContext = contextBuilder
+                .withAddonsConfig(AddonsConfig.builder()
+                        .withPersistence(true)
+                        .build())
+                .build();
+        PersistenceGenerator codeGenerator = new PersistenceGenerator(persistenceContext, null);
+
+        assertThat(codeGenerator.isEmpty()).isFalse();
+        assertThat(codeGenerator.isEnabled()).isTrue();
+    }
+
+}

--- a/kogito-codegen-modules/kogito-codegen-rules/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
+++ b/kogito-codegen-modules/kogito-codegen-rules/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
@@ -137,7 +137,12 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
     }
 
     @Override
-    public List<GeneratedFile> generate() {
+    public boolean isEmpty() {
+        return resources.isEmpty();
+    }
+
+    @Override
+    protected Collection<GeneratedFile> internalGenerate() {
         ReleaseIdImpl dummyReleaseId = new ReleaseIdImpl("dummy:dummy:0.0.0");
         if (!decisionTableSupported &&
                 resources.stream().anyMatch(r -> r.getResourceType() == ResourceType.DTABLE)) {

--- a/kogito-codegen-modules/kogito-codegen-rules/src/test/java/org/kie/kogito/codegen/rules/BigRuleSetCodegenTest.java
+++ b/kogito-codegen-modules/kogito-codegen-rules/src/test/java/org/kie/kogito/codegen/rules/BigRuleSetCodegenTest.java
@@ -17,7 +17,6 @@ package org.kie.kogito.codegen.rules;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 
 import org.drools.core.io.impl.ByteArrayResource;
 import org.junit.jupiter.api.Test;
@@ -39,7 +38,7 @@ public class BigRuleSetCodegenTest {
         IncrementalRuleCodegen incrementalRuleCodegen = IncrementalRuleCodegen.ofResources(
                 JavaKogitoBuildContext.builder().build(), resources);
 
-        List<GeneratedFile> generatedFiles = incrementalRuleCodegen.generate();
+        Collection<GeneratedFile> generatedFiles = incrementalRuleCodegen.generate();
         System.out.println(generatedFiles.size());
     }
 

--- a/kogito-codegen-modules/kogito-codegen-sample/kogito-codegen-sample-generator/src/main/java/org/kie/kogito/codegen/sample/generator/SampleCodegen.java
+++ b/kogito-codegen-modules/kogito-codegen-sample/kogito-codegen-sample-generator/src/main/java/org/kie/kogito/codegen/sample/generator/SampleCodegen.java
@@ -68,8 +68,13 @@ public class SampleCodegen implements Generator {
     }
 
     @Override
+    public boolean isEmpty() {
+        return sampleResources.isEmpty();
+    }
+
+    @Override
     public Collection<GeneratedFile> generate() {
-        if (sampleResources.isEmpty()) {
+        if (isEmpty()) {
             return Collections.emptyList();
         }
 

--- a/kogito-codegen-modules/kogito-codegen-sample/kogito-codegen-sample-generator/src/test/java/org/kie/kogito/codegen/sample/generator/SampleCodegenTest.java
+++ b/kogito-codegen-modules/kogito-codegen-sample/kogito-codegen-sample-generator/src/test/java/org/kie/kogito/codegen/sample/generator/SampleCodegenTest.java
@@ -49,6 +49,32 @@ class SampleCodegenTest {
 
     @ParameterizedTest
     @MethodSource("org.kie.kogito.codegen.api.utils.KogitoContextTestUtils#contextBuilders")
+    public void isEmpty(KogitoBuildContext.Builder contextBuilder) {
+        KogitoBuildContext context = contextBuilder.build();
+        SampleCodegen emptyCodeGenerator = SampleCodegen.ofCollectedResources(context, Collections.emptyList());
+
+        assertThat(emptyCodeGenerator.isEmpty()).isTrue();
+        assertThat(emptyCodeGenerator.isEnabled()).isFalse();
+
+        Collection<GeneratedFile> emptyGeneratedFiles = emptyCodeGenerator.generate();
+        assertThat(emptyGeneratedFiles.size()).isEqualTo(0);
+
+        Collection<CollectedResource> resources = Arrays.asList(
+                CollectedResourcesTestUtils.toCollectedResource("/sampleFile1.txt"),
+                CollectedResourcesTestUtils.toCollectedResource("/sampleFile2.txt"));
+        SampleCodegen codeGenerator = SampleCodegen.ofCollectedResources(
+                context, resources);
+
+        assertThat(codeGenerator.isEmpty()).isFalse();
+        assertThat(codeGenerator.isEnabled()).isTrue();
+
+        Collection<GeneratedFile> generatedFiles = codeGenerator.generate();
+        int minNumberOfResources = context.hasRESTForGenerator(codeGenerator) ? 1 : 0;
+        assertThat(generatedFiles.size()).isGreaterThanOrEqualTo(minNumberOfResources);
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.kie.kogito.codegen.api.utils.KogitoContextTestUtils#contextBuilders")
     void generate(KogitoBuildContext.Builder contextBuilder) {
         KogitoBuildContext context = contextBuilder.build();
         Collection<CollectedResource> resources = Arrays.asList(

--- a/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/ProcessClassesMojo.java
+++ b/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/ProcessClassesMojo.java
@@ -120,7 +120,6 @@ public class ProcessClassesMojo extends AbstractKieMojo {
                 // Json schema generation
                 Stream<Class<?>> classStream = reflections.getTypesAnnotatedWith(UserTask.class).stream();
                 generateJsonSchema(classStream).forEach(this::writeGeneratedFile);
-
             }
         } catch (Exception e) {
             throw new MojoExecutionException("Error during processing model classes", e);


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-5622

## Details
Kogito has a compile time execution (codegen) and a runtime execution (engine execution).
Kogito integration with Quarkus and Springboot is done differently:
- in Quarkus there are multiple extensions that implicitly brings in both the compile time (aka `deployment` using Quarkus naming) and the runtime for the selected engine (DMN, BPMN etc)
- in Springboot we have a single `kogito-maven-plugin` with all compile time code for all the possible engines even if the runtime part is not available

Quarkus behaviour is already correct while with SpringBoot there is a side effect: `kogito-maven-plugin` is performing some generation even for engines that are not available that can lead to compilation errors. This was not really possible until now but the new specific springboot starters made this problem now a blocker. 

This PR introduce a simple `isEmpty` check so that a generator that has no resources to consume is automatically disabled.

There is a corner case that it is still not properly addressed by this ticket: what if for example a user includes only processes but then in the resource folder provides also a DRL file? At the moment the `isEmpty` check will pass so the rule generator will execute.
We might consider to add a check at effective pom level to see if a runtime feature is available or we might decide to add a "marker" class to check to see if the project is properly configured. A similar check might require to have a project classLoader (aka a classloader with only runtime classpath) that is not available in Quarkus context (see [KOGITO-4270](https://issues.redhat.com/browse/KOGITO-4270))

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run all builds</b>  
  Please add comment: <b>Jenkins retest this</b>

* <b>Run (or rerun) specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] tests</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Run (or rerun) LTS specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Run (or rerun) native specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
