### PR TITLE
KOGITO-5660 - Fix illegal char in grafana dashboards for Windows OS

### DIFF
--- a/grafana-api/src/main/java/org/kie/kogito/grafana/GrafanaConfigurationWriter.java
+++ b/grafana-api/src/main/java/org/kie/kogito/grafana/GrafanaConfigurationWriter.java
@@ -148,7 +148,7 @@ public class GrafanaConfigurationWriter {
 
     public static String buildDashboardName(Optional<KogitoGAV> gav, String handlerName) {
         if (gav.isPresent()) {
-            return String.format("%s:%s - %s", gav.get().getArtifactId(), gav.get().getVersion(), handlerName);
+            return String.format("%s_%s - %s", gav.get().getArtifactId(), gav.get().getVersion(), handlerName);
         }
         return handlerName;
     }

--- a/grafana-api/src/test/java/org/kie/kogito/grafana/GrafanaConfigurationWriterTest.java
+++ b/grafana-api/src/test/java/org/kie/kogito/grafana/GrafanaConfigurationWriterTest.java
@@ -27,7 +27,7 @@ public class GrafanaConfigurationWriterTest {
     public void testGrafanaDashboardName() {
         KogitoGAV gav = new KogitoGAV("groupId", "artifactId", "versionId");
         String handlerName = "myHandler";
-        String expected = "artifactId:versionId - myHandler";
+        String expected = "artifactId_versionId - myHandler";
 
         String dashboardName = GrafanaConfigurationWriter.buildDashboardName(Optional.of(gav), handlerName);
 


### PR DESCRIPTION
Fixes https://github.com/kiegroup/kogito-examples/issues/835

Jira: https://issues.redhat.com/browse/KOGITO-5660

Examples PR: https://github.com/kiegroup/kogito-examples/pull/837

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run all builds</b>  
  Please add comment: <b>Jenkins retest this</b>

* <b>Run (or rerun) specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] tests</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Run (or rerun) LTS specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Run (or rerun) native specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
