### PR TITLE
[KOGITO-5674] Improve error reporting related to kogito-legacy-api

### DIFF
--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/canonical/ActivityGenerationModelTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/canonical/ActivityGenerationModelTest.java
@@ -18,6 +18,9 @@ package org.jbpm.bpmn2.canonical;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -422,9 +425,12 @@ public class ActivityGenerationModelTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testBusinessRuleTaskProcess() throws Exception {
+        // This is a workaround to make it compile. A process that includes rules will never execute without a full Kogito context
+        MockClassLoader classLoader = new MockClassLoader("org.kie.kogito.legacy.rules.KieRuntimeBuilder");
+
         BpmnProcess process = BpmnProcess.from(new ClassPathResource("BPMN2-BusinessRuleTask.bpmn2")).get(0);
 
-        ProcessMetaData metaData = ProcessToExecModelGenerator.INSTANCE.generate((WorkflowProcess) process.process());
+        ProcessMetaData metaData = new ProcessToExecModelGenerator(classLoader).generate((WorkflowProcess) process.process());
         String content = metaData.getGeneratedClassModel().toString();
         assertThat(content).isNotNull();
         log(content);
@@ -561,5 +567,22 @@ public class ActivityGenerationModelTest extends JbpmBpmn2TestCase {
             return super.findClass(name);
         }
 
+    }
+
+    private static class MockClassLoader extends ClassLoader {
+
+        private final Collection<String> mockedClass = new ArrayList<>();
+
+        private MockClassLoader(String ... mockedClass) {
+            this.mockedClass.addAll(Arrays.asList(mockedClass));
+        }
+
+        @Override
+        public Class<?> loadClass(String name) throws ClassNotFoundException {
+            if (mockedClass.contains(name)) {
+                return Object.class;
+            }
+            return super.loadClass(name);
+        }
     }
 }

--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/canonical/ActivityGenerationModelTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/canonical/ActivityGenerationModelTest.java
@@ -573,7 +573,7 @@ public class ActivityGenerationModelTest extends JbpmBpmn2TestCase {
 
         private final Collection<String> mockedClass = new ArrayList<>();
 
-        private MockClassLoader(String ... mockedClass) {
+        private MockClassLoader(String... mockedClass) {
             this.mockedClass.addAll(Arrays.asList(mockedClass));
         }
 

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/RuleSetNodeVisitor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/RuleSetNodeVisitor.java
@@ -88,6 +88,9 @@ public class RuleSetNodeVisitor extends AbstractNodeVisitor<RuleSetNode> {
         NameExpr methodScope = new NameExpr(getNodeId(node));
         MethodCallExpr m;
         if (ruleType.isRuleFlowGroup()) {
+            if (!hasClass("org.kie.kogito.legacy.rules.KieRuntimeBuilder")) {
+                throw new IllegalArgumentException("Rule task " + nodeName + "is invalid: the usage of RuleFlowGroup requires org.kie.kogito:kogito-legacy-api dependency");
+            }
             m = handleRuleFlowGroup(ruleType);
         } else if (ruleType.isRuleUnit()) {
             m = handleRuleUnit(variableScope, metadata, node, nodeName, ruleType);
@@ -140,7 +143,7 @@ public class RuleSetNodeVisitor extends AbstractNodeVisitor<RuleSetNode> {
         RuleUnitDescription description;
 
         try {
-            Class<?> unitClass = loadUnitClass(nodeName, unitName, metadata.getPackageName());
+            Class<?> unitClass = loadUnitClass(unitName, metadata.getPackageName());
             description = new ReflectiveRuleUnitDescription(null, (Class<? extends RuleUnitData>) unitClass);
         } catch (ClassNotFoundException e) {
             logger.warn("Rule task \"{}\": cannot load class {}. " +
@@ -194,12 +197,15 @@ public class RuleSetNodeVisitor extends AbstractNodeVisitor<RuleSetNode> {
 
     }
 
-    private Class<?> loadUnitClass(String nodeName, String unitName, String packageName) throws ClassNotFoundException {
+    private Class<?> loadUnitClass(String unitName, String packageName) throws ClassNotFoundException {
         ClassNotFoundException ex;
         try {
             return contextClassLoader.loadClass(unitName);
         } catch (ClassNotFoundException e) {
             ex = e;
+        }
+        if (packageName == null || packageName.isEmpty()) {
+            throw ex;
         }
         // maybe the name is not qualified. Let's try with tacking the packageName at the front
         try {
@@ -207,6 +213,15 @@ public class RuleSetNodeVisitor extends AbstractNodeVisitor<RuleSetNode> {
         } catch (ClassNotFoundException e) {
             // throw the original error
             throw ex;
+        }
+    }
+
+    private boolean hasClass(String className) {
+        try {
+            loadUnitClass(className, null);
+            return true;
+        } catch (Exception e) {
+            return false;
         }
     }
 }

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/RuleSetNodeVisitor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/RuleSetNodeVisitor.java
@@ -220,7 +220,7 @@ public class RuleSetNodeVisitor extends AbstractNodeVisitor<RuleSetNode> {
         try {
             loadUnitClass(className, null);
             return true;
-        } catch (Exception e) {
+        } catch (ClassNotFoundException e) {
             return false;
         }
     }

--- a/kogito-codegen-modules/kogito-codegen-api/src/test/java/org/kie/kogito/codegen/api/utils/KogitoContextTestUtils.java
+++ b/kogito-codegen-modules/kogito-codegen-api/src/test/java/org/kie/kogito/codegen/api/utils/KogitoContextTestUtils.java
@@ -20,9 +20,13 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.params.provider.Arguments;
+import org.kie.kogito.codegen.api.context.KogitoBuildContext;
 import org.kie.kogito.codegen.api.context.impl.JavaKogitoBuildContext;
 import org.kie.kogito.codegen.api.context.impl.QuarkusKogitoBuildContext;
 import org.kie.kogito.codegen.api.context.impl.SpringBootKogitoBuildContext;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singleton;
 
 public class KogitoContextTestUtils {
 
@@ -55,6 +59,11 @@ public class KogitoContextTestUtils {
                 return false;
             }
         };
+    }
+
+    public static KogitoBuildContext.Builder withLegacyApi(KogitoBuildContext.Builder contextBuilder) {
+        return contextBuilder
+                .withClassAvailabilityResolver(mockClassAvailabilityResolver(singleton("org.kie.kogito.legacy.rules.KieRuntimeBuilder"), emptyList()));
     }
 
 }

--- a/kogito-codegen-modules/kogito-codegen-rules/src/main/java/org/kie/kogito/codegen/rules/ProjectRuntimeGenerator.java
+++ b/kogito-codegen-modules/kogito-codegen-rules/src/main/java/org/kie/kogito/codegen/rules/ProjectRuntimeGenerator.java
@@ -141,7 +141,7 @@ public class ProjectRuntimeGenerator {
                 .orElseThrow(() -> new InvalidTemplateException(generator, "Cannot find getConfForSession method"));
 
         SwitchStmt switchStmt = getConfForSessionMethod.findFirst(SwitchStmt.class)
-                .orElseThrow(() -> new InvalidTemplateException(generator, "Cannot switch inside getConfForSession method"));
+                .orElseThrow(() -> new InvalidTemplateException(generator, "Cannot find switch inside getConfForSession method"));
         ;
 
         for (Map.Entry<String, BlockStmt> entry : modelMethod.getkSessionConfs().entrySet()) {

--- a/kogito-codegen-modules/kogito-codegen-rules/src/test/java/org/kie/kogito/codegen/rules/BigRuleSetCodegenTest.java
+++ b/kogito-codegen-modules/kogito-codegen-rules/src/test/java/org/kie/kogito/codegen/rules/BigRuleSetCodegenTest.java
@@ -25,21 +25,31 @@ import org.kie.api.io.ResourceType;
 import org.kie.kogito.codegen.api.GeneratedFile;
 import org.kie.kogito.codegen.api.context.impl.JavaKogitoBuildContext;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.kie.kogito.codegen.api.utils.KogitoContextTestUtils.withLegacyApi;
+
 public class BigRuleSetCodegenTest {
 
     @Test
     public void test() {
         // This test is used to check that compilation of large knowledge bases doesn't cause an Out Of Memory
         // We are not running the test with such a big kbase by default to avoid slowing down CI
-        // Collection<Resource> resources = generateResourcesToBeCompiled(17, 1000);
+        // int numberOfResource = 17;
+        // int rulesPerResource = 1000;
 
-        Collection<Resource> resources = generateResourcesToBeCompiled(2, 3);
+        int numberOfResource = 2;
+        int rulesPerResource = 3;
+
+        Collection<Resource> resources = generateResourcesToBeCompiled(numberOfResource, rulesPerResource);
 
         IncrementalRuleCodegen incrementalRuleCodegen = IncrementalRuleCodegen.ofResources(
-                JavaKogitoBuildContext.builder().build(), resources);
+                withLegacyApi(JavaKogitoBuildContext.builder()).build(), resources);
 
         Collection<GeneratedFile> generatedFiles = incrementalRuleCodegen.generate();
-        System.out.println(generatedFiles.size());
+
+        int legacyApiFiles = 2;
+        int domainClasses = 1;
+        assertThat(generatedFiles).hasSizeGreaterThan(legacyApiFiles + domainClasses);
     }
 
     private Collection<Resource> generateResourcesToBeCompiled(int numberOfResources, int rulesPerResource) {


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-5674

At the moment, if users try to use a legacy use case (ruleflowgroup in a process or kieSession in DRL) must include kogito-legacy-api as dependency.
This is not enforced at the moment and the compilation might fail with a very cryptic message like compilation failure in one of the generated classes (i.e. [KOGITO-5643](https://issues.redhat.com/browse/KOGITO-5643)).
This PR introduces a similar check both for processes and rules

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](CONTRIBUTING.md)
- [ ] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run all builds</b>  
  Please add comment: <b>Jenkins retest this</b>

* <b>Run (or rerun) specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] tests</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Run (or rerun) LTS specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Run (or rerun) native specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
