### PR TITLE
Fix proto file path when generating ProtostreamObjectMarshaller(#769)

### DIFF
--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/persistence/PersistenceGenerator.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/persistence/PersistenceGenerator.java
@@ -324,7 +324,7 @@ public class PersistenceGenerator extends AbstractGenerator {
             Expression chainExpression = newFileDescriptorSource;
             for (GeneratedFile generatedFile : protoFiles) {
                 String path = generatedFile.relativePath();
-                int idx = path.lastIndexOf(File.separator);
+                int idx = path.lastIndexOf('/');
                 String name = idx >= 0 && path.length() > idx + 1 ? path.substring(idx + 1) : path;
                 if (!name.endsWith(".proto")) {
                     continue;


### PR DESCRIPTION
Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

## Description

This PR is fix for when running https://github.com/kiegroup/kogito-examples/tree/stable/process-mongodb-persistence-springboot on windows environment. As the windows use `\\` as the file path separator, the previous string split will not work as expected. This is causing this issue reported here -> https://github.com/kiegroup/kogito-examples/issues/769
<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run all builds</b>  
  Please add comment: <b>Jenkins retest this</b>

* <b>Run (or rerun) specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] tests</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Run (or rerun) LTS specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Run (or rerun) native specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
