### PR TITLE
KOGITO-5713 Gradle integration test build should be skippable

### DIFF
--- a/integration-tests/integration-tests-quarkus-gradle/pom.xml
+++ b/integration-tests/integration-tests-quarkus-gradle/pom.xml
@@ -11,6 +11,8 @@
   <name>Kogito :: Integration Tests :: Quarkus :: Gradle</name>
 
   <properties>
+    <!-- skip evaluation if skipITs is set -->
+    <exec.skip>${skipITs}</exec.skip>
     <gradle.project.dir>${basedir}/integration-tests-quarkus-gradle-project</gradle.project.dir>
   </properties>
 

--- a/kogito-build/kogito-build-parent/pom.xml
+++ b/kogito-build/kogito-build-parent/pom.xml
@@ -839,6 +839,7 @@ limitations under the License.
         <skipITs>true</skipITs>
         <invoker.skip>true</invoker.skip>
         <archetype.test.skip>true</archetype.test.skip>
+        <exec.skip>true</exec.skip>
       </properties>
       <build>
         <defaultGoal>clean install</defaultGoal>
@@ -890,6 +891,7 @@ limitations under the License.
       <properties>
         <invoker.skip>true</invoker.skip>
         <archetype.test.skip>true</archetype.test.skip>
+        <exec.skip>true</exec.skip>
       </properties>
     </profile>
 

--- a/kogito-build/kogito-build-parent/pom.xml
+++ b/kogito-build/kogito-build-parent/pom.xml
@@ -794,6 +794,7 @@ limitations under the License.
         <skipTests>true</skipTests>
         <invoker.skip>true</invoker.skip>
         <archetype.test.skip>true</archetype.test.skip>
+        <exec.skip>true</exec.skip>
       </properties>
       <build>
         <defaultGoal>clean install</defaultGoal>


### PR DESCRIPTION
it now supports both `quickly` and `skipITs` and of course its native `exec.skip`

https://issues.redhat.com/browse/KOGITO-5713

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run all builds</b>  
  Please add comment: <b>Jenkins retest this</b>

* <b>Run (or rerun) specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] tests</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Run (or rerun) LTS specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Run (or rerun) native specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
