### PR TITLE
KOGITO-5747 Public API: Shared Modules (Incubation)

### DIFF
--- a/api/kogito-api-incubation-application/pom.xml
+++ b/api/kogito-api-incubation-application/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2021 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-api-parent</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>kogito-api-incubation-application</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Kogito :: API :: Public API :: Incubation :: Application</name>
+    <description>The Kogito Public Application API (Incubation).</description>
+
+    <properties>
+        <java.module.name>org.kie.kogito.api.incubation.application</java.module.name>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.kie.kogito</groupId>
+            <artifactId>kogito-api-incubation-common</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>de.skuzzle.enforcer</groupId>
+                        <artifactId>restrict-imports-enforcer-rule</artifactId>
+                        <version>${version.de.skuzzle.enforcer}</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id>check-restricted-imports</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <restrictImports implementation="de.skuzzle.enforcer.restrictimports.rule.RestrictImports">
+                                    <reason>Allow only module imports</reason>
+                                    <bannedImports>
+                                        <bannedImport>org.kie.kogito.**</bannedImport>
+                                    </bannedImports>
+                                    <allowedImports>
+                                        <!-- we only allow common.*  -->
+                                        <allowedImport>org.kie.kogito.incubation.common.**</allowedImport>
+                                    </allowedImports>
+                                </restrictImports>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/api/kogito-api-incubation-application/src/main/java/org/kie/kogito/incubation/application/AppRoot.java
+++ b/api/kogito-api-incubation-application/src/main/java/org/kie/kogito/incubation/application/AppRoot.java
@@ -15,11 +15,10 @@
  */
 package org.kie.kogito.incubation.application;
 
-import java.nio.file.Paths;
-
 import org.kie.kogito.incubation.common.ComponentRoot;
 import org.kie.kogito.incubation.common.Id;
-import org.kie.kogito.incubation.common.PathLocalId;
+import org.kie.kogito.incubation.common.LocalUri;
+import org.kie.kogito.incubation.common.LocalUriId;
 
 /**
  * Root path of an application.
@@ -32,12 +31,12 @@ import org.kie.kogito.incubation.common.PathLocalId;
  * Each component provides a fluent builder for an {@link Id} that is specific
  * to that component.
  */
-public abstract class AppRoot extends PathLocalId implements Id {
+public abstract class AppRoot extends LocalUriId implements Id {
 
     private final String name;
 
     protected AppRoot(String name) {
-        super(Paths.get("/"));
+        super(LocalUri.Root);
         this.name = name;
     }
 

--- a/api/kogito-api-incubation-application/src/main/java/org/kie/kogito/incubation/application/AppRoot.java
+++ b/api/kogito-api-incubation-application/src/main/java/org/kie/kogito/incubation/application/AppRoot.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.incubation.application;
+
+import java.nio.file.Paths;
+
+import org.kie.kogito.incubation.common.ComponentRoot;
+import org.kie.kogito.incubation.common.Id;
+import org.kie.kogito.incubation.common.PathLocalId;
+
+/**
+ * Root path of an application.
+ *
+ * An application has a name. Many applications may be created. The name creates
+ * a name space for each application, so that components may be individually
+ * addressed across application instances.
+ *
+ * An AppRoot retrieves "components" through {@link ComponentRoot}s.
+ * Each component provides a fluent builder for an {@link Id} that is specific
+ * to that component.
+ */
+public abstract class AppRoot extends PathLocalId implements Id {
+
+    private final String name;
+
+    protected AppRoot(String name) {
+        super(Paths.get("/"));
+        this.name = name;
+    }
+
+    /**
+     * subclasses should override this using the appropriate
+     * DI/ServiceLoading mechanism to allow the pattern <code>appRoot.get(Components.class)...</code>;
+     * e.g. <code>appRoot.get(ProcessIds.class).get("my.process.id).tasks().get("my.task")</code>
+     */
+    abstract public <T extends ComponentRoot> T get(Class<T> providerId);
+
+    /**
+     * Name is only used to differentiate multiple applications.
+     * Mostly useful in a distributed context, with RemoteIds.
+     */
+    public String name() {
+        return name;
+    }
+
+}

--- a/api/kogito-api-incubation-application/src/main/java/org/kie/kogito/incubation/application/ReflectiveAppRoot.java
+++ b/api/kogito-api-incubation-application/src/main/java/org/kie/kogito/incubation/application/ReflectiveAppRoot.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.incubation.application;
+
+import org.kie.kogito.incubation.common.ComponentRoot;
+
+/**
+ * Useful for testing. Creates Components reflectively.
+ */
+public class ReflectiveAppRoot extends AppRoot {
+    public ReflectiveAppRoot(String name) {
+        super(name);
+    }
+
+    public ReflectiveAppRoot() {
+        super("kogito-app");
+    }
+
+    @Override
+    public <T extends ComponentRoot> T get(Class<T> providerId) {
+        try {
+            return providerId.getConstructor().newInstance();
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+}

--- a/api/kogito-api-incubation-common/README.md
+++ b/api/kogito-api-incubation-common/README.md
@@ -1,0 +1,201 @@
+# Incubation API
+
+This readme documents the design of the `common` component and the `application` component.
+
+## General Expected Usage Example
+
+Every component should provide one or more service implementations. Each service takes an identifier 
+(a Path from a root) and usually a `DataContext`. The generic form of interaction should follow the pattern:
+
+
+```java
+   LocalId id = appRoot.get(MyComponent.class).get("componentName").subs().get("someSubComponent")
+   DataContext result = svc.evaluationMethod(id, dataContext);
+
+```
+
+for instance, evaluating a DMN may look like this:
+
+```java
+   LocalDecisionId decisionId = appRoot.get(DecisionIds.class).get(namespaceString, nameString);
+   DataContext result = svc.evaluate(decisionId, dataContext);
+
+```
+
+When a component admits subcomponents (e.g. tasks in processes, decision services in DMN, queries in rules, etc.),
+then there should be a way to construct that path with a fluent API:
+
+```java
+   LocalDecisionId decisionServiceId = appRoot.get(DecisionIds.class).get(namespaceString, nameString).services().get(serviceString);
+   DataContext result = svc.evaluate(decisionServiceId, dataContext);
+
+```
+
+
+If the types make sense, then a single `evaluate` method should be able to "parse" the provided ID, 
+even for different paths; i.e. it is perfectly acceptable, even preferrable:
+
+```java
+   DataContext result = svc.evaluate(serviceId, inputDataContext);
+   DataContext serviceResult = svc.evaluate(decisionServiceId, inputDataContext);
+
+``` 
+
+However, component developers are free to provide their own methods; multiple methods 
+should be returned, especially if they represent different actions; e.g.:
+
+
+```java
+   LocalProcessInstanceId lpid = svc.createProcess(processId, inputDataContext);
+   DataContext started = svc.start(lpid);
+   DataContext aborted = svc.abort(lpid);
+``` 
+
+
+
+## Application and Paths
+
+The `application` component provides the root of the typed builder API for paths (`appRoot`);
+
+i.e. paths such as `/processes/my.process` or `/predictions/my.prediction` are constructed 
+via `appRoot.get(ProcessIds.class).get("my.process")` or `appRoot.get(PredictionIds.class).get("my.prediction")` respectively. 
+The return type of this chain of methods is always an `Id` or a `LocalId`.
+
+The `<Component>Ids` class should implement `ComponentRoot`.
+
+paths admit subpaths if the Component admits subcomponents; e.g. a DMN admits services, so the path
+
+     /decisions/$id/services/$serviceId
+
+should be allowed. The method chain should reflect the structure of that path:
+
+    appRoot.get(DecisionIds.class).get(namespace, name).services().get(serviceId)
+
+
+A `RemoteId` is also available to "install" the path on a hostname:port pair. This is not useful at the moment, 
+it will be useful in a distributed setting.
+
+In the future such a path will be also parsable starting from a String (e.g. `LocalId.parse(String)`)
+
+Because of their construction, paths can be always rendered as a string, and can always be parsed from a string into a 
+typed representation (the `/prefix` and intermediated parts (such as `/services` specify the subtype). 
+This makes them trivially serializable for sending over the wire and trivially unserializable into their typed representation.
+
+
+
+## Main API (`common`)
+
+The `common` module provides basic interfaces so that each component may specialize one or more `LocalId` 
+definitions and provide one or more service implementation.
+
+Every component provides a pair of modules:
+
+- `kogito-api-incubation-<component>`: Paths and Identifiers
+- `kogito-api-incubation-<component>-services`: Service Interfaces
+
+
+### Paths and Identifiers
+
+The first module contains specializations of `LocalId` (e.g. `DecisionId`) and/or subpaths. For instance:
+
+- a "decision service ID" should be addressable, and that service Id is a subcomponent of a decision. 
+  Then `DecisionId` should expose the method `services()` and `appRoot.get(DecisionIds.class).get("my.decision").services().get("my.service.id")` 
+  should be the path constructor; it would create a `DecisionServiceId`
+
+### DataContext
+
+- A `DataContext` is a computational context. It contains all the data that is required by a service to perform its computation.
+- A `DataContext` can be always converted into another type (or another DataContext) using the method `DataContext#as(Class<T extends DataContext>)`.
+
+A DataContext can be always converted into another sub-type of DataContext. Converting a DataContext 
+into the same DataContext is a no-op just like (Object) new Object() is a no-op. You are always able to convert 
+a DataContext into an arbitrary sub-type; e.g. a MapDataContext into a POJO that implements DataContext.
+
+```java
+class Person implements DataContext, DefaultCastable { String name; }
+MapDataContext ctx = MapDataContext.create();
+ctx.set("name", "Paul");
+Person p = ctx.as(Person.class);
+String name = p.name; // "Paul"
+```
+
+`MapDataContext` provides methods `get(), set()` and wraps a map. This is the simplest and convenient way to pass data. 
+However, it is suggested to create your own class. In this case your POJO should extends `DataContext` and `DefaultCastable` 
+(the latter provides a default implementation of the `as()` method that is usually good for most cases)
+
+Note: `DefaultCastable#as` uses Jackson internally, but it's an implementation detail and it may change in the future if we decide so.
+
+### Service Interfaces
+
+Service interfaces should follow the generic pattern :
+
+    RETURN-TYPE VERB(IDENTIFIER [, optional DATACONTEXT])
+
+e.g.
+
+
+```java
+   LocalId id = appRoot.get(MyComponent.class).get("componentName").subs().get("someSubComponent")
+   DataContext result = svc.evaluationMethod(id, dataContext);
+
+```
+
+- Service interfaces do not extend a specific interface; component developers may define their own methods,  
+  although a certain degree of consistency is expected.
+- **RETURN-TYPE** should be always either an IDentifier or a DataContext. Implementations should usually take 
+  the most generic implementation `DataContext` as a parameter, and should usually return `DataContext` as a return type. 
+  It is allowed (as per Java spec) to return a subtype of DataContext, but this may not be required, as users can
+  always convert into a more specific type.
+- When a method *evaluates* the resource pointed by the IDENTIFIER and **completes** (i.e. stateless evaluation), 
+  then RETURN-TYPE should always be DataContext.
+- When a method *starts the evaluation* of the resource pointed by the IDENTIFIER but it may not **complete**, 
+  then RETURN-TYPE may be an identifier.  (e.g. `processService.create(id)` would return a `processInstanceId`)
+
+
+Asyncronous evaluation is allowed. In this case RETURN-TYPE should express the fact that evaluation is async. For instance:
+
+```java
+   LocalId id = appRoot.get(MyComponent.class).get("componentName").subs().get("someSubComponent")
+   CompletableFuture<DataContext> result = asyncSvc.evaluationMethod(id, dataContext);
+
+```
+
+i.e. a Process engine may provide `AsyncProcessService`
+
+```java
+   CompletableFuture<LocalProcessInstanceId> futureLpid = asyncSvc.createProcess(processId, inputDataContext);
+   CompletableFuture<DataContext> futureStarted = futureLpid.andThen(lpid -> asyncSvc.start(lpid));
+   ...
+``` 
+
+## Implementation
+
+Currently only for Quarkus. The implementation is being shipped as part of the extension for convenience 
+(it may be refactored to its own extension in the future). Implementation should provide:
+
+- injectable version of their component class -- used for wiring in `appRoot.get(MyComponent.class)`
+- injectable versions of their services
+
+Currently services delegate their implementation to the internal hidden API that is used for codegen. 
+The internal API should be considered deprecated and in the future codegen should be moved to the new API.
+
+Refer to the related PRs for more details.
+
+## Caveats
+
+### What about listeners?
+
+Currently listeners are plugged through annotation as we currently do already in Kogito. Since internally the APIs that 
+we use in codegen are being used, those will work automatically.
+
+### What about metadata?
+
+The API only deals with data, but what about meta-data? e.g. directives that should  
+be passed to the engine, that are not part of the Payload? (e.g. HTTP headers that should be passed to the engine 
+to configure a specific request)
+
+  ```java
+     var result = svc.evaluate(id, payload [ metadata ???] ) 
+  ```
+
+  This is currently under investigation.

--- a/api/kogito-api-incubation-common/pom.xml
+++ b/api/kogito-api-incubation-common/pom.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2021 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-api-parent</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>kogito-api-incubation-common</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Kogito :: API :: Public API :: Incubation :: Common</name>
+    <description>The Kogito Public Common API (Incubation).</description>
+
+    <properties>
+        <java.module.name>org.kie.kogito.api.incubation.common</java.module.name>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>de.skuzzle.enforcer</groupId>
+                        <artifactId>restrict-imports-enforcer-rule</artifactId>
+                        <version>${version.de.skuzzle.enforcer}</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id>check-restricted-imports</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <restrictImports implementation="de.skuzzle.enforcer.restrictimports.rule.RestrictImports">
+                                    <reason>Allow only module imports</reason>
+                                    <bannedImports>
+                                        <bannedImport>org.kie.kogito.**</bannedImport>
+                                    </bannedImports>
+                                    <allowedImports>
+                                        <!-- we always allow process.* as these will be movable to internal -->
+                                        <allowedImport>org.kie.kogito.incubation.common.**</allowedImport>
+                                    </allowedImports>
+                                </restrictImports>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/Castable.java
+++ b/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/Castable.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.incubation.common;
+
+/**
+ * Represents a type that can be converted into a {@link DataContext}
+ */
+public interface Castable {
+    /**
+     * Converts this object into the given type.
+     */
+    <T extends DataContext> T as(Class<T> type);
+}

--- a/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/ComponentRoot.java
+++ b/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/ComponentRoot.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.incubation.common;
+
+/**
+ * Root path of a component.
+ *
+ * <p>
+ * Each component should implement their root and provide a method of the form:
+ *
+ * <code><pre>
+ *   IdSubclass get(Params...)
+ * </pre></code>
+ * <p>
+ * The reason why there is no method in the interface is to allow implementors
+ * to define a <code>get()</code> method with as many parameters as desired,
+ * with the most appropriate types
+ * <p>
+ * e.g. these are all allowed
+ *
+ * <code><pre>
+ *   public RuleUnitId get(Class<?> ruleUnitDefinition)
+ *   public RuleUnitId get(String canonicalName)
+ *   public DecisionId get(String namespace, String name)
+ *   etc...
+ * </pre></code>
+ * <p>
+ * A <code>get()</code> method should however <strong>always</strong>
+ *
+ * <ul>
+ * <li>return a {@link LocalId} (or, sometimes an {@link Id} or
+ * a {@link RemoteId} may be appropriate).</li>
+ * <li>expect one or more parameters; these parameters must be used to construct the identifier
+ * and, ideally, should appear somehow in the identifier (or at least, it should be possible
+ * to map the identifier back on the originating parameters)</li>
+ * </ul>
+ * <p>
+ * While component writers are expected to adhere to such rules,
+ * they may otherwise choose to design these getters as they prefer.
+ * <p>
+ * The returned identifier should always be prefixed by the ComponentRoot prefix.
+ * <p>
+ * e.g. ProcessIds would start with <code>/processes</code>,
+ * DecisionIds would start with <code>/decisions</code>, etc.
+ * <p>
+ * ComponentRoots may be addressable directly;
+ * however, it is preferred to use them through some other interface.
+ * <p>
+ * e.g.:
+ *
+ * <code><pre>
+ *   &#64;Inject AppRoot appRoot;
+ *   // ...
+ *   var id = appRoot.get(ProcessIds.class).get("my-process-id)
+ * </pre></code>
+ *
+ *
+ *
+ * <code><pre>
+ *   &#64;Inject ProcessIds processIds;
+ *   // ...
+ *   var id = processIds.get("my-process-id)
+ * </pre></code>
+ */
+public interface ComponentRoot {
+}

--- a/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/DataContext.java
+++ b/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/DataContext.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.incubation.common;
+
+/**
+ * A type that represents a computational context.
+ *
+ * <ul>
+ * <li>A DataContext is a computational context. It contains all the data that
+ * is required by a service to perform its computation.</li>
+ * <li>A DataContext can be always converted into another type
+ * (or another DataContext) using the method {@link DataContext#as(Class)}</li>
+ * <li></li>A DataContext can be always converted into another sub-type of DataContext.</li>
+ * <li>Converting a DataContext into the same DataContext is a no-op just like (Object) new Object() is a no-op.
+ * <li>You are always able to convert a DataContext into an arbitrary sub-type; e.g. a {@link MapDataContext}
+ * into a class that implements DataContext.</li>
+ * </ul>
+ * <p>
+ * Example:
+ *
+ * <code><pre>
+ * class Person implements DataContext, DefaultCastable { String name; }
+ * MapDataContext ctx = MapDataContext.create();
+ * ctx.set("name", "Paul");
+ * Person p = ctx.as(Person.class);
+ * String name = p.name; // "Paul"
+ * </pre></code>
+ * <p>
+ * {@see MapDataContext}
+ */
+public interface DataContext extends Castable {
+}

--- a/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/DefaultCastable.java
+++ b/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/DefaultCastable.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.incubation.common;
+
+/**
+ * Utility interface, useful to mix-in to get a default `as` implementation.
+ * <p>
+ * Provides a default implementation for the {@link #as(Class)} method,
+ * delegating to {@link InternalObjectMapper#convertValue(Object, Class)}
+ */
+public interface DefaultCastable extends Castable {
+
+    default <T extends DataContext> T as(Class<T> type) {
+        return (T) InternalObjectMapper.convertValue(this, type);
+    }
+}

--- a/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/Id.java
+++ b/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/Id.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.incubation.common;
+
+/**
+ * An identifier for a resource. It always contains a local part.
+ */
+public interface Id {
+    LocalId toLocalId();
+}

--- a/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/InternalObjectMapper.java
+++ b/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/InternalObjectMapper.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.incubation.common;
+
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * For internal use only.
+ * Provides a method to convert an object into a given type.
+ * This is an implementation detail. We may move this to a separate module in the future.
+ */
+public class InternalObjectMapper {
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    static {
+        objectMapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE);
+        objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+    }
+
+    public static <T> T convertValue(Object self, Class<T> type) {
+        if (MapLikeDataContext.class == type || MapDataContext.class == type) {
+            return (T) MapDataContext.of(objectMapper.convertValue(self, Map.class));
+        }
+        return objectMapper.convertValue(self, type);
+    }
+
+    private InternalObjectMapper() {
+    }
+}

--- a/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/LocalId.java
+++ b/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/LocalId.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.incubation.common;
+
+import java.nio.file.Path;
+
+/**
+ * An identifier for a local resource
+ */
+public interface LocalId extends Id {
+    Path asPath();
+}

--- a/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/LocalId.java
+++ b/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/LocalId.java
@@ -16,11 +16,9 @@
 
 package org.kie.kogito.incubation.common;
 
-import java.nio.file.Path;
-
 /**
  * An identifier for a local resource
  */
 public interface LocalId extends Id {
-    Path asPath();
+    LocalUri asLocalUri();
 }

--- a/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/LocalUri.java
+++ b/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/LocalUri.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.incubation.common;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import java.util.StringTokenizer;
+
+/**
+ * A uri of the form: kogito-local:///a/b/c...
+ * <p>
+ * For instance: for "/a/b/c" the {@link LocalUri} is represented as:
+ *
+ * <pre>
+ * <code>
+ *       LocalUri(
+ *           LocalUri(
+ *               LocalUri(Root, "a"), "b"), "c")
+ * </code>
+ * </pre>
+ * <p>
+ * And it may be constructed with:
+ *
+ * <pre>
+ * <code>
+ *     LocalUri.Root.append("a").append("b").append("c");
+ * </code>
+ * </pre>
+ */
+public abstract class LocalUri {
+    public static final String SCHEME = "kogito-local";
+    public static final LocalUri Root = new LocalUriRoot();
+
+    public static LocalUri parse(String path) {
+        if (path.startsWith(SCHEME)) {
+            URI parsed = URI.create(path);
+            path = parsed.getPath();
+        }
+        if (!path.startsWith("/"))
+            throw new IllegalArgumentException("Path must start at root /");
+        StringTokenizer tok = new StringTokenizer(path, "/");
+        LocalUri hpath = Root;
+        while (tok.hasMoreTokens()) {
+            hpath = hpath.append(tok.nextToken());
+        }
+        return hpath;
+    }
+
+    // this is a closed hierarchy
+    private LocalUri() {
+    }
+
+    public abstract String path();
+
+    public abstract LocalUri parent();
+
+    public abstract boolean startsWith(String component);
+
+    public LocalUri append(String component) {
+        return new LocalUriPathComponent(this, component);
+    }
+
+    public URI toUri() {
+        try {
+            return new URI(SCHEME, "", this.path(), null);
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return toUri().toString();
+    }
+
+    /**
+     * Root of a {@link LocalUri}: "/"
+     */
+    public static class LocalUriRoot extends LocalUri {
+        private LocalUriRoot() {
+        }
+
+        @Override
+        public LocalUri parent() {
+            return null;
+        }
+
+        public boolean startsWith(String component) {
+            return false;
+        }
+
+        @Override
+        public String path() {
+            return "/";
+        }
+
+        // it is a singleton: we don't need to override equals, hashCode
+    }
+
+    /**
+     * A component of a {@link LocalUri}.
+     */
+    public static class LocalUriPathComponent extends LocalUri {
+
+        private final LocalUri parent;
+        private final String component;
+
+        private LocalUriPathComponent(LocalUri parent, String component) {
+            this.parent = parent;
+            this.component = URLEncoder.encode(component, StandardCharsets.UTF_8);
+        }
+
+        @Override
+        public LocalUri parent() {
+            return parent;
+        }
+
+        /**
+         * Returns true when the path starts with the given argument.
+         * <p>
+         * e.g. when component = "a" then "/a/b/c" startsWith "a"
+         */
+        public boolean startsWith(String component) {
+            return this.parent() == Root && this.component.equals(component)
+                    || this.parent().startsWith(component);
+        }
+
+        @Override
+        public String path() {
+            return parent == Root ? ("/" + component) : (parent.path() + "/" + component);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
+            LocalUriPathComponent that = (LocalUriPathComponent) o;
+            return Objects.equals(parent, that.parent) && Objects.equals(component, that.component);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(parent, component);
+        }
+    }
+}

--- a/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/LocalUriId.java
+++ b/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/LocalUriId.java
@@ -16,7 +16,6 @@
 
 package org.kie.kogito.incubation.common;
 
-import java.nio.file.Path;
 import java.util.Objects;
 
 /**
@@ -25,15 +24,15 @@ import java.util.Objects;
  * Components should extend this class to get a default base implementation of their
  * LocalId.
  */
-public abstract class PathLocalId implements LocalId {
-    private final Path path;
+public abstract class LocalUriId implements LocalId {
+    private final LocalUri path;
 
-    public PathLocalId(Path path) {
+    public LocalUriId(LocalUri path) {
         this.path = path;
     }
 
     @Override
-    public Path asPath() {
+    public LocalUri asLocalUri() {
         return path;
     }
 
@@ -44,14 +43,14 @@ public abstract class PathLocalId implements LocalId {
 
     @Override
     public String toString() {
-        return String.format("PathLocalId(%s)", path);
+        return String.format("LocalUriId(%s)", path);
     }
 
     @Override
     public boolean equals(Object o) {
         return this == o ||
                 o instanceof LocalId &&
-                        Objects.equals(path, ((Id) o).toLocalId().asPath());
+                        Objects.equals(path, ((Id) o).toLocalId().asLocalUri());
     }
 
     @Override

--- a/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/MapDataContext.java
+++ b/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/MapDataContext.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.incubation.common;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+/**
+ * A data context that wraps a <code>Map<String, Object></code>.
+ */
+public class MapDataContext implements MapLikeDataContext {
+
+    public static <T> MapDataContext from(T object) {
+        return InternalObjectMapper.convertValue(object, MapDataContext.class);
+    }
+
+    public static MapDataContext of(Map<String, Object> map) {
+        return new MapDataContext(map);
+    }
+
+    public static MapDataContext create() {
+        return new MapDataContext();
+    }
+
+    @JsonIgnore
+    private final Map<String, Object> map = new HashMap<>();
+
+    // package-private constructors for Quarkus
+    MapDataContext() {
+    }
+
+    // package-private constructors for Quarkus
+    MapDataContext(Map<String, Object> map) {
+        this();
+        this.map.putAll(map);
+    }
+
+    @Override
+    public <T extends DataContext> T as(Class<T> type) {
+        return InternalObjectMapper.convertValue(map, type);
+    }
+
+    // required to unwrap the POJO to the map
+    @JsonAnySetter
+    @Override
+    public void set(String key, Object value) {
+        map.put(key, value);
+    }
+
+    @Override
+    public Object get(String key) {
+        return map.get(key);
+    }
+
+    @Override
+    public <T> T get(String key, Class<T> expectedType) {
+        return null;
+    }
+
+    // required to unwrap the map to the root of the mapped object
+    @JsonAnyGetter
+    public Map<String, Object> toMap() {
+        return map;
+    }
+
+    @Override
+    public String toString() {
+        return "MapDataContext{" +
+                "map=" + map +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        MapDataContext that = (MapDataContext) o;
+        return Objects.equals(map, that.map);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(map);
+    }
+}

--- a/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/MapLikeDataContext.java
+++ b/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/MapLikeDataContext.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.incubation.common;
+
+/**
+ * A DataContext that behaves like a Map.
+ */
+public interface MapLikeDataContext extends DataContext {
+    void set(String key, Object value);
+
+    Object get(String key);
+
+    <T> T get(String key, Class<T> expectedType);
+}

--- a/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/PathLocalId.java
+++ b/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/PathLocalId.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.incubation.common;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * An abstract class for a {@link LocalId} that is represented as a Path.
+ * <p>
+ * Components should extend this class to get a default base implementation of their
+ * LocalId.
+ */
+public abstract class PathLocalId implements LocalId {
+    private final Path path;
+
+    public PathLocalId(Path path) {
+        this.path = path;
+    }
+
+    @Override
+    public Path asPath() {
+        return path;
+    }
+
+    @Override
+    public LocalId toLocalId() {
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("PathLocalId(%s)", path);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return this == o ||
+                o instanceof LocalId &&
+                        Objects.equals(path, ((Id) o).toLocalId().asPath());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(path);
+    }
+}

--- a/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/RemoteId.java
+++ b/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/RemoteId.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.incubation.common;
+
+/**
+ * An identifier for a remote resource
+ */
+public interface RemoteId extends Id {
+}

--- a/api/kogito-api-incubation-common/src/test/java/org/kie/kogito/incubation/common/DataContextTest.java
+++ b/api/kogito-api-incubation-common/src/test/java/org/kie/kogito/incubation/common/DataContextTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.incubation.common;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public class DataContextTest {
+    public static class Address {
+        String street;
+    }
+
+    public static class User implements DataContext, DefaultCastable {
+        String firstName;
+        String lastName;
+        Address addr;
+    }
+
+    @Test
+    public void fromMap() {
+        MapDataContext ctx = MapDataContext.create();
+        ctx.set("firstName", "Paul");
+        ctx.set("lastName", "McCartney");
+
+        User u = ctx.as(User.class);
+        assertEquals("Paul", u.firstName);
+        assertEquals("McCartney", u.lastName);
+    }
+
+    @Test
+    public void toMap() {
+        User u = new User();
+        u.firstName = "Paul";
+        u.lastName = "McCartney";
+
+        MapLikeDataContext ctx = u.as(MapLikeDataContext.class);
+        assertEquals("Paul", ctx.get("firstName"));
+        assertEquals("McCartney", ctx.get("lastName"));
+
+        MapLikeDataContext ctx2 = u.as(MapDataContext.class);
+        assertEquals("Paul", ctx2.get("firstName"));
+        assertEquals("McCartney", ctx2.get("lastName"));
+    }
+
+    @Test
+    public void nestedValue() {
+        User u = new User();
+        u.firstName = "Paul";
+        u.lastName = "McCartney";
+        u.addr = new Address();
+        u.addr.street = "Abbey Rd.";
+
+        MapDataContext ctx = u.as(MapDataContext.class);
+        assertNotEquals(Address.class, ctx.get("addr").getClass());
+        Address addr = InternalObjectMapper.convertValue(ctx.get("addr"), Address.class);
+        assertEquals("Abbey Rd.", addr.street);
+    }
+}

--- a/api/kogito-api-incubation-common/src/test/java/org/kie/kogito/incubation/common/LocalUriTest.java
+++ b/api/kogito-api-incubation-common/src/test/java/org/kie/kogito/incubation/common/LocalUriTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.incubation.common;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class LocalUriTest {
+    @Test
+    public void testToString() {
+        LocalUri hpath = LocalUri.Root.append("example").append("some-id").append("instances").append("some-instance-id");
+        assertEquals("/example/some-id/instances/some-instance-id", hpath.path());
+    }
+
+    @Test
+    public void testStartsWith() {
+        LocalUri hpath = LocalUri.Root.append("example").append("some-id").append("instances").append("some-instance-id");
+        assertTrue(hpath.startsWith("example"));
+    }
+
+    @Test
+    public void testParse() {
+        String path = "/example/some-id/instances/some-instance-id";
+        LocalUri hpath = LocalUri.Root.append("example").append("some-id").append("instances").append("some-instance-id");
+        LocalUri parsedHPath = LocalUri.parse(path);
+        assertEquals(hpath, parsedHPath);
+
+    }
+
+    @Test
+    public void testParseMalformed() {
+        String path = "/example////some-id//instances/some-instance-id";
+        LocalUri hpath = LocalUri.Root.append("example").append("some-id").append("instances").append("some-instance-id");
+        LocalUri parsedHPath = LocalUri.parse(path);
+        assertEquals(hpath, parsedHPath);
+    }
+
+    @Test
+    public void testParseMalformedRelative() {
+        String path = "example////some-id//instances/some-instance-id";
+        assertThrows(IllegalArgumentException.class, () -> LocalUri.parse(path));
+    }
+
+    @Test
+    public void testUrlEncoding() {
+        LocalUri path = LocalUri.Root.append("URL unsafe").append("??").append("Compon/ents").append("are \\ encoded");
+        assertEquals("/URL+unsafe/%3F%3F/Compon%2Fents/are+%5C+encoded", path.path());
+    }
+
+    @Test
+    public void testUriConversion() {
+        String path = "/example/some-id/instances/some-instance-id";
+        LocalUri parsed = LocalUri.parse(path);
+        assertEquals(parsed.toUri().toString(), String.format("%s://%s", LocalUri.SCHEME, parsed.path()));
+    }
+
+}

--- a/api/kogito-api-incubation-common/src/test/java/org/kie/kogito/incubation/common/PathLocalIdTest.java
+++ b/api/kogito-api-incubation-common/src/test/java/org/kie/kogito/incubation/common/PathLocalIdTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.incubation.common;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class PathLocalIdTest {
+
+    ExampleRoot exampleRoot = new ExampleRoot();
+
+    @Test
+    public void testId() {
+        ExampleLocalId exampleLocalId = exampleRoot.get("some-id");
+        assertEquals("/example/some-id", exampleLocalId.asLocalUri().path());
+    }
+
+    @Test
+    public void testIdNested() {
+        ExampleInstanceLocalId exampleLocalId = exampleRoot.get("some-id").instances().get("some-instance-id");
+        assertEquals("/example/some-id/instances/some-instance-id", exampleLocalId.asLocalUri().path());
+    }
+
+    @Test
+    public void testStartsWith() {
+        ExampleInstanceLocalId exampleLocalId = exampleRoot.get("some-id").instances().get("some-instance-id");
+        assertTrue(exampleLocalId.asLocalUri().startsWith("example"));
+    }
+
+    static class ExampleRoot implements ComponentRoot {
+        public ExampleLocalId get(String identifier) {
+            return new ExampleLocalId(identifier);
+        }
+    }
+
+    static class ExampleLocalId extends LocalUriId {
+        private static String PREFIX = "example";
+
+        private ExampleLocalId(String identifier) {
+            super(LocalUri.Root.append(PREFIX).append(identifier));
+        }
+
+        public ExampleInstanceLocalIdFactory instances() {
+            return new ExampleInstanceLocalIdFactory(this);
+        }
+
+    }
+
+    static class ExampleInstanceLocalIdFactory {
+        LocalUri parent;
+
+        public ExampleInstanceLocalIdFactory(ExampleLocalId parent) {
+            this.parent = parent.asLocalUri().append("instances");
+        }
+
+        ExampleInstanceLocalId get(String identifier) {
+            return new ExampleInstanceLocalId(parent, identifier);
+        }
+    }
+
+    static class ExampleInstanceLocalId extends LocalUriId {
+
+        public ExampleInstanceLocalId(LocalUri parent, String identifier) {
+            super(parent.append(identifier));
+        }
+    }
+
+}

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -19,6 +19,8 @@
   <modules>
     <module>kogito-events-api</module>
     <module>kogito-api</module>
+    <module>kogito-api-incubation-common</module>
+    <module>kogito-api-incubation-application</module>
     <module>kogito-services</module>
     <module>kogito-timer</module>
     <module>kogito-legacy-api</module>

--- a/kogito-bom/pom.xml
+++ b/kogito-bom/pom.xml
@@ -66,6 +66,42 @@
 
       <dependency>
         <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-api-incubation-common</artifactId>
+        <version>${project.version}</version>
+        <classifier>javadoc</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-api-incubation-common</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-api-incubation-common</artifactId>
+        <version>${project.version}</version>
+        <classifier>sources</classifier>
+      </dependency>
+
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-api-incubation-application</artifactId>
+        <version>${project.version}</version>
+        <classifier>javadoc</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-api-incubation-application</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-api-incubation-application</artifactId>
+        <version>${project.version}</version>
+        <classifier>sources</classifier>
+      </dependency>
+
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-services</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common/pom.xml
@@ -18,6 +18,10 @@
             <artifactId>svm</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.kie.kogito</groupId>
+            <artifactId>kogito-api-incubation-application</artifactId>
+        </dependency>
 
         <!-- required because of native image substitution  -->
         <dependency>
@@ -91,6 +95,18 @@
                         </path>
                     </annotationProcessorPaths>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jboss.jandex</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                        <goals>
+                            <goal>jandex</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common/src/main/java/org/kie/kogito/incubation/application/quarkus/QuarkusAppRoot.java
+++ b/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common/src/main/java/org/kie/kogito/incubation/application/quarkus/QuarkusAppRoot.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.incubation.application.quarkus;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+import org.kie.kogito.incubation.application.AppRoot;
+import org.kie.kogito.incubation.common.ComponentRoot;
+
+@ApplicationScoped
+public class QuarkusAppRoot extends AppRoot {
+    @Inject
+    private Instance<ComponentRoot> componentRoots;
+
+    QuarkusAppRoot() {
+        super("kogito-app");
+    }
+
+    @Override
+    public <T extends ComponentRoot> T get(Class<T> providerId) {
+        return componentRoots.select(providerId).get();
+    }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-5747

Blocks:
- #1547 
- #1549 
- #1550 
- #1551 

## Description

These shared modules make available the `common` component and the `application` component. 

#### General Expected Usage Example

Every component should provide one or more service implementations. Each service takes an identifier (a Path from a root) and usually a `DataContext`. The generic form of interaction should follow the pattern:


```java
   LocalId id = appRoot.get(MyComponent.class).get("componentName").subs().get("someSubComponent")
   DataContext result = svc.evaluationMethod(id, dataContext);

```

for instance, evaluating a DMN may look like this:

```java
   LocalDecisionId decisionId = appRoot.get(DecisionIds.class).get(namespaceString, nameString);
   DataContext result = svc.evaluate(decisionId, dataContext);

```

When a component admits subcomponents (e.g. tasks in processes, decision services in DMN, queries in rules, etc.), then there should be a way to construct that path with a fluent API:

```java
   LocalDecisionId decisionServiceId = appRoot.get(DecisionIds.class).get(namespaceString, nameString).services().get(serviceString);
   DataContext result = svc.evaluate(decisionServiceId, dataContext);

```


If the types make sense, then a single `evaluate` method should be able to "parse" the provided ID, even for different paths; i.e. it is perfectly acceptable, even preferrable:

```java
   DataContext result = svc.evaluate(serviceId, inputDataContext);
   DataContext serviceResult = svc.evaluate(decisionServiceId, inputDataContext);

``` 

However, component developers are free to provide their own methods; multiple methods should be returned, especially if they represent different actions; e.g.:

 
```java
   LocalProcessInstanceId lpid = svc.createProcess(processId, inputDataContext);
   DataContext started = svc.start(lpid);
   DataContext aborted = svc.abort(lpid);
``` 



### Application and Paths

The `application` component provides the root of the typed builder API for paths (`appRoot`); 

i.e. paths such as `/processes/my.process` or `/predictions/my.prediction` are constructed via `appRoot.get(ProcessIds.class).get("my.process")` or `appRoot.get(PredictionIds.class).get("my.prediction")` respectively. The return type of this chain of methods is always an `Id` or a `LocalId`.

The `<Component>Ids` class should implement `ComponentRoot`.

paths admit subpaths if the Component admits subcomponents; e.g. a DMN admits services, so the path 

     /decisions/$id/services/$serviceId

should be allowed. The method chain should reflect the structure of that path:

    appRoot.get(DecisionIds.class).get(namespace, name).services().get(serviceId)


A `RemoteId` is also available to "install" the path on a hostname:port pair. This is not useful at the moment, it will be useful in a distributed setting.

In the future such a path will be also parsable starting from a String (e.g. `LocalId.parse(String)`)

Because of their construction, paths can be always rendered as a string, and can always be parsed from a string into a typed representation (the `/prefix` and intermediated parts (such as `/services` specify the subtype). This makes them trivially serializable for sending over the wire and trivially unserializable into their typed representation.



### Main API (`common`)

The `common` module provides basic interfaces so that each component may specialize one or more `LocalId` definitions and provide one or more service implementation. 

Every component provides a pair of modules:

- `kogito-api-incubation-<component>`: Paths and Identifiers
- `kogito-api-incubation-<component>-services`: Service Interfaces



#### Paths and Identifiers

The first module contains specializations of `LocalId` (e.g. `DecisionId`) and/or subpaths. For instance:

- a "decision service ID" should be addressable, and that service Id is a subcomponent of a decision. Then `DecisionId` should expose the method `services()` and `appRoot.get(DecisionIds.class).get("my.decision").services().get("my.service.id")` should be the path constructor; it would create a `DecisionServiceId`

#### DataContext

- A `DataContext` is a computational context. It contains all the data that is required by a service to perform its computation.
- A `DataContext` can be always converted into another type (or another DataContext) using the method `DataContext#as(Class<T extends DataContext>)`.

A DataContext can be always converted into another sub-type of DataContext. Converting a DataContext into the same DataContext is a no-op just like (Object) new Object() is a no-op. You are always able to convert a DataContext into an arbitrary sub-type; e.g. a MapDataContext into a POJO that implements DataContext.

```java
class Person implements DataContext, DefaultCastable { String name; }
MapDataContext ctx = MapDataContext.create();
ctx.set("name", "Paul");
Person p = ctx.as(Person.class);
String name = p.name; // "Paul"
```

`MapDataContext` provides methods `get(), set()` and wraps a map. This is the simplest and convenient way to pass data. However, it is suggested to create your own class. In this case your POJO should extends `DataContext` and `DefaultCastable` (the latter provides a default implementation of the `as()` method that is usually good for most cases)

Note: `DefaultCastable#as` uses Jackson internally, but it's an implementation detail and it may change in the future if we decide so.



#### Service Interfaces

Service interfaces should follow the generic pattern :

    RETURN-TYPE VERB(IDENTIFIER [, optional DATACONTEXT])

e.g.


```java
   LocalId id = appRoot.get(MyComponent.class).get("componentName").subs().get("someSubComponent")
   DataContext result = svc.evaluationMethod(id, dataContext);

```

- Service interfaces do not extend a specific interface; component developers may define their own methods, although a certain degree of consistency is expected.
- **RETURN-TYPE** should be always either an IDentifier or a DataContext. Implementations should usually take the most generic implementation `DataContext` as a parameter, and should usually return `DataContext` as a return type. It is allowed (as per Java spec) to return a subtype of DataContext, but this may not be required, as users can always convert into a more specific type.
- When a method *evaluates* the resource pointed by the IDENTIFIER and **completes** (i.e. stateless evaluation), then RETURN-TYPE should always be DataContext.
- When a method *starts the evaluation* of the resource pointed by the IDENTIFIER but it may not **complete**, then RETURN-TYPE may be an identifier.  (e.g. `processService.create(id)` would return a `processInstanceId`)


Asyncronous evaluation is allowed. In this case RETURN-TYPE should express the fact that evaluation is async. For instance:

```java
   LocalId id = appRoot.get(MyComponent.class).get("componentName").subs().get("someSubComponent")
   CompletableFuture<DataContext> result = asyncSvc.evaluationMethod(id, dataContext);

```

i.e. a Process engine may provide `AsyncProcessService`

```java
   CompletableFuture<LocalProcessInstanceId> futureLpid = asyncSvc.createProcess(processId, inputDataContext);
   CompletableFuture<DataContext> futureStarted = futureLpid.andThen(lpid -> asyncSvc.start(lpid));
   ...
``` 

### Implementation

Currently only for Quarkus. The implementation is being shipped as part of the extension for convenience (it may be refactored to its own extension in the future). Implementation should provide:

- injectable version of their component class -- used for wiring in `appRoot.get(MyComponent.class)`
- injectable versions of their services

Currently services delegate their implementation to the internal hidden API that is used for codegen. The internal API should be considered deprecated and in the future codegen should be moved to the new API.

Refer to the related PRs for more details.

### Caveats

- **What about listeners?**

Currently listeners are plugged through annotation as we currently do already in Kogito. Since internally the APIs that we use in codegen are being used, those will work automatically.

- **What about metadata?** The API only deals with data, but what about meta-data? e.g. directives that should be passed to the engine, that are not part of the Payload? (e.g. HTTP headers that should be passed to the engine to configure a specific request)

  ```java
     var result = svc.evaluate(id, payload [ metadata ???] ) 
  ```

  This is currently an open question. 

  * A proposal is to allow the DataContext to also include metadata 
  * Another proposal is to have some is that the `as` method does not just convert but it's a sort of "view"; so `ctx.as(MetaDataContext.class)` may show the metadata and _not_ the plain data -- I like this but I am not sure how to implement it.



<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run all builds</b>  
  Please add comment: <b>Jenkins retest this</b>

* <b>Run (or rerun) specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] tests</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Run (or rerun) LTS specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Run (or rerun) native specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
