### PR TITLE
KOGITO-5514 - Validate variables use in script tasks

### DIFF
--- a/jbpm/jbpm-bpmn2/src/test/resources/BPMN2-MultiInstanceLoopCharacteristicsProcessWithOutput.bpmn2
+++ b/jbpm/jbpm-bpmn2/src/test/resources/BPMN2-MultiInstanceLoopCharacteristicsProcessWithOutput.bpmn2
@@ -49,7 +49,7 @@
         <script>
           System.out.println( &quot;start item:&quot; + item ); item = item + &quot; changed&quot;;
           System.out.println(&quot;update item to:&quot; + item);
-          context.setVariable(&quot;itemOut&quot;, item);
+          kcontext.setVariable(&quot;itemOut&quot;, item);
 </script>
       </scriptTask>
       <sequenceFlow id="_2-2-4-_2-2-3" sourceRef="_2-2-4" targetRef="_2-2-3"/>

--- a/jbpm/jbpm-bpmn2/src/test/resources/BPMN2-MultiInstanceLoopCharacteristicsProcessWithOutputCmpCond.bpmn2
+++ b/jbpm/jbpm-bpmn2/src/test/resources/BPMN2-MultiInstanceLoopCharacteristicsProcessWithOutputCmpCond.bpmn2
@@ -50,7 +50,7 @@
         <script>
           System.out.println( &quot;start item:&quot; + item ); item = item + &quot; changed&quot;;
           System.out.println(&quot;update item to:&quot; + item);
-          context.setVariable(&quot;itemOut&quot;, item);
+          kcontext.setVariable(&quot;itemOut&quot;, item);
 </script>
       </scriptTask>
       <sequenceFlow id="_2-2-4-_2-2-3" sourceRef="_2-2-4" targetRef="_2-2-3"/>

--- a/jbpm/jbpm-bpmn2/src/test/resources/subprocess/ErrorsBetweenProcess-Process.bpmn2
+++ b/jbpm/jbpm-bpmn2/src/test/resources/subprocess/ErrorsBetweenProcess-Process.bpmn2
@@ -67,8 +67,7 @@
     <bpmn2:scriptTask id="ScriptTask_3" name="Script Salida Error">
       <bpmn2:incoming>SequenceFlow_4</bpmn2:incoming>
       <bpmn2:outgoing>SequenceFlow_6</bpmn2:outgoing>
-      <bpmn2:script>System.out.println(&quot;Error: Al salir, event: &quot;+event);
-//System.out.println(&quot;Error: Al salir, pasoVariable= &quot;+pasoVariable);</bpmn2:script>
+      <bpmn2:script>System.out.println(&quot;Error: Al salir, event: &quot;+event);</bpmn2:script>
     </bpmn2:scriptTask>
     <bpmn2:endEvent id="EndEvent_1" name="Fin Main">
       <bpmn2:incoming>SequenceFlow_7</bpmn2:incoming>

--- a/jbpm/jbpm-flow-builder/pom.xml
+++ b/jbpm/jbpm-flow-builder/pom.xml
@@ -68,6 +68,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/jbpm/jbpm-flow-builder/src/test/java/org/jbpm/compiler/canonical/ProcessToExecModelGeneratorTest.java
+++ b/jbpm/jbpm-flow-builder/src/test/java/org/jbpm/compiler/canonical/ProcessToExecModelGeneratorTest.java
@@ -15,18 +15,24 @@
  */
 package org.jbpm.compiler.canonical;
 
-import org.assertj.core.api.Assertions;
+import java.util.stream.Stream;
+
 import org.jbpm.process.builder.dialect.feel.FeelCompilationException;
 import org.jbpm.process.core.datatype.impl.type.ObjectDataType;
 import org.jbpm.process.core.datatype.impl.type.StringDataType;
 import org.jbpm.ruleflow.core.RuleFlowProcessFactory;
 import org.jbpm.workflow.core.node.Split;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.api.definition.process.Process;
 import org.kie.api.definition.process.WorkflowProcess;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -78,6 +84,57 @@ public class ProcessToExecModelGeneratorTest {
         assertEquals("com.myspace.demo.OrdersProcess", processMetadata.getProcessClassName());
         assertNotNull(processMetadata.getGeneratedClassModel());
         assertEquals(1, processMetadata.getWorkItems().size());
+    }
+
+    public static Stream<Arguments> invalidVariables() {
+        return Stream.of(
+                Arguments.of(new String[] {
+                        "com.myspace.demo.Order order2 = null; System.out.println(\"Order has been created \" + order);java.util.Arrays.toString(new int[]{1, 2});System.out.println(orders);",
+                        "uses unknown variable in the script: orders" }),
+                Arguments.of(new String[] {
+                        "a = 2",
+                        "unable to parse Java content: Parse error. Found \"}\", expected one of  \"!=\" \"%\" \"%=\" \"&\" \"&&\" \"&=\" \"*\" \"*=\" \"+\" \"+=\" \"-\" \"-=\" \"->\" \"/\" \"/=\" \"::\" \";\" \"<\" \"<<=\" \"<=\" \"=\" \"==\" \">\" \">=\" \">>=\" \">>>=\" \"?\" \"^\" \"^=\" \"instanceof\" \"|\" \"|=\" \"||\"" }),
+                Arguments.of(new String[] {
+                        "a = 2;",
+                        "uses unknown variable in the script: a" }),
+                Arguments.of(new String[] {
+                        "a.toString(); Integer i = Integer.valueOf(\"1\");",
+                        "uses unknown variable in the script: a" }),
+                Arguments.of(new String[] {
+                        "System.out.println(\"[\" + (new java.util.Date()) + \"] [\" + java.lang.Thread.currentThread().getName() +\"]\");\n" +
+                                "java.util.ArrayList list = new java.util.ArrayList();\n" +
+                                "System.out.println(Integer.valueOf(x));",
+                        "uses unknown variable in the script: x" }));
+    }
+
+    @ParameterizedTest(name = "{index} {0}")
+    @MethodSource("invalidVariables")
+    public void testScriptInvalidVariable(String script, String message) {
+        RuleFlowProcessFactory factory = RuleFlowProcessFactory.createProcess("demo.orders");
+        factory
+                .variable("order", new ObjectDataType("com.myspace.demo.Order"))
+                .variable("approver", new ObjectDataType("String"))
+                .name("orders")
+                .packageName("com.myspace.demo")
+                .dynamic(false)
+                .version("1.0")
+                .startNode(1)
+                .name("start")
+                .done()
+                .actionNode(2)
+                .name("Dump order 1")
+                .action("java", script)
+                .done()
+                .endNode(3)
+                .name("end")
+                .terminate(false)
+                .done()
+                .connection(1, 2)
+                .connection(2, 3);
+
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> factory.validate())
+                .withMessage(format("Process could not be validated ![Process 'orders' [demo.orders]: Node 'Dump order 1' [2] %s]", message));
     }
 
     @Test
@@ -158,7 +215,7 @@ public class ProcessToExecModelGeneratorTest {
     }
 
     @Test
-    public void testGatewayFEELwrongIfMissingElse() {
+    public void testGatewayFEELWrongIfMissingElse() {
         RuleFlowProcessFactory factory = RuleFlowProcessFactory.createProcess("demo.orders");
         factory
                 .variable("approver", new StringDataType())
@@ -186,7 +243,7 @@ public class ProcessToExecModelGeneratorTest {
                 .connection(1, 2, "cA")
                 .connection(1, 3, "cB");
 
-        Assertions.assertThatExceptionOfType(FeelCompilationException.class)
+        assertThatExceptionOfType(FeelCompilationException.class)
                 .isThrownBy(() -> {
                     WorkflowProcess process = factory.validate().getProcess();
                     ProcessMetaData processMetadata = ProcessToExecModelGenerator.INSTANCE.generate(process);
@@ -223,7 +280,7 @@ public class ProcessToExecModelGeneratorTest {
                 .connection(1, 2, "cA")
                 .connection(1, 3, "cB");
 
-        Assertions.assertThatExceptionOfType(FeelCompilationException.class)
+        assertThatExceptionOfType(FeelCompilationException.class)
                 .isThrownBy(() -> {
                     WorkflowProcess process = factory.validate().getProcess();
                     ProcessMetaData processMetadata = ProcessToExecModelGenerator.INSTANCE.generate(process);

--- a/jbpm/jbpm-flow-builder/src/test/java/org/jbpm/integrationtests/ProcessEventListenerTest.java
+++ b/jbpm/jbpm-flow-builder/src/test/java/org/jbpm/integrationtests/ProcessEventListenerTest.java
@@ -153,7 +153,7 @@ public class ProcessEventListenerTest extends AbstractBaseTest {
                     "      </eventFilters>\n" +
                     "    </eventNode>\n" +
                     "    <actionNode id=\"3\" name=\"Signal Event\" >\n" +
-                    "      <action type=\"expression\" dialect=\"java\" >context.getProcessInstance().signalEvent(\"MyEvent\", \"MyValue\");</action>\n" +
+                    "      <action type=\"expression\" dialect=\"java\" >kcontext.getProcessInstance().signalEvent(\"MyEvent\", \"MyValue\");</action>\n" +
                     "    </actionNode>\n" +
                     "    <join id=\"4\" name=\"Join\" type=\"1\" />\n" +
                     "    <end id=\"5\" name=\"End\" />\n" +

--- a/jbpm/jbpm-flow-builder/src/test/java/org/jbpm/integrationtests/ProcessEventTest.java
+++ b/jbpm/jbpm-flow-builder/src/test/java/org/jbpm/integrationtests/ProcessEventTest.java
@@ -57,7 +57,7 @@ public class ProcessEventTest extends AbstractBaseTest {
                         "      </eventFilters>\n" +
                         "    </eventNode>\n" +
                         "    <actionNode id=\"3\" name=\"Signal Event\" >\n" +
-                        "      <action type=\"expression\" dialect=\"java\" >context.getProcessInstance().signalEvent(\"MyEvent\", \"MyValue\");</action>\n" +
+                        "      <action type=\"expression\" dialect=\"java\" >kcontext.getProcessInstance().signalEvent(\"MyEvent\", \"MyValue\");</action>\n" +
                         "    </actionNode>\n" +
                         "    <join id=\"4\" name=\"Join\" type=\"1\" />\n" +
                         "    <end id=\"5\" name=\"End\" />\n" +
@@ -251,7 +251,7 @@ public class ProcessEventTest extends AbstractBaseTest {
                         "    <composite id=\"2\" name=\"CompositeNode\" >\n" +
                         "      <nodes>\n" +
                         "        <actionNode id=\"1\" name=\"Signal Event\" >\n" +
-                        "          <action type=\"expression\" dialect=\"java\" >context.getProcessInstance().signalEvent(\"MyEvent\", \"MyValue\");</action>\n" +
+                        "          <action type=\"expression\" dialect=\"java\" >kcontext.getProcessInstance().signalEvent(\"MyEvent\", \"MyValue\");</action>\n" +
                         "        </actionNode>\n" +
                         "        <eventNode id=\"2\" name=\"Event\" variableName=\"MyVar\" >\n" +
                         "          <eventFilters>\n" +

--- a/jbpm/jbpm-flow-builder/src/test/java/org/jbpm/integrationtests/ProcessExceptionHandlerTest.java
+++ b/jbpm/jbpm-flow-builder/src/test/java/org/jbpm/integrationtests/ProcessExceptionHandlerTest.java
@@ -189,7 +189,7 @@ public class ProcessExceptionHandlerTest extends AbstractBaseTest {
                         "      </variables>\n" +
                         "      <exceptionHandlers>\n" +
                         "        <exceptionHandler faultName=\"MyFault\" type=\"action\" faultVariable=\"FaultVariable\" >\n" +
-                        "          <action type=\"expression\" name=\"Trigger\" dialect=\"java\" >context.getProcessInstance().signalEvent(\"MyEvent\", null);</action>\n" +
+                        "          <action type=\"expression\" name=\"Trigger\" dialect=\"java\" >kcontext.getProcessInstance().signalEvent(\"MyEvent\", null);</action>\n" +
                         "        </exceptionHandler>\n" +
                         "      </exceptionHandlers>\n" +
                         "      <nodes>\n" +
@@ -200,7 +200,7 @@ public class ProcessExceptionHandlerTest extends AbstractBaseTest {
                         "          </eventFilters>\n" +
                         "        </eventNode>\n" +
                         "        <actionNode id=\"3\" name=\"Action\" >\n" +
-                        "          <action type=\"expression\" dialect=\"java\" >list.add(context.getVariable(\"FaultVariable\"));</action>\n" +
+                        "          <action type=\"expression\" dialect=\"java\" >list.add(kcontext.getVariable(\"FaultVariable\"));</action>\n" +
                         "        </actionNode>\n" +
                         "      </nodes>\n" +
                         "      <connections>\n" +

--- a/jbpm/jbpm-flow-builder/src/test/java/org/jbpm/integrationtests/ProcessSplitTest.java
+++ b/jbpm/jbpm-flow-builder/src/test/java/org/jbpm/integrationtests/ProcessSplitTest.java
@@ -291,18 +291,18 @@ public class ProcessSplitTest extends AbstractBaseTest {
                         "" +
                         "  <nodes>" +
                         "    <actionNode id=\"2\" name=\"Action\" >" +
-                        "        <action type=\"expression\" dialect=\"java\" >insert(context.getProcessInstance());</action>" +
+                        "        <action type=\"expression\" dialect=\"java\" >insert(kcontext.getProcessInstance());</action>" +
                         "    </actionNode>" +
                         "    <split id=\"4\" name=\"Split\" type=\"2\" >" +
                         "      <constraints>" +
                         "        <constraint toNodeId=\"8\" toType=\"DROOLS_DEFAULT\" priority=\"2\" type=\"code\" dialect=\"java\" >return true;</constraint>" +
-                        "        <constraint toNodeId=\"6\" toType=\"DROOLS_DEFAULT\" priority=\"1\" type=\"code\" dialect=\"java\" >return context.getVariable(\"name\") != null &amp;&amp; ((String) context.getVariable(\"name\")).length() > 0;</constraint>"
+                        "        <constraint toNodeId=\"6\" toType=\"DROOLS_DEFAULT\" priority=\"1\" type=\"code\" dialect=\"java\" >return kcontext.getVariable(\"name\") != null &amp;&amp; ((String) kcontext.getVariable(\"name\")).length() > 0;</constraint>"
                         +
                         "      </constraints>" +
                         "    </split>" +
                         "    <end id=\"8\" name=\"End\" />" +
                         "    <actionNode id=\"6\" name=\"Action\" >" +
-                        "        <action type=\"expression\" dialect=\"java\" >list.add(context.getProcessInstance().getStringId());</action>" +
+                        "        <action type=\"expression\" dialect=\"java\" >list.add(kcontext.getProcessInstance().getStringId());</action>" +
                         "    </actionNode>" +
                         "    <start id=\"1\" name=\"Start\" />" +
                         "    <end id=\"3\" name=\"End\" />" +
@@ -361,7 +361,7 @@ public class ProcessSplitTest extends AbstractBaseTest {
                         "    <split id=\"4\" name=\"Split\" type=\"2\" >" +
                         "      <constraints>" +
                         "        <constraint toNodeId=\"8\" toType=\"DROOLS_DEFAULT\" priority=\"2\" type=\"code\" dialect=\"mvel\" >return true;</constraint>" +
-                        "        <constraint toNodeId=\"6\" toType=\"DROOLS_DEFAULT\" priority=\"1\" type=\"code\" dialect=\"mvel\" >return context.getVariable(\"person\") != null &amp;&amp; ((org.jbpm.integrationtests.test.Person) context.getVariable(\"person\")).name != null;</constraint>"
+                        "        <constraint toNodeId=\"6\" toType=\"DROOLS_DEFAULT\" priority=\"1\" type=\"code\" dialect=\"mvel\" >return kcontext.getVariable(\"person\") != null &amp;&amp; ((org.jbpm.integrationtests.test.Person) kcontext.getVariable(\"person\")).name != null;</constraint>"
                         +
                         "      </constraints>" +
                         "    </split>" +
@@ -485,7 +485,7 @@ public class ProcessSplitTest extends AbstractBaseTest {
                         "" +
                         "  <nodes>" +
                         "    <actionNode id=\"2\" name=\"Action\" >" +
-                        "        <action type=\"expression\" dialect=\"mvel\" >insert(context.getProcessInstance());</action>" +
+                        "        <action type=\"expression\" dialect=\"mvel\" >insert(kcontext.getProcessInstance());</action>" +
                         "    </actionNode>" +
                         "    <split id=\"4\" name=\"Split\" type=\"2\" >" +
                         "      <constraints>" +
@@ -495,7 +495,7 @@ public class ProcessSplitTest extends AbstractBaseTest {
                         "    </split>" +
                         "    <end id=\"8\" name=\"End\" />" +
                         "    <actionNode id=\"6\" name=\"Action\" >" +
-                        "        <action type=\"expression\" dialect=\"mvel\" >list.add(context.getProcessInstance().getStringId());</action>" +
+                        "        <action type=\"expression\" dialect=\"mvel\" >list.add(kcontext.getProcessInstance().getStringId());</action>" +
                         "    </actionNode>" +
                         "    <start id=\"1\" name=\"Start\" />" +
                         "    <end id=\"3\" name=\"End\" />" +
@@ -548,7 +548,7 @@ public class ProcessSplitTest extends AbstractBaseTest {
                         "" +
                         "  <nodes>" +
                         "    <actionNode id=\"2\" name=\"Action\" >" +
-                        "        <action type=\"expression\" dialect=\"java\" >insert(context.getProcessInstance());</action>" +
+                        "        <action type=\"expression\" dialect=\"java\" >insert(kcontext.getProcessInstance());</action>" +
                         "    </actionNode>" +
                         "    <split id=\"4\" name=\"Split\" type=\"2\" >" +
                         "      <constraints>" +
@@ -558,7 +558,7 @@ public class ProcessSplitTest extends AbstractBaseTest {
                         "    </split>" +
                         "    <end id=\"8\" name=\"End\" />" +
                         "    <actionNode id=\"6\" name=\"Action\" >" +
-                        "        <action type=\"expression\" dialect=\"java\" >list.add(context.getProcessInstance().getStringId());</action>" +
+                        "        <action type=\"expression\" dialect=\"java\" >list.add(kcontext.getProcessInstance().getStringId());</action>" +
                         "    </actionNode>" +
                         "    <start id=\"1\" name=\"Start\" />" +
                         "    <end id=\"3\" name=\"End\" />" +
@@ -612,7 +612,7 @@ public class ProcessSplitTest extends AbstractBaseTest {
                         "" +
                         "  <nodes>" +
                         "    <actionNode id=\"2\" name=\"Action\" >" +
-                        "        <action type=\"expression\" dialect=\"mvel\" >insert(context.getProcessInstance());</action>" +
+                        "        <action type=\"expression\" dialect=\"mvel\" >insert(kcontext.getProcessInstance());</action>" +
                         "    </actionNode>" +
                         "    <split id=\"4\" name=\"Split\" type=\"2\" >" +
                         "      <constraints>" +
@@ -622,7 +622,7 @@ public class ProcessSplitTest extends AbstractBaseTest {
                         "    </split>" +
                         "    <end id=\"8\" name=\"End\" />" +
                         "    <actionNode id=\"6\" name=\"Action\" >" +
-                        "        <action type=\"expression\" dialect=\"mvel\" >list.add(context.getProcessInstance().getStringId());</action>" +
+                        "        <action type=\"expression\" dialect=\"mvel\" >list.add(kcontext.getProcessInstance().getStringId());</action>" +
                         "    </actionNode>" +
                         "    <start id=\"1\" name=\"Start\" />" +
                         "    <end id=\"3\" name=\"End\" />" +
@@ -670,7 +670,7 @@ public class ProcessSplitTest extends AbstractBaseTest {
                         "" +
                         "  <nodes>" +
                         "    <actionNode id=\"2\" name=\"Action\" >" +
-                        "        <action type=\"expression\" dialect=\"java\" >insert(context.getProcessInstance());</action>" +
+                        "        <action type=\"expression\" dialect=\"java\" >insert(kcontext.getProcessInstance());</action>" +
                         "    </actionNode>" +
                         "    <split id=\"4\" name=\"Split\" type=\"2\" >" +
                         "      <constraints>" +
@@ -680,7 +680,7 @@ public class ProcessSplitTest extends AbstractBaseTest {
                         "    </split>" +
                         "    <end id=\"8\" name=\"End\" />" +
                         "    <actionNode id=\"6\" name=\"Action\" >" +
-                        "        <action type=\"expression\" dialect=\"java\" >list.add(context.getProcessInstance().getStringId());</action>" +
+                        "        <action type=\"expression\" dialect=\"java\" >list.add(kcontext.getProcessInstance().getStringId());</action>" +
                         "    </actionNode>" +
                         "    <start id=\"1\" name=\"Start\" />" +
                         "    <end id=\"3\" name=\"End\" />" +

--- a/jbpm/jbpm-flow-builder/src/test/java/org/jbpm/integrationtests/ProcessStartTest.java
+++ b/jbpm/jbpm-flow-builder/src/test/java/org/jbpm/integrationtests/ProcessStartTest.java
@@ -76,8 +76,8 @@ public class ProcessStartTest extends AbstractBaseTest {
                         "      </triggers>\n" +
                         "    </start>\n" +
                         "    <actionNode id=\"2\" name=\"Action\" >\n" +
-                        "      <action type=\"expression\" dialect=\"java\" >myList.add(context.getVariable(\"SomeVar\"));\n" +
-                        "myList.add(context.getVariable(\"SomeOtherVar\"));</action>\n" +
+                        "      <action type=\"expression\" dialect=\"java\" >myList.add(kcontext.getVariable(\"SomeVar\"));\n" +
+                        "myList.add(kcontext.getVariable(\"SomeOtherVar\"));</action>\n" +
                         "    </actionNode>\n" +
                         "    <end id=\"3\" name=\"End\" />\n" +
                         "  </nodes>\n" +
@@ -156,8 +156,8 @@ public class ProcessStartTest extends AbstractBaseTest {
                         "      </triggers>\n" +
                         "    </start>\n" +
                         "    <actionNode id=\"2\" name=\"Action\" >\n" +
-                        "      <action type=\"expression\" dialect=\"java\" >myList.add(context.getVariable(\"SomeVar\"));\n" +
-                        "myList.add(context.getVariable(\"SomeOtherVar\"));</action>\n" +
+                        "      <action type=\"expression\" dialect=\"java\" >myList.add(kcontext.getVariable(\"SomeVar\"));\n" +
+                        "myList.add(kcontext.getVariable(\"SomeOtherVar\"));</action>\n" +
                         "    </actionNode>\n" +
                         "    <end id=\"3\" name=\"End\" />\n" +
                         "  </nodes>\n" +

--- a/jbpm/jbpm-flow-builder/src/test/resources/org/jbpm/integrationtests/test_ProcessMultithreadEvent.rf
+++ b/jbpm/jbpm-flow-builder/src/test/resources/org/jbpm/integrationtests/test_ProcessMultithreadEvent.rf
@@ -25,7 +25,7 @@
       </eventFilters>
     </eventNode>
     <actionNode id="5" name="action1" >
-      <action type="expression" dialect="java" >context.setVariable("var", "action1"); try { Thread.sleep(3000); } catch (Throwable t) {} list.add(context.getVariable("var"));</action>
+      <action type="expression" dialect="java" >kcontext.setVariable("var", "action1"); try { Thread.sleep(3000); } catch (Throwable t) {} list.add(kcontext.getVariable("var"));</action>
     </actionNode>
     <eventNode id="6" name="Event" >
       <eventFilters>
@@ -33,7 +33,7 @@
       </eventFilters>
     </eventNode>
     <actionNode id="7" name="action2" >
-      <action type="expression" dialect="java" >context.setVariable("var", "action2"); try { Thread.sleep(3000); } catch (Throwable t) {} list.add(context.getVariable("var"));</action>
+      <action type="expression" dialect="java" >kcontext.setVariable("var", "action2"); try { Thread.sleep(3000); } catch (Throwable t) {} list.add(kcontext.getVariable("var"));</action>
     </actionNode>
   </nodes>
 

--- a/jbpm/jbpm-flow/pom.xml
+++ b/jbpm/jbpm-flow/pom.xml
@@ -57,6 +57,10 @@
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-dmn</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.github.javaparser</groupId>
+      <artifactId>javaparser-symbol-solver-core</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.drools</groupId>

--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -165,6 +165,11 @@
         <artifactId>javaparser-core</artifactId>
         <version>${version.com.github.javaparser}</version>
       </dependency>
+      <dependency>
+        <groupId>com.github.javaparser</groupId>
+        <artifactId>javaparser-symbol-solver-core</artifactId>
+        <version>${version.com.github.javaparser}</version>
+      </dependency>
 
       <!-- marshalling -->
       <dependency>

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/ProcessGenerator.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/ProcessGenerator.java
@@ -481,18 +481,18 @@ public class ProcessGenerator {
                 // add message produces as field
                 if (trigger.getType().equals(TriggerMetaData.TriggerType.ProduceMessage)) {
                     String producerFieldType = packageName + "." + typeName + "MessageProducer_" + trigger.getOwnerId();
-                    String producerFielName = "producer_" + trigger.getOwnerId();
+                    String producerFieldName = "producer_" + trigger.getOwnerId();
 
-                    FieldDeclaration producerFieldieldDeclaration = new FieldDeclaration()
-                            .addVariable(new VariableDeclarator(new ClassOrInterfaceType(null, producerFieldType), producerFielName));
-                    cls.addMember(producerFieldieldDeclaration);
+                    FieldDeclaration producerFieldDeclaration = new FieldDeclaration()
+                            .addVariable(new VariableDeclarator(new ClassOrInterfaceType(null, producerFieldType), producerFieldName));
+                    cls.addMember(producerFieldDeclaration);
 
                     if (context.hasDI()) {
-                        context.getDependencyInjectionAnnotator().withInjection(producerFieldieldDeclaration);
+                        context.getDependencyInjectionAnnotator().withInjection(producerFieldDeclaration);
                     } else {
 
                         AssignExpr assignExpr = new AssignExpr(
-                                new FieldAccessExpr(new ThisExpr(), producerFielName),
+                                new FieldAccessExpr(new ThisExpr(), producerFieldName),
                                 new ObjectCreationExpr().setType(producerFieldType),
                                 AssignExpr.Operator.ASSIGN);
 


### PR DESCRIPTION
With this enhancement users you see a specific error message such as: 
`Node 'Dump order' [2] uses unknown variable(s) in the script: [orders]`
instead of getting a generic fail to validate process class without knowing the reason