### PR TITLE
KOGITO-5553: Move SocketUtils to kogito-test-utils

### DIFF
--- a/kogito-test-utils/src/main/java/org/kie/kogito/test/utils/SocketUtils.java
+++ b/kogito-test-utils/src/main/java/org/kie/kogito/test/utils/SocketUtils.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.test.utils;
+
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.security.SecureRandom;
+
+import javax.net.ServerSocketFactory;
+
+public final class SocketUtils {
+
+    protected static final int PORT_RANGE_MIN = 1024;
+    protected static final int PORT_RANGE_MAX = 65535;
+    private static final SecureRandom RND = new SecureRandom();
+
+    private SocketUtils() {
+    }
+
+    public static final int findAvailablePort() {
+        int portRange = PORT_RANGE_MAX - PORT_RANGE_MIN;
+        int candidatePort;
+        int searchCounter = 0;
+        do {
+            if (searchCounter > portRange) {
+                throw new IllegalStateException(String.format(
+                        "Could not find an available port in the range [%d, %d] after %d attempts",
+                        PORT_RANGE_MIN, PORT_RANGE_MAX, searchCounter));
+            }
+            candidatePort = findRandomPort(PORT_RANGE_MIN, PORT_RANGE_MAX);
+            searchCounter++;
+        } while (!isPortAvailable(candidatePort));
+
+        return candidatePort;
+    }
+
+    private static final int findRandomPort(int minPort, int maxPort) {
+        int portRange = maxPort - minPort;
+        return minPort + RND.nextInt(portRange + 1);
+    }
+
+    private static final boolean isPortAvailable(int port) {
+        try {
+            ServerSocket serverSocket = ServerSocketFactory.getDefault().createServerSocket(port, 1, InetAddress.getByName("localhost"));
+            serverSocket.close();
+            return true;
+        } catch (Exception ex) {
+            return false;
+        }
+    }
+}

--- a/kogito-test-utils/src/test/java/org/kie/kogito/test/utils/SocketUtilsTest.java
+++ b/kogito-test-utils/src/test/java/org/kie/kogito/test/utils/SocketUtilsTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.test.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.kie.kogito.test.utils.SocketUtils.PORT_RANGE_MAX;
+import static org.kie.kogito.test.utils.SocketUtils.PORT_RANGE_MIN;
+
+public class SocketUtilsTest {
+
+    @Test
+    public void findAvailablePortTest() {
+        int availablePort = SocketUtils.findAvailablePort();
+        assertTrue(availablePort <= PORT_RANGE_MAX);
+        assertTrue(availablePort >= PORT_RANGE_MIN);
+    }
+
+}


### PR DESCRIPTION

jira related: https://issues.redhat.com/browse/KOGITO-5553
As part of unification between jobs and data-index integration test we need a common place to avoid duplicate SocketUtils..  moving that to  kogito-test-utils.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run all builds</b>  
  Please add comment: <b>Jenkins retest this</b>

* <b>Run (or rerun) specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] tests</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Run (or rerun) LTS specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Run (or rerun) native specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
