### PR TITLE
[KOGITO-5394] WorkItem retry implementation 

### DIFF
--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/ProcessFactoryTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/ProcessFactoryTest.java
@@ -16,12 +16,14 @@
 package org.jbpm.bpmn2;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.jbpm.bpmn2.objects.ExceptionOnPurposeHandler;
 import org.jbpm.bpmn2.objects.TestWorkItemHandler;
 import org.jbpm.bpmn2.xml.XmlBPMNProcessDumper;
 import org.jbpm.process.instance.LightProcessRuntime;
+import org.jbpm.process.instance.LightProcessRuntimeServiceProvider;
 import org.jbpm.ruleflow.core.RuleFlowProcess;
 import org.jbpm.ruleflow.core.RuleFlowProcessFactory;
 import org.jbpm.test.util.NodeLeftCountDownProcessEventListener;
@@ -407,7 +409,7 @@ public class ProcessFactoryTest extends JbpmBpmn2TestCase {
 
         final RuleFlowProcess process = factory.validate().getProcess();
 
-        final LightProcessRuntime processRuntime = LightProcessRuntime.ofProcess(process);
+        final LightProcessRuntime processRuntime = LightProcessRuntime.of(null, Collections.singletonList(process), new LightProcessRuntimeServiceProvider());
 
         processRuntime.getKogitoWorkItemManager().registerWorkItemHandler(task, new ExceptionOnPurposeHandler());
 

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/ProcessSupplier.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/ProcessSupplier.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.process.core;
+
+import java.util.function.Supplier;
+
+public interface ProcessSupplier extends Supplier<org.kie.api.definition.process.Process> {
+
+}

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/DummyKnowledgeRuntime.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/DummyKnowledgeRuntime.java
@@ -23,7 +23,6 @@ import org.drools.core.common.InternalAgenda;
 import org.drools.core.common.InternalKnowledgeRuntime;
 import org.drools.core.common.WorkingMemoryAction;
 import org.drools.core.impl.EnvironmentImpl;
-import org.drools.core.runtime.process.InternalProcessRuntime;
 import org.drools.core.time.TimerService;
 import org.jbpm.workflow.instance.impl.CodegenNodeInstanceFactoryRegistry;
 import org.kie.api.KieBase;
@@ -103,7 +102,7 @@ class DummyKnowledgeRuntime implements InternalKnowledgeRuntime, KogitoProcessRu
 
     @Override
     public KogitoProcessEventSupport getProcessEventSupport() {
-        return ((org.jbpm.process.instance.InternalProcessRuntime) processRuntime).getProcessEventSupport();
+        return processRuntime.getProcessEventSupport();
     }
 
     @Override
@@ -116,6 +115,7 @@ class DummyKnowledgeRuntime implements InternalKnowledgeRuntime, KogitoProcessRu
         return environment;
     }
 
+    @Override
     public JobsService getJobsService() {
         return null;
     }
@@ -273,7 +273,7 @@ class DummyKnowledgeRuntime implements InternalKnowledgeRuntime, KogitoProcessRu
 
     @Override
     public KogitoProcessInstance createProcessInstance(String processId, Map<String, Object> parameters) {
-        return null;
+        return (KogitoProcessInstance) processRuntime.createProcessInstance(processId, null, parameters);
     }
 
     @Override
@@ -282,10 +282,12 @@ class DummyKnowledgeRuntime implements InternalKnowledgeRuntime, KogitoProcessRu
 
     }
 
+    @Override
     public KogitoProcessInstance startProcessInstance(String processInstanceId) {
         return null;
     }
 
+    @Override
     public KogitoProcessInstance startProcessInstance(String processInstanceId, String trigger) {
         return null;
     }
@@ -301,6 +303,7 @@ class DummyKnowledgeRuntime implements InternalKnowledgeRuntime, KogitoProcessRu
 
     }
 
+    @Override
     public void signalEvent(String type, Object event, String processInstanceId) {
 
     }
@@ -338,14 +341,17 @@ class DummyKnowledgeRuntime implements InternalKnowledgeRuntime, KogitoProcessRu
         return (WorkItemManager) getKogitoWorkItemManager();
     }
 
+    @Override
     public KogitoProcessInstance getProcessInstance(String processInstanceId) {
         return null;
     }
 
+    @Override
     public KogitoProcessInstance getProcessInstance(String processInstanceId, boolean readonly) {
         return null;
     }
 
+    @Override
     public void abortProcessInstance(String processInstanceId) {
 
     }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/WorkItemNodeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/WorkItemNodeInstance.java
@@ -71,7 +71,6 @@ import org.kie.kogito.process.EventDescription;
 import org.kie.kogito.process.GroupedNamedDataType;
 import org.kie.kogito.process.IOEventDescription;
 import org.kie.kogito.process.NamedDataType;
-import org.kie.kogito.process.workitem.WorkItemExecutionException;
 import org.kie.kogito.process.workitems.InternalKogitoWorkItem;
 import org.kie.kogito.process.workitems.InternalKogitoWorkItemManager;
 import org.kie.kogito.process.workitems.impl.KogitoWorkItemImpl;
@@ -100,6 +99,8 @@ public class WorkItemNodeInstance extends StateBasedNodeInstance implements Even
     private String workItemId;
     private transient InternalKogitoWorkItem workItem;
     private String exceptionHandlingProcessInstanceId;
+
+    private int triggerCount = 0;
 
     protected WorkItemNode getWorkItemNode() {
         return (WorkItemNode) getNode();
@@ -143,11 +144,6 @@ public class WorkItemNodeInstance extends StateBasedNodeInstance implements Even
         if (getNodeInstanceContainer().getNodeInstance(getStringId()) == null) {
             return;
         }
-        // TODO this should be included for ruleflow only, not for BPEL
-        //        if (!Node.CONNECTION_DEFAULT_TYPE.equals(type)) {
-        //            throw new IllegalArgumentException(
-        //                "A WorkItemNode only accepts default incoming connections!");
-        //        }
         WorkItemNode workItemNode = getWorkItemNode();
         createWorkItem(workItemNode);
         if (workItemNode.isWaitForCompletion()) {
@@ -159,28 +155,42 @@ public class WorkItemNodeInstance extends StateBasedNodeInstance implements Even
         workItem.setNodeId(getNodeId());
         workItem.setNodeInstance(this);
         workItem.setProcessInstance(getProcessInstance());
-        if (isInversionOfControl()) {
-            getProcessInstance().getKnowledgeRuntime().update(getProcessInstance().getKnowledgeRuntime().getFactHandle(this), this);
-        } else {
-            try {
-                ((InternalKogitoWorkItemManager) getProcessInstance().getKnowledgeRuntime().getWorkItemManager()).internalExecuteWorkItem(workItem);
-            } catch (WorkItemHandlerNotFoundException wihnfe) {
-                getProcessInstance().setState(STATE_ABORTED);
-                throw wihnfe;
-            } catch (ProcessWorkItemHandlerException handlerException) {
-                this.workItemId = workItem.getStringId();
-                handleWorkItemHandlerException(handlerException, workItem);
-            } catch (WorkItemExecutionException e) {
-                handleException(e.getErrorCode(), e);
-            } catch (Exception e) {
-                String exceptionName = e.getClass().getName();
-                handleException(exceptionName, e);
-            }
-        }
+        processWorkItemHandler(() -> ((InternalKogitoWorkItemManager) KogitoProcessRuntime.asKogitoProcessRuntime(getProcessInstance().getKnowledgeRuntime()).getKogitoWorkItemManager())
+                .internalExecuteWorkItem(workItem));
         if (!workItemNode.isWaitForCompletion()) {
             triggerCompleted();
         }
         this.workItemId = workItem.getStringId();
+    }
+
+    private void processWorkItemHandler(Runnable handler) {
+        if (isInversionOfControl()) {
+            ((ProcessInstance) getProcessInstance()).getKnowledgeRuntime()
+                    .update(((ProcessInstance) getProcessInstance()).getKnowledgeRuntime().getFactHandle(this), this);
+        } else {
+            try {
+                handler.run();
+            } catch (WorkItemHandlerNotFoundException wihnfe) {
+                getProcessInstance().setState(ProcessInstance.STATE_ABORTED);
+                throw wihnfe;
+            } catch (ProcessWorkItemHandlerException handlerException) {
+                if (triggerCount++ < handlerException.getRetries() + 1) {
+                    this.workItemId = workItem.getStringId();
+                    handleWorkItemHandlerException(handlerException, workItem);
+                } else {
+                    throw handlerException;
+                }
+            } catch (Exception e) {
+                String exceptionName = e.getClass().getName();
+                ExceptionScopeInstance exceptionScopeInstance = (ExceptionScopeInstance) resolveContextInstance(ExceptionScope.EXCEPTION_SCOPE, exceptionName);
+                if (exceptionScopeInstance == null) {
+                    throw new WorkflowRuntimeException(this, getProcessInstance(), "Unable to execute Action: " + e.getMessage(), e);
+                }
+                // workItemId must be set otherwise cancel activity will not find the right work item
+                this.workItemId = workItem.getStringId();
+                exceptionScopeInstance.handleException(exceptionName, e);
+            }
+        }
     }
 
     protected void handleException(String exceptionName, Exception e) {
@@ -624,10 +634,11 @@ public class WorkItemNodeInstance extends StateBasedNodeInstance implements Even
         if (handlerException == null) {
             handlerException = (ProcessWorkItemHandlerException) ((WorkflowProcessInstance) processInstance).getVariable("Error");
         }
-
+        InternalKogitoWorkItemManager kogitoWorkItemManager =
+                (InternalKogitoWorkItemManager) KogitoProcessRuntime.asKogitoProcessRuntime(getProcessInstance().getKnowledgeRuntime()).getKogitoWorkItemManager();
         switch (handlerException.getStrategy()) {
             case ABORT:
-                KogitoProcessRuntime.asKogitoProcessRuntime(getProcessInstance().getKnowledgeRuntime()).getKogitoWorkItemManager().abortWorkItem(getWorkItem().getStringId());
+                kogitoWorkItemManager.abortWorkItem(getWorkItem().getStringId());
                 break;
             case RETHROW:
                 String exceptionName = handlerException.getCause().getClass().getName();
@@ -640,17 +651,11 @@ public class WorkItemNodeInstance extends StateBasedNodeInstance implements Even
                 break;
             case RETRY:
                 Map<String, Object> parameters = new HashMap<>(getWorkItem().getParameters());
-
                 parameters.putAll(processInstance.getVariables());
-
-                ((InternalKogitoWorkItemManager) getProcessInstance()
-                        .getKnowledgeRuntime().getWorkItemManager()).retryWorkItem(getWorkItem().getStringId(), parameters);
+                processWorkItemHandler(() -> kogitoWorkItemManager.retryWorkItem(getWorkItem().getStringId(), parameters));
                 break;
             case COMPLETE:
-                KogitoProcessRuntime kruntime = KogitoProcessRuntime.asKogitoProcessRuntime(getProcessInstance().getKnowledgeRuntime());
-                kruntime.getKogitoWorkItemManager().completeWorkItem(getWorkItem().getStringId(), processInstance.getVariables());
-                break;
-            default:
+                kogitoWorkItemManager.completeWorkItem(getWorkItem().getStringId(), processInstance.getVariables());
                 break;
         }
 

--- a/jbpm/jbpm-flow/src/test/java/org/jbpm/process/instance/LightProcessRuntimeTest.java
+++ b/jbpm/jbpm-flow/src/test/java/org/jbpm/process/instance/LightProcessRuntimeTest.java
@@ -20,8 +20,15 @@ import java.util.Collections;
 import org.jbpm.ruleflow.core.RuleFlowProcess;
 import org.jbpm.ruleflow.core.RuleFlowProcessFactory;
 import org.junit.jupiter.api.Test;
+import org.kie.kogito.Application;
+import org.kie.kogito.Model;
+import org.kie.kogito.process.Processes;
+import org.kie.kogito.process.impl.AbstractProcess;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class LightProcessRuntimeTest {
 
@@ -50,8 +57,30 @@ public class LightProcessRuntimeTest {
                 new LightProcessRuntimeServiceProvider();
 
         MyProcess myProcess = new MyProcess();
-        LightProcessRuntimeContext rtc = new LightProcessRuntimeContext(
-                Collections.singletonList(myProcess.process));
+        LightProcessRuntimeContext rtc = new LightProcessRuntimeContext(null, Collections.singletonList(myProcess.process));
+
+        LightProcessRuntime rt = new LightProcessRuntime(rtc, services);
+
+        rt.startProcess(myProcess.process.getId());
+
+        assertEquals("Hello!", myProcess.result);
+
+    }
+
+    @Test
+    public <T extends Model> void testInstantiationAnother() {
+        LightProcessRuntimeServiceProvider services =
+                new LightProcessRuntimeServiceProvider();
+
+        MyProcess myProcess = new MyProcess();
+        Application app = mock(Application.class);
+        Processes processes = mock(Processes.class);
+        AbstractProcess process = mock(AbstractProcess.class);
+        when(processes.processById(anyString())).thenReturn(process);
+        when(process.get()).thenReturn(myProcess.process);
+        when(app.get(Processes.class)).thenReturn(processes);
+
+        LightProcessRuntimeContext rtc = new LightProcessRuntimeContext(app, Collections.emptyList());
 
         LightProcessRuntime rt = new LightProcessRuntime(rtc, services);
 


### PR DESCRIPTION
This JIRA can be split in two parts

- First one is a carry forward from v7 to support retries in ProcessWorkItemHandlerException, which just involve ```workItemNodeInstance```
- Second one is to change the engine to support createProcessInstance of subprocess for error handling in Kogito (by hacking  ```DummyKnowledgeImplementation```).  This second one is tricky. I just add a Map to be able to access process definition from process id (the InternalProcessRuntime  instance can only start same type of process than the catching one), but I feel we should refactor the engine core in next release. There are too many layers that might be simplified