### PR TITLE
[RHPAM-3890][1.11.x] Use BOM managed version for non-productized Quarkus test artifacts

### DIFF
--- a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-deployment/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-deployment/pom.xml
@@ -31,7 +31,6 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5-internal</artifactId>
-      <version>${version.io.quarkus}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Signed-off-by: Alberto Morales Perez <almorale@redhat.com>

Backport for: https://github.com/kiegroup/kogito-runtimes/pull/1576