### PR TITLE
KOGITO-5789 use activating property for kogito-quarkus-test-list

### DIFF
--- a/integration-tests/integration-tests-quarkus-decisions/pom.xml
+++ b/integration-tests/integration-tests-quarkus-decisions/pom.xml
@@ -10,6 +10,10 @@
   <artifactId>integration-tests-quarkus-decisions</artifactId>
   <name>Kogito :: Integration Tests :: Quarkus :: Decisions</name>
 
+  <properties>
+    <quarkus.test.list.include>true</quarkus.test.list.include>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/integration-tests/integration-tests-quarkus-norest/pom.xml
+++ b/integration-tests/integration-tests-quarkus-norest/pom.xml
@@ -10,6 +10,11 @@
   <artifactId>integration-tests-quarkus-norest</artifactId>
   <name>Kogito :: Integration Tests :: Quarkus :: Without REST</name>
 
+  <properties>
+    <!-- excluded because of https://issues.redhat.com/browse/KOGITO-5338 -->
+    <quarkus.test.list.include>false</quarkus.test.list.include>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/integration-tests/integration-tests-quarkus-predictions/pom.xml
+++ b/integration-tests/integration-tests-quarkus-predictions/pom.xml
@@ -10,6 +10,10 @@
   <artifactId>integration-tests-quarkus-predictions</artifactId>
   <name>Kogito :: Integration Tests :: Quarkus :: Predictions</name>
 
+  <properties>
+    <quarkus.test.list.include>true</quarkus.test.list.include>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-infinispan/pom.xml
+++ b/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-infinispan/pom.xml
@@ -12,6 +12,10 @@
   <artifactId>integration-tests-quarkus-processes-infinispan</artifactId>
   <name>Kogito :: Integration Tests :: Quarkus :: Processes :: Persistence :: Infinispan</name>
 
+  <properties>
+    <quarkus.test.list.include>true</quarkus.test.list.include>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-jdbc/pom.xml
+++ b/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-jdbc/pom.xml
@@ -12,6 +12,11 @@
   <artifactId>integration-tests-quarkus-processes-jdbc</artifactId>
   <name>Kogito :: Integration Tests :: Quarkus :: Processes :: Persistence :: JDBC</name>
 
+  <properties>
+    <!-- excluded because of https://issues.redhat.com/browse/KOGITO-5651 -->
+    <quarkus.test.list.include>false</quarkus.test.list.include>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-kafka-persistence/pom.xml
+++ b/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-kafka-persistence/pom.xml
@@ -12,6 +12,11 @@
   <artifactId>integration-tests-quarkus-processes-kafka-persistence</artifactId>
   <name>Kogito :: Integration Tests :: Quarkus :: Processes :: Persistence :: Kafka</name>
 
+  <properties>
+    <!-- excluded because of https://issues.redhat.com/browse/KOGITO-5653 -->
+    <quarkus.test.list.include>false</quarkus.test.list.include>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.kie.kogito</groupId>

--- a/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-mongodb/pom.xml
+++ b/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-mongodb/pom.xml
@@ -12,6 +12,11 @@
   <artifactId>integration-tests-quarkus-processes-mongodb</artifactId>
   <name>Kogito :: Integration Tests :: Quarkus :: Processes :: Persistence :: MongoDB</name>
 
+  <properties>
+    <!-- excluded because of https://issues.redhat.com/browse/KOGITO-5654 -->
+    <quarkus.test.list.include>false</quarkus.test.list.include>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-postgresql/pom.xml
+++ b/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-postgresql/pom.xml
@@ -12,6 +12,11 @@
   <artifactId>integration-tests-quarkus-processes-postgresql</artifactId>
   <name>Kogito :: Integration Tests :: Quarkus :: Processes :: Persistence :: PostgreSQL</name>
 
+  <properties>
+    <!-- excluded because of https://issues.redhat.com/browse/KOGITO-5655 -->
+    <quarkus.test.list.include>false</quarkus.test.list.include>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/integration-tests/integration-tests-quarkus-processes/pom.xml
+++ b/integration-tests/integration-tests-quarkus-processes/pom.xml
@@ -11,6 +11,11 @@
   <artifactId>integration-tests-quarkus-processes</artifactId>
   <name>Kogito :: Integration Tests :: Quarkus :: Processes</name>
 
+  <properties>
+    <!-- excluded because of https://issues.redhat.com/browse/KOGITO-5340 -->
+    <quarkus.test.list.include>false</quarkus.test.list.include>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/integration-tests/integration-tests-quarkus-rules/pom.xml
+++ b/integration-tests/integration-tests-quarkus-rules/pom.xml
@@ -10,6 +10,10 @@
   <artifactId>integration-tests-quarkus-rules</artifactId>
   <name>Kogito :: Integration Tests :: Quarkus :: Rules</name>
 
+  <properties>
+    <quarkus.test.list.include>true</quarkus.test.list.include>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/kogito-build/kogito-build-parent/pom.xml
+++ b/kogito-build/kogito-build-parent/pom.xml
@@ -104,7 +104,7 @@
     <version.org.xolstice.maven.protobuf>0.6.1</version.org.xolstice.maven.protobuf>
     <version.plugin.plugin>3.6.0</version.plugin.plugin>
     <version.project.sources.plugin>0.3</version.project.sources.plugin>
-    <version.rpkgtests.maven.plugin>0.10.0</version.rpkgtests.maven.plugin>
+    <version.rpkgtests.maven.plugin>0.11.0</version.rpkgtests.maven.plugin>
     <version.resources.plugin>3.1.0</version.resources.plugin>
     <version.site.plugin>3.7.1</version.site.plugin>
     <version.shade.plugin>3.0.0</version.shade.plugin>

--- a/kogito-codegen-modules/kogito-codegen-integration-tests/pom.xml
+++ b/kogito-codegen-modules/kogito-codegen-integration-tests/pom.xml
@@ -11,6 +11,11 @@
     <artifactId>kogito-codegen-integration-tests</artifactId>
     <name>Kogito :: Codegen Integration Tests</name>
 
+    <properties>
+        <!-- excluded because of https://issues.redhat.com/browse/KOGITO-5808 -->
+        <quarkus.test.list.include>false</quarkus.test.list.include>
+    </properties>
+
     <dependencies>
 
         <!-- test -->

--- a/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test-hot-reload/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test-hot-reload/pom.xml
@@ -12,6 +12,11 @@
     <artifactId>kogito-quarkus-decisions-integration-test-hot-reload</artifactId>
     <name>Kogito :: Quarkus Decicions Extension :: Integration Tests (Hot Reload)</name>
 
+    <properties>
+        <!-- excluded because of https://issues.redhat.com/browse/KOGITO-5341 -->
+        <quarkus.test.list.include>false</quarkus.test.list.include>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.kie.kogito</groupId>

--- a/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>kogito-quarkus-decisions-integration-test</artifactId>
     <name>Kogito :: Quarkus Decisions Extension :: Integration Tests</name>
 
+    <properties>
+        <quarkus.test.list.include>true</quarkus.test.list.include>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.kie.kogito</groupId>

--- a/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-integration-test-maven-devmode/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-integration-test-maven-devmode/pom.xml
@@ -13,6 +13,11 @@
   <artifactId>kogito-quarkus-integration-test-maven-devmode</artifactId>
   <name>Kogito :: Quarkus Extension :: Integration Tests (Maven devmode)</name>
 
+  <properties>
+    <!-- excluded because of https://issues.redhat.com/browse/KOGITO-5656 -->
+    <quarkus.test.list.include>false</quarkus.test.list.include>
+  </properties>
+
   <dependencies>
 
     <!-- this is used implicitly by hot reload tests so let's make Maven aware of it -->

--- a/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-integration-test/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-integration-test/pom.xml
@@ -13,6 +13,10 @@
     <artifactId>kogito-quarkus-integration-test</artifactId>
     <name>Kogito :: Quarkus Extension :: Integration Tests</name>
 
+    <properties>
+        <quarkus.test.list.include>true</quarkus.test.list.include>
+    </properties>
+
      <dependencies>
         <dependency>
             <groupId>org.kie.kogito</groupId>

--- a/quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions-integration-test/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions-integration-test/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>kogito-quarkus-predictions-integration-test</artifactId>
     <name>Kogito :: Quarkus Predictions Extension :: Integration Tests</name>
 
+    <properties>
+        <quarkus.test.list.include>true</quarkus.test.list.include>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.kie.kogito</groupId>

--- a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-integration-test-hot-reload/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-integration-test-hot-reload/pom.xml
@@ -13,6 +13,11 @@
     <artifactId>kogito-quarkus-processes-integration-test-hot-reload</artifactId>
     <name>Kogito :: Quarkus Processes Extension :: Integration Tests (Hot Reload)</name>
 
+    <properties>
+        <!-- excluded because of https://issues.redhat.com/browse/KOGITO-5831 -->
+        <quarkus.test.list.include>false</quarkus.test.list.include>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.kie.kogito</groupId>

--- a/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test-hot-reload/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test-hot-reload/pom.xml
@@ -12,6 +12,11 @@
     <artifactId>kogito-quarkus-rules-integration-test-hot-reload</artifactId>
     <name>Kogito :: Quarkus Rules Extension :: Integration Tests (Hot Reload)</name>
 
+    <properties>
+        <!-- excluded because of https://issues.redhat.com/browse/KOGITO-5344 -->
+        <quarkus.test.list.include>false</quarkus.test.list.include>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.kie.kogito</groupId>

--- a/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test-session/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test-session/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>kogito-quarkus-rules-integration-test-session</artifactId>
     <name>Kogito :: Quarkus Rules Extension :: Integration Tests (KieSession API)</name>
 
+    <properties>
+        <quarkus.test.list.include>true</quarkus.test.list.include>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.kie.kogito</groupId>

--- a/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>kogito-quarkus-rules-integration-test</artifactId>
     <name>Kogito :: Quarkus Rules Extension :: Integration Tests</name>
 
+    <properties>
+        <quarkus.test.list.include>true</quarkus.test.list.include>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.kie.kogito</groupId>

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/pom.xml
@@ -12,6 +12,10 @@
   <artifactId>kogito-quarkus-serverless-workflow-integration-test</artifactId>
   <name>Kogito :: Quarkus Workflows Extension :: Integration Tests</name>
 
+  <properties>
+    <quarkus.test.list.include>true</quarkus.test.list.include>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.kie.kogito</groupId>

--- a/quarkus/extensions/kogito-quarkus-test-list/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-test-list/pom.xml
@@ -45,39 +45,7 @@
             <phase>generate-resources</phase>
             <configuration>
               <testJarsPath>${test.list.file.location}</testJarsPath>
-              <fileSets>
-                <fileSet>
-                  <directory>${project.root.dir}/integration-tests/</directory>
-                  <includes>
-                    <include>*quarkus*/pom.xml</include>
-                    <include>integration-tests-quarkus-processes-persistence/*/pom.xml</include>
-                  </includes>
-                  <excludes>
-                    <!-- Explicitly mentioning failing tests. -->
-                    <exclude>integration-tests-kogito-plugin/pom.xml</exclude>
-                    <exclude>integration-tests-quarkus-norest/pom.xml</exclude>
-                    <exclude>integration-tests-quarkus-processes/pom.xml</exclude>
-                    <exclude>integration-tests-quarkus-processes-persistence/pom.xml</exclude>
-                  </excludes>
-                </fileSet>
-                <fileSet>
-                  <directory>${project.root.dir}/quarkus/extensions/</directory>
-                  <includes>
-                    <include>kogito-quarkus-decisions-extension/*-integration-test*/pom.xml</include>
-                    <include>kogito-quarkus-extension/*-integration-test*/pom.xml</include>
-                    <include>kogito-quarkus-predictions-extension/*-integration-test*/pom.xml</include>
-                    <include>kogito-quarkus-rules-extension/*-integration-test*/pom.xml</include>
-                    <include>kogito-quarkus-serverless-workflow-extension/*-integration-test*/pom.xml</include>
-                  </includes>
-                  <excludes>
-                    <!-- Explicitly mentioning failing tests. -->
-                    <exclude>**/kogito-quarkus-decisions-integration-test-hot-reload/pom.xml</exclude>
-                    <exclude>**/kogito-quarkus-integration-test-hot-reload/pom.xml</exclude>
-                    <exclude>**/kogito-quarkus-rules-integration-test-hot-reload/pom.xml</exclude>
-                    <exclude>**/kogito-quarkus-rules-integration-test-legacy/pom.xml</exclude>
-                  </excludes>
-                </fileSet>
-              </fileSets>
+              <activatingPropertyName>quarkus.test.list.include</activatingPropertyName>
             </configuration>
           </execution>
         </executions>

--- a/quarkus/extensions/pom.xml
+++ b/quarkus/extensions/pom.xml
@@ -34,7 +34,6 @@
     <module>kogito-quarkus-decisions-extension</module>
     <module>kogito-quarkus-predictions-extension</module>
     <module>kogito-quarkus-processes-extension</module>
-    <module>kogito-quarkus-test-list</module>
   </modules>
 
   <profiles>
@@ -47,6 +46,17 @@
       </activation>
       <modules>
         <module>kogito-quarkus-serverless-workflow-extension</module>
+      </modules>
+    </profile>
+    <profile>
+      <id>integration-test-modules</id>
+      <activation>
+        <property>
+          <name>!excludeITModules</name>
+        </property>
+      </activation>
+      <modules>
+        <module>kogito-quarkus-test-list</module>
       </modules>
     </profile>
   </profiles>


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-5789

* Use newly added property in rpkgtests-maven-plugin to include just projects part of current reactor.
* configure kogito-quarkus-test-list as IT module (excluded by `-DexcludeITModules`).

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run all builds</b>  
  Please add comment: <b>Jenkins retest this</b>

* <b>Run (or rerun) specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] tests</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Run (or rerun) LTS specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Run (or rerun) native specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
