### PR TITLE
KOGITO-3931 - Messaging type variables validation

### DIFF
--- a/api/kogito-services/src/main/java/org/kie/kogito/services/event/impl/AbstractMessageConsumer.java
+++ b/api/kogito-services/src/main/java/org/kie/kogito/services/event/impl/AbstractMessageConsumer.java
@@ -43,9 +43,9 @@ public abstract class AbstractMessageConsumer<M extends Model, D, T extends Abst
     private Class<?> outputClass;
     private EventConverter<String> eventConverter;
 
-    // in general we should favor the non-empty constructor
+    // in general, we should favor the non-empty constructor
     // but there is an issue with Quarkus https://github.com/quarkusio/quarkus/issues/2949#issuecomment-513017781
-    // use this in conjuction with setParams()
+    // use this in conjunction with setParams()
     public AbstractMessageConsumer() {
     }
 

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/IntermediateThrowEventHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/IntermediateThrowEventHandler.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.drools.core.xml.ExtensibleXmlParser;
 import org.jbpm.bpmn2.core.Escalation;
 import org.jbpm.bpmn2.core.IntermediateLink;
@@ -46,6 +47,7 @@ import org.w3c.dom.Text;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 
+import static java.lang.String.format;
 import static org.jbpm.bpmn2.xml.ProcessHandler.createJavaAction;
 
 public class IntermediateThrowEventHandler extends AbstractNodeHandler {
@@ -247,10 +249,12 @@ public class IntermediateThrowEventHandler extends AbstractNodeHandler {
                 if (messages == null) {
                     throw new ProcessParsingValidationException("No messages found");
                 }
+                if (StringUtils.isEmpty(messageRef)) {
+                    throw new ProcessParsingValidationException(format("Node '%s' message name is missing", node.getName() == null ? node.getId() : node.getName()));
+                }
                 Message message = messages.get(messageRef);
                 if (message == null) {
-                    throw new ProcessParsingValidationException(
-                            "Could not find message " + messageRef);
+                    throw new ProcessParsingValidationException(format("Node '%s' message %s is missing data assignment", node.getName() == null ? node.getId() : node.getName(), messageRef));
                 }
                 String variable = (String) actionNode.getMetaData(MAPPING_VARIABLE_KEY);
                 Variable v = (Variable) ((ProcessBuildData) parser.getData()).getMetaData("Variable");

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ActionNodeVisitor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ActionNodeVisitor.java
@@ -68,7 +68,7 @@ public class ActionNodeVisitor extends AbstractNodeVisitor<ActionNode> {
             LambdaExpr lambda = TriggerMetaData.buildCompensationLambdaExpr(compensateNode);
             body.addStatement(getFactoryMethod(getNodeId(node), METHOD_ACTION, lambda));
         } else if (node.getMetaData(TRIGGER_REF) != null) { // if there is trigger defined on end event create TriggerMetaData for it
-            LambdaExpr lambda = TriggerMetaData.buildLambdaExpr(node, metadata);
+            LambdaExpr lambda = TriggerMetaData.buildLambdaExpr(node, metadata, variableScope);
             body.addStatement(getFactoryMethod(getNodeId(node), METHOD_ACTION, lambda));
         } else if (node.getMetaData(REF) != null && EVENT_TYPE_SIGNAL.equals(node.getMetaData(EVENT_TYPE))) {
             body.addStatement(getFactoryMethod(getNodeId(node), METHOD_ACTION, TriggerMetaData.buildAction((String) node.getMetaData(REF),

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/BoundaryEventNodeVisitor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/BoundaryEventNodeVisitor.java
@@ -68,7 +68,8 @@ public class BoundaryEventNodeVisitor extends AbstractNodeVisitor<BoundaryEventN
                     (String) nodeMetaData.get(TRIGGER_TYPE),
                     (String) nodeMetaData.get(MESSAGE_TYPE),
                     node.getVariableName(),
-                    String.valueOf(node.getId())).validate());
+                    node,
+                    metadata.getProcessId()).validate(variableScope));
         } else if (EVENT_TYPE_COMPENSATION.equalsIgnoreCase(eventType) && node.getAttachedToNodeId() != null) {
             body.addStatement(getFactoryMethod(getNodeId(node), METHOD_ADD_COMPENSATION_HANDLER, new StringLiteralExpr(node.getAttachedToNodeId())));
         }

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/EndNodeVisitor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/EndNodeVisitor.java
@@ -67,7 +67,7 @@ public class EndNodeVisitor extends AbstractNodeVisitor<EndNode> {
             LambdaExpr lambda = TriggerMetaData.buildCompensationLambdaExpr(compensateNode);
             body.addStatement(getFactoryMethod(getNodeId(node), ActionNodeFactory.METHOD_ACTION, lambda));
         } else if (node.getMetaData(TRIGGER_REF) != null) {
-            LambdaExpr lambda = TriggerMetaData.buildLambdaExpr(node, metadata);
+            LambdaExpr lambda = TriggerMetaData.buildLambdaExpr(node, metadata, variableScope);
             body.addStatement(getFactoryMethod(getNodeId(node), METHOD_ACTION, lambda));
         } else if (node.getMetaData(REF) != null && EVENT_TYPE_SIGNAL.equals(node.getMetaData(EVENT_TYPE))) {
             body.addStatement(getFactoryMethod(getNodeId(node), METHOD_ACTION, TriggerMetaData.buildAction((String) node.getMetaData(REF),

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/EventNodeVisitor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/EventNodeVisitor.java
@@ -15,7 +15,6 @@
  */
 package org.jbpm.compiler.canonical;
 
-import java.text.MessageFormat;
 import java.util.Map;
 
 import org.jbpm.process.core.context.variable.Variable;
@@ -58,21 +57,13 @@ public class EventNodeVisitor extends AbstractNodeVisitor<EventNode> {
             metadata.addSignal(node.getType(), variable != null ? variable.getType().getStringType() : null);
         } else if (EVENT_TYPE_MESSAGE.equals(node.getMetaData(EVENT_TYPE))) {
             Map<String, Object> nodeMetaData = node.getMetaData();
-            try {
-                TriggerMetaData triggerMetaData = new TriggerMetaData((String) nodeMetaData.get(TRIGGER_REF),
-                        (String) nodeMetaData.get(TRIGGER_TYPE),
-                        (String) nodeMetaData.get(MESSAGE_TYPE),
-                        node.getVariableName(),
-                        String.valueOf(node.getId())).validate();
-                metadata.addTrigger(triggerMetaData);
-            } catch (IllegalArgumentException e) {
-                throw new IllegalArgumentException(
-                        MessageFormat.format(
-                                "Invalid parameters for event node \"{0}\": {1}",
-                                node.getName(),
-                                e.getMessage()),
-                        e);
-            }
+            TriggerMetaData triggerMetaData = new TriggerMetaData((String) nodeMetaData.get(TRIGGER_REF),
+                    (String) nodeMetaData.get(TRIGGER_TYPE),
+                    (String) nodeMetaData.get(MESSAGE_TYPE),
+                    node.getVariableName(),
+                    node,
+                    metadata.getProcessId()).validate(variableScope);
+            metadata.addTrigger(triggerMetaData);
         }
         visitMetaData(node.getMetaData(), body, getNodeId(node));
         body.addStatement(getDoneMethod(getNodeId(node)));

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/StartNodeVisitor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/StartNodeVisitor.java
@@ -62,7 +62,7 @@ public class StartNodeVisitor extends AbstractNodeVisitor<StartNode> {
                     new IntegerLiteralExpr(node.getTimer().getTimeType())));
 
         } else if (node.getTriggers() != null && !node.getTriggers().isEmpty()) {
-            TriggerMetaData triggerMetaData = buildTriggerMetadata(node);
+            TriggerMetaData triggerMetaData = buildTriggerMetadata(node, variableScope, metadata.getProcessId());
             metadata.addTrigger(triggerMetaData);
             handleSignal(node, node.getMetaData(), body, variableScope, metadata);
         } else {
@@ -71,12 +71,12 @@ public class StartNodeVisitor extends AbstractNodeVisitor<StartNode> {
         }
     }
 
-    private TriggerMetaData buildTriggerMetadata(StartNode node) {
+    private TriggerMetaData buildTriggerMetadata(StartNode node, VariableScope variableScope, String processId) {
         return new TriggerMetaData((String) node.getMetaData(TRIGGER_REF),
                 (String) node.getMetaData(TRIGGER_TYPE),
                 (String) node.getMetaData(MESSAGE_TYPE),
                 (String) node.getMetaData(TRIGGER_MAPPING),
-                String.valueOf(node.getId())).validate();
+                node, processId).validate(variableScope);
     }
 
     protected void handleSignal(StartNode startNode, Map<String, Object> nodeMetaData, BlockStmt body, VariableScope variableScope, ProcessMetaData metadata) {

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/type/BooleanDataType.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/type/BooleanDataType.java
@@ -24,9 +24,7 @@ import org.jbpm.process.core.datatype.DataType;
 /**
  * Representation of a boolean datatype.
  */
-public final class BooleanDataType
-        implements
-        DataType {
+public final class BooleanDataType implements DataType {
 
     private static final long serialVersionUID = 510l;
 

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/type/EnumDataType.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/type/EnumDataType.java
@@ -21,6 +21,7 @@ import java.io.ObjectOutput;
 import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import org.jbpm.process.core.datatype.DataType;
 
@@ -127,5 +128,22 @@ public class EnumDataType implements DataType {
 
         }
         return this.valueMap;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof EnumDataType)) {
+            return false;
+        }
+        EnumDataType that = (EnumDataType) o;
+        return Objects.equals(getClassName(), that.getClassName());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getClassName());
     }
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/type/FloatDataType.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/type/FloatDataType.java
@@ -24,9 +24,7 @@ import org.jbpm.process.core.datatype.DataType;
 /**
  * Representation of a float datatype.
  */
-public final class FloatDataType
-        implements
-        DataType {
+public final class FloatDataType implements DataType {
 
     private static final long serialVersionUID = 510l;
 

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/type/IntegerDataType.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/type/IntegerDataType.java
@@ -24,9 +24,7 @@ import org.jbpm.process.core.datatype.DataType;
 /**
  * Representation of an integer datatype.
  */
-public class IntegerDataType
-        implements
-        DataType {
+public class IntegerDataType implements DataType {
 
     private static final long serialVersionUID = 510l;
 
@@ -47,7 +45,7 @@ public class IntegerDataType
     }
 
     public Object readValue(String value) {
-        return new Integer(value);
+        return Integer.valueOf(value);
     }
 
     public String writeValue(Object value) {

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/type/ObjectDataType.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/type/ObjectDataType.java
@@ -18,6 +18,7 @@ package org.jbpm.process.core.datatype.impl.type;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.util.Objects;
 
 import org.jbpm.process.core.datatype.DataType;
 import org.jbpm.process.core.datatype.impl.coverter.TypeConverterRegistry;
@@ -95,5 +96,22 @@ public class ObjectDataType implements DataType {
 
     public String getStringType() {
         return className == null ? "java.lang.Object" : className;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ObjectDataType)) {
+            return false;
+        }
+        ObjectDataType that = (ObjectDataType) o;
+        return Objects.equals(getClassName(), that.getClassName());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getClassName());
     }
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/validation/RuleFlowProcessValidator.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/validation/RuleFlowProcessValidator.java
@@ -738,8 +738,7 @@ public class RuleFlowProcessValidator implements ProcessValidator {
         List<CompositeNode> compositeNodes = new ArrayList<>();
         for (int i = 0; i < nodes.length; i++) {
             final org.kie.api.definition.process.Node node = nodes[i];
-            processNodes.put(node,
-                    Boolean.FALSE);
+            processNodes.put(node, Boolean.FALSE);
             if (node instanceof EventNode) {
                 eventNodes.add(node);
             }
@@ -750,22 +749,19 @@ public class RuleFlowProcessValidator implements ProcessValidator {
         if (isDynamic) {
             for (org.kie.api.definition.process.Node node : nodes) {
                 if (node.getIncomingConnections(Node.CONNECTION_DEFAULT_TYPE).isEmpty()) {
-                    processNode(node,
-                            processNodes);
+                    processNode(node, processNodes);
                 }
             }
         } else {
             final List<org.kie.api.definition.process.Node> start = RuleFlowProcess.getStartNodes(nodes);
             if (start != null) {
                 for (org.kie.api.definition.process.Node s : start) {
-                    processNode(s,
-                            processNodes);
+                    processNode(s, processNodes);
                 }
             }
             if (container instanceof CompositeNode) {
                 for (CompositeNode.NodeAndType nodeAndTypes : ((CompositeNode) container).getLinkedIncomingNodes().values()) {
-                    processNode(nodeAndTypes.getNode(),
-                            processNodes);
+                    processNode(nodeAndTypes.getNode(), processNodes);
                 }
             }
         }

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/ChannelMappingStrategy.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/ChannelMappingStrategy.java
@@ -22,5 +22,7 @@ import org.jbpm.compiler.canonical.TriggerMetaData;
 import org.kie.kogito.codegen.api.context.KogitoBuildContext;
 
 public interface ChannelMappingStrategy {
+
     Map<TriggerMetaData, String> getChannelMapping(KogitoBuildContext kogitoBuildContext, Collection<TriggerMetaData> metadata);
+
 }

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/ProcessGenerator.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/ProcessGenerator.java
@@ -481,18 +481,18 @@ public class ProcessGenerator {
                 // add message produces as field
                 if (trigger.getType().equals(TriggerMetaData.TriggerType.ProduceMessage)) {
                     String producerFieldType = packageName + "." + typeName + "MessageProducer_" + trigger.getOwnerId();
-                    String producerFielName = "producer_" + trigger.getOwnerId();
+                    String producerFieldName = "producer_" + trigger.getOwnerId();
 
-                    FieldDeclaration producerFieldieldDeclaration = new FieldDeclaration()
-                            .addVariable(new VariableDeclarator(new ClassOrInterfaceType(null, producerFieldType), producerFielName));
-                    cls.addMember(producerFieldieldDeclaration);
+                    FieldDeclaration producerFieldDeclaration = new FieldDeclaration()
+                            .addVariable(new VariableDeclarator(new ClassOrInterfaceType(null, producerFieldType), producerFieldName));
+                    cls.addMember(producerFieldDeclaration);
 
                     if (context.hasDI()) {
-                        context.getDependencyInjectionAnnotator().withInjection(producerFieldieldDeclaration);
+                        context.getDependencyInjectionAnnotator().withInjection(producerFieldDeclaration);
                     } else {
 
                         AssignExpr assignExpr = new AssignExpr(
-                                new FieldAccessExpr(new ThisExpr(), producerFielName),
+                                new FieldAccessExpr(new ThisExpr(), producerFieldName),
                                 new ObjectCreationExpr().setType(producerFieldType),
                                 AssignExpr.Operator.ASSIGN);
 


### PR DESCRIPTION
Enhanced validation for message related nodes, for instance now if the variables ( target and source ) don't match the data type, users will get the following error:
`IllegalArgumentException: Node 'pong start' message 'pong_start' trigger source variable 'message' has different data type 'java.lang.String', from expected 'Float'.`