### PR TITLE
[1.11.x][KOGITO-5832] dispose a rule unit instance in the generated rest endpoint after it has been used to serve a request

### DIFF
--- a/api/kogito-api/src/main/java/org/kie/kogito/rules/RuleUnitInstance.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/rules/RuleUnitInstance.java
@@ -31,4 +31,6 @@ public interface RuleUnitInstance<T extends RuleUnitData> {
     <Q> Q executeQuery(Class<? extends RuleUnitQuery<Q>> query);
 
     <T extends SessionClock> T getClock();
+
+    void dispose();
 }

--- a/drools/kogito-ruleunits/src/main/java/org/kie/kogito/rules/units/AbstractRuleUnitInstance.java
+++ b/drools/kogito-ruleunits/src/main/java/org/kie/kogito/rules/units/AbstractRuleUnitInstance.java
@@ -47,6 +47,11 @@ public class AbstractRuleUnitInstance<T extends RuleUnitData> implements RuleUni
     }
 
     @Override
+    public void dispose() {
+        runtime.dispose();
+    }
+
+    @Override
     public List<Map<String, Object>> executeQuery(String query) {
         fire();
         return runtime.getQueryResults(query).toList();

--- a/kogito-codegen-modules/kogito-codegen-rules/src/main/resources/class-templates/rules/RestQueryJavaTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-rules/src/main/resources/class-templates/rules/RestQueryJavaTemplate.java
@@ -47,6 +47,7 @@ public class $unit$Query$name$Endpoint {
         RuleUnitInstance<$UnitType$> instance = ruleUnit.createInstance();
         // Do not return the result directly to allow post execution codegen (like monitoring)
         List<$ReturnType$> response = instance.executeQuery($unit$Query$name$.class);
+        instance.dispose();
         return response;
     }
 

--- a/kogito-codegen-modules/kogito-codegen-rules/src/main/resources/class-templates/rules/RestQueryQuarkusTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-rules/src/main/resources/class-templates/rules/RestQueryQuarkusTemplate.java
@@ -48,6 +48,7 @@ public class $unit$Query$name$Endpoint {
         RuleUnitInstance<$UnitType$> instance = ruleUnit.createInstance();
         // Do not return the result directly to allow post execution codegen (like monitoring)
         List<$ReturnType$> response = instance.executeQuery($unit$Query$name$.class);
+        instance.dispose();
         return response;
     }
 

--- a/kogito-codegen-modules/kogito-codegen-rules/src/main/resources/class-templates/rules/RestQuerySpringTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-rules/src/main/resources/class-templates/rules/RestQuerySpringTemplate.java
@@ -48,6 +48,7 @@ public class $unit$Query$name$Endpoint {
         RuleUnitInstance<$UnitType$> instance = ruleUnit.createInstance();
         // Do not return the result directly to allow post execution codegen (like monitoring)
         List<$ReturnType$> response = instance.executeQuery($unit$Query$name$.class);
+        instance.dispose();
         return response;
     }
 


### PR DESCRIPTION
Backport of https://github.com/kiegroup/kogito-runtimes/pull/1597