### PR TITLE
[KOGITO-5394] Workitem error Handling strategy

### DIFF
--- a/api/kogito-api/src/main/java/org/kie/kogito/internal/process/runtime/KogitoProcessRuntime.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/internal/process/runtime/KogitoProcessRuntime.java
@@ -24,6 +24,7 @@ import org.kie.api.runtime.KieRuntime;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.process.ProcessRuntime;
 import org.kie.api.runtime.rule.AgendaFilter;
+import org.kie.kogito.Application;
 import org.kie.kogito.internal.process.event.KogitoProcessEventSupport;
 import org.kie.kogito.jobs.JobsService;
 
@@ -208,6 +209,8 @@ public interface KogitoProcessRuntime {
     KogitoProcessEventSupport getProcessEventSupport();
 
     ProcessEventManager getProcessEventManager();
+
+    Application getApplication();
 
     @Deprecated
     KieRuntime getKieRuntime();

--- a/api/kogito-api/src/main/java/org/kie/kogito/process/ProcessInstance.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/process/ProcessInstance.java
@@ -162,9 +162,17 @@ public interface ProcessInstance<T> {
      * Returns list of currently active work items.
      *
      * @param policies optional list of policies to be enforced
-     * @return non empty list of identifiers of currently active tasks.
+     * @return list of work items
      */
     List<WorkItem> workItems(Policy<?>... policies);
+
+    /**
+     * Returns list of filtered work items
+     * 
+     * @param p the predicate to be applied to the node holding the work item
+     * @return list of work items
+     */
+    List<WorkItem> workItems(Predicate<KogitoNodeInstance> p, Policy<?>... policies);
 
     /**
      * Returns identifier of this process instance

--- a/integration-tests/integration-tests-quarkus-processes/src/main/java/org/acme/CustomTaskWorkItemHandler.java
+++ b/integration-tests/integration-tests-quarkus-processes/src/main/java/org/acme/CustomTaskWorkItemHandler.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.acme;
+
+import org.kie.api.runtime.process.ProcessWorkItemHandlerException;
+import org.kie.api.runtime.process.ProcessWorkItemHandlerException.HandlingStrategy;
+import org.kie.kogito.internal.process.runtime.KogitoWorkItem;
+import org.kie.kogito.internal.process.runtime.KogitoWorkItemHandler;
+import org.kie.kogito.internal.process.runtime.KogitoWorkItemManager;
+
+public class CustomTaskWorkItemHandler implements KogitoWorkItemHandler {
+
+    @Override
+    public void executeWorkItem(KogitoWorkItem workItem, KogitoWorkItemManager manager) {
+        throw new ProcessWorkItemHandlerException("error_handling", HandlingStrategy.COMPLETE, null);
+    }
+
+    @Override
+    public void abortWorkItem(KogitoWorkItem workItem, KogitoWorkItemManager manager) {
+
+    }
+}

--- a/integration-tests/integration-tests-quarkus-processes/src/main/java/org/acme/WIHRegister.java
+++ b/integration-tests/integration-tests-quarkus-processes/src/main/java/org/acme/WIHRegister.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.acme;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.kie.kogito.process.impl.DefaultWorkItemHandlerConfig;
+
+@ApplicationScoped
+public class WIHRegister extends DefaultWorkItemHandlerConfig {
+    {
+        register("CustomTask", new CustomTaskWorkItemHandler());
+    }
+}

--- a/integration-tests/integration-tests-quarkus-processes/src/main/resources/error-handling.bpmn
+++ b/integration-tests/integration-tests-quarkus-processes/src/main/resources/error-handling.bpmn
@@ -1,0 +1,93 @@
+<bpmn2:definitions xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" xmlns:xsi="xsi" id="_UJD9oP39EDmDHJjzXcsbjw" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
+  <bpmn2:itemDefinition id="_inoutItem" structureRef="String"/>
+  <bpmn2:process id="error_handling" drools:packageName="org.acme" drools:version="1.0" drools:adHoc="false" name="error-handling" isExecutable="true" processType="Public">
+    <bpmn2:property id="inout" itemSubjectRef="_inoutItem" name="inout"/>
+    <bpmn2:sequenceFlow id="_381115D1-83D2-48B1-BCBD-044C32837CA1" sourceRef="_3CDC6E61-DCC5-4831-8BBB-417CFF517CB0" targetRef="_A6902151-5E9D-48F7-95E9-375E41CF3E6F"/>
+    <bpmn2:sequenceFlow id="_00AB4A77-D70F-4086-8BA6-57DD017A5323" sourceRef="_75AC8C0C-CFBD-4ADF-A3B4-83AB90581A73" targetRef="_3CDC6E61-DCC5-4831-8BBB-417CFF517CB0">
+      <bpmn2:extensionElements>
+        <drools:metaData name="isAutoConnection.source">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+        <drools:metaData name="isAutoConnection.target">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+    </bpmn2:sequenceFlow>
+    <bpmn2:endEvent id="_A6902151-5E9D-48F7-95E9-375E41CF3E6F">
+      <bpmn2:incoming>_381115D1-83D2-48B1-BCBD-044C32837CA1</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:scriptTask id="_3CDC6E61-DCC5-4831-8BBB-417CFF517CB0" name="Hello" scriptFormat="http://www.java.com/java">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Hello]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_00AB4A77-D70F-4086-8BA6-57DD017A5323</bpmn2:incoming>
+      <bpmn2:outgoing>_381115D1-83D2-48B1-BCBD-044C32837CA1</bpmn2:outgoing>
+      <bpmn2:script>kcontext.setVariable("inout","pepito");
+System.out.println("Hello World");</bpmn2:script>
+    </bpmn2:scriptTask>
+    <bpmn2:startEvent id="_75AC8C0C-CFBD-4ADF-A3B4-83AB90581A73">
+      <bpmn2:outgoing>_00AB4A77-D70F-4086-8BA6-57DD017A5323</bpmn2:outgoing>
+    </bpmn2:startEvent>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram>
+    <bpmndi:BPMNPlane bpmnElement="error_handling">
+      <bpmndi:BPMNShape id="shape__75AC8C0C-CFBD-4ADF-A3B4-83AB90581A73" bpmnElement="_75AC8C0C-CFBD-4ADF-A3B4-83AB90581A73">
+        <dc:Bounds height="56" width="56" x="176" y="198"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__3CDC6E61-DCC5-4831-8BBB-417CFF517CB0" bpmnElement="_3CDC6E61-DCC5-4831-8BBB-417CFF517CB0">
+        <dc:Bounds height="76" width="143" x="315" y="188"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__A6902151-5E9D-48F7-95E9-375E41CF3E6F" bpmnElement="_A6902151-5E9D-48F7-95E9-375E41CF3E6F">
+        <dc:Bounds height="56" width="56" x="627" y="198"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="edge_shape__75AC8C0C-CFBD-4ADF-A3B4-83AB90581A73_to_shape__3CDC6E61-DCC5-4831-8BBB-417CFF517CB0" bpmnElement="_00AB4A77-D70F-4086-8BA6-57DD017A5323">
+        <di:waypoint x="232" y="226"/>
+        <di:waypoint x="315" y="226"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_shape__3CDC6E61-DCC5-4831-8BBB-417CFF517CB0_to_shape__A6902151-5E9D-48F7-95E9-375E41CF3E6F" bpmnElement="_381115D1-83D2-48B1-BCBD-044C32837CA1">
+        <di:waypoint x="386.5" y="226"/>
+        <di:waypoint x="655" y="226"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters/>
+          <bpsim:ElementParameters elementRef="_75AC8C0C-CFBD-4ADF-A3B4-83AB90581A73">
+            <bpsim:TimeParameters>
+              <bpsim:ProcessingTime>
+                <bpsim:NormalDistribution mean="0" standardDeviation="0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters elementRef="_3CDC6E61-DCC5-4831-8BBB-417CFF517CB0">
+            <bpsim:TimeParameters>
+              <bpsim:ProcessingTime>
+                <bpsim:NormalDistribution mean="0" standardDeviation="0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters>
+              <bpsim:Availability>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:Availability>
+              <bpsim:Quantity>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters>
+              <bpsim:UnitCost>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_UJD9oP39EDmDHJjzXcsbjw</bpmn2:source>
+    <bpmn2:target>_UJD9oP39EDmDHJjzXcsbjw</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>

--- a/integration-tests/integration-tests-quarkus-processes/src/main/resources/exce-proc.bpmn
+++ b/integration-tests/integration-tests-quarkus-processes/src/main/resources/exce-proc.bpmn
@@ -1,0 +1,121 @@
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_wPwikP39EDmgoMcouFRnRA" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
+  <bpmn2:itemDefinition id="_inoutItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__520D606E-BE97-4343-BCD6-41F6969A4D7C_MessageInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__520D606E-BE97-4343-BCD6-41F6969A4D7C_inoutOutputXItem" structureRef="String"/>
+  <bpmn2:process id="exce_proc" drools:packageName="com.example" drools:version="1.0" drools:adHoc="false" name="exce-proc" isExecutable="true" processType="Public">
+    <bpmn2:property id="inout" itemSubjectRef="_inoutItem" name="inout"/>
+    <bpmn2:sequenceFlow id="_B118B09A-AE1B-4853-952F-9F863E5CC42E" sourceRef="_520D606E-BE97-4343-BCD6-41F6969A4D7C" targetRef="_57CB8A8D-1EB1-4009-B2D7-5BF5D6DB51E7"/>
+    <bpmn2:sequenceFlow id="_1EAF811C-D97C-49DE-B606-0385A66520EB" sourceRef="_683B9260-BF50-478D-B3C2-B0D0FD58ACB6" targetRef="_520D606E-BE97-4343-BCD6-41F6969A4D7C">
+      <bpmn2:extensionElements>
+        <drools:metaData name="isAutoConnection.source">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+        <drools:metaData name="isAutoConnection.target">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+    </bpmn2:sequenceFlow>
+    <bpmn2:endEvent id="_57CB8A8D-1EB1-4009-B2D7-5BF5D6DB51E7">
+      <bpmn2:incoming>_B118B09A-AE1B-4853-952F-9F863E5CC42E</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:startEvent id="_683B9260-BF50-478D-B3C2-B0D0FD58ACB6">
+      <bpmn2:outgoing>_1EAF811C-D97C-49DE-B606-0385A66520EB</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:task id="_520D606E-BE97-4343-BCD6-41F6969A4D7C" drools:taskName="CustomTask" name="Custom Task">
+      <bpmn2:documentation><![CDATA[Basic minimal custom task.]]></bpmn2:documentation>
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Custom Task]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_1EAF811C-D97C-49DE-B606-0385A66520EB</bpmn2:incoming>
+      <bpmn2:outgoing>_B118B09A-AE1B-4853-952F-9F863E5CC42E</bpmn2:outgoing>
+      <bpmn2:ioSpecification>
+        <bpmn2:dataInput id="_520D606E-BE97-4343-BCD6-41F6969A4D7C_MessageInputX" drools:dtype="String" itemSubjectRef="__520D606E-BE97-4343-BCD6-41F6969A4D7C_MessageInputXItem" name="Message"/>
+        <bpmn2:dataInput id="_520D606E-BE97-4343-BCD6-41F6969A4D7C_TaskNameInputX" drools:dtype="Object" name="TaskName"/>
+        <bpmn2:dataOutput id="_520D606E-BE97-4343-BCD6-41F6969A4D7C_inoutOutputX" drools:dtype="String" itemSubjectRef="__520D606E-BE97-4343-BCD6-41F6969A4D7C_inoutOutputXItem" name="inout"/>
+        <bpmn2:inputSet>
+          <bpmn2:dataInputRefs>_520D606E-BE97-4343-BCD6-41F6969A4D7C_MessageInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_520D606E-BE97-4343-BCD6-41F6969A4D7C_TaskNameInputX</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet>
+          <bpmn2:dataOutputRefs>_520D606E-BE97-4343-BCD6-41F6969A4D7C_inoutOutputX</bpmn2:dataOutputRefs>
+        </bpmn2:outputSet>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation>
+        <bpmn2:sourceRef>inout</bpmn2:sourceRef>
+        <bpmn2:targetRef>_520D606E-BE97-4343-BCD6-41F6969A4D7C_MessageInputX</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation>
+        <bpmn2:targetRef>_520D606E-BE97-4343-BCD6-41F6969A4D7C_TaskNameInputX</bpmn2:targetRef>
+        <bpmn2:assignment>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA[CustomTask]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_520D606E-BE97-4343-BCD6-41F6969A4D7C_TaskNameInputX]]></bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataOutputAssociation>
+        <bpmn2:sourceRef>_520D606E-BE97-4343-BCD6-41F6969A4D7C_inoutOutputX</bpmn2:sourceRef>
+        <bpmn2:targetRef>inout</bpmn2:targetRef>
+      </bpmn2:dataOutputAssociation>
+    </bpmn2:task>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram>
+    <bpmndi:BPMNPlane bpmnElement="exce_proc">
+      <bpmndi:BPMNShape id="shape__520D606E-BE97-4343-BCD6-41F6969A4D7C" bpmnElement="_520D606E-BE97-4343-BCD6-41F6969A4D7C">
+        <dc:Bounds height="102" width="154" x="291" y="143"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__683B9260-BF50-478D-B3C2-B0D0FD58ACB6" bpmnElement="_683B9260-BF50-478D-B3C2-B0D0FD58ACB6">
+        <dc:Bounds height="56" width="56" x="160" y="166"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__57CB8A8D-1EB1-4009-B2D7-5BF5D6DB51E7" bpmnElement="_57CB8A8D-1EB1-4009-B2D7-5BF5D6DB51E7">
+        <dc:Bounds height="56" width="56" x="520" y="166"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="edge_shape__683B9260-BF50-478D-B3C2-B0D0FD58ACB6_to_shape__520D606E-BE97-4343-BCD6-41F6969A4D7C" bpmnElement="_1EAF811C-D97C-49DE-B606-0385A66520EB">
+        <di:waypoint x="188" y="222"/>
+        <di:waypoint x="291" y="194"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_shape__520D606E-BE97-4343-BCD6-41F6969A4D7C_to_shape__57CB8A8D-1EB1-4009-B2D7-5BF5D6DB51E7" bpmnElement="_B118B09A-AE1B-4853-952F-9F863E5CC42E">
+        <di:waypoint x="368" y="194"/>
+        <di:waypoint x="548" y="194"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters/>
+          <bpsim:ElementParameters elementRef="_520D606E-BE97-4343-BCD6-41F6969A4D7C">
+            <bpsim:TimeParameters>
+              <bpsim:ProcessingTime>
+                <bpsim:NormalDistribution mean="0" standardDeviation="0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters>
+              <bpsim:Availability>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:Availability>
+              <bpsim:Quantity>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters>
+              <bpsim:UnitCost>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters elementRef="_683B9260-BF50-478D-B3C2-B0D0FD58ACB6">
+            <bpsim:TimeParameters>
+              <bpsim:ProcessingTime>
+                <bpsim:NormalDistribution mean="0" standardDeviation="0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_wPwikP39EDmgoMcouFRnRA</bpmn2:source>
+    <bpmn2:target>_wPwikP39EDmgoMcouFRnRA</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>

--- a/integration-tests/integration-tests-quarkus-processes/src/test/java/org/kie/kogito/integrationtests/quarkus/BasicRestIT.java
+++ b/integration-tests/integration-tests-quarkus-processes/src/test/java/org/kie/kogito/integrationtests/quarkus/BasicRestIT.java
@@ -16,6 +16,7 @@
 
 package org.kie.kogito.integrationtests.quarkus;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -272,5 +273,22 @@ class BasicRestIT {
                 .body("[0].name", is("Task"));
 
         assertExpectedUnitOfWorkEvents(1);
+    }
+
+    @Test
+    void testCustomErrorStrategy() {
+        Map<String, String> params = Collections.singletonMap("inout", "javierito");
+
+        given()
+                .contentType(ContentType.JSON)
+                .when()
+                .body(params)
+                .post("/exce_proc")
+                .then()
+                .statusCode(201)
+                .body("id", not(emptyOrNullString()))
+                .body("inout", is("pepito"))
+                .header("Location", not(emptyOrNullString()));
+
     }
 }

--- a/jbpm/jbpm-bpmn2/pom.xml
+++ b/jbpm/jbpm-bpmn2/pom.xml
@@ -96,6 +96,11 @@
       <artifactId>xstream</artifactId>
       <scope>test</scope>
     </dependency>
+     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 

--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/handler/WorkItemHandlerExceptionHandlingTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/handler/WorkItemHandlerExceptionHandlingTest.java
@@ -17,23 +17,45 @@ package org.jbpm.bpmn2.handler;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
+import org.drools.core.runtime.process.ProcessRuntimeFactory;
 import org.jbpm.bpmn2.JbpmBpmn2TestCase;
 import org.jbpm.bpmn2.objects.TestWorkItemHandler;
 import org.jbpm.process.core.context.variable.VariableScope;
+import org.jbpm.process.instance.ProcessRuntimeFactoryServiceImpl;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.kie.api.runtime.process.ProcessRuntime;
 import org.kie.api.runtime.process.ProcessWorkItemHandlerException.HandlingStrategy;
+import org.kie.api.runtime.process.WorkflowProcessInstance;
+import org.kie.kogito.Application;
+import org.kie.kogito.Model;
 import org.kie.kogito.internal.process.runtime.KogitoProcessInstance;
+import org.kie.kogito.internal.process.runtime.KogitoProcessRuntime;
 import org.kie.kogito.internal.process.runtime.KogitoWorkItem;
+import org.kie.kogito.process.Process;
+import org.kie.kogito.process.ProcessInstance;
+import org.kie.kogito.process.Processes;
+import org.kie.kogito.process.impl.AbstractProcess;
+import org.kie.kogito.process.impl.AbstractProcessInstance;
 
 import static org.jbpm.process.core.context.variable.VariableScope.VARIABLE_STRICT_ENABLED_PROPERTY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 public class WorkItemHandlerExceptionHandlingTest extends JbpmBpmn2TestCase {
 
     private static Boolean strictVariableSetting = Boolean.parseBoolean(System.getProperty(VARIABLE_STRICT_ENABLED_PROPERTY, Boolean.FALSE.toString()));
+    private static Application application;
+
+    static {
+        application = mock(Application.class);
+        ProcessRuntimeFactory.setProcessRuntimeFactoryService(new ProcessRuntimeFactoryServiceImpl(application));
+    }
 
     @BeforeAll
     public static void setup() throws Exception {
@@ -43,6 +65,87 @@ public class WorkItemHandlerExceptionHandlingTest extends JbpmBpmn2TestCase {
     @AfterAll
     public static void clean() throws Exception {
         VariableScope.setVariableStrictOption(strictVariableSetting);
+    }
+
+    private static class DummyProcess extends AbstractProcess<Model> {
+
+        private org.kie.api.definition.process.Process process;
+        private KogitoProcessRuntime kruntime;
+
+        public DummyProcess(KogitoProcessRuntime kruntime, String processId) {
+            this.kruntime = kruntime;
+            this.process = kruntime.getKieBase().getProcess(processId);
+        }
+
+        @Override
+        public ProcessInstance<Model> createInstance(Model parameters) {
+            return new DummyProcessInstance(this, parameters, (ProcessRuntime) kruntime.getProcessEventManager());
+
+        }
+
+        @Override
+        public Model createModel() {
+            return new Model() {
+            };
+        }
+
+        @Override
+        public ProcessInstance<Model> createInstance(WorkflowProcessInstance wpi) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ProcessInstance<Model> createReadOnlyInstance(WorkflowProcessInstance wpi) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public org.kie.api.definition.process.Process process() {
+            return process;
+        }
+    }
+
+    private static class DummyProcessInstance extends AbstractProcessInstance<Model> {
+        public DummyProcessInstance(AbstractProcess<Model> process, Model variables, ProcessRuntime rt) {
+            super(process, variables, rt);
+        }
+
+        @Override
+        protected void unbind(Model variables, Map<String, Object> vmap) {
+            try {
+                super.unbind(variables, vmap);
+            } catch (Exception ex) {
+            }
+
+        }
+    }
+
+    private static class DummyProcesses implements org.kie.kogito.process.Processes {
+
+        private Map<String, Process<? extends Model>> mappedProcesses = new ConcurrentHashMap<>();
+        private KogitoProcessRuntime kruntime;
+
+        public DummyProcesses(KogitoProcessRuntime kogitoRuntime) {
+            this.kruntime = kogitoRuntime;
+        }
+
+        @Override
+        public org.kie.kogito.process.Process<? extends org.kie.kogito.Model> processById(String processId) {
+            return mappedProcesses.computeIfAbsent(processId, p -> new DummyProcess(kruntime, p));
+        }
+
+        @Override
+        public java.util.Collection<String> processIds() {
+            return mappedProcesses.keySet();
+        }
+    }
+
+    @Override
+    protected KogitoProcessRuntime createKogitoProcessRuntime(String... processNames) throws Exception {
+        KogitoProcessRuntime kogitoRuntime = spy(super.createKogitoProcessRuntime(processNames));
+        when(kogitoRuntime.getApplication()).thenReturn(application);
+        when(application.get(Processes.class)).thenReturn(new DummyProcesses(kogitoRuntime));
+        return kogitoRuntime;
     }
 
     @Test

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/AbstractProcessRuntime.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/AbstractProcessRuntime.java
@@ -23,31 +23,54 @@ import org.drools.core.event.KogitoProcessEventSupportImpl;
 import org.drools.core.event.ProcessEventSupport;
 import org.jbpm.process.instance.event.KogitoProcessEventListenerAdapter;
 import org.kie.api.event.process.ProcessEventListener;
+import org.kie.kogito.Application;
 import org.kie.kogito.internal.process.event.KogitoProcessEventListener;
 import org.kie.kogito.internal.process.event.KogitoProcessEventSupport;
+import org.kie.kogito.internal.process.runtime.KogitoProcessRuntime;
 
 public abstract class AbstractProcessRuntime implements InternalProcessRuntime {
 
     protected KogitoProcessEventSupport processEventSupport;
+    protected KogitoProcessRuntimeImpl kogitoProcessRuntime = new KogitoProcessRuntimeImpl(this);
+    private final Application application;
 
     private final Map<ProcessEventListener, KogitoProcessEventListener> listenersMap = new IdentityHashMap<>();
 
+    protected AbstractProcessRuntime(Application application) {
+        this.application = application;
+    }
+
+    @Override
+    public KogitoProcessRuntime getKogitoProcessRuntime() {
+        return kogitoProcessRuntime;
+    }
+
+    @Override
     public KogitoProcessEventSupport getProcessEventSupport() {
         return processEventSupport;
     }
 
+    @Override
+    public Application getApplication() {
+        return application;
+    }
+
+    @Override
     public void setProcessEventSupport(ProcessEventSupport processEventSupport) {
         throw new UnsupportedOperationException();
     }
 
+    @Override
     public void addEventListener(final ProcessEventListener listener) {
         ((KogitoProcessEventSupportImpl) this.processEventSupport).addEventListener(asKogitoProcessEventListener(listener));
     }
 
+    @Override
     public void removeEventListener(final ProcessEventListener listener) {
         ((KogitoProcessEventSupportImpl) this.processEventSupport).removeEventListener(removeKogitoProcessEventListener(listener));
     }
 
+    @Override
     public List<ProcessEventListener> getProcessEventListeners() {
         return (List<ProcessEventListener>) (Object) ((KogitoProcessEventSupportImpl) this.processEventSupport).getEventListeners();
     }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/DummyKnowledgeRuntime.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/DummyKnowledgeRuntime.java
@@ -48,6 +48,7 @@ import org.kie.api.runtime.rule.LiveQuery;
 import org.kie.api.runtime.rule.QueryResults;
 import org.kie.api.runtime.rule.ViewChangedEventListener;
 import org.kie.api.time.SessionClock;
+import org.kie.kogito.Application;
 import org.kie.kogito.internal.process.event.KogitoProcessEventSupport;
 import org.kie.kogito.internal.process.runtime.KogitoProcessInstance;
 import org.kie.kogito.internal.process.runtime.KogitoProcessRuntime;
@@ -247,27 +248,27 @@ class DummyKnowledgeRuntime implements InternalKnowledgeRuntime, KogitoProcessRu
 
     @Override
     public KogitoProcessInstance startProcess(String processId) {
-        return null;
+        return (KogitoProcessInstance) processRuntime.startProcess(processId);
     }
 
     @Override
     public KogitoProcessInstance startProcess(String processId, Map<String, Object> parameters) {
-        return null;
+        return (KogitoProcessInstance) processRuntime.startProcess(processId, parameters);
     }
 
     @Override
     public KogitoProcessInstance startProcess(String processId, AgendaFilter agendaFilter) {
-        return null;
+        return (KogitoProcessInstance) processRuntime.startProcess(processId, agendaFilter);
     }
 
     @Override
     public KogitoProcessInstance startProcess(String processId, Map<String, Object> parameters, AgendaFilter agendaFilter) {
-        return null;
+        return (KogitoProcessInstance) processRuntime.startProcess(processId, parameters, agendaFilter);
     }
 
     @Override
     public ProcessInstance startProcessFromNodeIds(String s, Map<String, Object> map, String... strings) {
-        throw new UnsupportedOperationException("org.jbpm.process.instance.DummyKnowledgeRuntime.startProcessFromNodeIds -> TODO");
+        return processRuntime.startProcessFromNodeIds(s, map, strings);
 
     }
 
@@ -284,17 +285,17 @@ class DummyKnowledgeRuntime implements InternalKnowledgeRuntime, KogitoProcessRu
 
     @Override
     public KogitoProcessInstance startProcessInstance(String processInstanceId) {
-        return null;
+        return processRuntime.getKogitoProcessRuntime().startProcessInstance(processInstanceId);
     }
 
     @Override
     public KogitoProcessInstance startProcessInstance(String processInstanceId, String trigger) {
-        return null;
+        return processRuntime.getKogitoProcessRuntime().startProcessInstance(processInstanceId, trigger);
     }
 
     @Override
     public void signalEvent(String type, Object event) {
-
+        processRuntime.getKogitoProcessRuntime().signalEvent(type, event);
     }
 
     @Override
@@ -305,7 +306,7 @@ class DummyKnowledgeRuntime implements InternalKnowledgeRuntime, KogitoProcessRu
 
     @Override
     public void signalEvent(String type, Object event, String processInstanceId) {
-
+        processRuntime.getKogitoProcessRuntime().signalEvent(type, event, processInstanceId);
     }
 
     @Override
@@ -459,5 +460,10 @@ class DummyKnowledgeRuntime implements InternalKnowledgeRuntime, KogitoProcessRu
     @Override
     public TimerService getTimerService() {
         return null;
+    }
+
+    @Override
+    public Application getApplication() {
+        return processRuntime.getApplication();
     }
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/InternalProcessRuntime.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/InternalProcessRuntime.java
@@ -16,6 +16,7 @@
 package org.jbpm.process.instance;
 
 import org.drools.core.common.InternalKnowledgeRuntime;
+import org.kie.kogito.Application;
 import org.kie.kogito.internal.process.event.KogitoProcessEventSupport;
 import org.kie.kogito.internal.process.runtime.KogitoProcessRuntime;
 import org.kie.kogito.jobs.JobsService;
@@ -35,4 +36,7 @@ public interface InternalProcessRuntime extends org.drools.core.runtime.process.
     InternalKnowledgeRuntime getInternalKieRuntime();
 
     JobsService getJobsService();
+
+    Application getApplication();
+
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/KogitoProcessRuntimeImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/KogitoProcessRuntimeImpl.java
@@ -23,6 +23,7 @@ import org.kie.api.event.process.ProcessEventManager;
 import org.kie.api.runtime.KieRuntime;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.AgendaFilter;
+import org.kie.kogito.Application;
 import org.kie.kogito.internal.process.event.KogitoProcessEventSupport;
 import org.kie.kogito.internal.process.runtime.KogitoProcessInstance;
 import org.kie.kogito.internal.process.runtime.KogitoProcessRuntime;
@@ -169,5 +170,10 @@ public class KogitoProcessRuntimeImpl implements KogitoProcessRuntime {
         } finally {
             delegate.getInternalKieRuntime().endOperation();
         }
+    }
+
+    @Override
+    public Application getApplication() {
+        return delegate.getApplication();
     }
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/LightProcessRuntimeContext.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/LightProcessRuntimeContext.java
@@ -21,23 +21,18 @@ import java.util.Optional;
 
 import org.drools.core.common.WorkingMemoryAction;
 import org.jbpm.process.core.ContextContainer;
-import org.jbpm.process.core.ProcessSupplier;
 import org.jbpm.process.core.context.variable.VariableScope;
 import org.jbpm.process.instance.context.variable.VariableScopeInstance;
 import org.jbpm.ruleflow.instance.RuleFlowProcessInstance;
 import org.kie.api.definition.process.Process;
 import org.kie.api.event.rule.DefaultAgendaEventListener;
 import org.kie.internal.process.CorrelationKey;
-import org.kie.kogito.Application;
-import org.kie.kogito.process.Processes;
 
 public class LightProcessRuntimeContext implements ProcessRuntimeContext {
 
-    private Processes allProcesses;
     private Collection<Process> processes;
 
-    public LightProcessRuntimeContext(Application app, Collection<Process> processes) {
-        this.allProcesses = app != null ? app.get(Processes.class) : null;
+    public LightProcessRuntimeContext(Collection<Process> processes) {
         this.processes = processes;
     }
 
@@ -48,11 +43,7 @@ public class LightProcessRuntimeContext implements ProcessRuntimeContext {
 
     @Override
     public Optional<Process> findProcess(String id) {
-        Optional<Process> result = processes.stream().filter(p -> p.getId().equals(id)).findAny();
-        if (result.isEmpty() && allProcesses != null) {
-            result = Optional.ofNullable(((ProcessSupplier) allProcesses.processById(id)).get());
-        }
-        return result;
+        return processes.stream().filter(p -> p.getId().equals(id)).findAny();
     }
 
     @Override

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/ProcessRuntimeFactoryServiceImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/ProcessRuntimeFactoryServiceImpl.java
@@ -17,11 +17,22 @@ package org.jbpm.process.instance;
 
 import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.runtime.process.ProcessRuntimeFactoryService;
+import org.kie.kogito.Application;
 
 public class ProcessRuntimeFactoryServiceImpl implements ProcessRuntimeFactoryService {
 
+    private Application application;
+
+    public ProcessRuntimeFactoryServiceImpl() {
+    }
+
+    public ProcessRuntimeFactoryServiceImpl(Application application) {
+        this.application = application;
+    }
+
+    @Override
     public InternalProcessRuntime newProcessRuntime(InternalWorkingMemory workingMemory) {
-        return new ProcessRuntimeImpl(workingMemory);
+        return new ProcessRuntimeImpl(application, workingMemory);
     }
 
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/ProcessRuntimeImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/ProcessRuntimeImpl.java
@@ -60,6 +60,7 @@ import org.kie.internal.command.RegistryContext;
 import org.kie.internal.process.CorrelationKey;
 import org.kie.internal.runtime.StatefulKnowledgeSession;
 import org.kie.internal.utils.CompositeClassLoader;
+import org.kie.kogito.Application;
 import org.kie.kogito.internal.process.runtime.KogitoProcessInstance;
 import org.kie.kogito.internal.process.runtime.KogitoProcessRuntime;
 import org.kie.kogito.jobs.DurationExpirationTime;
@@ -81,9 +82,8 @@ public class ProcessRuntimeImpl extends AbstractProcessRuntime {
     private JobsService jobService;
     private UnitOfWorkManager unitOfWorkManager;
 
-    private final KogitoProcessRuntimeImpl kogitoProcessRuntime = new KogitoProcessRuntimeImpl(this);
-
-    public ProcessRuntimeImpl(InternalKnowledgeRuntime kruntime) {
+    public ProcessRuntimeImpl(Application application, InternalKnowledgeRuntime kruntime) {
+        super(application);
         this.kruntime = kruntime;
         TimerService timerService = kruntime.getTimerService();
         if (!(timerService.getTimerJobFactoryManager() instanceof CommandServiceTimerJobFactoryManager)) {
@@ -103,7 +103,8 @@ public class ProcessRuntimeImpl extends AbstractProcessRuntime {
         initProcessActivationListener();
     }
 
-    public ProcessRuntimeImpl(InternalWorkingMemory workingMemory) {
+    public ProcessRuntimeImpl(Application application, InternalWorkingMemory workingMemory) {
+        super(application);
         TimerService timerService = workingMemory.getTimerService();
         if (!(timerService.getTimerJobFactoryManager() instanceof CommandServiceTimerJobFactoryManager)) {
             timerService.setTimerJobFactoryManager(new ThreadSafeTrackableTimeJobFactoryManager());
@@ -201,7 +202,6 @@ public class ProcessRuntimeImpl extends AbstractProcessRuntime {
     @Override
     public ProcessInstance startProcessInstance(long l) {
         throw new UnsupportedOperationException();
-
     }
 
     @Override
@@ -251,6 +251,7 @@ public class ProcessRuntimeImpl extends AbstractProcessRuntime {
                 parameters);
     }
 
+    @Override
     public ProcessInstanceManager getProcessInstanceManager() {
         return processInstanceManager;
     }
@@ -260,10 +261,12 @@ public class ProcessRuntimeImpl extends AbstractProcessRuntime {
         return jobService;
     }
 
+    @Override
     public SignalManager getSignalManager() {
         return signalManager;
     }
 
+    @Override
     public Collection<ProcessInstance> getProcessInstances() {
         return (Collection<ProcessInstance>) (Object) processInstanceManager.getProcessInstances();
     }
@@ -288,7 +291,7 @@ public class ProcessRuntimeImpl extends AbstractProcessRuntime {
     }
 
     public KogitoProcessInstance getProcessInstance(String id, boolean readOnly) {
-        return (KogitoProcessInstance) processInstanceManager.getProcessInstance(id, readOnly);
+        return processInstanceManager.getProcessInstance(id, readOnly);
     }
 
     public void removeProcessInstance(KogitoProcessInstance processInstance) {
@@ -352,6 +355,7 @@ public class ProcessRuntimeImpl extends AbstractProcessRuntime {
 
     private void initProcessActivationListener() {
         kruntime.addEventListener(new DefaultAgendaEventListener() {
+            @Override
             public void matchCreated(MatchCreatedEvent event) {
                 String ruleFlowGroup = ((RuleImpl) event.getMatch().getRule()).getRuleFlowGroup();
                 if ("DROOLS_SYSTEM".equals(ruleFlowGroup)) {
@@ -386,6 +390,7 @@ public class ProcessRuntimeImpl extends AbstractProcessRuntime {
         });
 
         kruntime.addEventListener(new DefaultAgendaEventListener() {
+            @Override
             public void afterRuleFlowGroupDeactivated(final RuleFlowGroupDeactivatedEvent event) {
                 if (kruntime instanceof StatefulKnowledgeSession) {
                     signalManager.signalEvent("RuleFlowGroup_" + event.getRuleFlowGroup().getName() + "_" + ((StatefulKnowledgeSession) kruntime).getIdentifier(),
@@ -412,6 +417,7 @@ public class ProcessRuntimeImpl extends AbstractProcessRuntime {
         return unitOfWorkManager;
     }
 
+    @Override
     public void signalEvent(String type, Object event) {
         signalManager.signalEvent(type, event);
     }
@@ -421,15 +427,18 @@ public class ProcessRuntimeImpl extends AbstractProcessRuntime {
         throw new UnsupportedOperationException();
     }
 
+    @Override
     public void dispose() {
         this.processEventSupport.reset();
         kruntime = null;
     }
 
+    @Override
     public void clearProcessInstances() {
         this.processInstanceManager.clearProcessInstances();
     }
 
+    @Override
     public void clearProcessInstancesState() {
         this.processInstanceManager.clearProcessInstancesState();
     }
@@ -519,10 +528,12 @@ public class ProcessRuntimeImpl extends AbstractProcessRuntime {
             this.eventTransformer = eventTransformer;
         }
 
+        @Override
         public String[] getEventTypes() {
             return null;
         }
 
+        @Override
         public void signalEvent(final String type,
                 Object event) {
             for (EventFilter filter : eventFilters) {
@@ -590,11 +601,13 @@ public class ProcessRuntimeImpl extends AbstractProcessRuntime {
             this.event = event;
         }
 
+        @Override
         public void execute(InternalWorkingMemory workingMemory) {
 
             signalEvent(type, event);
         }
 
+        @Override
         public void execute(InternalKnowledgeRuntime kruntime) {
             signalEvent(type, event);
         }

--- a/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcessInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcessInstance.java
@@ -430,9 +430,14 @@ public abstract class AbstractProcessInstance<T extends Model> implements Proces
 
     @Override
     public List<WorkItem> workItems(Policy<?>... policies) {
+        return workItems(WorkItemNodeInstance.class::isInstance, policies);
+    }
+
+    @Override
+    public List<WorkItem> workItems(Predicate<KogitoNodeInstance> p, Policy<?>... policies) {
         return processInstance().getNodeInstances(true)
                 .stream()
-                .filter(ni -> ni instanceof WorkItemNodeInstance && ((WorkItemNodeInstance) ni).getWorkItem().enforce(policies))
+                .filter(ni -> p.test(ni) && ((WorkItemNodeInstance) ni).getWorkItem().enforce(policies))
                 .map(ni -> new BaseWorkItem(ni.getStringId(),
                         ((WorkItemNodeInstance) ni).getWorkItemId(),
                         Long.toString(((WorkItemNodeInstance) ni).getNode().getId()),

--- a/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/ProcessServiceImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/ProcessServiceImpl.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 import org.jbpm.process.instance.impl.humantask.HumanTaskHelper;
 import org.jbpm.process.instance.impl.humantask.HumanTaskTransition;
 import org.jbpm.util.JsonSchemaUtil;
+import org.jbpm.workflow.instance.node.HumanTaskNodeInstance;
 import org.kie.kogito.Application;
 import org.kie.kogito.MapOutput;
 import org.kie.kogito.MappableToModel;
@@ -132,7 +133,7 @@ public class ProcessServiceImpl implements ProcessService {
     public <T extends Model> Optional<List<WorkItem>> getTasks(Process<T> process, String id, String user, List<String> groups) {
         return process.instances()
                 .findById(id, ProcessInstanceReadMode.READ_ONLY)
-                .map(pi -> pi.workItems(Policies.of(user, groups)));
+                .map(pi -> pi.workItems(HumanTaskNodeInstance.class::isInstance, Policies.of(user, groups)));
     }
 
     @Override

--- a/jbpm/jbpm-flow/src/test/java/org/jbpm/process/instance/LightProcessRuntimeTest.java
+++ b/jbpm/jbpm-flow/src/test/java/org/jbpm/process/instance/LightProcessRuntimeTest.java
@@ -20,17 +20,10 @@ import java.util.Collections;
 import org.jbpm.ruleflow.core.RuleFlowProcess;
 import org.jbpm.ruleflow.core.RuleFlowProcessFactory;
 import org.junit.jupiter.api.Test;
-import org.kie.kogito.Application;
-import org.kie.kogito.Model;
-import org.kie.kogito.process.Processes;
-import org.kie.kogito.process.impl.AbstractProcess;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
-public class LightProcessRuntimeTest {
+class LightProcessRuntimeTest {
 
     static class MyProcess {
         String result;
@@ -52,35 +45,12 @@ public class LightProcessRuntimeTest {
     }
 
     @Test
-    public void testInstantiation() {
+    void testInstantiation() {
         LightProcessRuntimeServiceProvider services =
                 new LightProcessRuntimeServiceProvider();
 
         MyProcess myProcess = new MyProcess();
-        LightProcessRuntimeContext rtc = new LightProcessRuntimeContext(null, Collections.singletonList(myProcess.process));
-
-        LightProcessRuntime rt = new LightProcessRuntime(rtc, services);
-
-        rt.startProcess(myProcess.process.getId());
-
-        assertEquals("Hello!", myProcess.result);
-
-    }
-
-    @Test
-    public <T extends Model> void testInstantiationAnother() {
-        LightProcessRuntimeServiceProvider services =
-                new LightProcessRuntimeServiceProvider();
-
-        MyProcess myProcess = new MyProcess();
-        Application app = mock(Application.class);
-        Processes processes = mock(Processes.class);
-        AbstractProcess process = mock(AbstractProcess.class);
-        when(processes.processById(anyString())).thenReturn(process);
-        when(process.get()).thenReturn(myProcess.process);
-        when(app.get(Processes.class)).thenReturn(processes);
-
-        LightProcessRuntimeContext rtc = new LightProcessRuntimeContext(app, Collections.emptyList());
+        LightProcessRuntimeContext rtc = new LightProcessRuntimeContext(Collections.singletonList(myProcess.process));
 
         LightProcessRuntime rt = new LightProcessRuntime(rtc, services);
 


### PR DESCRIPTION
Further changes needed for error handling strategy to work

- Change the approach to start subprocess, using Kogito API to do that
- If a workItem is not a UserTask, REST GET tasks API was failing (not all work items are user tasks and tasks api is intended to return just user tasks, so a new method was added to ProcessInstance interface, allowing filtering of work items) 
- Adding test to integration
