### PR TITLE
[1.11.x][KOGITO-5906] Enabling Event Fact type (#1609)

### DIFF
--- a/drools/drools-core/src/main/java/org/drools/core/kogito/factory/KogitoEventFactHandle.java
+++ b/drools/drools-core/src/main/java/org/drools/core/kogito/factory/KogitoEventFactHandle.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.drools.core.kogito.factory;
+
+import org.drools.core.WorkingMemoryEntryPoint;
+import org.drools.core.common.EventFactHandle;
+import org.drools.core.factmodel.traits.TraitTypeEnum;
+import org.drools.core.rule.EntryPointId;
+import org.drools.core.ruleunit.InternalStoreCallback;
+import org.kie.kogito.rules.DataHandle;
+
+public class KogitoEventFactHandle extends EventFactHandle implements KogitoInternalFactHandle {
+    public KogitoEventFactHandle() {
+    }
+
+    public KogitoEventFactHandle(long id, Object object, long recency, long timestamp, long duration, WorkingMemoryEntryPoint wmEntryPoint) {
+        super(id, object, recency, timestamp, duration, wmEntryPoint);
+    }
+
+    public KogitoEventFactHandle(long id, Object object, long recency, long timestamp, long duration, WorkingMemoryEntryPoint wmEntryPoint, boolean isTraitOrTraitable) {
+        super(id, object, recency, timestamp, duration, wmEntryPoint, isTraitOrTraitable);
+    }
+
+    public KogitoEventFactHandle(long id, int identityHashCode, Object object, long recency, long timestamp, long duration, EntryPointId entryPointId, TraitTypeEnum traitType) {
+        super(id, identityHashCode, object, recency, timestamp, duration, entryPointId, traitType);
+    }
+
+    private DataHandle dataHandle;
+    private InternalStoreCallback dataStore;
+
+    @Override
+    public DataHandle getDataHandle() {
+        return dataHandle;
+    }
+
+    @Override
+    public void setDataHandle(DataHandle dataHandle) {
+        this.dataHandle = dataHandle;
+    }
+
+    @Override
+    public InternalStoreCallback getDataStore() {
+        return dataStore;
+    }
+
+    @Override
+    public void setDataStore(InternalStoreCallback dataStore) {
+        this.dataStore = dataStore;
+    }
+}

--- a/kogito-codegen-modules/kogito-codegen-rules/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
+++ b/kogito-codegen-modules/kogito-codegen-rules/src/main/java/org/kie/kogito/codegen/rules/IncrementalRuleCodegen.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.stream.Stream;
@@ -171,18 +172,15 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
             throw new RuleCodegenError(modelBuilder.getErrors().getErrors());
         }
 
-        Map<String, String> modelsByUnit = new HashMap<>();
-
-        List<GeneratedFile> generatedFiles = new ArrayList<>(generateModels(modelBuilder, modelsByUnit));
-
-        boolean hasRuleUnits = !ruleUnitGenerators.isEmpty();
+        List<GeneratedFile> generatedFiles = new ArrayList<>(generateModels(modelBuilder));
 
         List<DroolsError> errors = new ArrayList<>();
+        boolean hasRuleUnits = !ruleUnitGenerators.isEmpty();
 
         if (hasRuleUnits) {
             generateRuleUnits(errors, generatedFiles);
         } else if (context().hasClassAvailable("org.kie.kogito.legacy.rules.KieRuntimeBuilder")) {
-            generateProject(dummyReleaseId, modelsByUnit, generatedFiles);
+            generateProject(dummyReleaseId, modelBuilder, generatedFiles);
         } else if (hasRuleFiles()) { // this additional check is necessary because also properties or java files can be loaded
             throw new IllegalStateException("Found DRL files using legacy API, add org.kie.kogito:kogito-legacy-api dependency to enable it");
         }
@@ -232,13 +230,11 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
         return resources.stream().filter(r -> r.getSourcePath().equals(resource.getSourcePath() + ".properties")).findFirst().orElse(null);
     }
 
-    private List<GeneratedFile> generateModels(ModelBuilderImpl<KogitoPackageSources> modelBuilder, Map<String, String> modelsByUnit) {
+    private List<GeneratedFile> generateModels(ModelBuilderImpl<KogitoPackageSources> modelBuilder) {
         List<GeneratedFile> modelFiles = new ArrayList<>();
         List<org.drools.modelcompiler.builder.GeneratedFile> legacyModelFiles = new ArrayList<>();
 
         for (KogitoPackageSources pkgSources : modelBuilder.getPackageSources()) {
-            pkgSources.getModelsByUnit().forEach((unit, model) -> modelsByUnit.put(ruleUnit2KieBaseName(unit), model));
-
             pkgSources.collectGeneratedFiles(legacyModelFiles);
 
             org.drools.modelcompiler.builder.GeneratedFile reflectConfigSource = pkgSources.getReflectConfigSource();
@@ -272,25 +268,32 @@ public class IncrementalRuleCodegen extends AbstractGenerator {
                 .collect(toList());
     }
 
-    private void generateProject(ReleaseIdImpl dummyReleaseId, Map<String, String> modelsByUnit, List<GeneratedFile> generatedFiles) {
-        Map<String, List<String>> modelsByKBase = new HashMap<>();
-        for (Map.Entry<String, String> entry : modelsByUnit.entrySet()) {
-            modelsByKBase.put(entry.getKey(), Collections.singletonList(entry.getValue()));
-        }
-
-        ModelSourceClass modelSourceClass = new ModelSourceClass(dummyReleaseId, kieModuleModel.getKieBaseModels(), modelsByKBase);
-
-        generatedFiles.add(new GeneratedFile(
-                RULE_TYPE,
-                modelSourceClass.getName(),
-                modelSourceClass.generate()));
+    private void generateProject(ReleaseIdImpl dummyReleaseId, ModelBuilderImpl<KogitoPackageSources> modelBuilder, List<GeneratedFile> generatedFiles) {
+        ModelSourceClass modelSourceClass = new ModelSourceClass(dummyReleaseId, kieModuleModel.getKieBaseModels(), getModelByKBase(modelBuilder));
+        generatedFiles.add(new GeneratedFile(RULE_TYPE, modelSourceClass.getName(), modelSourceClass.generate()));
 
         ProjectRuntimeGenerator projectRuntimeGenerator = new ProjectRuntimeGenerator(modelSourceClass.getModelMethod(), context());
+        generatedFiles.add(new GeneratedFile(RULE_TYPE, projectRuntimeGenerator.getName(), projectRuntimeGenerator.generate()));
+    }
 
-        generatedFiles.add(new GeneratedFile(
-                RULE_TYPE,
-                projectRuntimeGenerator.getName(),
-                projectRuntimeGenerator.generate()));
+    private Map<String, List<String>> getModelByKBase(ModelBuilderImpl<KogitoPackageSources> modelBuilder) {
+        Map<String, String> modelsByPackage = getModelsByPackage(modelBuilder);
+        Map<String, List<String>> modelsByKBase = new HashMap<>();
+        for (Map.Entry<String, KieBaseModel> entry : kieModuleModel.getKieBaseModels().entrySet()) {
+            List<String> kieBasePackages = entry.getValue().getPackages();
+            boolean isAllPackages = kieBasePackages.isEmpty() || (kieBasePackages.size() == 1 && kieBasePackages.get(0).equals("*"));
+            modelsByKBase.put(entry.getKey(),
+                    isAllPackages ? new ArrayList<>(modelsByPackage.values()) : kieBasePackages.stream().map(modelsByPackage::get).filter(Objects::nonNull).collect(toList()));
+        }
+        return modelsByKBase;
+    }
+
+    private Map<String, String> getModelsByPackage(ModelBuilderImpl<KogitoPackageSources> modelBuilder) {
+        Map<String, String> modelsByPackage = new HashMap<>();
+        for (KogitoPackageSources pkgSources : modelBuilder.getPackageSources()) {
+            modelsByPackage.put(pkgSources.getPackageName(), pkgSources.getPackageName() + "." + pkgSources.getRulesFileName());
+        }
+        return modelsByPackage;
     }
 
     private void generateRuleUnits(List<DroolsError> errors, List<GeneratedFile> generatedFiles) {

--- a/kogito-codegen-modules/kogito-codegen-rules/src/main/java/org/kie/kogito/codegen/rules/KogitoPackageSources.java
+++ b/kogito-codegen-modules/kogito-codegen-rules/src/main/java/org/kie/kogito/codegen/rules/KogitoPackageSources.java
@@ -28,7 +28,6 @@ import org.drools.modelcompiler.builder.PackageModel;
 import org.drools.modelcompiler.builder.PackageModelWriter;
 import org.drools.modelcompiler.builder.PackageSources;
 import org.drools.modelcompiler.builder.QueryModel;
-import org.drools.modelcompiler.builder.RuleWriter;
 import org.kie.internal.ruleunit.RuleUnitDescription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,18 +54,20 @@ public class KogitoPackageSources extends PackageSources {
             REFLECTION_PERMISSIONS +
             "    }\n" +
             "]";
+
     private GeneratedFile reflectConfigSource;
-    private Map<String, String> modelsByUnit = new HashMap<>();
     private Collection<RuleUnitDescription> ruleUnits;
     private String rulesFileName;
     private Map<String, Collection<QueryModel>> queries;
+
+    private String pkgName;
 
     public static KogitoPackageSources dumpSources(PackageModel pkgModel) {
         KogitoPackageSources sources = dumpPojos(pkgModel);
 
         PackageModelWriter packageModelWriter = new PackageModelWriter(pkgModel);
 
-        RuleWriter rules = PackageSources.writeRules(pkgModel, sources, packageModelWriter);
+        PackageSources.writeRules(pkgModel, sources, packageModelWriter);
         sources.rulesFileName = pkgModel.getRulesFileName();
 
         sources.ruleUnits = pkgModel.getRuleUnits();
@@ -78,12 +79,12 @@ public class KogitoPackageSources extends PackageSources {
             }
         }
 
-        sources.modelsByUnit.putAll(rules.getModelsByUnit());
         return sources;
     }
 
-    public static KogitoPackageSources dumpPojos(PackageModel pkgModel) {
+    private static KogitoPackageSources dumpPojos(PackageModel pkgModel) {
         KogitoPackageSources sources = new KogitoPackageSources();
+        sources.pkgName = pkgModel.getName();
 
         List<String> pojoClasses = new ArrayList<>();
         PackageModelWriter packageModelWriter = new PackageModelWriter(pkgModel);
@@ -109,8 +110,8 @@ public class KogitoPackageSources extends PackageSources {
         return pojoClasses.stream().collect(Collectors.joining(JSON_DELIMITER, JSON_PREFIX, JSON_SUFFIX));
     }
 
-    public Map<String, String> getModelsByUnit() {
-        return modelsByUnit;
+    public String getPackageName() {
+        return pkgName;
     }
 
     public Collection<RuleUnitDescription> getRuleUnits() {

--- a/kogito-codegen-modules/kogito-codegen-rules/src/main/java/org/kie/kogito/codegen/rules/ProjectRuntimeGenerator.java
+++ b/kogito-codegen-modules/kogito-codegen-rules/src/main/java/org/kie/kogito/codegen/rules/ProjectRuntimeGenerator.java
@@ -29,6 +29,7 @@ import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.BreakStmt;
 import com.github.javaparser.ast.stmt.IfStmt;
 import com.github.javaparser.ast.stmt.Statement;
 import com.github.javaparser.ast.stmt.SwitchEntry;
@@ -147,6 +148,7 @@ public class ProjectRuntimeGenerator {
         for (Map.Entry<String, BlockStmt> entry : modelMethod.getkSessionConfs().entrySet()) {
             StringLiteralExpr sessionName = new StringLiteralExpr(entry.getKey());
             SwitchEntry switchEntry = new SwitchEntry(new NodeList<>(sessionName), SwitchEntry.Type.STATEMENT_GROUP, new NodeList<>(entry.getValue()));
+            switchEntry.addStatement(new BreakStmt().setValue(null));
             switchStmt.getEntries().add(switchEntry);
         }
     }

--- a/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test-session/src/main/java/org/kie/kogito/quarkus/drools/ProbeCounter.java
+++ b/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test-session/src/main/java/org/kie/kogito/quarkus/drools/ProbeCounter.java
@@ -15,8 +15,23 @@
  */
 package org.kie.kogito.quarkus.drools;
 
-import io.quarkus.test.junit.NativeImageTest;
+public class ProbeCounter {
+    private int total = 0;
 
-@NativeImageTest
-public class NativeRuntimeIT extends RuntimeIT {
+    public void setTotal(final int total) {
+        this.total = total;
+    }
+
+    public int getTotal() {
+        return total;
+    }
+
+    public void addValue() {
+        total += 1;
+        synchronized (this) {
+            if (total == 10) {
+                notify();
+            }
+        }
+    }
 }

--- a/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test-session/src/main/java/org/kie/kogito/quarkus/drools/ProbeEvent.java
+++ b/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test-session/src/main/java/org/kie/kogito/quarkus/drools/ProbeEvent.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.quarkus.drools;
+
+public class ProbeEvent {
+
+    private int value = 1;
+
+    public int getValue() {
+        return value;
+    }
+
+    public ProbeEvent(final int value) {
+        this.value = value;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final ProbeEvent that = (ProbeEvent) o;
+
+        return value == that.value;
+    }
+
+    @Override
+    public int hashCode() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return "ProbeEvent{" +
+                "value=" + value +
+                '}';
+    }
+}

--- a/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test-session/src/main/java/org/kie/kogito/quarkus/drools/StockTick.java
+++ b/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test-session/src/main/java/org/kie/kogito/quarkus/drools/StockTick.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.quarkus.drools;
+
+import java.util.Date;
+
+import org.kie.api.definition.type.Duration;
+import org.kie.api.definition.type.Role;
+
+@Role(Role.Type.EVENT)
+@Duration("duration")
+public class StockTick {
+
+    private String company;
+    private double price;
+    private long time;
+    private long duration;
+
+    public StockTick(String company) {
+        this(company, 0.0);
+    }
+
+    public StockTick(final String company,
+            final double price) {
+        this(company, price, System.currentTimeMillis());
+    }
+
+    public StockTick(final String company,
+            final double price,
+            final long time) {
+        super();
+        this.company = company;
+        this.price = price;
+        this.time = time;
+    }
+
+    public StockTick(final String company,
+            final double price,
+            final long time,
+            final long duration) {
+        super();
+        this.company = company;
+        this.price = price;
+        this.time = time;
+        this.duration = duration;
+    }
+
+    public String getCompany() {
+        return company;
+    }
+
+    public void setCompany(final String company) {
+        this.company = company;
+    }
+
+    public double getPrice() {
+        return price;
+    }
+
+    public void setPrice(final double price) {
+        this.price = price;
+    }
+
+    public long getTime() {
+        return time;
+    }
+
+    public void setTime(final long time) {
+        this.time = time;
+    }
+
+    public long getDuration() {
+        return duration;
+    }
+
+    public void setDuration(final long duration) {
+        this.duration = duration;
+    }
+
+    public Date getDateTimestamp() {
+        return new Date(this.time);
+    }
+
+    public String toString() {
+        return "StockTick( " + this.company + " : " + this.price + " )";
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((company == null) ? 0 : company.hashCode());
+        result = prime * result + (int) (time ^ (time >>> 32));
+        return result;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final StockTick other = (StockTick) obj;
+        if (company == null) {
+            if (other.company != null) {
+                return false;
+            }
+        } else if (!company.equals(other.company)) {
+            return false;
+        }
+        return time == other.time;
+    }
+}

--- a/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test-session/src/main/resources/META-INF/kmodule.xml
+++ b/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test-session/src/main/resources/META-INF/kmodule.xml
@@ -3,4 +3,13 @@
   <kbase name="canDrinkKB" packages="org.drools.simple.candrink">
     <ksession name="canDrinkKS" default="true" />
   </kbase>
+  <kbase name="cepKB" packages="org.drools.cep" eventProcessingMode="stream">
+    <ksession name="cepKS" clockType="pseudo"/>
+  </kbase>
+  <kbase name="probeKB" packages="org.drools.probe" eventProcessingMode="stream">
+    <ksession name="probeKS"/>
+  </kbase>
+  <kbase name="allKB" packages="*" eventProcessingMode="stream">
+    <ksession name="allKS"/>
+  </kbase>
 </kmodule>

--- a/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test-session/src/main/resources/org/drools/cep/cep.drl
+++ b/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test-session/src/main/resources/org/drools/cep/cep.drl
@@ -1,0 +1,9 @@
+package org.drools.cep
+
+import org.kie.kogito.quarkus.drools.StockTick
+
+rule R when
+    $a : StockTick( company == "DROO" )
+    $b : StockTick( company == "ACME", this after[5s,8s] $a )
+then
+end

--- a/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test-session/src/main/resources/org/drools/probe/probe.drl
+++ b/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test-session/src/main/resources/org/drools/probe/probe.drl
@@ -1,0 +1,24 @@
+package org.drools.probe
+
+import org.kie.kogito.quarkus.drools.ProbeEvent;
+import org.kie.kogito.quarkus.drools.ProbeCounter;
+
+declare ProbeCounter
+    @role (event)
+end
+declare ProbeEvent
+    @role (event)
+end
+
+rule "Probe rule" when
+    $pc : ProbeCounter()
+    $pe : ProbeEvent( this not before $pc )
+then
+   $pc.addValue();
+end
+
+rule "Halt rule" when
+    ProbeCounter (total == 10)
+then
+   drools.halt();
+end

--- a/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test-session/src/test/java/org/kie/kogito/quarkus/drools/RuntimeIT.java
+++ b/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test-session/src/test/java/org/kie/kogito/quarkus/drools/RuntimeIT.java
@@ -15,15 +15,24 @@
  */
 package org.kie.kogito.quarkus.drools;
 
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
 import javax.inject.Inject;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.kie.api.KieBase;
+import org.kie.api.definition.KiePackage;
 import org.kie.api.runtime.KieSession;
+import org.kie.api.time.SessionPseudoClock;
 import org.kie.kogito.legacy.rules.KieRuntimeBuilder;
 
 import io.quarkus.test.junit.QuarkusTest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
 public class RuntimeIT {
@@ -33,7 +42,13 @@ public class RuntimeIT {
 
     @Test
     public void testRuleEvaluation() {
+        // canDrinkKS is the default session
         KieSession ksession = runtimeBuilder.newKieSession();
+
+        List<String> pkgNames = ksession.getKieBase().getKiePackages().stream().map(KiePackage::getName).collect(Collectors.toList());
+        assertEquals(2, pkgNames.size());
+        assertTrue(pkgNames.contains("org.kie.kogito.quarkus.drools"));
+        assertTrue(pkgNames.contains("org.drools.simple.candrink"));
 
         Result result = new Result();
         ksession.insert(result);
@@ -41,5 +56,61 @@ public class RuntimeIT {
         ksession.fireAllRules();
 
         assertEquals("Mark can NOT drink", result.toString());
+    }
+
+    @Test
+    public void testCepEvaluation() {
+        KieSession ksession = runtimeBuilder.newKieSession("cepKS");
+
+        SessionPseudoClock clock = ksession.getSessionClock();
+
+        ksession.insert(new StockTick("DROO"));
+        clock.advanceTime(6, TimeUnit.SECONDS);
+        ksession.insert(new StockTick("ACME"));
+
+        assertEquals(1, ksession.fireAllRules());
+
+        clock.advanceTime(4, TimeUnit.SECONDS);
+        ksession.insert(new StockTick("ACME"));
+
+        assertEquals(0, ksession.fireAllRules());
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    public void testFireUntiHalt() {
+        KieSession ksession = runtimeBuilder.newKieSession("probeKS");
+
+        new Thread(ksession::fireUntilHalt).start();
+        final ProbeCounter pc = new ProbeCounter();
+
+        ksession.insert(pc);
+        for (int i = 0; i < 10; i++) {
+            ksession.insert(new ProbeEvent(i));
+        }
+
+        synchronized (pc) {
+            if (pc.getTotal() < 10) {
+                try {
+                    pc.wait();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+
+        assertEquals(10, pc.getTotal());
+    }
+
+    @Test
+    public void testAllPkgsKBase() {
+        KieBase kBase = runtimeBuilder.getKieBase("allKB");
+
+        List<String> pkgNames = kBase.getKiePackages().stream().map(KiePackage::getName).collect(Collectors.toList());
+        assertEquals(4, pkgNames.size());
+        assertTrue(pkgNames.contains("org.kie.kogito.quarkus.drools"));
+        assertTrue(pkgNames.contains("org.drools.simple.candrink"));
+        assertTrue(pkgNames.contains("org.drools.cep"));
+        assertTrue(pkgNames.contains("org.drools.probe"));
     }
 }


### PR DESCRIPTION
* [KOGITO-5906] enable cep

* wip

* wip

* fix generation of ProjectRuntime for legacy kmodules

* wip

* small refactor

(cherry picked from commit 6c2bc763e0c2ae33113aea99299c1c6067c8c3b9)

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](CONTRIBUTING.md)
- [ ] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run all builds</b>  
  Please add comment: <b>Jenkins retest this</b>

* <b>Run (or rerun) specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] tests</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Run (or rerun) LTS specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Run (or rerun) native specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
