### PR TITLE
KOGITO-5748 - Public API: Straight-Through Process Modules (Incubatio…

### DIFF
--- a/quarkus/extensions/kogito-quarkus-processes-extension/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-processes-extension/pom.xml
@@ -16,8 +16,6 @@
   <modules>
     <module>kogito-quarkus-processes</module>
     <module>kogito-quarkus-processes-deployment</module>
-    <module>kogito-quarkus-processes-integration-test</module>
-    <module>kogito-quarkus-processes-integration-test-hot-reload</module>
   </modules>
 
   <profiles>
@@ -29,6 +27,7 @@
         </property>
       </activation>
       <modules>
+        <module>kogito-quarkus-processes-integration-test</module>
         <module>kogito-quarkus-processes-integration-test-hot-reload</module>
       </modules>
     </profile>


### PR DESCRIPTION
…n) - fix modules organization

FYI @evacchi we need to have a way to exclude IT modules from the build. IT modules were included to default modules by #1547 probably by a mistake.
