### PR TITLE
KOGITO-5975  Public API: MapDataContext#get(String,Class<T>) returns null

### DIFF
--- a/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/MapDataContext.java
+++ b/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/MapDataContext.java
@@ -73,7 +73,7 @@ public class MapDataContext implements MapLikeDataContext {
 
     @Override
     public <T> T get(String key, Class<T> expectedType) {
-        return null;
+        return InternalObjectMapper.convertValue(map.get(key), expectedType);
     }
 
     // required to unwrap the map to the root of the mapped object

--- a/api/kogito-api-incubation-common/src/test/java/org/kie/kogito/incubation/common/DataContextTest.java
+++ b/api/kogito-api-incubation-common/src/test/java/org/kie/kogito/incubation/common/DataContextTest.java
@@ -18,18 +18,42 @@ package org.kie.kogito.incubation.common;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DataContextTest {
     public static class Address {
         String street;
+
+        @Override
+        public boolean equals(Object o) {
+            return (o instanceof Address)
+                    && Objects.equals(((Address) o).street, street);
+        }
+
     }
 
     public static class User implements DataContext, DefaultCastable {
         String firstName;
         String lastName;
         Address addr;
+
+        @Override
+        public boolean equals(Object o) {
+            if (o instanceof User) {
+                User user = (User) o;
+                return Objects.equals(firstName, user.firstName)
+                        && Objects.equals(lastName, user.lastName)
+                        && Objects.equals(addr, user.addr);
+            } else return false;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(firstName, lastName, addr);
+        }
     }
 
     @Test
@@ -70,5 +94,21 @@ public class DataContextTest {
         assertNotEquals(Address.class, ctx.get("addr").getClass());
         Address addr = InternalObjectMapper.convertValue(ctx.get("addr"), Address.class);
         assertEquals("Abbey Rd.", addr.street);
+    }
+
+    @Test
+    public void getTypedValueFromMap() {
+        User u = new User();
+        u.firstName = "Paul";
+        u.lastName = "McCartney";
+        u.addr = new Address();
+        u.addr.street = "Abbey Rd.";
+
+        MapDataContext mdc = MapDataContext.of(Map.of("Paul", u));
+        User paul = (User) mdc.get("Paul");
+        User user = mdc.get("Paul", User.class);
+        assertNotNull(user);
+        assertEquals(paul, user);
+
     }
 }

--- a/api/kogito-api-incubation-common/src/test/java/org/kie/kogito/incubation/common/DataContextTest.java
+++ b/api/kogito-api-incubation-common/src/test/java/org/kie/kogito/incubation/common/DataContextTest.java
@@ -16,10 +16,10 @@
 
 package org.kie.kogito.incubation.common;
 
-import org.junit.jupiter.api.Test;
-
 import java.util.Map;
 import java.util.Objects;
+
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -47,7 +47,8 @@ public class DataContextTest {
                 return Objects.equals(firstName, user.firstName)
                         && Objects.equals(lastName, user.lastName)
                         && Objects.equals(addr, user.addr);
-            } else return false;
+            } else
+                return false;
         }
 
         @Override


### PR DESCRIPTION
The method is present but erroneously stubbed (returned null: discovered this while working on examples)

It should pull the data from the map and then return a value of that type (performing a conversion -- not a cast -- if necessary)

e.g.:

```java

        User u = new User();
        u.firstName = "Paul";
        u.lastName = "McCartney";
        u.addr = new Address();
        u.addr.street = "Abbey Rd.";

        MapDataContext mdc = MapDataContext.of(Map.of("Paul", u));
        User paul = (User) mdc.get("Paul"); // returns Object
        User user = mdc.get("Paul", User.class); // returns User


```

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run all builds</b>  
  Please add comment: <b>Jenkins retest this</b>

* <b>Run (or rerun) specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] tests</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Run (or rerun) LTS specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Run (or rerun) native specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [runtimes|optaplanner|apps|examples] native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
