### PR TITLE
KOGITO-6031  Gradle integration test should not use quarkus platform BOM

### DIFF
--- a/integration-tests/integration-tests-quarkus-gradle/src/main/resources/gradle.properties
+++ b/integration-tests/integration-tests-quarkus-gradle/src/main/resources/gradle.properties
@@ -1,7 +1,7 @@
 # Gradle properties
 quarkusPluginId=io.quarkus
 quarkusPluginVersion=${version.io.quarkus}
-quarkusPlatformGroupId=io.quarkus.platform
+quarkusPlatformGroupId=io.quarkus
 quarkusPlatformArtifactId=quarkus-bom
 quarkusPlatformVersion=${version.io.quarkus}
 kogitoVersion=${project.version}


### PR DESCRIPTION
this creates a chicken and egg problem when quarkus platform is unreleased, but the core is already available

the solution should be to use io:quarkus:quarkus-bom instead of  io:quarkus.**platform**:quarkus-bom instead of 