### PR TITLE
KOGITO-5841  Public API: Allow extra-metadata in DataContext

### DIFF
--- a/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/EmptyDataContext.java
+++ b/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/EmptyDataContext.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.incubation.common;
+
+/**
+ * An empty DataContext singleton
+ */
+public final class EmptyDataContext implements DataContext, DefaultCastable {
+    public static final DataContext Instance = new EmptyDataContext();
+
+    private EmptyDataContext() {
+    }
+}

--- a/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/EmptyDataContext.java
+++ b/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/EmptyDataContext.java
@@ -16,9 +16,12 @@
 
 package org.kie.kogito.incubation.common;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
 /**
  * An empty DataContext singleton
  */
+@JsonSerialize // ensure Jackson won't complain even if it is an empty object
 public final class EmptyDataContext implements DataContext, DefaultCastable {
     public static final DataContext Instance = new EmptyDataContext();
 

--- a/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/EmptyMetaDataContext.java
+++ b/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/EmptyMetaDataContext.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.incubation.common;
+
+/**
+ * An empty DataContext singleton
+ */
+public final class EmptyDataContext implements DataContext, DefaultCastable {
+    public static final DataContext Instance = new EmptyDataContext();
+
+    private EmptyDataContext() {
+    }
+}

--- a/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/EmptyMetaDataContext.java
+++ b/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/EmptyMetaDataContext.java
@@ -16,9 +16,12 @@
 
 package org.kie.kogito.incubation.common;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
 /**
  * An empty DataContext singleton
  */
+@JsonSerialize // ensure Jackson won't complain even if it is an empty object
 public final class EmptyMetaDataContext implements MetaDataContext {
     public static final MetaDataContext Instance = new EmptyMetaDataContext();
 

--- a/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/EmptyMetaDataContext.java
+++ b/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/EmptyMetaDataContext.java
@@ -19,9 +19,9 @@ package org.kie.kogito.incubation.common;
 /**
  * An empty DataContext singleton
  */
-public final class EmptyDataContext implements DataContext, DefaultCastable {
-    public static final DataContext Instance = new EmptyDataContext();
+public final class EmptyMetaDataContext implements MetaDataContext {
+    public static final MetaDataContext Instance = new EmptyMetaDataContext();
 
-    private EmptyDataContext() {
+    private EmptyMetaDataContext() {
     }
 }

--- a/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/ExtendedDataContext.java
+++ b/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/ExtendedDataContext.java
@@ -40,35 +40,35 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  *
  */
 public final class ExtendedDataContext implements DataContext {
-    public static ExtendedDataContext of(DataContext meta, DataContext data) {
+    public static ExtendedDataContext of(MetaDataContext meta, DataContext data) {
         return new ExtendedDataContext(meta, data);
     }
 
     public static ExtendedDataContext ofData(DataContext data) {
-        return new ExtendedDataContext(EmptyDataContext.Instance, data);
+        return new ExtendedDataContext(EmptyMetaDataContext.Instance, data);
     }
 
-    private DataContext meta = EmptyDataContext.Instance;
+    private MetaDataContext meta = EmptyMetaDataContext.Instance;
     private DataContext data = EmptyDataContext.Instance;
 
     ExtendedDataContext() {
     }
 
-    ExtendedDataContext(DataContext meta, DataContext data) {
+    ExtendedDataContext(MetaDataContext meta, DataContext data) {
         this.meta = meta;
         this.data = data;
     }
 
-    void setMeta(DataContext meta) {
+    void setMeta(MetaDataContext meta) {
         this.meta = meta;
     }
 
-    void setData(DataContext meta) {
-        this.meta = meta;
+    void setData(DataContext data) {
+        this.data = data;
     }
 
     @JsonProperty("meta")
-    public DataContext meta() {
+    public MetaDataContext meta() {
         return meta;
     }
 

--- a/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/ExtendedDataContext.java
+++ b/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/ExtendedDataContext.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.incubation.common;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * An extended DataContext includes a <code>meta</code> section
+ * and a <code>data</code> section.
+ * <p>
+ * Meta contains meta-data about the data context.
+ * <p>
+ * Converting an extended context is equivalent to converting
+ * the Data section, unless the type is ExtendedDataContext; e.g.:
+ *
+ * <code><pre>
+ *     ExtendedDataContext edc = ...;
+ *     var res = edc.as(MapDataContext.class);
+ *     // is equivalent to
+ *     var res = edc.data().as(MapDataContext.class);
+ *     // however:
+ *     var res = edc.as(ExtendedDataContext.class);
+ *     // res .equals( mdc )
+ * </pre></code>
+ *
+ *
+ */
+public final class ExtendedDataContext implements DataContext {
+    public static ExtendedDataContext of(DataContext meta, DataContext data) {
+        return new ExtendedDataContext(meta, data);
+    }
+
+    public static ExtendedDataContext ofData(DataContext data) {
+        return new ExtendedDataContext(EmptyDataContext.Instance, data);
+    }
+
+    private DataContext meta = EmptyDataContext.Instance;
+    private DataContext data = EmptyDataContext.Instance;
+
+    ExtendedDataContext() {
+    }
+
+    ExtendedDataContext(DataContext meta, DataContext data) {
+        this.meta = meta;
+        this.data = data;
+    }
+
+    void setMeta(DataContext meta) {
+        this.meta = meta;
+    }
+
+    void setData(DataContext meta) {
+        this.meta = meta;
+    }
+
+    @JsonProperty("meta")
+    public DataContext meta() {
+        return meta;
+    }
+
+    @JsonProperty("data")
+    public DataContext data() {
+        return data;
+    }
+
+    public <T extends DataContext> T as(Class<T> type) {
+        if (type == ExtendedDataContext.class || type == DataContext.class) {
+            return (T) this;
+        } else {
+            return this.data().as(type);
+        }
+    }
+}

--- a/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/InternalObjectMapper.java
+++ b/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/InternalObjectMapper.java
@@ -39,6 +39,13 @@ public class InternalObjectMapper {
         if (MapLikeDataContext.class == type || MapDataContext.class == type) {
             return (T) MapDataContext.of(objectMapper.convertValue(self, Map.class));
         }
+        if (ExtendedDataContext.class == type) {
+            if (self instanceof DataContext) {
+                return (T) ExtendedDataContext.ofData((DataContext) self);
+            } else {
+                return (T) ExtendedDataContext.ofData(convertValue(self, MapDataContext.class));
+            }
+        }
         return objectMapper.convertValue(self, type);
     }
 

--- a/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/MapDataContext.java
+++ b/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/MapDataContext.java
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 /**
  * A data context that wraps a <code>Map<String, Object></code>.
  */
-public class MapDataContext implements MapLikeDataContext {
+public class MapDataContext implements MapLikeDataContext, MetaDataContext {
 
     public static <T> MapDataContext from(T object) {
         return InternalObjectMapper.convertValue(object, MapDataContext.class);

--- a/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/MetaDataContext.java
+++ b/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/MetaDataContext.java
@@ -1,2 +1,20 @@
-package org.kie.kogito.incubation.common;public class MetaDataContext {
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.incubation.common;
+
+public interface MetaDataContext {
 }

--- a/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/MetaDataContext.java
+++ b/api/kogito-api-incubation-common/src/main/java/org/kie/kogito/incubation/common/MetaDataContext.java
@@ -1,0 +1,2 @@
+package org.kie.kogito.incubation.common;public class MetaDataContext {
+}

--- a/api/kogito-api-incubation-common/src/test/java/org/kie/kogito/incubation/common/DataContextTest.java
+++ b/api/kogito-api-incubation-common/src/test/java/org/kie/kogito/incubation/common/DataContextTest.java
@@ -17,46 +17,12 @@
 package org.kie.kogito.incubation.common;
 
 import java.util.Map;
-import java.util.Objects;
 
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public class DataContextTest {
-    public static class Address {
-        String street;
-
-        @Override
-        public boolean equals(Object o) {
-            return (o instanceof Address)
-                    && Objects.equals(((Address) o).street, street);
-        }
-
-    }
-
-    public static class User implements DataContext, DefaultCastable {
-        String firstName;
-        String lastName;
-        Address addr;
-
-        @Override
-        public boolean equals(Object o) {
-            if (o instanceof User) {
-                User user = (User) o;
-                return Objects.equals(firstName, user.firstName)
-                        && Objects.equals(lastName, user.lastName)
-                        && Objects.equals(addr, user.addr);
-            } else
-                return false;
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(firstName, lastName, addr);
-        }
-    }
-
     @Test
     public void fromMap() {
         MapDataContext ctx = MapDataContext.create();

--- a/api/kogito-api-incubation-common/src/test/java/org/kie/kogito/incubation/common/DataContexts.java
+++ b/api/kogito-api-incubation-common/src/test/java/org/kie/kogito/incubation/common/DataContexts.java
@@ -50,3 +50,22 @@ class User implements DataContext, DefaultCastable {
         return Objects.hash(firstName, lastName, addr);
     }
 }
+
+class CustomMeta implements MetaDataContext {
+    String value;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        CustomMeta that = (CustomMeta) o;
+        return Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+}

--- a/api/kogito-api-incubation-common/src/test/java/org/kie/kogito/incubation/common/DataContexts.java
+++ b/api/kogito-api-incubation-common/src/test/java/org/kie/kogito/incubation/common/DataContexts.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.incubation.common;
+
+import java.util.Objects;
+
+class Address {
+    String street;
+
+    @Override
+    public boolean equals(Object o) {
+        return (o instanceof Address)
+                && Objects.equals(((Address) o).street, street);
+    }
+
+}
+
+class User implements DataContext, DefaultCastable {
+    String firstName;
+    String lastName;
+    Address addr;
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof User) {
+            User user = (User) o;
+            return Objects.equals(firstName, user.firstName)
+                    && Objects.equals(lastName, user.lastName)
+                    && Objects.equals(addr, user.addr);
+        } else
+            return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(firstName, lastName, addr);
+    }
+}

--- a/api/kogito-api-incubation-common/src/test/java/org/kie/kogito/incubation/common/ExtendedDataContextTest.java
+++ b/api/kogito-api-incubation-common/src/test/java/org/kie/kogito/incubation/common/ExtendedDataContextTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.incubation.common;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public class ExtendedDataContextTest {
+
+    @Test
+    public void convertReturnsDataSection() {
+        User data = new User();
+        data.firstName = "Paul";
+        data.lastName = "McCartney";
+        data.addr = new Address();
+        data.addr.street = "Abbey Rd.";
+
+        MapDataContext meta = MapDataContext.create();
+        meta.set("meta-value", "this is not data");
+
+        ExtendedDataContext ctx = ExtendedDataContext.of(data, meta);
+
+        assertEquals(ctx.data().as(MapDataContext.class), ctx.as(MapDataContext.class),
+                "Converting an ExtendedContext should be equivalent to converting its data section");
+
+    }
+
+    @Test
+    public void convertToExtendedIsNoOp() {
+        User data = new User();
+        data.firstName = "Paul";
+        data.lastName = "McCartney";
+        data.addr = new Address();
+        data.addr.street = "Abbey Rd.";
+
+        MapDataContext meta = MapDataContext.create();
+        meta.set("meta-value", "this is not data");
+
+        ExtendedDataContext ctx = ExtendedDataContext.of(data, meta);
+
+        assertSame(ctx, ctx.as(DataContext.class));
+        assertSame(ctx, ctx.as(ExtendedDataContext.class));
+
+        assertEquals(ctx.data().as(MapDataContext.class), ctx.as(MapDataContext.class),
+                "Converting an ExtendedContext should be equivalent to converting its data section");
+
+    }
+
+    @Test
+    public void convertDataContextToExtendedWraps() {
+        User data = new User();
+        data.firstName = "Paul";
+        data.lastName = "McCartney";
+        data.addr = new Address();
+        data.addr.street = "Abbey Rd.";
+
+        ExtendedDataContext edc = data.as(ExtendedDataContext.class);
+        assertEquals(data, edc.data());
+    }
+
+}

--- a/api/kogito-api-incubation-common/src/test/java/org/kie/kogito/incubation/common/ExtendedDataContextTest.java
+++ b/api/kogito-api-incubation-common/src/test/java/org/kie/kogito/incubation/common/ExtendedDataContextTest.java
@@ -74,4 +74,56 @@ public class ExtendedDataContextTest {
         assertEquals(data, edc.data());
     }
 
+    @Test
+    public void convertMapDataContextToExtendedWraps() {
+        User data = new User();
+        data.firstName = "Paul";
+        data.lastName = "McCartney";
+        data.addr = new Address();
+        data.addr.street = "Abbey Rd.";
+
+        MapDataContext mapData = data.as(MapDataContext.class);
+        ExtendedDataContext edc = mapData.as(ExtendedDataContext.class);
+        assertEquals(mapData, edc.data());
+    }
+
+    @Test
+    public void convertMetaToMap() {
+        User data = new User();
+        data.firstName = "Paul";
+        data.lastName = "McCartney";
+        data.addr = new Address();
+        data.addr.street = "Abbey Rd.";
+
+        MapDataContext meta = MapDataContext.create();
+        meta.set("meta-value", "this is not data");
+
+        ExtendedDataContext ctx = ExtendedDataContext.of(meta, data);
+
+        assertEquals(meta, ctx.meta());
+
+        MapDataContext fromMeta = MapDataContext.from(ctx.meta());
+        assertEquals(meta, fromMeta);
+
+    }
+
+    @Test
+    public void convertCustomMetaToMap() {
+        User data = new User();
+        data.firstName = "Paul";
+        data.lastName = "McCartney";
+        data.addr = new Address();
+        data.addr.street = "Abbey Rd.";
+
+        CustomMeta meta = new CustomMeta();
+        meta.value = "this is not data";
+
+        ExtendedDataContext ctx = ExtendedDataContext.of(meta, data);
+
+        assertEquals(meta, ctx.meta());
+
+        MapDataContext fromMeta = MapDataContext.from(ctx.meta());
+        assertEquals(meta.value, fromMeta.get("value"));
+    }
+
 }

--- a/api/kogito-api-incubation-common/src/test/java/org/kie/kogito/incubation/common/ExtendedDataContextTest.java
+++ b/api/kogito-api-incubation-common/src/test/java/org/kie/kogito/incubation/common/ExtendedDataContextTest.java
@@ -34,7 +34,7 @@ public class ExtendedDataContextTest {
         MapDataContext meta = MapDataContext.create();
         meta.set("meta-value", "this is not data");
 
-        ExtendedDataContext ctx = ExtendedDataContext.of(data, meta);
+        ExtendedDataContext ctx = ExtendedDataContext.of(meta, data);
 
         assertEquals(ctx.data().as(MapDataContext.class), ctx.as(MapDataContext.class),
                 "Converting an ExtendedContext should be equivalent to converting its data section");
@@ -52,7 +52,7 @@ public class ExtendedDataContextTest {
         MapDataContext meta = MapDataContext.create();
         meta.set("meta-value", "this is not data");
 
-        ExtendedDataContext ctx = ExtendedDataContext.of(data, meta);
+        ExtendedDataContext ctx = ExtendedDataContext.of(meta, data);
 
         assertSame(ctx, ctx.as(DataContext.class));
         assertSame(ctx, ctx.as(ExtendedDataContext.class));

--- a/api/kogito-api-incubation-decisions-services/src/main/java/org/kie/kogito/incubation/decisions/services/DecisionService.java
+++ b/api/kogito-api-incubation-decisions-services/src/main/java/org/kie/kogito/incubation/decisions/services/DecisionService.java
@@ -17,8 +17,9 @@
 package org.kie.kogito.incubation.decisions.services;
 
 import org.kie.kogito.incubation.common.DataContext;
+import org.kie.kogito.incubation.common.ExtendedDataContext;
 import org.kie.kogito.incubation.common.LocalId;
 
 public interface DecisionService {
-    DataContext evaluate(LocalId decisionId, DataContext inputContext);
+    ExtendedDataContext evaluate(LocalId decisionId, DataContext inputContext);
 }

--- a/api/kogito-api-incubation-decisions-services/src/test/java/org/kie/kogito/incubation/decisions/services/TestTypes.java
+++ b/api/kogito-api-incubation-decisions-services/src/test/java/org/kie/kogito/incubation/decisions/services/TestTypes.java
@@ -36,10 +36,10 @@ public class TestTypes {
         // let's just make the compiler happy
         DecisionService svc = new DecisionService() {
             @Override
-            public DataContext evaluate(LocalId id, DataContext ctx) {
+            public ExtendedDataContext evaluate(LocalId id, DataContext ctx) {
                 // ... parses and resolves the id ...
                 // .. then evaluates ...
-                return ctx;
+                return ExtendedDataContext.ofData(ctx);
             }
         };
         MapDataContext ctx = MapDataContext.create();

--- a/api/kogito-api-incubation-predictions-services/src/main/java/org/kie/kogito/incubation/predictions/services/PredictionService.java
+++ b/api/kogito-api-incubation-predictions-services/src/main/java/org/kie/kogito/incubation/predictions/services/PredictionService.java
@@ -17,8 +17,9 @@
 package org.kie.kogito.incubation.predictions.services;
 
 import org.kie.kogito.incubation.common.DataContext;
+import org.kie.kogito.incubation.common.ExtendedDataContext;
 import org.kie.kogito.incubation.common.LocalId;
 
 public interface PredictionService {
-    DataContext evaluate(LocalId decisionId, DataContext inputContext);
+    ExtendedDataContext evaluate(LocalId decisionId, DataContext inputContext);
 }

--- a/api/kogito-api-incubation-predictions-services/src/test/java/org/kie/kogito/incubation/predictions/services/TestTypes.java
+++ b/api/kogito-api-incubation-predictions-services/src/test/java/org/kie/kogito/incubation/predictions/services/TestTypes.java
@@ -35,10 +35,10 @@ public class TestTypes {
         // let's just make the compiler happy
         PredictionService svc = new PredictionService() {
             @Override
-            public DataContext evaluate(LocalId id, DataContext ctx) {
+            public ExtendedDataContext evaluate(LocalId id, DataContext ctx) {
                 // ... parses and resolves the id ...
                 // .. then evaluates ...
-                return ctx;
+                return ExtendedDataContext.ofData(ctx);
             }
         };
         MapDataContext ctx = MapDataContext.create();

--- a/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test/src/test/java/org/kie/kogito/quarkus/dmn/CustomEndpointIT.java
+++ b/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test/src/test/java/org/kie/kogito/quarkus/dmn/CustomEndpointIT.java
@@ -33,10 +33,10 @@ public class CustomEndpointIT {
                 .contentType(ContentType.JSON)
                 .accept(ContentType.JSON)
                 .body(DMNIT.ADULT_PAYLOAD)
-                .post("/dmnModel")
+                .post("/custom")
                 .then()
                 .statusCode(200)
-                .body("d.Hello", Matchers.is("Hello Luca"));
+                .body("data.d.Hello", Matchers.is("Hello Luca"));
     }
 
 }

--- a/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions/src/main/java/org/kie/kogito/core/decision/incubation/quarkus/support/QuarkusDecisionService.java
+++ b/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions/src/main/java/org/kie/kogito/core/decision/incubation/quarkus/support/QuarkusDecisionService.java
@@ -39,7 +39,7 @@ public class QuarkusDecisionService implements DecisionService {
     Instance<DecisionModels> decisionModelsInstance;
 
     @Override
-    public DataContext evaluate(LocalId decisionId, DataContext inputContext) {
+    public ExtendedDataContext evaluate(LocalId decisionId, DataContext inputContext) {
         LocalDecisionId localDecisionId;
         LocalDecisionServiceId decisionServiceId = null;
         if (decisionId instanceof LocalDecisionId) {

--- a/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions/src/main/java/org/kie/kogito/core/decision/incubation/quarkus/support/QuarkusDecisionService.java
+++ b/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions/src/main/java/org/kie/kogito/core/decision/incubation/quarkus/support/QuarkusDecisionService.java
@@ -26,6 +26,7 @@ import org.kie.kogito.decision.DecisionModel;
 import org.kie.kogito.decision.DecisionModels;
 import org.kie.kogito.dmn.rest.DMNJSONUtils;
 import org.kie.kogito.incubation.common.DataContext;
+import org.kie.kogito.incubation.common.ExtendedDataContext;
 import org.kie.kogito.incubation.common.LocalId;
 import org.kie.kogito.incubation.common.MapDataContext;
 import org.kie.kogito.incubation.decisions.LocalDecisionId;
@@ -69,6 +70,8 @@ public class QuarkusDecisionService implements DecisionService {
                     ctx, decisionServiceId.serviceId());
         }
 
-        return MapDataContext.of(dmnResult.getContext().getAll());
+        MapDataContext meta = MapDataContext.of(dmnResult.getContext().getMetadata().asMap());
+        MapDataContext data = MapDataContext.of(dmnResult.getContext().getAll());
+        return ExtendedDataContext.of(meta, data);
     }
 }

--- a/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions/src/main/java/org/kie/kogito/core/decision/incubation/quarkus/support/QuarkusDecisionService.java
+++ b/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions/src/main/java/org/kie/kogito/core/decision/incubation/quarkus/support/QuarkusDecisionService.java
@@ -16,19 +16,19 @@
 
 package org.kie.kogito.core.decision.incubation.quarkus.support;
 
+import java.util.Map;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
 import org.kie.dmn.api.core.DMNContext;
+import org.kie.dmn.api.core.DMNMetadata;
 import org.kie.dmn.api.core.DMNResult;
 import org.kie.kogito.decision.DecisionModel;
 import org.kie.kogito.decision.DecisionModels;
 import org.kie.kogito.dmn.rest.DMNJSONUtils;
-import org.kie.kogito.incubation.common.DataContext;
-import org.kie.kogito.incubation.common.ExtendedDataContext;
-import org.kie.kogito.incubation.common.LocalId;
-import org.kie.kogito.incubation.common.MapDataContext;
+import org.kie.kogito.incubation.common.*;
 import org.kie.kogito.incubation.decisions.LocalDecisionId;
 import org.kie.kogito.incubation.decisions.LocalDecisionServiceId;
 import org.kie.kogito.incubation.decisions.services.DecisionService;
@@ -60,7 +60,17 @@ public class QuarkusDecisionService implements DecisionService {
                 decisionModels.getDecisionModel(
                         localDecisionId.namespace(), localDecisionId.name());
 
-        DMNContext ctx = DMNJSONUtils.ctx(decisionModel, inputContext.as(MapDataContext.class).toMap());
+        ExtendedDataContext extendedDataContext = inputContext.as(ExtendedDataContext.class);
+
+        Map<String, Object> map = extendedDataContext.data().as(MapDataContext.class).toMap();
+        DMNContext ctx = DMNJSONUtils.ctx(decisionModel, map);
+        MetaDataContext inputMeta = extendedDataContext.meta();
+        MapDataContext mapInputMeta = MapDataContext.from(inputMeta);
+        DMNMetadata metadata = ctx.getMetadata();
+        for (Map.Entry<String, Object> kv : mapInputMeta.toMap().entrySet()) {
+            metadata.set(kv.getKey(), kv.getValue());
+        }
+
         DMNResult dmnResult;
 
         if (decisionServiceId == null) {

--- a/quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions-integration-test/src/test/java/org/kie/kogito/quarkus/pmml/CustomEndpointIT.java
+++ b/quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions-integration-test/src/test/java/org/kie/kogito/quarkus/pmml/CustomEndpointIT.java
@@ -39,10 +39,9 @@ public class CustomEndpointIT {
                         "fld2", 2.0,
                         "fld3", "y"))
                 .post("/custom")
-                .peek()
                 .then()
                 .statusCode(200)
-                .body("fld4", is(52.5f));
+                .body("data.fld4", is(52.5f));
     }
 
 }

--- a/quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions/src/main/java/org/kie/kogito/core/prediction/incubation/quarkus/support/QuarkusPredictionService.java
+++ b/quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions/src/main/java/org/kie/kogito/core/prediction/incubation/quarkus/support/QuarkusPredictionService.java
@@ -37,7 +37,7 @@ public class QuarkusPredictionService implements PredictionService {
     Instance<PredictionModels> predictionModels;
 
     @Override
-    public DataContext evaluate(LocalId predictionId, DataContext inputContext) {
+    public ExtendedDataContext evaluate(LocalId predictionId, DataContext inputContext) {
         LocalPredictionId localPredictionId;
         if (predictionId instanceof LocalPredictionId) {
             localPredictionId = (LocalPredictionId) predictionId;

--- a/quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions/src/main/java/org/kie/kogito/core/prediction/incubation/quarkus/support/QuarkusPredictionService.java
+++ b/quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions/src/main/java/org/kie/kogito/core/prediction/incubation/quarkus/support/QuarkusPredictionService.java
@@ -24,9 +24,7 @@ import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
 import org.kie.api.pmml.PMML4Result;
-import org.kie.kogito.incubation.common.DataContext;
-import org.kie.kogito.incubation.common.LocalId;
-import org.kie.kogito.incubation.common.MapDataContext;
+import org.kie.kogito.incubation.common.*;
 import org.kie.kogito.incubation.predictions.LocalPredictionId;
 import org.kie.kogito.incubation.predictions.services.PredictionService;
 import org.kie.kogito.prediction.PredictionModel;
@@ -59,6 +57,8 @@ public class QuarkusPredictionService implements PredictionService {
                 pmml4Result.getResultVariables().get(
                         pmml4Result.getResultObjectName()));
 
-        return MapDataContext.of(resultMap);
+        MapDataContext meta = MapDataContext.of(InternalObjectMapper.convertValue(pmml4Result, Map.class));
+        MapDataContext data = MapDataContext.of(resultMap);
+        return ExtendedDataContext.of(meta, data);
     }
 }


### PR DESCRIPTION
**This is intended also as a RFC**.

related: https://github.com/kiegroup/kogito-examples/pull/941

Introduce the `ExtendedDataContext` that services may opt-in to return. 

An `ExtendedDataContext` contains a `meta()` and a `data()` section. 

```java
public final class ExtendedDataContext implements DataContext {
      public DataContext meta();
      public DataContext data();
} 
```

`ExtendedDataContext.as(T)` is equivalent to `ExtendedDataContext.data().as(T)` unless `T=ExtendedDataContext`

Thus, to access MetaData users may write:

```
DataContext ctx = svc.evaluate(id, input);
ExtendedDataContext ectx = ctx.as(ExtendedDataContext.class);
DataContext meta = ectx.meta() 
```

`meta` and `data` are both `DataContexts` so they may be converted to another type as any other `DataContext`.

For instance, engines may provide their own typed context; e.g:

```java
DMNMetaDataContext meta = ectx.meta().as(DMNMetaDataContext.class); 
```

If a service does not return an `ExtendedDataContext`, then conversion to `ExtendedDataContext` is equivalent to wrapping `ExtendedDataContext` around the original context; as such:

```java
MapDataContext mdc = MapDataContext.create();
mdc.set(......);
ExtendedDataContext edc = mdc.as(ExtendedDataContext.class);
// edc.data().equals(mdc)
```

