### PR TITLE
KOGITO-6113 shorten index name for oracle

### DIFF
--- a/addons/common/persistence/jdbc/src/main/java/org/kie/kogito/persistence/jdbc/GenericRepository.java
+++ b/addons/common/persistence/jdbc/src/main/java/org/kie/kogito/persistence/jdbc/GenericRepository.java
@@ -106,6 +106,7 @@ public class GenericRepository extends Repository {
             LOGGER.info("DDL successfully done for ProcessInstance");
         } catch (SQLException e) {
             var msg = "Error creating process_instances table, the database should be configured properly before starting the application";
+            LOGGER.error(msg, e);
             throw new RuntimeException(msg);
         }
     }

--- a/addons/common/persistence/jdbc/src/main/resources/sql/create_tables_Oracle.sql
+++ b/addons/common/persistence/jdbc/src/main/resources/sql/create_tables_Oracle.sql
@@ -4,4 +4,4 @@ CREATE TABLE process_instances(
     process_id varchar2(4000) NOT NULL,
     version number(19),
     CONSTRAINT process_instances_pkey PRIMARY KEY (id));
-CREATE INDEX idx_process_instances_process_id ON process_instances (process_id);
+CREATE INDEX idx_process_instances_proc_id ON process_instances (process_id);


### PR DESCRIPTION
Fix for: https://issues.redhat.com/browse/KOGITO-6113
ORACLE JDBC index name too long
Many thanks for submitting your Pull Request :heart:! 