### PR TITLE
KOGITO-5508 Data Index Dev Service

### DIFF
--- a/integration-tests/integration-tests-quarkus-processes/pom.xml
+++ b/integration-tests/integration-tests-quarkus-processes/pom.xml
@@ -31,7 +31,7 @@
   <dependencies>
     <dependency>
       <groupId>org.kie.kogito</groupId>
-      <artifactId>kogito-quarkus</artifactId>
+      <artifactId>kogito-quarkus-processes</artifactId>
     </dependency>
     <dependency>
       <groupId>org.kie.kogito</groupId>

--- a/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-integration-test-maven-devmode/src/test/resources/projects/classic-inst/src/main/resources/application.properties
+++ b/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-integration-test-maven-devmode/src/test/resources/projects/classic-inst/src/main/resources/application.properties
@@ -15,3 +15,4 @@
 #
 
 quarkus.http.port=65535
+quarkus.kogito.devservices.enabled=false

--- a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-deployment/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-deployment/pom.xml
@@ -22,6 +22,10 @@
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-quarkus-processes</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-devservices-common</artifactId>
+    </dependency>
     <!-- codegen dependencies -->
     <dependency>
       <groupId>org.kie.kogito</groupId>

--- a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-deployment/src/main/java/org/kie/kogito/quarkus/processes/deployment/KogitoBuildTimeConfig.java
+++ b/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-deployment/src/main/java/org/kie/kogito/quarkus/processes/deployment/KogitoBuildTimeConfig.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.quarkus.processes.deployment;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(name = "kogito", phase = ConfigPhase.BUILD_TIME)
+public class KogitoBuildTimeConfig {
+
+    /**
+     * Configuration for DevServices. DevServices allows Quarkus to automatically start Data Index in dev and test mode.
+     */
+    @ConfigItem
+    public KogitoDevServicesBuildTimeConfig devservices;
+}

--- a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-deployment/src/main/java/org/kie/kogito/quarkus/processes/deployment/KogitoDevServicesBuildTimeConfig.java
+++ b/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-deployment/src/main/java/org/kie/kogito/quarkus/processes/deployment/KogitoDevServicesBuildTimeConfig.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.quarkus.processes.deployment;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+@ConfigGroup
+public class KogitoDevServicesBuildTimeConfig {
+
+    /**
+     * If Dev Services for Kogito has been explicitly enabled or disabled. Dev Services are generally enabled
+     * by default, unless there is an existing configuration present.
+     */
+    @ConfigItem
+    public Optional<Boolean> enabled = Optional.empty();
+
+    /**
+     * Optional fixed port the dev service will listen to.
+     * <p>
+     * If not defined, 8180 will be used.
+     */
+    @ConfigItem(defaultValue = "8180")
+    public Optional<Integer> port;
+
+    /**
+     * The Data Index image to use.
+     */
+    @ConfigItem(defaultValue = "quay.io/kiegroup/kogito-data-index-ephemeral")
+    public String imageName;
+
+    /**
+     * Indicates if the Data Index instance managed by Quarkus Dev Services is shared.
+     * When shared, Quarkus looks for running containers using label-based service discovery.
+     * If a matching container is found, it is used, and so a second one is not started.
+     * Otherwise, Dev Services for a new Data Index instance.
+     * <p>
+     * The discovery uses the {@code kogito-dev-service-data-index} label.
+     * The value is configured using the {@code service-name} property.
+     * <p>
+     * Container sharing is only used in dev mode.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean shared;
+
+    /**
+     * The value of the {@code kogito-dev-service-data-index} label attached to the started container.
+     * This property is used when {@code shared} is set to {@code true}.
+     * In this case, before starting a container, Dev Services looks for a container with the
+     * {@code kogito-dev-service-data-index} label
+     * set to the configured value. If found, it will use this container instead of starting a new one. Otherwise, it
+     * starts a new container with the {@code kogito-dev-service-data-index} label set to the specified value.
+     */
+    @ConfigItem(defaultValue = "kogito-data-index")
+    public String serviceName;
+
+}

--- a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-deployment/src/main/java/org/kie/kogito/quarkus/processes/deployment/KogitoDevServicesProcessor.java
+++ b/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-deployment/src/main/java/org/kie/kogito/quarkus/processes/deployment/KogitoDevServicesProcessor.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.quarkus.processes.deployment;
+
+import java.io.Closeable;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.kie.kogito.quarkus.processes.devservices.DataIndexEventPublisher;
+import org.kie.kogito.quarkus.processes.devservices.DataIndexInMemoryContainer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.utility.DockerImageName;
+
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.IsDockerWorking;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.CuratedApplicationShutdownBuildItem;
+import io.quarkus.deployment.builditem.DevServicesSharedNetworkBuildItem;
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
+import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
+import io.quarkus.deployment.console.ConsoleInstalledBuildItem;
+import io.quarkus.deployment.console.StartupLogCompressor;
+import io.quarkus.deployment.dev.devservices.GlobalDevServicesConfig;
+import io.quarkus.deployment.logging.LoggingSetupBuildItem;
+import io.quarkus.devservices.common.ContainerAddress;
+import io.quarkus.devservices.common.ContainerLocator;
+import io.quarkus.runtime.LaunchMode;
+
+import static org.kie.kogito.quarkus.processes.devservices.DataIndexEventPublisher.KOGITO_DATA_INDEX;
+
+/**
+ * Starts a Data Index as dev service if needed.
+ */
+public class KogitoDevServicesProcessor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(KogitoDevServicesProcessor.class);
+    private static final ContainerLocator LOCATOR = new ContainerLocator(DataIndexInMemoryContainer.DEV_SERVICE_LABEL, DataIndexInMemoryContainer.PORT);
+
+    static volatile Closeable closeable;
+    static volatile DataIndexDevServiceConfig cfg;
+    static volatile boolean first = true;
+
+    private final IsDockerWorking isDockerWorking = new IsDockerWorking(true);
+
+    @BuildStep(onlyIf = { GlobalDevServicesConfig.Enabled.class, IsDevelopment.class })
+    public void startDataIndexDevService(
+            BuildProducer<AdditionalBeanBuildItem> additionalBean,
+            BuildProducer<SystemPropertyBuildItem> systemProperties,
+            LaunchModeBuildItem launchMode,
+            KogitoBuildTimeConfig buildTimeConfig,
+            Optional<DevServicesSharedNetworkBuildItem> devServicesSharedNetwork,
+            Optional<ConsoleInstalledBuildItem> consoleInstalled,
+            CuratedApplicationShutdownBuildItem applicationShutdown,
+            LoggingSetupBuildItem loggingSetup) {
+
+        DataIndexDevServiceConfig configuration = getConfiguration(buildTimeConfig);
+
+        if (configuration.devServicesEnabled) {
+            additionalBean.produce(AdditionalBeanBuildItem.builder().addBeanClass(DataIndexEventPublisher.class).build());
+        }
+
+        if (closeable != null) {
+            boolean shouldShutdown = !configuration.equals(cfg);
+            if (!shouldShutdown) {
+                return;
+            }
+            shutdownDataIndex();
+            cfg = null;
+        }
+
+        StartupLogCompressor compressor = new StartupLogCompressor(
+                (launchMode.isTest() ? "(test) " : "") + "Kogito Data Index Dev Service starting:",
+                consoleInstalled, loggingSetup);
+
+        DataIndexInstance dataIndex;
+        try {
+            dataIndex = startDataIndex(configuration, launchMode, devServicesSharedNetwork.isPresent());
+            if (dataIndex != null) {
+                closeable = dataIndex.getCloseable();
+                systemProperties.produce(new SystemPropertyBuildItem(KOGITO_DATA_INDEX, dataIndex.getUrl()));
+            }
+            compressor.close();
+        } catch (Throwable t) {
+            compressor.closeAndDumpCaptured();
+            throw new RuntimeException("Failed to start Kogito Data Index Dev Services", t);
+        }
+
+        // Configure the watch dog
+        if (first) {
+            first = false;
+            Runnable closeTask = () -> {
+                if (closeable != null) {
+                    shutdownDataIndex();
+                }
+                first = true;
+                closeable = null;
+                cfg = null;
+            };
+            applicationShutdown.addCloseTask(closeTask, true);
+        }
+        cfg = configuration;
+
+        if (dataIndex != null && dataIndex.isOwner()) {
+            LOGGER.info(
+                    "Dev Services for Kogito Data Index started at {}",
+                    dataIndex.getUrl());
+        }
+
+    }
+
+    private void shutdownDataIndex() {
+        if (closeable != null) {
+            try {
+                closeable.close();
+            } catch (Throwable e) {
+                LOGGER.error("Failed to stop Kogito Data Index", e);
+            } finally {
+                closeable = null;
+            }
+        }
+    }
+
+    private DataIndexInstance startDataIndex(DataIndexDevServiceConfig config, LaunchModeBuildItem launchMode, boolean useSharedNetwork) {
+        if (!config.devServicesEnabled) {
+            // explicitly disabled
+            LOGGER.debug("Not starting dev services for Kogito, as it has been disabled in the config.");
+            return null;
+        }
+
+        if (!isDockerWorking.getAsBoolean()) {
+            LOGGER.warn(
+                    "Docker isn't working, unable to start Data Index image.");
+            return null;
+        }
+
+        final Optional<ContainerAddress> maybeContainerAddress = LOCATOR.locateContainer(config.serviceName,
+                config.shared,
+                launchMode.getLaunchMode());
+
+        // Starting Data Index
+        final Supplier<DataIndexInstance> dataIndexSupplier = () -> {
+            try {
+
+                DataIndexInMemoryContainer container = new DataIndexInMemoryContainer(
+                        DockerImageName.parse(config.imageName),
+                        config.fixedExposedPort,
+                        launchMode.getLaunchMode() == LaunchMode.DEVELOPMENT ? config.serviceName : null,
+                        useSharedNetwork);
+                container.start();
+
+                return new DataIndexInstance(container.getUrl(), container::close);
+            } catch (Exception ex) {
+                throw new RuntimeException(ex);
+            }
+        };
+
+        return maybeContainerAddress.map(containerAddress -> new DataIndexInstance(containerAddress.getUrl(), null))
+                .orElseGet(dataIndexSupplier);
+    }
+
+    private DataIndexDevServiceConfig getConfiguration(KogitoBuildTimeConfig cfg) {
+        KogitoDevServicesBuildTimeConfig devServicesConfig = cfg.devservices;
+        return new DataIndexDevServiceConfig(devServicesConfig);
+    }
+
+    private static class DataIndexInstance {
+        private final String url;
+        private final Closeable closeable;
+
+        public DataIndexInstance(String url, Closeable closeable) {
+            this.url = url;
+            this.closeable = closeable;
+        }
+
+        public boolean isOwner() {
+            return closeable != null;
+        }
+
+        public String getUrl() {
+            return url;
+        }
+
+        public Closeable getCloseable() {
+            return closeable;
+        }
+    }
+
+    private static final class DataIndexDevServiceConfig {
+
+        private final boolean devServicesEnabled;
+        private final String imageName;
+        private final Integer fixedExposedPort;
+        private final boolean shared;
+        private final String serviceName;
+
+        public DataIndexDevServiceConfig(KogitoDevServicesBuildTimeConfig config) {
+            this.devServicesEnabled = config.enabled.orElse(true);
+            this.imageName = config.imageName;
+            this.fixedExposedPort = config.port.orElse(0);
+            this.shared = config.shared;
+            this.serviceName = config.serviceName;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            DataIndexDevServiceConfig that = (DataIndexDevServiceConfig) o;
+            return devServicesEnabled == that.devServicesEnabled && Objects.equals(imageName, that.imageName)
+                    && Objects.equals(fixedExposedPort, that.fixedExposedPort);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(devServicesEnabled, imageName, fixedExposedPort);
+        }
+    }
+
+}

--- a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-deployment/src/main/java/org/kie/kogito/quarkus/processes/deployment/ProcessesAssetsProcessor.java
+++ b/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-deployment/src/main/java/org/kie/kogito/quarkus/processes/deployment/ProcessesAssetsProcessor.java
@@ -43,6 +43,8 @@ import org.kie.kogito.codegen.api.GeneratedFileType;
 import org.kie.kogito.codegen.api.context.KogitoBuildContext;
 import org.kie.kogito.codegen.json.JsonSchemaGenerator;
 import org.kie.kogito.codegen.process.persistence.PersistenceGenerator;
+import org.kie.kogito.core.process.incubation.quarkus.support.QuarkusProcessIdFactory;
+import org.kie.kogito.core.process.incubation.quarkus.support.QuarkusStraightThroughProcessService;
 import org.kie.kogito.quarkus.common.deployment.InMemoryClassLoader;
 import org.kie.kogito.quarkus.common.deployment.KogitoGeneratedClassesBuildItem;
 import org.kie.kogito.serialization.process.ObjectMarshallerStrategy;
@@ -51,6 +53,7 @@ import org.kie.kogito.serialization.process.protobuf.KogitoProcessInstanceProtob
 import org.kie.kogito.serialization.process.protobuf.KogitoTypesProtobuf;
 import org.kie.kogito.serialization.process.protobuf.KogitoWorkItemsProtobuf;
 
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.GeneratedBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -133,6 +136,11 @@ public class ProcessesAssetsProcessor {
                 "org.kie.kogito.event.Topic",
                 "org.kie.kogito.event.CloudEventMeta",
                 "org.kie.kogito.jobs.api.Job");
+    }
+
+    @BuildStep
+    public AdditionalBeanBuildItem additionalBeans() {
+        return AdditionalBeanBuildItem.builder().addBeanClasses(QuarkusStraightThroughProcessService.class, QuarkusProcessIdFactory.class).build();
     }
 
     /**

--- a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-deployment/src/main/java/org/kie/kogito/quarkus/processes/devservices/DataIndexInMemoryContainer.java
+++ b/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-deployment/src/main/java/org/kie/kogito/quarkus/processes/devservices/DataIndexInMemoryContainer.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.quarkus.processes.devservices;
+
+import java.util.Collections;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.utility.Base58;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * This container wraps Data Index Service container
+ */
+public class DataIndexInMemoryContainer extends GenericContainer<DataIndexInMemoryContainer> {
+
+    public static final int PORT = 8080;
+    /**
+     * This allows other applications to discover the running service and use it instead of starting a new instance.
+     */
+    public static final String DEV_SERVICE_LABEL = "kogito-dev-service-data-index";
+    private static final Logger LOGGER = LoggerFactory.getLogger(DataIndexInMemoryContainer.class);
+    private final int port;
+    private final boolean useSharedNetwork;
+    private String hostName = null;
+
+    public DataIndexInMemoryContainer(DockerImageName dockerImageName, int fixedExposedPort, String serviceName, boolean useSharedNetwork) {
+        super(dockerImageName);
+        this.port = fixedExposedPort;
+        this.useSharedNetwork = useSharedNetwork;
+        withPrivilegedMode(true);
+        withNetwork(Network.SHARED);
+        if (useSharedNetwork) {
+            hostName = "data-index-" + Base58.randomString(5);
+            setNetworkAliases(Collections.singletonList(hostName));
+        } else {
+            withExposedPorts(PORT);
+        }
+        if (serviceName != null) { // Only adds the label in dev mode.
+            withLabel(DEV_SERVICE_LABEL, serviceName);
+        }
+        withLogConsumer(new Slf4jLogConsumer(LOGGER));
+    }
+
+    @Override
+    protected void configure() {
+        super.configure();
+        if ((port > 0) && !useSharedNetwork) {
+            addFixedExposedPort(port, PORT);
+        }
+    }
+
+    public String getUrl() {
+        return String.format("http://%s:%s", getHostToUse(), getPortToUse());
+    }
+
+    private String getHostToUse() {
+        return useSharedNetwork ? hostName : getHost();
+    }
+
+    private int getPortToUse() {
+        return useSharedNetwork ? PORT : getMappedPort(PORT);
+    }
+
+}

--- a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-deployment/src/main/resources/dev-templates/dataindex.html
+++ b/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-deployment/src/main/resources/dev-templates/dataindex.html
@@ -1,0 +1,16 @@
+{#include main fluid=true}
+{#style}
+.main-container {
+    margin: 0;
+    padding: 0;
+}
+{/style}
+{#title}Data Index GraphQL UI{/title}
+{#body}
+<div class="row">
+    <div class="col-xs-12 col-sm-12 col-md-12">
+        <iframe style="width: 100vw;height: 100vh;position: relative;" src="{config:property('kogito.data-index.url')}/graphiql/" style="border:none;"></iframe>
+    </div>
+</div>
+{/body}
+{/include}

--- a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-deployment/src/main/resources/dev-templates/embedded.html
+++ b/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-deployment/src/main/resources/dev-templates/embedded.html
@@ -1,0 +1,4 @@
+<a href="{urlbase}/dataindex" class="badge badge-light">
+    <i class="fa fa-map-signs fa-fw"></i>
+    Data Index GraphQL UI
+</a>

--- a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-integration-test-hot-reload/src/test/resources/application.properties
+++ b/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-integration-test-hot-reload/src/test/resources/application.properties
@@ -15,3 +15,4 @@
 #
 
 quarkus.http.port=65535
+quarkus.kogito.devservices.enabled=false

--- a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes/pom.xml
@@ -30,6 +30,10 @@
       <groupId>org.kie.kogito</groupId>
       <artifactId>process-serialization-protobuf</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.smallrye.reactive</groupId>
+      <artifactId>smallrye-mutiny-vertx-web-client</artifactId>
+    </dependency>
   </dependencies>
 
   <build>
@@ -60,10 +64,6 @@
             </configuration>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.jboss.jandex</groupId>
-        <artifactId>jandex-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes/src/main/java/org/kie/kogito/quarkus/processes/devservices/DataIndexEventPublisher.java
+++ b/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes/src/main/java/org/kie/kogito/quarkus/processes/devservices/DataIndexEventPublisher.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.quarkus.processes.devservices;
+
+import java.util.Collection;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.kie.kogito.event.DataEvent;
+import org.kie.kogito.event.EventPublisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.Vertx;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.predicate.ResponsePredicate;
+
+@ApplicationScoped
+public class DataIndexEventPublisher implements EventPublisher {
+
+    public static final String KOGITO_DATA_INDEX = "kogito.data-index.url";
+    private static final Logger LOGGER = LoggerFactory.getLogger(DataIndexEventPublisher.class);
+
+    @ConfigProperty(name = KOGITO_DATA_INDEX)
+    String dataIndexUrl;
+
+    @Inject
+    Vertx vertx;
+
+    WebClient webClient;
+
+    @PostConstruct
+    public void init() {
+        webClient = WebClient.create(vertx);
+    }
+
+    @Override
+    public void publish(DataEvent<?> event) {
+        LOGGER.debug("Sending event to data index: {}", event);
+        switch (event.getType()) {
+            case "ProcessInstanceEvent":
+                webClient.postAbs(dataIndexUrl + "/processes")
+                        .expect(ResponsePredicate.SC_ACCEPTED)
+                        .sendJson(event, result -> {
+                            if (result.failed()) {
+                                LOGGER.error("Failed to send message to Data Index", result.cause());
+                            } else {
+                                LOGGER.debug("Event published to Data Index");
+                            }
+                        });
+                break;
+            case "UserTaskInstanceEvent":
+                webClient.postAbs(dataIndexUrl + "/tasks")
+                        .expect(ResponsePredicate.SC_ACCEPTED)
+                        .sendJson(event, result -> {
+                            if (result.failed()) {
+                                LOGGER.error("Failed to send message to Data Index", result.cause());
+                            } else {
+                                LOGGER.debug("Event published to Data Index");
+                            }
+                        });
+                break;
+            default:
+                LOGGER.debug("Unknown type of event '{}', ignoring for this publisher", event.getType());
+        }
+    }
+
+    @Override
+    public void publish(Collection<DataEvent<?>> events) {
+        events.forEach(this::publish);
+    }
+
+}

--- a/quarkus/test/src/main/java/org/kie/kogito/testcontainers/quarkus/KafkaQuarkusTestResource.java
+++ b/quarkus/test/src/main/java/org/kie/kogito/testcontainers/quarkus/KafkaQuarkusTestResource.java
@@ -55,7 +55,10 @@ public class KafkaQuarkusTestResource extends ConditionalQuarkusTestResource<Kog
 
     @Override
     public void init(Map<String, String> initArgs) {
-        topics = Arrays.stream(initArgs.getOrDefault(KOGITO_KAFKA_TOPICS, "").split(",")).collect(toList());
+        String topicsString = initArgs.get(KOGITO_KAFKA_TOPICS);
+        if (topicsString != null && !topicsString.trim().isEmpty()) {
+            topics = Arrays.stream(topicsString.split(",")).collect(toList());
+        }
     }
 
     @Override


### PR DESCRIPTION
To test this, start a Kogito project that contains the `kogito-quarkus-processes` extension.
That should start Data Index in the background. To access the data index UI, jump to Quarkus Dev mode UI:
![Selection_101](https://user-images.githubusercontent.com/570894/139803649-701188ce-9024-429b-93f8-7e40ab694c5b.png)

![Selection_100](https://user-images.githubusercontent.com/570894/139803664-0bd2c858-6f75-4dd4-b7d9-c200c7fe0de8.png)

Clicking on Data Index GraphQL UI bring the UI allowing to query for process instances and tasks.
Start a new process instance and check if results show up in the UI once querying.