### PR TITLE
KOGITO-5891: JSON Schema generation for ProcessModelInput

### DIFF
--- a/api/kogito-api/src/main/java/org/kie/kogito/ProcessInput.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/ProcessInput.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target(TYPE)
+public @interface ProcessInput {
+
+    String PROCESS_NAME_PARAM = "processName";
+
+    String processName();
+}

--- a/api/kogito-api/src/main/java/org/kie/kogito/ProcessInput.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/ProcessInput.java
@@ -25,7 +25,5 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target(TYPE)
 public @interface ProcessInput {
 
-    String PROCESS_NAME_PARAM = "processName";
-
     String processName();
 }

--- a/integration-tests/integration-tests-quarkus-processes/src/test/java/org/kie/kogito/integrationtests/quarkus/ProcessIT.java
+++ b/integration-tests/integration-tests-quarkus-processes/src/test/java/org/kie/kogito/integrationtests/quarkus/ProcessIT.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.integrationtests.quarkus;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+
+import org.acme.travels.Traveller;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchema;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+@QuarkusIntegrationTest
+public class ProcessIT {
+
+    static {
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+    }
+
+    @Test
+    void testProcessSchema() throws IOException {
+        testProcessSchema("approvals", "test_approvals.json");
+        testProcessSchema("cinema", "test_cinema.json");
+        testProcessSchema("greetings", "test_greetings.json");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testStartProcess() {
+        Traveller traveller = new Traveller("pepe", "rubiales", "pepe.rubiales@gmail.com", "Spanish");
+
+        String processId = given()
+                .contentType(ContentType.JSON)
+                .when()
+                .body(Collections.singletonMap("traveller", traveller))
+                .post("/approvals")
+                .then()
+                .statusCode(201)
+                .extract()
+                .path("id");
+
+        given()
+                .accept(ContentType.JSON)
+                .when()
+                .get("/approvals/{id}", processId)
+                .then()
+                .statusCode(200)
+                .body("id", equalTo(processId))
+                .body("traveller.firstName", equalTo(traveller.getFirstName()))
+                .body("traveller.lastName", equalTo(traveller.getLastName()))
+                .body("traveller.email", equalTo(traveller.getEmail()))
+                .body("traveller.nationality", equalTo(traveller.getNationality()));
+    }
+
+    private void testProcessSchema(String processId, String schemaFileName) throws IOException {
+        // Quarkus returns URI with "quarkus://" scheme when running via CLI and this is not compatible with
+        // matchesJsonSchemaInClasspath, while matchesJsonSchema directly accepts InputStream
+        try (InputStream jsonSchema = Thread.currentThread().getContextClassLoader().getResourceAsStream(
+                "testJsonSchema/" + schemaFileName)) {
+            assertThat(jsonSchema).isNotNull();
+
+            given()
+                    .contentType(ContentType.JSON)
+                    .when()
+                    .get("/" + processId + "/schema")
+                    .then()
+                    .statusCode(200)
+                    .body(matchesJsonSchema(jsonSchema));
+        }
+
+    }
+}

--- a/integration-tests/integration-tests-quarkus-processes/src/test/java/org/kie/kogito/integrationtests/quarkus/TaskIT.java
+++ b/integration-tests/integration-tests-quarkus-processes/src/test/java/org/kie/kogito/integrationtests/quarkus/TaskIT.java
@@ -113,7 +113,7 @@ class TaskIT {
 
     @Test
     void testJsonSchemaFiles() {
-        long expectedJsonSchemas = 9;
+        long expectedJsonSchemas = 25;
         Path jsonDir = Paths.get("target", "classes").resolve(JsonSchemaUtil.getJsonDir());
         try (Stream<Path> paths = Files.walk(jsonDir)) {
             long generatedJsonSchemas = paths

--- a/integration-tests/integration-tests-quarkus-processes/src/test/resources/testJsonSchema/test_approvals.json
+++ b/integration-tests/integration-tests-quarkus-processes/src/test/resources/testJsonSchema/test_approvals.json
@@ -1,16 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "type": "object",
-  "properties": {
-    "approved": {
-      "type": "boolean",
-      "output": true
-    },
-    "traveller": {
-      "input": true,
-      "$ref": "#/definitions/Traveller"
-    }
-  },
   "definitions": {
     "Address": {
       "type": "object",
@@ -51,6 +40,21 @@
           "type": "boolean"
         }
       }
+    }
+  },
+  "type": "object",
+  "properties": {
+    "approver": {
+      "type": "string"
+    },
+    "firstLineApproval": {
+      "type": "boolean"
+    },
+    "secondLineApproval": {
+      "type": "boolean"
+    },
+    "traveller": {
+      "$ref": "#/definitions/Traveller"
     }
   }
 }

--- a/integration-tests/integration-tests-quarkus-processes/src/test/resources/testJsonSchema/test_approvals.json
+++ b/integration-tests/integration-tests-quarkus-processes/src/test/resources/testJsonSchema/test_approvals.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "definitions": {
     "Address": {
       "type": "object",

--- a/integration-tests/integration-tests-quarkus-processes/src/test/resources/testJsonSchema/test_approvals_firstLineApproval.json
+++ b/integration-tests/integration-tests-quarkus-processes/src/test/resources/testJsonSchema/test_approvals_firstLineApproval.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "type": "object",
   "properties": {
     "approved": {

--- a/integration-tests/integration-tests-quarkus-processes/src/test/resources/testJsonSchema/test_approvals_firstLineApproval_instance.json
+++ b/integration-tests/integration-tests-quarkus-processes/src/test/resources/testJsonSchema/test_approvals_firstLineApproval_instance.json
@@ -7,24 +7,33 @@
       "output": true
     },
     "traveller": {
+      "input": true,
+      "$ref": "#/definitions/Traveller"
+    }
+  },
+  "definitions": {
+    "Address": {
+      "type": "object",
+      "properties": {
+        "city": {
+          "type": "string"
+        },
+        "country": {
+          "type": "string"
+        },
+        "street": {
+          "type": "string"
+        },
+        "zipCode": {
+          "type": "string"
+        }
+      }
+    },
+    "Traveller": {
       "type": "object",
       "properties": {
         "address": {
-          "type": "object",
-          "properties": {
-            "city": {
-              "type": "string"
-            },
-            "country": {
-              "type": "string"
-            },
-            "street": {
-              "type": "string"
-            },
-            "zipCode": {
-              "type": "string"
-            }
-          }
+          "$ref": "#/definitions/Address"
         },
         "email": {
           "type": "string"
@@ -41,8 +50,7 @@
         "processed": {
           "type": "boolean"
         }
-      },
-      "input": true
+      }
     }
   },
   "phases": [

--- a/integration-tests/integration-tests-quarkus-processes/src/test/resources/testJsonSchema/test_approvals_firstLineApproval_instance.json
+++ b/integration-tests/integration-tests-quarkus-processes/src/test/resources/testJsonSchema/test_approvals_firstLineApproval_instance.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "type": "object",
   "properties": {
     "approved": {

--- a/integration-tests/integration-tests-quarkus-processes/src/test/resources/testJsonSchema/test_cinema.json
+++ b/integration-tests/integration-tests-quarkus-processes/src/test/resources/testJsonSchema/test_cinema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "definitions": {
     "Movie": {
       "type": "object",

--- a/integration-tests/integration-tests-quarkus-processes/src/test/resources/testJsonSchema/test_cinema.json
+++ b/integration-tests/integration-tests-quarkus-processes/src/test/resources/testJsonSchema/test_cinema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "Movie": {
+      "type": "object",
+      "properties": {
+        "genre": {
+          "$ref": "#/definitions/MovieGenre"
+        },
+        "name": {
+          "type": "string"
+        },
+        "rating": {
+          "$ref": "#/definitions/Rating"
+        },
+        "releaseYear": {
+          "type": "integer"
+        }
+      }
+    },
+    "MovieGenre": {
+      "type": "string",
+      "enum": [
+        "COMEDY",
+        "FANTASY",
+        "HORROR",
+        "SCI_FI",
+        "WESTERN"
+      ]
+    },
+    "Rating": {
+      "type": "string",
+      "enum": [
+        "G",
+        "NC_17",
+        "PG",
+        "PG_13",
+        "R",
+        "UR"
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "movie": {
+      "$ref": "#/definitions/Movie"
+    },
+    "rating": {}
+  }
+}

--- a/integration-tests/integration-tests-quarkus-processes/src/test/resources/testJsonSchema/test_greetings.json
+++ b/integration-tests/integration-tests-quarkus-processes/src/test/resources/testJsonSchema/test_greetings.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "type": "object",
   "properties": {
     "test": {

--- a/integration-tests/integration-tests-quarkus-processes/src/test/resources/testJsonSchema/test_greetings.json
+++ b/integration-tests/integration-tests-quarkus-processes/src/test/resources/testJsonSchema/test_greetings.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "test": {
+      "type": "string"
+    }
+  }
+}

--- a/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/main/java/org/acme/travels/Traveller.java
+++ b/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/main/java/org/acme/travels/Traveller.java
@@ -27,6 +27,10 @@ public class Traveller {
 
 	}
 
+	public Traveller(String firstName, String lastName, String email, String nationality) {
+		this(firstName, lastName, email, nationality, null);
+	}
+
 	public Traveller(String firstName, String lastName, String email, String nationality, Address address) {
 		super();
 		this.firstName = firstName;

--- a/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/test/java/org/kie/kogito/integrationtests/springboot/ProcessTest.java
+++ b/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/test/java/org/kie/kogito/integrationtests/springboot/ProcessTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.integrationtests.springboot;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+
+import org.acme.travels.Traveller;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchema;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = KogitoSpringbootApplication.class)
+public class ProcessTest {
+
+    @Test
+    void testProcessSchema() throws IOException {
+        testProcessSchema("approvals", "test_approvals.json");
+        testProcessSchema("cinema", "test_cinema.json");
+        testProcessSchema("greetings", "test_greetings.json");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testStartProcess() {
+        Traveller traveller = new Traveller("pepe", "rubiales", "pepe.rubiales@gmail.com", "Spanish");
+
+        String processId = given()
+                .contentType(ContentType.JSON)
+                .when()
+                .body(Collections.singletonMap("traveller", traveller))
+                .post("/approvals")
+                .then()
+                .statusCode(201)
+                .extract()
+                .path("id");
+
+        given()
+                .accept(ContentType.JSON)
+                .when()
+                .get("/approvals/{id}", processId)
+                .then()
+                .statusCode(200)
+                .body("id", equalTo(processId))
+                .body("traveller.firstName", equalTo(traveller.getFirstName()))
+                .body("traveller.lastName", equalTo(traveller.getLastName()))
+                .body("traveller.email", equalTo(traveller.getEmail()))
+                .body("traveller.nationality", equalTo(traveller.getNationality()));
+    }
+
+    private void testProcessSchema(String processId, String schemaFileName) throws IOException {
+        // Quarkus returns URI with "quarkus://" scheme when running via CLI and this is not compatible with
+        // matchesJsonSchemaInClasspath, while matchesJsonSchema directly accepts InputStream
+        try (InputStream jsonSchema = Thread.currentThread().getContextClassLoader().getResourceAsStream(
+                "testJsonSchema/" + schemaFileName)) {
+            assertThat(jsonSchema).isNotNull();
+
+            given()
+                    .contentType(ContentType.JSON)
+                    .when()
+                    .get("/" + processId + "/schema")
+                    .then()
+                    .statusCode(200)
+                    .body(matchesJsonSchema(jsonSchema));
+        }
+    }
+}

--- a/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/test/java/org/kie/kogito/integrationtests/springboot/TaskTest.java
+++ b/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/test/java/org/kie/kogito/integrationtests/springboot/TaskTest.java
@@ -98,7 +98,7 @@ public class TaskTest extends BaseRestTest {
 
     @Test
     void testJsonSchemaFiles() {
-        long expectedJsonSchemas = 9;
+        long expectedJsonSchemas = 19;
         Path jsonDir = Paths.get("target", "classes").resolve(JsonSchemaUtil.getJsonDir());
         try (Stream<Path> paths = Files.walk(jsonDir)) {
             long generatedJsonSchemas = paths

--- a/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/test/resources/testJsonSchema/test_approvals.json
+++ b/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/test/resources/testJsonSchema/test_approvals.json
@@ -1,16 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "type": "object",
-  "properties": {
-    "approved": {
-      "type": "boolean",
-      "output": true
-    },
-    "traveller": {
-      "input": true,
-      "$ref": "#/definitions/Traveller"
-    }
-  },
   "definitions": {
     "Address": {
       "type": "object",
@@ -51,6 +40,21 @@
           "type": "boolean"
         }
       }
+    }
+  },
+  "type": "object",
+  "properties": {
+    "approver": {
+      "type": "string"
+    },
+    "firstLineApproval": {
+      "type": "boolean"
+    },
+    "secondLineApproval": {
+      "type": "boolean"
+    },
+    "traveller": {
+      "$ref": "#/definitions/Traveller"
     }
   }
 }

--- a/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/test/resources/testJsonSchema/test_approvals.json
+++ b/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/test/resources/testJsonSchema/test_approvals.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "definitions": {
     "Address": {
       "type": "object",

--- a/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/test/resources/testJsonSchema/test_approvals_firstLineApproval.json
+++ b/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/test/resources/testJsonSchema/test_approvals_firstLineApproval.json
@@ -2,25 +2,38 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
+    "approved": {
+      "type": "boolean",
+      "output": true
+    },
     "traveller": {
+      "input": true,
+      "$ref": "#/definitions/Traveller"
+    }
+  },
+  "definitions": {
+    "Address": {
+      "type": "object",
+      "properties": {
+        "city": {
+          "type": "string"
+        },
+        "country": {
+          "type": "string"
+        },
+        "street": {
+          "type": "string"
+        },
+        "zipCode": {
+          "type": "string"
+        }
+      }
+    },
+    "Traveller": {
       "type": "object",
       "properties": {
         "address": {
-          "type": "object",
-          "properties": {
-            "city": {
-              "type": "string"
-            },
-            "country": {
-              "type": "string"
-            },
-            "street": {
-              "type": "string"
-            },
-            "zipCode": {
-              "type": "string"
-            }
-          }
+          "$ref": "#/definitions/Address"
         },
         "email": {
           "type": "string"
@@ -33,13 +46,11 @@
         },
         "nationality": {
           "type": "string"
+        },
+        "processed": {
+          "type": "boolean"
         }
-      },
-      "input": true
-    },
-    "approved": {
-      "type": "boolean",
-      "output": true
+      }
     }
   }
 }

--- a/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/test/resources/testJsonSchema/test_approvals_firstLineApproval.json
+++ b/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/test/resources/testJsonSchema/test_approvals_firstLineApproval.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "type": "object",
   "properties": {
     "approved": {

--- a/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/test/resources/testJsonSchema/test_approvals_firstLineApproval_instance.json
+++ b/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/test/resources/testJsonSchema/test_approvals_firstLineApproval_instance.json
@@ -7,24 +7,33 @@
       "output": true
     },
     "traveller": {
+      "input": true,
+      "$ref": "#/definitions/Traveller"
+    }
+  },
+  "definitions": {
+    "Address": {
+      "type": "object",
+      "properties": {
+        "city": {
+          "type": "string"
+        },
+        "country": {
+          "type": "string"
+        },
+        "street": {
+          "type": "string"
+        },
+        "zipCode": {
+          "type": "string"
+        }
+      }
+    },
+    "Traveller": {
       "type": "object",
       "properties": {
         "address": {
-          "type": "object",
-          "properties": {
-            "city": {
-              "type": "string"
-            },
-            "country": {
-              "type": "string"
-            },
-            "street": {
-              "type": "string"
-            },
-            "zipCode": {
-              "type": "string"
-            }
-          }
+          "$ref": "#/definitions/Address"
         },
         "email": {
           "type": "string"
@@ -41,8 +50,7 @@
         "processed": {
           "type": "boolean"
         }
-      },
-      "input": true
+      }
     }
   },
   "phases": [

--- a/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/test/resources/testJsonSchema/test_approvals_firstLineApproval_instance.json
+++ b/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/test/resources/testJsonSchema/test_approvals_firstLineApproval_instance.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "type": "object",
   "properties": {
     "approved": {

--- a/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/test/resources/testJsonSchema/test_cinema.json
+++ b/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/test/resources/testJsonSchema/test_cinema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "definitions": {
     "Movie": {
       "type": "object",

--- a/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/test/resources/testJsonSchema/test_cinema.json
+++ b/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/test/resources/testJsonSchema/test_cinema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "Movie": {
+      "type": "object",
+      "properties": {
+        "genre": {
+          "$ref": "#/definitions/MovieGenre"
+        },
+        "name": {
+          "type": "string"
+        },
+        "rating": {
+          "$ref": "#/definitions/Rating"
+        },
+        "releaseYear": {
+          "type": "integer"
+        }
+      }
+    },
+    "MovieGenre": {
+      "type": "string",
+      "enum": [
+        "COMEDY",
+        "FANTASY",
+        "HORROR",
+        "SCI_FI",
+        "WESTERN"
+      ]
+    },
+    "Rating": {
+      "type": "string",
+      "enum": [
+        "G",
+        "NC_17",
+        "PG",
+        "PG_13",
+        "R",
+        "UR"
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "movie": {
+      "$ref": "#/definitions/Movie"
+    },
+    "rating": {}
+  }
+}

--- a/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/test/resources/testJsonSchema/test_greetings.json
+++ b/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/test/resources/testJsonSchema/test_greetings.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "type": "object",
   "properties": {
     "test": {

--- a/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/test/resources/testJsonSchema/test_greetings.json
+++ b/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/test/resources/testJsonSchema/test_greetings.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "test": {
+      "type": "string"
+    }
+  }
+}

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ProcessToExecModelGenerator.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ProcessToExecModelGenerator.java
@@ -215,11 +215,10 @@ public class ProcessToExecModelGenerator {
 
         @Override
         public void accept(CompilationUnit cu) {
-            Optional<ClassOrInterfaceDeclaration> clazz = cu.findFirst(ClassOrInterfaceDeclaration.class);
-            if (clazz.isEmpty()) {
-                throw new NoSuchElementException("Cannot find class declaration in the template");
-            }
-            clazz.get().addAndGetAnnotation(ProcessInput.class)
+            ClassOrInterfaceDeclaration clazz = cu.findFirst(ClassOrInterfaceDeclaration.class)
+                    .orElseThrow(() -> new NoSuchElementException("Cannot find class declaration in the template"));
+
+            clazz.addAndGetAnnotation(ProcessInput.class)
                     .addPair(PROCESS_NAME_PARAM, new StringLiteralExpr(processId));
         }
     }

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ProcessToExecModelGenerator.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ProcessToExecModelGenerator.java
@@ -60,6 +60,7 @@ public class ProcessToExecModelGenerator {
     private static final String PROCESS_CLASS_SUFFIX = "Process";
     private static final String MODEL_CLASS_SUFFIX = "Model";
     private static final String PROCESS_TEMPLATE_FILE = "/class-templates/ProcessTemplate.java";
+    private static final String PROCESS_NAME_PARAM = "processName";
 
     private final ProcessVisitor processVisitor;
 
@@ -219,7 +220,7 @@ public class ProcessToExecModelGenerator {
                 throw new NoSuchElementException("Cannot find class declaration in the template");
             }
             clazz.get().addAndGetAnnotation(ProcessInput.class)
-                    .addPair(ProcessInput.PROCESS_NAME_PARAM, new StringLiteralExpr(processId));
+                    .addPair(PROCESS_NAME_PARAM, new StringLiteralExpr(processId));
         }
     }
 

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/util/JsonSchemaUtil.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/util/JsonSchemaUtil.java
@@ -43,8 +43,12 @@ public class JsonSchemaUtil {
     private static ObjectMapper mapper = new ObjectMapper();
     private static Path jsonDir = Paths.get("META-INF", "jsonSchema");
 
+    public static String getJsonSchemaName(String id) {
+        return id.replace('.', '#').replaceAll("\\s", "_");
+    }
+
     public static String getJsonSchemaName(String processId, String taskName) {
-        return (processId + "_" + taskName).replace('.', '#').replaceAll("\\s", "_");
+        return getJsonSchemaName(processId + "_" + taskName);
     }
 
     public static Path getJsonDir() {
@@ -55,8 +59,16 @@ public class JsonSchemaUtil {
         return key + ".json";
     }
 
+    public static Map<String, Object> load(ClassLoader cl, String processId) {
+        return loadSchema(cl, processId);
+    }
+
     public static Map<String, Object> load(ClassLoader cl, String processId, String taskName) {
-        Path jsonFile = jsonDir.resolve(getFileName(getJsonSchemaName(processId, taskName)));
+        return loadSchema(cl, getJsonSchemaName(processId, taskName));
+    }
+
+    private static Map<String, Object> loadSchema(ClassLoader cl, String schemaId) {
+        Path jsonFile = jsonDir.resolve(getFileName(schemaId));
         try (InputStream in = cl.getResourceAsStream(jsonFile.toString())) {
             if (in == null) {
                 throw new IllegalArgumentException("Cannot find file " + jsonFile + " in classpath");

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/json/JsonSchemaGenerator.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/json/JsonSchemaGenerator.java
@@ -22,14 +22,17 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.jbpm.util.JsonSchemaUtil;
+import org.kie.kogito.ProcessInput;
 import org.kie.kogito.UserTask;
 import org.kie.kogito.UserTaskParam;
+import org.kie.kogito.codegen.VariableInfo;
 import org.kie.kogito.codegen.api.GeneratedFile;
 import org.kie.kogito.codegen.api.GeneratedFileType;
 import org.slf4j.Logger;
@@ -41,11 +44,17 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.victools.jsonschema.generator.CustomDefinition.AttributeInclusion;
 import com.github.victools.jsonschema.generator.CustomPropertyDefinition;
 import com.github.victools.jsonschema.generator.FieldScope;
+import com.github.victools.jsonschema.generator.Option;
 import com.github.victools.jsonschema.generator.OptionPreset;
 import com.github.victools.jsonschema.generator.SchemaGenerationContext;
 import com.github.victools.jsonschema.generator.SchemaGenerator;
 import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
+import com.github.victools.jsonschema.generator.SchemaKeyword;
 import com.github.victools.jsonschema.generator.SchemaVersion;
+import com.github.victools.jsonschema.generator.impl.DefinitionKey;
+import com.github.victools.jsonschema.generator.impl.SchemaGenerationContextImpl;
+import com.github.victools.jsonschema.generator.naming.DefaultSchemaDefinitionNamingStrategy;
+import com.github.victools.jsonschema.generator.naming.SchemaDefinitionNamingStrategy;
 
 public class JsonSchemaGenerator {
 
@@ -59,8 +68,8 @@ public class JsonSchemaGenerator {
     public static class ClassBuilder {
 
         private Stream<Class<?>> stream;
-        private Function<? super Class<?>, String> getSchemaName = JsonSchemaGenerator::getKey;
-        private Predicate<? super Class<?>> shouldGenSchema = JsonSchemaGenerator::isUserTaskClass;
+        private Function<? super Class<?>, String> getSchemaName = JsonSchemaGenerator::getSchemaName;
+        private Predicate<? super Class<?>> shouldGenSchema = JsonSchemaGenerator::shouldGenSchema;
         private SchemaVersion schemaVersion = DEFAULT_SCHEMA_VERSION;
 
         public ClassBuilder(Stream<Class<?>> stream) {
@@ -85,20 +94,19 @@ public class JsonSchemaGenerator {
         public JsonSchemaGenerator build() {
             Map<String, List<Class<?>>> map = stream
                     .filter(shouldGenSchema)
-                    .filter(this::ensureNotNull)
+                    .filter(this::ensureHasAnnotations)
                     .collect(Collectors.groupingBy(getSchemaName));
 
             return new JsonSchemaGenerator(map, schemaVersion);
         }
 
-        private boolean ensureNotNull(Class<?> c) {
-            UserTask userTask = c.getAnnotation(UserTask.class);
-            boolean isNull = userTask == null;
-            if (isNull) {
-                logger.warn("Could not retrieve UserTask annotation from class {} but was expected. " +
+        private boolean ensureHasAnnotations(Class<?> c) {
+            boolean needsJsonSchema = shouldGenSchema(c);
+            if (!needsJsonSchema) {
+                logger.warn("Could not retrieve neither UserTask nor Process annotation from class {} but was expected. " +
                         "This may be a class loader bug. If JsonSchemas have been generated you may ignore this message.", c);
             }
-            return !isNull;
+            return needsJsonSchema;
         }
     }
 
@@ -108,9 +116,14 @@ public class JsonSchemaGenerator {
     }
 
     public Collection<GeneratedFile> generate() throws IOException {
+
         SchemaGeneratorConfigBuilder builder = new SchemaGeneratorConfigBuilder(schemaVersion, OptionPreset.PLAIN_JSON);
-        builder.forTypesInGeneral().withStringFormatResolver(target -> target.getSimpleTypeDescription().equals("Date") ? "date-time" : null);
-        builder.forFields().withIgnoreCheck(JsonSchemaGenerator::isNotUserTaskParam).withCustomDefinitionProvider(this::getInputOutput);
+        builder.with(Option.DEFINITIONS_FOR_ALL_OBJECTS);
+        builder.forTypesInGeneral()
+                .withStringFormatResolver(target -> target.getSimpleTypeDescription().equals("Date") ? "date-time" : null);
+        builder.forFields()
+                .withIgnoreCheck(JsonSchemaGenerator::checkFields)
+                .withCustomDefinitionProvider(this::getInputOutput);
         SchemaGenerator generator = new SchemaGenerator(builder.build());
         ObjectWriter writer = new ObjectMapper().writer();
 
@@ -133,26 +146,44 @@ public class JsonSchemaGenerator {
         return files;
     }
 
-    private CustomPropertyDefinition getInputOutput(FieldScope f, SchemaGenerationContext context) {
-        UserTaskParam param = f.getAnnotation(UserTaskParam.class);
-        ObjectNode objectNode = context.createDefinition(f.getDeclaredType());
+    private CustomPropertyDefinition getInputOutput(FieldScope scope, SchemaGenerationContext context) {
+        UserTaskParam param = scope.getAnnotation(UserTaskParam.class);
+
         if (param != null) {
+            ObjectNode objectNode = context.createStandardDefinitionReference(scope.getDeclaredType(), null);
             objectNode.put(param.value().toString().toLowerCase(), true);
+
+            Optional<DefinitionKey> optional = ((SchemaGenerationContextImpl) context).getDefinedTypes().stream().filter(key -> key.getType().equals(scope.getDeclaredType())).findFirst();
+
+            if (optional.isPresent()) {
+                DefinitionKey definitionKey = ((SchemaGenerationContextImpl) context).getDefinedTypes().stream().filter(key -> key.getType().equals(scope.getDeclaredType())).findFirst().get();
+                SchemaDefinitionNamingStrategy strategy = Optional.ofNullable(context.getGeneratorConfig().getDefinitionNamingStrategy()).orElse(new DefaultSchemaDefinitionNamingStrategy());
+                String refPath =
+                        context.getKeyword(SchemaKeyword.TAG_REF_MAIN) + "/" + context.getKeyword(SchemaKeyword.TAG_DEFINITIONS) + "/" + strategy.getDefinitionNameForKey(definitionKey, context);
+                objectNode.put(context.getKeyword(SchemaKeyword.TAG_REF), refPath);
+            }
+
+            return new CustomPropertyDefinition(objectNode, AttributeInclusion.YES);
         }
-        return new CustomPropertyDefinition(objectNode, AttributeInclusion.NO);
+        return null;
     }
 
-    private static String getKey(Class<?> c) {
+    private static String getSchemaName(Class<?> c) {
+        if (c.isAnnotationPresent(ProcessInput.class)) {
+            ProcessInput process = c.getAnnotation(ProcessInput.class);
+            return JsonSchemaUtil.getJsonSchemaName(process.processName());
+        }
         UserTask userTask = c.getAnnotation(UserTask.class);
         return JsonSchemaUtil.getJsonSchemaName(userTask.processName(), userTask.taskName());
     }
 
-    private static boolean isUserTaskClass(Class<?> c) {
-        return c.isAnnotationPresent(UserTask.class);
+    private static boolean shouldGenSchema(Class<?> c) {
+        return c.isAnnotationPresent(UserTask.class) || c.isAnnotationPresent(ProcessInput.class);
     }
 
-    private static boolean isNotUserTaskParam(FieldScope fieldScope) {
-        return fieldScope.getDeclaringType().getErasedType().isAnnotationPresent(UserTask.class) && fieldScope.getAnnotation(UserTaskParam.class) == null;
+    private static boolean checkFields(FieldScope fieldScope) {
+        return (fieldScope.getDeclaringType().getErasedType().isAnnotationPresent(UserTask.class) && fieldScope.getAnnotation(UserTaskParam.class) == null)
+                || (fieldScope.getDeclaringType().getErasedType().isAnnotationPresent(ProcessInput.class) && fieldScope.getAnnotation(VariableInfo.class) == null);
     }
 
     private Path pathFor(String name) {

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/json/JsonSchemaGenerator.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/json/JsonSchemaGenerator.java
@@ -72,7 +72,7 @@ public class JsonSchemaGenerator {
 
         private Stream<Class<?>> stream;
         private Function<? super Class<?>, String> getSchemaName = JsonSchemaGenerator::getSchemaName;
-        private Predicate<? super Class<?>> shouldGenSchema = JsonSchemaGenerator::shouldGenSchema;
+        private Predicate<? super Class<?>> shouldGenSchema = clazz -> true;
         private SchemaVersion schemaVersion = DEFAULT_SCHEMA_VERSION;
 
         public ClassBuilder(Stream<Class<?>> stream) {
@@ -104,7 +104,7 @@ public class JsonSchemaGenerator {
         }
 
         private boolean ensureHasAnnotations(Class<?> c) {
-            boolean needsJsonSchema = shouldGenSchema(c);
+            boolean needsJsonSchema = c.isAnnotationPresent(UserTask.class) || c.isAnnotationPresent(ProcessInput.class);
             if (!needsJsonSchema) {
                 logger.warn("Could not retrieve neither UserTask nor Process annotation from class {} but was expected. " +
                         "This may be a class loader bug. If JsonSchemas have been generated you may ignore this message.", c);
@@ -189,10 +189,6 @@ public class JsonSchemaGenerator {
         }
         UserTask userTask = c.getAnnotation(UserTask.class);
         return JsonSchemaUtil.getJsonSchemaName(userTask.processName(), userTask.taskName());
-    }
-
-    private static boolean shouldGenSchema(Class<?> c) {
-        return c.isAnnotationPresent(UserTask.class) || c.isAnnotationPresent(ProcessInput.class);
     }
 
     private static boolean checkFields(FieldScope fieldScope) {

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/json/JsonUtils.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/json/JsonUtils.java
@@ -38,16 +38,16 @@ import com.fasterxml.jackson.databind.node.ValueNode;
 
 public class JsonUtils {
 
+    private static final Logger logger = LoggerFactory.getLogger(JsonUtils.class);
+
     /* see https://stackoverflow.com/questions/9895041/merging-two-json-documents-using-jackson for alternative approaches to merge */
     private JsonUtils() {
     }
 
-    private static final Logger logger = LoggerFactory.getLogger(JsonUtils.class);
-
     /**
      * Merge two JSON documents.
      *
-     * @param src    JsonNode to be merged
+     * @param src JsonNode to be merged
      * @param target JsonNode to merge to
      */
     public static void merge(JsonNode src, JsonNode target) {
@@ -127,8 +127,8 @@ public class JsonUtils {
     }
 
     private static void updateObject(JsonNode target,
-                                     ValueNode value,
-                                     Map.Entry<String, JsonNode> src) {
+            ValueNode value,
+            Map.Entry<String, JsonNode> src) {
         boolean newEntry = true;
         Iterator<Map.Entry<String, JsonNode>> iter = target.fields();
         while (iter.hasNext()) {

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/RestResourceQuarkusTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/RestResourceQuarkusTemplate.java
@@ -86,6 +86,14 @@ public class $Type$Resource {
     }
 
     @GET
+    @Path("schema")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Map<String, Object> getResourceSchema_$name$() {
+        return JsonSchemaUtil.load(this.getClass().getClassLoader(), process.id());
+    }
+
+
+    @GET
     @Path("/{id}")
     @Produces(MediaType.APPLICATION_JSON)
     public $Type$Output getResource_$name$(@PathParam("id") String id) {

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/RestResourceSpringTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/RestResourceSpringTemplate.java
@@ -82,6 +82,11 @@ public class $Type$Resource {
         return processService.getProcessInstanceOutput(process);
     }
 
+    @GetMapping(value = "/schema", produces = MediaType.APPLICATION_JSON_VALUE)
+    public Map<String, Object> getResourceSchema_$name$() {
+        return JsonSchemaUtil.load(this.getClass().getClassLoader(), process.id());
+    }
+
     @GetMapping(value = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
     public $Type$Output getResource_$name$(@PathVariable("id") String id) {
         return processService.findById(process, id).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));

--- a/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/json/JsonSchemaGeneratorTest.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/json/JsonSchemaGeneratorTest.java
@@ -19,13 +19,16 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Date;
 import java.util.EnumSet;
+import java.util.Iterator;
 import java.util.Set;
 import java.util.stream.Stream;
 
 import org.jbpm.util.JsonSchemaUtil;
 import org.junit.jupiter.api.Test;
+import org.kie.kogito.ProcessInput;
 import org.kie.kogito.UserTask;
 import org.kie.kogito.UserTaskParam;
+import org.kie.kogito.codegen.VariableInfo;
 import org.kie.kogito.codegen.api.GeneratedFile;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -36,6 +39,8 @@ import com.github.victools.jsonschema.generator.SchemaVersion;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -98,6 +103,36 @@ public class JsonSchemaGeneratorTest {
         private String name;
     }
 
+    @ProcessInput(processName = "processName")
+    private static class ProcessInputModel {
+
+        @VariableInfo
+        private Color color;
+
+        @VariableInfo
+        private Person person;
+    }
+
+    @ProcessInput(processName = "emptyProcessName")
+    private static class EmptyProcessInputModel {
+
+        private Color color;
+
+        private Person person;
+    }
+
+    private static class Person {
+
+        @SuppressWarnings("unused")
+        private String name;
+        @SuppressWarnings("unused")
+        private int age;
+        @SuppressWarnings("unused")
+        private Address address;
+        @SuppressWarnings("unused")
+        private Person parent;
+    }
+
     private static class Address {
 
         @SuppressWarnings("unused")
@@ -116,11 +151,13 @@ public class JsonSchemaGeneratorTest {
     public void testJsonSchemaGenerator() throws IOException {
         Collection<GeneratedFile> files =
                 new JsonSchemaGenerator.ClassBuilder(
-                        Stream.of(PersonInputParams.class, PersonOutputParams.class, IgnoredClass.class))
+                        Stream.of(EmptyProcessInputModel.class, PersonInputParams.class, ProcessInputModel.class, PersonOutputParams.class, IgnoredClass.class))
                                 .build().generate();
-        assertEquals(1, files.size());
-        GeneratedFile file = files.iterator().next();
-        assertSchema("org#jbpm#test_test.json", file, SchemaVersion.DRAFT_7);
+        assertEquals(3, files.size());
+        Iterator<GeneratedFile> iterator = files.iterator();
+        assertEmptyProcessSchema("emptyProcessName.json", iterator.next(), SchemaVersion.DRAFT_7);
+        assertProcessSchema("processName.json", iterator.next(), SchemaVersion.DRAFT_7);
+        assertTaskSchema("org#jbpm#test_test.json", iterator.next(), SchemaVersion.DRAFT_7);
     }
 
     @Test
@@ -139,11 +176,13 @@ public class JsonSchemaGeneratorTest {
     public void testJsonSchemaGeneratorDraft2019() throws IOException {
         Collection<GeneratedFile> files =
                 new JsonSchemaGenerator.ClassBuilder(
-                        Stream.of(PersonInputParams.class, PersonOutputParams.class, IgnoredClass.class))
+                        Stream.of(EmptyProcessInputModel.class, PersonInputParams.class, ProcessInputModel.class, PersonOutputParams.class, IgnoredClass.class))
                                 .withSchemaVersion("DRAFT_2019_09").build().generate();
-        assertEquals(1, files.size());
-        GeneratedFile file = files.iterator().next();
-        assertSchema("org#jbpm#test_test.json", file, SchemaVersion.DRAFT_2019_09);
+        assertEquals(3, files.size());
+        Iterator<GeneratedFile> iterator = files.iterator();
+        assertEmptyProcessSchema("emptyProcessName.json", iterator.next(), SchemaVersion.DRAFT_2019_09);
+        assertProcessSchema("processName.json", iterator.next(), SchemaVersion.DRAFT_2019_09);
+        assertTaskSchema("org#jbpm#test_test.json", iterator.next(), SchemaVersion.DRAFT_2019_09);
     }
 
     @Test
@@ -151,7 +190,7 @@ public class JsonSchemaGeneratorTest {
         Collection<GeneratedFile> files = new JsonSchemaGenerator.ClassBuilder(Stream.of(PersonInputOutputParams.class)).build().generate();
         assertEquals(1, files.size());
         GeneratedFile file = files.iterator().next();
-        assertSchema("InputOutput_test.json", file, SchemaVersion.DRAFT_7);
+        assertTaskSchema("InputOutput_test.json", file, SchemaVersion.DRAFT_7);
     }
 
     @Test
@@ -168,29 +207,111 @@ public class JsonSchemaGeneratorTest {
         assertTrue(files.isEmpty());
     }
 
-    private void assertSchema(String fileName, GeneratedFile file, SchemaVersion schemaVersion) throws IOException {
+    @Test
+    public void testJsonSchemaGenerationForProcess() throws IOException {
+        Collection<GeneratedFile> files = new JsonSchemaGenerator.ClassBuilder(Stream.of(ProcessInputModel.class)).build().generate();
+        assertEquals(1, files.size());
+        assertProcessSchema("processName.json", files.iterator().next(), SchemaVersion.DRAFT_7);
+    }
+
+    @Test
+    public void testJsonSchemaGenerationForEmptyProcessModel() throws IOException {
+        Collection<GeneratedFile> files = new JsonSchemaGenerator.ClassBuilder(Stream.of(EmptyProcessInputModel.class)).build().generate();
+        assertEquals(1, files.size());
+
+        assertEmptyProcessSchema("emptyProcessName.json", files.iterator().next(), SchemaVersion.DRAFT_7);
+    }
+
+    private void assertEmptyProcessSchema(String fileName, GeneratedFile file, SchemaVersion schemaVersion) throws IOException {
+        assertEquals(JsonSchemaUtil.getJsonDir().resolve(fileName).toString(), file.relativePath());
+
+        ObjectReader reader = new ObjectMapper().reader();
+        JsonNode node = reader.readTree(file.contents());
+
+        assertEquals(schemaVersion.getIdentifier(), node.get("$schema").asText());
+        assertEquals("object", node.get("type").asText());
+        assertNull(node.get("properties"));
+    }
+
+    private void assertProcessSchema(String fileName, GeneratedFile file, SchemaVersion schemaVersion) throws IOException {
         assertEquals(JsonSchemaUtil.getJsonDir().resolve(fileName).toString(), file.relativePath());
         ObjectReader reader = new ObjectMapper().reader();
         JsonNode node = reader.readTree(file.contents());
         assertEquals(schemaVersion.getIdentifier(), node.get("$schema").asText());
+
+        // assert definitions
+        String definitionsPath = resolveDefinitionsProperty(schemaVersion);
+        assertEquals(3, node.get(definitionsPath).size());
+        assertPersonNode(node.get(definitionsPath).get("Person"), definitionsPath);
+        assertAddressNode(node.get(definitionsPath).get("Address"));
+        assertColorNode(node.get(definitionsPath).get("Color"));
+
+        assertEquals("object", node.get("type").asText());
+        JsonNode properties = node.get("properties");
+        assertEquals(2, properties.size());
+        JsonNode color = properties.get("color");
+        assertEquals("#/" + definitionsPath + "/Color", color.get("$ref").asText());
+        JsonNode address = properties.get("person");
+        assertEquals("#/" + definitionsPath + "/Person", address.get("$ref").asText());
+    }
+
+    private void assertTaskSchema(String fileName, GeneratedFile file, SchemaVersion schemaVersion) throws IOException {
+        assertEquals(JsonSchemaUtil.getJsonDir().resolve(fileName).toString(), file.relativePath());
+        ObjectReader reader = new ObjectMapper().reader();
+        JsonNode node = reader.readTree(file.contents());
+        assertEquals(schemaVersion.getIdentifier(), node.get("$schema").asText());
+
+        // assert definitions
+        String definitionsPath = resolveDefinitionsProperty(schemaVersion);
+        assertEquals(2, node.get(definitionsPath).size());
+        assertAddressNode(node.get(definitionsPath).get("Address"));
+        assertColorNode(node.get(definitionsPath).get("Color"));
+
         assertEquals("object", node.get("type").asText());
         JsonNode properties = node.get("properties");
         assertEquals(4, properties.size());
         assertEquals("integer", properties.get("age").get("type").asText());
         assertEquals("string", properties.get("name").get("type").asText());
         JsonNode color = properties.get("color");
-        assertEquals("string", color.get("type").asText());
-        assertTrue(color.get("enum") instanceof ArrayNode);
-        ArrayNode colors = (ArrayNode) color.get("enum");
-        Set<Color> colorValues = EnumSet.noneOf(Color.class);
-        colors.forEach(x -> colorValues.add(Color.valueOf(x.asText())));
-        assertArrayEquals(Color.values(), colorValues.toArray());
+        assertEquals("#/" + definitionsPath + "/Color", color.get("$ref").asText());
         JsonNode address = properties.get("address");
-        assertEquals("object", address.get("type").asText());
-        JsonNode addressProperties = address.get("properties");
+        assertEquals("#/" + definitionsPath + "/Address", address.get("$ref").asText());
+    }
+
+    private void assertPersonNode(JsonNode personNode, String definitionsPath) {
+        assertNotNull(personNode);
+
+        assertEquals("object", personNode.get("type").asText());
+        JsonNode personProperties = personNode.get("properties");
+        assertEquals("string", personProperties.get("name").get("type").asText());
+        assertEquals("integer", personProperties.get("age").get("type").asText());
+        assertEquals("#/" + definitionsPath + "/Address", personProperties.get("address").get("$ref").asText());
+        assertEquals("#/" + definitionsPath + "/Person", personProperties.get("parent").get("$ref").asText());
+    }
+
+    private void assertAddressNode(JsonNode addressNode) {
+        assertNotNull(addressNode);
+
+        assertEquals("object", addressNode.get("type").asText());
+        JsonNode addressProperties = addressNode.get("properties");
         assertEquals("string", addressProperties.get("street").get("type").asText());
         JsonNode dateNode = addressProperties.get("date");
         assertEquals("string", dateNode.get("type").asText());
         assertEquals("date-time", dateNode.get("format").asText());
+    }
+
+    private void assertColorNode(JsonNode colorNode) {
+        assertNotNull(colorNode);
+
+        assertEquals("string", colorNode.get("type").asText());
+        assertTrue(colorNode.get("enum") instanceof ArrayNode);
+        ArrayNode colors = (ArrayNode) colorNode.get("enum");
+        Set<Color> colorValues = EnumSet.noneOf(Color.class);
+        colors.forEach(x -> colorValues.add(Color.valueOf(x.asText())));
+        assertArrayEquals(Color.values(), colorValues.toArray());
+    }
+
+    private String resolveDefinitionsProperty(SchemaVersion schemaVersion) {
+        return SchemaVersion.DRAFT_7.equals(schemaVersion) ? "definitions" : "$defs";
     }
 }

--- a/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/json/JsonUtilsTest.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/json/JsonUtilsTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class JsonUtilsTest {
 
     @Test
-    public void testMerge() {
+    public void testFullMerge() {
         ObjectMapper mapper = new ObjectMapper();
 
         JsonNode node1 = createJson(mapper, createJson(mapper, "numbers", Arrays.asList(1, 2, 3)));
@@ -52,12 +52,59 @@ public class JsonUtilsTest {
         JsonNode numbers = merged.get("numbers");
         assertTrue(numbers instanceof ArrayNode);
         ArrayNode numbersNode = (ArrayNode) numbers;
-        assertEquals(4, numbersNode.get(0).asInt());
-        assertEquals(5, numbersNode.get(1).asInt());
-        assertEquals(6, numbersNode.get(2).asInt());
+        assertEquals(6, numbersNode.size());
+        assertEquals(1, numbersNode.get(0).asInt());
+        assertEquals(2, numbersNode.get(1).asInt());
+        assertEquals(3, numbersNode.get(2).asInt());
+        assertEquals(4, numbersNode.get(3).asInt());
+        assertEquals(5, numbersNode.get(4).asInt());
+        assertEquals(6, numbersNode.get(5).asInt());
         assertEquals(false, merged.get("boolean").asBoolean());
         assertEquals("javier", merged.get("string").asText());
         assertEquals(1, merged.get("number").asInt());
+    }
+
+    @Test
+    public void testArrayIntoObjectMerge() {
+        ObjectMapper mapper = new ObjectMapper();
+
+        JsonNode src = createJson(mapper, createJson(mapper, "property", Arrays.asList(1, 2, 3)));
+        JsonNode target = createJson(mapper, mapper.createObjectNode().put("property", 4));
+
+        JsonUtils.merge(src, target);
+
+        assertEquals(1, target.size());
+        JsonNode merged = target.get("merged");
+        assertEquals(1, merged.size());
+        JsonNode property = merged.get("property");
+        assertTrue(property instanceof ArrayNode);
+        ArrayNode propertyNode = (ArrayNode) property;
+        assertEquals(4, propertyNode.size());
+        assertEquals(1, propertyNode.get(0).asInt());
+        assertEquals(2, propertyNode.get(1).asInt());
+        assertEquals(3, propertyNode.get(2).asInt());
+        assertEquals(4, propertyNode.get(3).asInt());
+    }
+
+    @Test
+    public void testArrayIntoNewPropertyMerge() {
+        ObjectMapper mapper = new ObjectMapper();
+
+        JsonNode src = createJson(mapper, createJson(mapper, "property", Arrays.asList(1, 2, 3)));
+        JsonNode target = createJson(mapper, mapper.createObjectNode());
+
+        JsonUtils.merge(src, target);
+
+        assertEquals(1, target.size());
+        JsonNode merged = target.get("merged");
+        assertEquals(1, merged.size());
+        JsonNode property = merged.get("property");
+        assertTrue(property instanceof ArrayNode);
+        ArrayNode propertyNode = (ArrayNode) property;
+        assertEquals(3, propertyNode.size());
+        assertEquals(1, propertyNode.get(0).asInt());
+        assertEquals(2, propertyNode.get(1).asInt());
+        assertEquals(3, propertyNode.get(2).asInt());
     }
 
     private JsonNode createJson(ObjectMapper mapper, String name, Collection<Integer> integers) {

--- a/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/json/JsonUtilsTest.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/json/JsonUtilsTest.java
@@ -80,10 +80,10 @@ public class JsonUtilsTest {
         assertTrue(property instanceof ArrayNode);
         ArrayNode propertyNode = (ArrayNode) property;
         assertEquals(4, propertyNode.size());
-        assertEquals(1, propertyNode.get(0).asInt());
-        assertEquals(2, propertyNode.get(1).asInt());
-        assertEquals(3, propertyNode.get(2).asInt());
-        assertEquals(4, propertyNode.get(3).asInt());
+        assertEquals(4, propertyNode.get(0).asInt());
+        assertEquals(1, propertyNode.get(1).asInt());
+        assertEquals(2, propertyNode.get(2).asInt());
+        assertEquals(3, propertyNode.get(3).asInt());
     }
 
     @Test

--- a/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/ProcessClassesMojo.java
+++ b/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/ProcessClassesMojo.java
@@ -35,6 +35,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.drools.compiler.compiler.io.memory.MemoryFileSystem;
 import org.kie.kogito.Model;
+import org.kie.kogito.ProcessInput;
 import org.kie.kogito.UserTask;
 import org.kie.kogito.codegen.api.GeneratedFile;
 import org.kie.kogito.codegen.api.GeneratedFileType;
@@ -119,8 +120,11 @@ public class ProcessClassesMojo extends AbstractKieMojo {
                 generatedResources.forEach(this::writeGeneratedFile);
 
                 // Json schema generation
-                Stream<Class<?>> classStream = reflections.getTypesAnnotatedWith(UserTask.class).stream();
-                generateJsonSchema(classStream).forEach(this::writeGeneratedFile);
+                Stream<Class<?>> processClassStream = reflections.getTypesAnnotatedWith(ProcessInput.class).stream();
+                generateJsonSchema(processClassStream).forEach(this::writeGeneratedFile);
+
+                Stream<Class<?>> userTaskClassStream = reflections.getTypesAnnotatedWith(UserTask.class).stream();
+                generateJsonSchema(userTaskClassStream).forEach(this::writeGeneratedFile);
             }
         } catch (Exception e) {
             throw new MojoExecutionException("Error during processing model classes", e);

--- a/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/ProcessClassesMojo.java
+++ b/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/ProcessClassesMojo.java
@@ -159,7 +159,6 @@ public class ProcessClassesMojo extends AbstractKieMojo {
 
     private Collection<GeneratedFile> generateJsonSchema(Stream<Class<?>> classes) throws IOException {
         return new JsonSchemaGenerator.ClassBuilder(classes)
-                .withGenSchemaPredicate(x -> true)
                 .withSchemaVersion(schemaVersion).build()
                 .generate();
     }

--- a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-deployment/src/main/java/org/kie/kogito/quarkus/processes/deployment/ProcessesAssetsProcessor.java
+++ b/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-deployment/src/main/java/org/kie/kogito/quarkus/processes/deployment/ProcessesAssetsProcessor.java
@@ -272,16 +272,14 @@ public class ProcessesAssetsProcessor {
         annotations.addAll(index.getAnnotations(DotName.createSimple(ProcessInput.class.getCanonicalName())));
         annotations.addAll(index.getAnnotations(DotName.createSimple(UserTask.class.getCanonicalName())));
 
-        System.out.println(annotations);
-
-        List<Class<?>> stream = annotations.stream()
+        List<Class<?>> annotatedClasses = annotations.stream()
                 .map(ann -> loadClassFromAnnotation(ann, cl))
                 .filter(Optional::isPresent)
                 .map(Optional::get).collect(Collectors.toList());
 
-        JsonSchemaGenerator jsonSchemaGenerator = new JsonSchemaGenerator.ClassBuilder(stream.stream())
-                .withGenSchemaPredicate(x -> true)
-                .withSchemaVersion(System.getProperty("kogito.jsonSchema.version")).build();
+        JsonSchemaGenerator jsonSchemaGenerator = new JsonSchemaGenerator.ClassBuilder(annotatedClasses.stream())
+                .withSchemaVersion(System.getProperty("kogito.jsonSchema.version"))
+                .build();
 
         return jsonSchemaGenerator.generate();
     }

--- a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-deployment/src/main/java/org/kie/kogito/quarkus/processes/deployment/ProcessesAssetsProcessor.java
+++ b/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-deployment/src/main/java/org/kie/kogito/quarkus/processes/deployment/ProcessesAssetsProcessor.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.inject.Inject;
@@ -37,6 +38,7 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.Type;
 import org.kie.kogito.Model;
+import org.kie.kogito.ProcessInput;
 import org.kie.kogito.UserTask;
 import org.kie.kogito.codegen.api.GeneratedFile;
 import org.kie.kogito.codegen.api.GeneratedFileType;
@@ -265,15 +267,19 @@ public class ProcessesAssetsProcessor {
     private Collection<GeneratedFile> generateJsonSchema(KogitoBuildContext context, IndexView index, Map<String, byte[]> generatedClasses) throws IOException {
         ClassLoader cl = new InMemoryClassLoader(context.getClassLoader(), generatedClasses);
 
-        Collection<AnnotationInstance> annotations =
-                index.getAnnotations(DotName.createSimple(UserTask.class.getCanonicalName()));
+        List<AnnotationInstance> annotations = new ArrayList<>();
 
-        Stream<Class<?>> stream = annotations.stream()
+        annotations.addAll(index.getAnnotations(DotName.createSimple(ProcessInput.class.getCanonicalName())));
+        annotations.addAll(index.getAnnotations(DotName.createSimple(UserTask.class.getCanonicalName())));
+
+        System.out.println(annotations);
+
+        List<Class<?>> stream = annotations.stream()
                 .map(ann -> loadClassFromAnnotation(ann, cl))
                 .filter(Optional::isPresent)
-                .map(Optional::get);
+                .map(Optional::get).collect(Collectors.toList());
 
-        JsonSchemaGenerator jsonSchemaGenerator = new JsonSchemaGenerator.ClassBuilder(stream)
+        JsonSchemaGenerator jsonSchemaGenerator = new JsonSchemaGenerator.ClassBuilder(stream.stream())
                 .withGenSchemaPredicate(x -> true)
                 .withSchemaVersion(System.getProperty("kogito.jsonSchema.version")).build();
 

--- a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-integration-test-hot-reload/src/test/java/io/quarkus/it/kogito/jbpm/HotReloadIT.java
+++ b/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-integration-test-hot-reload/src/test/java/io/quarkus/it/kogito/jbpm/HotReloadIT.java
@@ -184,7 +184,51 @@ public class HotReloadIT {
     }
 
     @Test
-    public void testJsonSchema() {
+    public void testProcessJsonSchema() {
+
+        String jsonSchema = given()
+                .baseUri("http://localhost:" + HTTP_TEST_PORT)
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .when()
+                .get("/" + PROCESS_NAME + "/schema")
+                .then()
+                .statusCode(200)
+                .extract().body().asString();
+
+        assertNotNull(jsonSchema);
+        assertFalse(jsonSchema.isEmpty());
+
+        test.modifyResourceFile(RESOURCE_FILE, s -> s.replaceAll(PROCESS_NAME, "new_" + PROCESS_NAME));
+
+        // old endpoint should not work anymore
+        given()
+                .baseUri("http://localhost:" + HTTP_TEST_PORT)
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .when()
+                .get("/" + PROCESS_NAME + "/schema")
+                .then()
+                .statusCode(404);
+
+        String newJsonSchema = given()
+                .baseUri("http://localhost:" + HTTP_TEST_PORT)
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .when()
+                .get("/new_" + PROCESS_NAME + "/schema")
+                .then()
+                .statusCode(200)
+                .extract().body().asString();
+
+        assertNotNull(newJsonSchema);
+        assertFalse(newJsonSchema.isEmpty());
+
+        assertEquals(jsonSchema, newJsonSchema);
+    }
+
+    @Test
+    public void testUserTaskJsonSchema() {
 
         String jsonSchema = given()
                 .baseUri("http://localhost:" + HTTP_TEST_PORT)


### PR DESCRIPTION
Adding JSON schema generation for ProcessModelnput, so we can use it in our quarkus runtime tools extension to start processes via form.

It also fixes a recursivity issue generating schemas when there are cross-dependencies between models in a variable, by using schema refs.

This is part of an ensemble, please merge with:
https://github.com/kiegroup/kogito-runtimes/pull/1697
https://github.com/kiegroup/kogito-apps/pull/1121

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](CONTRIBUTING.md)
- [ ] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run all builds</b>  
  Please add comment: <b>Jenkins retest this</b>

* <b>Run (or rerun) specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Run (or rerun) LTS specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Run (or rerun) native specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
