### PR TITLE
KOGITO-6145 DMN codegen heuristic for DMN Editor encoding

### DIFF
--- a/kogito-codegen-modules/kogito-codegen-decisions/src/main/java/org/kie/kogito/codegen/decision/DecisionContainerGenerator.java
+++ b/kogito-codegen-modules/kogito-codegen-decisions/src/main/java/org/kie/kogito/codegen/decision/DecisionContainerGenerator.java
@@ -15,14 +15,9 @@
  */
 package org.kie.kogito.codegen.decision;
 
+import java.io.BufferedReader;
 import java.util.Collection;
-
-import org.kie.kogito.codegen.api.context.KogitoBuildContext;
-import org.kie.kogito.codegen.api.io.CollectedResource;
-import org.kie.kogito.codegen.api.template.InvalidTemplateException;
-import org.kie.kogito.codegen.api.template.TemplatedGenerator;
-import org.kie.kogito.codegen.core.AbstractApplicationSection;
-import org.kie.kogito.dmn.DmnExecutionIdSupplier;
+import java.util.Optional;
 
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
@@ -30,13 +25,23 @@ import com.github.javaparser.ast.body.InitializerDeclaration;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.NullLiteralExpr;
+import com.github.javaparser.ast.expr.StringLiteralExpr;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import org.kie.kogito.codegen.api.context.KogitoBuildContext;
+import org.kie.kogito.codegen.api.io.CollectedResource;
+import org.kie.kogito.codegen.api.template.InvalidTemplateException;
+import org.kie.kogito.codegen.api.template.TemplatedGenerator;
+import org.kie.kogito.codegen.core.AbstractApplicationSection;
+import org.kie.kogito.dmn.DmnExecutionIdSupplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.kie.kogito.codegen.core.CodegenUtils.newObject;
 import static org.kie.kogito.codegen.decision.ReadResourceUtil.getReadResourceMethod;
 
 public class DecisionContainerGenerator extends AbstractApplicationSection {
 
+    private static final Logger LOG = LoggerFactory.getLogger(DecisionContainerGenerator.class);
     protected static final String PMML_ABSTRACT_CLASS = "org.kie.kogito.pmml.AbstractPredictionModels";
     protected static final String PMML_FUNCTION = PMML_ABSTRACT_CLASS + ".kieRuntimeFactoryFunction";
     private static final String SECTION_CLASS_NAME = "DecisionModels";
@@ -76,12 +81,33 @@ public class DecisionContainerGenerator extends AbstractApplicationSection {
         setupDecisionModelTransformerVariable(initMethod);
 
         for (CollectedResource resource : resources) {
+            Optional<String> encoding = determineEncoding(resource);
             MethodCallExpr getResAsStream = getReadResourceMethod(applicationClass, resource);
             MethodCallExpr isr = new MethodCallExpr("readResource").addArgument(getResAsStream);
+            encoding.map(StringLiteralExpr::new).ifPresent(isr::addArgument);
             initMethod.addArgument(isr);
         }
 
         return compilationUnit;
+    }
+
+    private Optional<String> determineEncoding(CollectedResource resource) {
+        try {
+            BufferedReader br = new BufferedReader(resource.resource().getReader());
+            StringBuilder sb = new StringBuilder(br.readLine());
+            sb.append(br.readLine());
+            String head = sb.toString();
+            boolean prologUTF8 = head.startsWith("<?xml version=\"1.0\" encoding=\"UTF-8\"") || head.startsWith("<?xml version=\"1.0\" encoding=\"utf-8\"");
+            boolean kogitoDMNEditor = head.contains("xmlns:kie=\"http://www.drools.org/kie/dmn");
+            LOG.debug("resource {} determineEncoding results; prologUTF8 {}, kogitoDMNEditor {}.", resource.resource(), prologUTF8, kogitoDMNEditor);
+            if (prologUTF8 || kogitoDMNEditor) {
+                return Optional.of("UTF-8");
+            } else {
+                return Optional.empty();
+            }
+        } catch (Exception e) {
+            return Optional.empty();
+        }
     }
 
     private void setupPmmlIfAvailable(MethodCallExpr initMethod) {

--- a/kogito-codegen-modules/kogito-codegen-decisions/src/main/java/org/kie/kogito/codegen/decision/DecisionContainerGenerator.java
+++ b/kogito-codegen-modules/kogito-codegen-decisions/src/main/java/org/kie/kogito/codegen/decision/DecisionContainerGenerator.java
@@ -19,14 +19,6 @@ import java.io.BufferedReader;
 import java.util.Collection;
 import java.util.Optional;
 
-import com.github.javaparser.StaticJavaParser;
-import com.github.javaparser.ast.CompilationUnit;
-import com.github.javaparser.ast.body.InitializerDeclaration;
-import com.github.javaparser.ast.expr.Expression;
-import com.github.javaparser.ast.expr.MethodCallExpr;
-import com.github.javaparser.ast.expr.NullLiteralExpr;
-import com.github.javaparser.ast.expr.StringLiteralExpr;
-import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import org.kie.kogito.codegen.api.context.KogitoBuildContext;
 import org.kie.kogito.codegen.api.io.CollectedResource;
 import org.kie.kogito.codegen.api.template.InvalidTemplateException;
@@ -35,6 +27,15 @@ import org.kie.kogito.codegen.core.AbstractApplicationSection;
 import org.kie.kogito.dmn.DmnExecutionIdSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.InitializerDeclaration;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.NullLiteralExpr;
+import com.github.javaparser.ast.expr.StringLiteralExpr;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
 
 import static org.kie.kogito.codegen.core.CodegenUtils.newObject;
 import static org.kie.kogito.codegen.decision.ReadResourceUtil.getReadResourceMethod;

--- a/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test/src/main/resources/a.dmn
+++ b/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test/src/main/resources/a.dmn
@@ -31,7 +31,7 @@
       <dmn:contextEntry>
         <dmn:variable id="_c6259584-414b-438b-a69b-b536f1f13818" name="Hello" typeRef="Any"/>
         <dmn:literalExpression id="_b4bd08a1-3ca6-475b-8555-eeed6432bc2f">
-          <dmn:text>"Hello " + p.name</dmn:text>
+          <dmn:text>"Certidão Hello " + p.name</dmn:text>
         </dmn:literalExpression>
       </dmn:contextEntry>
       <dmn:contextEntry>

--- a/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test/src/test/java/org/kie/kogito/quarkus/dmn/CustomEndpointIT.java
+++ b/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test/src/test/java/org/kie/kogito/quarkus/dmn/CustomEndpointIT.java
@@ -36,7 +36,7 @@ public class CustomEndpointIT {
                 .post("/custom")
                 .then()
                 .statusCode(200)
-                .body("data.d.Hello", Matchers.is("Hello Luca"));
+                .body("data.d.Hello", Matchers.is("Certidão Hello Luca"));
     }
 
 }

--- a/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test/src/test/java/org/kie/kogito/quarkus/dmn/DMNIT.java
+++ b/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test/src/test/java/org/kie/kogito/quarkus/dmn/DMNIT.java
@@ -66,7 +66,7 @@ public class DMNIT {
                 .post("/dmnModel")
                 .then()
                 .statusCode(200)
-                .body("d.Hello", is("Hello Luca"));
+                .body("d.Hello", is("Certidão Hello Luca"));
     }
 
     @Test
@@ -78,7 +78,7 @@ public class DMNIT {
                 .post("/dmnModel/dmnresult")
                 .then()
                 .statusCode(200)
-                .body("dmnContext.d.Hello", is("Hello Luca"));
+                .body("dmnContext.d.Hello", is("Certidão Hello Luca"));
     }
 
     @Test


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-6145

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run all builds</b>  
  Please add comment: <b>Jenkins retest this</b>

* <b>Run (or rerun) specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Run (or rerun) LTS specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Run (or rerun) native specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
