### PR TITLE
Revert "[1.14.x] Update version to 1.14.0-SNAPSHOT"

### DIFF
--- a/addons/common/events/decisions/pom.xml
+++ b/addons/common/events/decisions/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-events-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-addons-events-decisions</artifactId>

--- a/addons/common/events/mongodb/pom.xml
+++ b/addons/common/events/mongodb/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-addons-events-parent</artifactId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-addons-events-mongodb</artifactId>

--- a/addons/common/events/pom.xml
+++ b/addons/common/events/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-common-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-events-parent</artifactId>
   <packaging>pom</packaging>

--- a/addons/common/events/predictions/pom.xml
+++ b/addons/common/events/predictions/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-events-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-addons-events-predictions</artifactId>

--- a/addons/common/events/rules/pom.xml
+++ b/addons/common/events/rules/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-events-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-addons-events-rules</artifactId>

--- a/addons/common/explainability/pom.xml
+++ b/addons/common/explainability/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-common-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/common/human-task-prediction/api/pom.xml
+++ b/addons/common/human-task-prediction/api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-human-task-prediction-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-human-task-prediction-api</artifactId>
   <name>Kogito :: Add-Ons :: Predictions :: API</name>

--- a/addons/common/human-task-prediction/pom.xml
+++ b/addons/common/human-task-prediction/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-common-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-human-task-prediction-parent</artifactId>
   <packaging>pom</packaging>

--- a/addons/common/human-task-prediction/smile/pom.xml
+++ b/addons/common/human-task-prediction/smile/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-human-task-prediction-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-human-task-prediction-smile</artifactId>
   <name>Kogito :: Add-Ons :: Predictions :: SMILE</name>

--- a/addons/common/jobs/api/pom.xml
+++ b/addons/common/jobs/api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-jobs-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-jobs-api</artifactId>
   <name>Kogito :: Add-Ons :: Jobs :: API</name>

--- a/addons/common/jobs/management-common/pom.xml
+++ b/addons/common/jobs/management-common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kogito-addons-jobs-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/common/jobs/pom.xml
+++ b/addons/common/jobs/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-common-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-jobs-parent</artifactId>
   <packaging>pom</packaging>

--- a/addons/common/knative/eventing/pom.xml
+++ b/addons/common/knative/eventing/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-knative-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/common/knative/pom.xml
+++ b/addons/common/knative/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-common-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/common/kubernetes/pom.xml
+++ b/addons/common/kubernetes/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-common-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/common/mail/pom.xml
+++ b/addons/common/mail/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-common-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/common/messaging/common/pom.xml
+++ b/addons/common/messaging/common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-messaging-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-addons-messaging</artifactId>

--- a/addons/common/messaging/pom.xml
+++ b/addons/common/messaging/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-common-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-messaging-parent</artifactId>
   <packaging>pom</packaging>

--- a/addons/common/messaging/utils/pom.xml
+++ b/addons/common/messaging/utils/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-messaging-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-addons-cloudevents-utils</artifactId>

--- a/addons/common/monitoring/core/pom.xml
+++ b/addons/common/monitoring/core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-monitoring-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <name>Kogito :: Add-Ons :: Monitoring Core Api</name>

--- a/addons/common/monitoring/elastic/pom.xml
+++ b/addons/common/monitoring/elastic/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-monitoring-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/common/monitoring/pom.xml
+++ b/addons/common/monitoring/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-common-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-monitoring-parent</artifactId>
   <name>Kogito :: Add-Ons :: Monitoring</name>

--- a/addons/common/monitoring/prometheus/pom.xml
+++ b/addons/common/monitoring/prometheus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-monitoring-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/common/persistence/ddl/pom.xml
+++ b/addons/common/persistence/ddl/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-addons-persistence-parent</artifactId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/addons/common/persistence/filesystem/pom.xml
+++ b/addons/common/persistence/filesystem/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-persistence-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-persistence-filesystem</artifactId>
   <name>Kogito :: Add-Ons :: Persistence :: File System</name>

--- a/addons/common/persistence/infinispan/pom.xml
+++ b/addons/common/persistence/infinispan/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-persistence-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-persistence-infinispan</artifactId>
   <name>Kogito :: Add-Ons :: Persistence :: Infinispan</name>

--- a/addons/common/persistence/jdbc/pom.xml
+++ b/addons/common/persistence/jdbc/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-persistence-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-persistence-jdbc</artifactId>
   <name>Kogito :: Add-Ons :: Persistence :: JDBC</name>

--- a/addons/common/persistence/mongodb/pom.xml
+++ b/addons/common/persistence/mongodb/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-persistence-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/common/persistence/pom.xml
+++ b/addons/common/persistence/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-common-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-persistence-parent</artifactId>
   <packaging>pom</packaging>

--- a/addons/common/persistence/postgresql/pom.xml
+++ b/addons/common/persistence/postgresql/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-persistence-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-persistence-postgresql</artifactId>
   <name>Kogito :: Add-Ons :: Persistence :: PostgreSQL</name>

--- a/addons/common/pom.xml
+++ b/addons/common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/common/process-management/pom.xml
+++ b/addons/common/process-management/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-common-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/common/process-svg/pom.xml
+++ b/addons/common/process-svg/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kogito-addons-common-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/common/rest-exception-handler/pom.xml
+++ b/addons/common/rest-exception-handler/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-common-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/common/task-management/pom.xml
+++ b/addons/common/task-management/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-common-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/common/tracing/decision-api/pom.xml
+++ b/addons/common/tracing/decision-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-tracing-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/common/tracing/decision-common/pom.xml
+++ b/addons/common/tracing/decision-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-tracing-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/common/tracing/pom.xml
+++ b/addons/common/tracing/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-common-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/common/tracing/typedvalue-api/pom.xml
+++ b/addons/common/tracing/typedvalue-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-tracing-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/deprecated/cloudevents-common-addon/pom.xml
+++ b/addons/deprecated/cloudevents-common-addon/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-deprecated-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/deprecated/cloudevents-quarkus-addon/pom.xml
+++ b/addons/deprecated/cloudevents-quarkus-addon/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-deprecated-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/deprecated/cloudevents-spring-boot-addon/pom.xml
+++ b/addons/deprecated/cloudevents-spring-boot-addon/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-deprecated-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/deprecated/cloudevents-utils/pom.xml
+++ b/addons/deprecated/cloudevents-utils/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-deprecated-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/deprecated/knative-eventing-addon/pom.xml
+++ b/addons/deprecated/knative-eventing-addon/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-deprecated-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/deprecated/kogito-addons-quarkus-cloudevents-multi/pom.xml
+++ b/addons/deprecated/kogito-addons-quarkus-cloudevents-multi/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-deprecated-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-cloudevents-multi</artifactId>
   <name>Kogito :: Add-Ons :: Deprecated :: CloudEvents :: Multi channel :: Quarkus</name>

--- a/addons/deprecated/kogito-addons-quarkus-cloudevents/pom.xml
+++ b/addons/deprecated/kogito-addons-quarkus-cloudevents/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-deprecated-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/deprecated/kogito-addons-quarkus-events-smallrye/pom.xml
+++ b/addons/deprecated/kogito-addons-quarkus-events-smallrye/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-deprecated-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-events-smallrye</artifactId>
   <name>Kogito :: Add-Ons :: Deprecated :: Events :: Smallrye Messaging</name>

--- a/addons/deprecated/kogito-addons-springboot-cloudevents/pom.xml
+++ b/addons/deprecated/kogito-addons-springboot-cloudevents/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-deprecated-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/deprecated/kogito-addons-springboot-events-kafka/pom.xml
+++ b/addons/deprecated/kogito-addons-springboot-events-kafka/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-deprecated-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-springboot-events-kafka</artifactId>
   <name>Kogito :: Add-Ons :: Events :: SprintBoot :: Kafka</name>

--- a/addons/deprecated/kogito-event-driven-decisions-common/pom.xml
+++ b/addons/deprecated/kogito-event-driven-decisions-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-deprecated-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/deprecated/kogito-event-driven-decisions-quarkus-addon/pom.xml
+++ b/addons/deprecated/kogito-event-driven-decisions-quarkus-addon/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-deprecated-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/deprecated/kogito-event-driven-decisions-springboot-addon/pom.xml
+++ b/addons/deprecated/kogito-event-driven-decisions-springboot-addon/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-deprecated-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/deprecated/monitoring-core-common/pom.xml
+++ b/addons/deprecated/monitoring-core-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-deprecated-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/deprecated/monitoring-core-quarkus-addon/pom.xml
+++ b/addons/deprecated/monitoring-core-quarkus-addon/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-deprecated-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/deprecated/monitoring-core-springboot-addon/pom.xml
+++ b/addons/deprecated/monitoring-core-springboot-addon/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-deprecated-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/deprecated/monitoring-prometheus-common/pom.xml
+++ b/addons/deprecated/monitoring-prometheus-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-deprecated-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/deprecated/monitoring-prometheus-quarkus-addon/pom.xml
+++ b/addons/deprecated/monitoring-prometheus-quarkus-addon/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-deprecated-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/deprecated/monitoring-prometheus-springboot-addon/pom.xml
+++ b/addons/deprecated/monitoring-prometheus-springboot-addon/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-deprecated-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/deprecated/pom.xml
+++ b/addons/deprecated/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/pom.xml
+++ b/addons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-build-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../kogito-build/kogito-build-parent/pom.xml</relativePath>
   </parent>
   <artifactId>kogito-addons</artifactId>

--- a/api/kogito-api-incubation-application/pom.xml
+++ b/api/kogito-api-incubation-application/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-api-parent</artifactId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-api-incubation-application</artifactId>

--- a/api/kogito-api-incubation-common-objectmapper/pom.xml
+++ b/api/kogito-api-incubation-common-objectmapper/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-api-parent</artifactId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-api-incubation-common-objectmapper</artifactId>

--- a/api/kogito-api-incubation-common/pom.xml
+++ b/api/kogito-api-incubation-common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-api-parent</artifactId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-api-incubation-common</artifactId>

--- a/api/kogito-api-incubation-decisions-services/pom.xml
+++ b/api/kogito-api-incubation-decisions-services/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-api-parent</artifactId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-api-incubation-decisions-services</artifactId>

--- a/api/kogito-api-incubation-decisions/pom.xml
+++ b/api/kogito-api-incubation-decisions/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-api-parent</artifactId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-api-incubation-decisions</artifactId>

--- a/api/kogito-api-incubation-predictions-services/pom.xml
+++ b/api/kogito-api-incubation-predictions-services/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-api-parent</artifactId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-api-incubation-predictions-services</artifactId>

--- a/api/kogito-api-incubation-predictions/pom.xml
+++ b/api/kogito-api-incubation-predictions/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-api-parent</artifactId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-api-incubation-predictions</artifactId>

--- a/api/kogito-api-incubation-processes-services/pom.xml
+++ b/api/kogito-api-incubation-processes-services/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-api-parent</artifactId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-api-incubation-processes-services</artifactId>

--- a/api/kogito-api-incubation-processes/pom.xml
+++ b/api/kogito-api-incubation-processes/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-api-parent</artifactId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-api-incubation-processes</artifactId>

--- a/api/kogito-api-incubation-rules-services/pom.xml
+++ b/api/kogito-api-incubation-rules-services/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-api-parent</artifactId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-api-incubation-rules-services</artifactId>

--- a/api/kogito-api-incubation-rules/pom.xml
+++ b/api/kogito-api-incubation-rules/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-api-parent</artifactId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-api-incubation-rules</artifactId>

--- a/api/kogito-api/pom.xml
+++ b/api/kogito-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-api-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-api</artifactId>

--- a/api/kogito-events-api/pom.xml
+++ b/api/kogito-events-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-api-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-events-api</artifactId>

--- a/api/kogito-legacy-api/pom.xml
+++ b/api/kogito-legacy-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-api-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-legacy-api</artifactId>

--- a/api/kogito-services/pom.xml
+++ b/api/kogito-services/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-api-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-services</artifactId>

--- a/api/kogito-timer/pom.xml
+++ b/api/kogito-timer/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>kogito-api-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-build-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../kogito-build/kogito-build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools/drools-compiler/pom.xml
+++ b/drools/drools-compiler/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>drools</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-compiler</artifactId>

--- a/drools/drools-core-dynamic/pom.xml
+++ b/drools/drools-core-dynamic/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>drools</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-core-dynamic</artifactId>

--- a/drools/drools-core-static/pom.xml
+++ b/drools/drools-core-static/pom.xml
@@ -7,7 +7,7 @@
    <parent>
      <groupId>org.kie.kogito</groupId>
      <artifactId>drools</artifactId>
-     <version>1.14.0-SNAPSHOT</version>
+     <version>2.0.0-SNAPSHOT</version>
    </parent>
 
     <artifactId>drools-core-static</artifactId>

--- a/drools/drools-core/pom.xml
+++ b/drools/drools-core/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>drools</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-core</artifactId>

--- a/drools/drools-decisiontables/pom.xml
+++ b/drools/drools-decisiontables/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>drools</artifactId>
         <groupId>org.kie.kogito</groupId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/drools/kogito-dmn/pom.xml
+++ b/drools/kogito-dmn/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>drools</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-dmn</artifactId>

--- a/drools/kogito-drools-model/pom.xml
+++ b/drools/kogito-drools-model/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>drools</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-drools-model</artifactId>

--- a/drools/kogito-drools/pom.xml
+++ b/drools/kogito-drools/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>drools</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-drools</artifactId>

--- a/drools/kogito-pmml-api-dependencies/pom.xml
+++ b/drools/kogito-pmml-api-dependencies/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>drools</artifactId>
-     <version>1.14.0-SNAPSHOT</version>
+     <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-pmml-api-dependencies</artifactId>

--- a/drools/kogito-pmml-dependencies/pom.xml
+++ b/drools/kogito-pmml-dependencies/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>drools</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-pmml-dependencies</artifactId>

--- a/drools/kogito-pmml-openapi/pom.xml
+++ b/drools/kogito-pmml-openapi/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>drools</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools/kogito-pmml/pom.xml
+++ b/drools/kogito-pmml/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>drools</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-pmml</artifactId>

--- a/drools/kogito-ruleunits/pom.xml
+++ b/drools/kogito-ruleunits/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>drools</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-ruleunits</artifactId>

--- a/drools/kogito-scenario-simulation/pom.xml
+++ b/drools/kogito-scenario-simulation/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>drools</artifactId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-scenario-simulation</artifactId>

--- a/drools/pom.xml
+++ b/drools/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-build-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../kogito-build/kogito-build-parent/pom.xml</relativePath>
   </parent>
 

--- a/grafana-api/pom.xml
+++ b/grafana-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-build-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../kogito-build/kogito-build-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/integration-tests/integration-tests-kogito-plugin/pom.xml
+++ b/integration-tests/integration-tests-kogito-plugin/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>integration-tests</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>integration-tests-kogito-plugin</artifactId>
   <name>Kogito :: Integration Tests :: Maven Plugin</name>

--- a/integration-tests/integration-tests-quarkus-decisions/pom.xml
+++ b/integration-tests/integration-tests-quarkus-decisions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>integration-tests</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>integration-tests-quarkus-decisions</artifactId>
   <name>Kogito :: Integration Tests :: Quarkus :: Decisions</name>

--- a/integration-tests/integration-tests-quarkus-gradle/pom.xml
+++ b/integration-tests/integration-tests-quarkus-gradle/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>integration-tests</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>integration-tests-quarkus-gradle</artifactId>
   <name>Kogito :: Integration Tests :: Quarkus :: Gradle</name>

--- a/integration-tests/integration-tests-quarkus-norest/pom.xml
+++ b/integration-tests/integration-tests-quarkus-norest/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>integration-tests</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>integration-tests-quarkus-norest</artifactId>
   <name>Kogito :: Integration Tests :: Quarkus :: Without REST</name>

--- a/integration-tests/integration-tests-quarkus-predictions/pom.xml
+++ b/integration-tests/integration-tests-quarkus-predictions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>integration-tests</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>integration-tests-quarkus-predictions</artifactId>
   <name>Kogito :: Integration Tests :: Quarkus :: Predictions</name>

--- a/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-processes-persistence-common/pom.xml
+++ b/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-processes-persistence-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>integration-tests-quarkus-processes-persistence</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-infinispan/pom.xml
+++ b/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-infinispan/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>integration-tests-quarkus-processes-persistence</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-jdbc/pom.xml
+++ b/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-jdbc/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>integration-tests-quarkus-processes-persistence</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-kafka-persistence/pom.xml
+++ b/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-kafka-persistence/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>integration-tests-quarkus-processes-persistence</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-mongodb/pom.xml
+++ b/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-mongodb/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>integration-tests-quarkus-processes-persistence</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-postgresql/pom.xml
+++ b/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-postgresql/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>integration-tests-quarkus-processes-persistence</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/integration-tests/integration-tests-quarkus-processes-persistence/pom.xml
+++ b/integration-tests/integration-tests-quarkus-processes-persistence/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <artifactId>integration-tests</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/integration-tests/integration-tests-quarkus-processes/pom.xml
+++ b/integration-tests/integration-tests-quarkus-processes/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>integration-tests</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>integration-tests-quarkus-processes</artifactId>

--- a/integration-tests/integration-tests-quarkus-rules/pom.xml
+++ b/integration-tests/integration-tests-quarkus-rules/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>integration-tests</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>integration-tests-quarkus-rules</artifactId>
   <name>Kogito :: Integration Tests :: Quarkus :: Rules</name>

--- a/integration-tests/integration-tests-springboot/pom.xml
+++ b/integration-tests/integration-tests-springboot/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>integration-tests</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>integration-tests-springboot</artifactId>
   <name>Kogito :: Integration Tests :: Spring Boot</name>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-build-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../kogito-build/kogito-build-parent/pom.xml</relativePath>
   </parent>
   <artifactId>integration-tests</artifactId>

--- a/jbpm/jbpm-bpmn2/pom.xml
+++ b/jbpm/jbpm-bpmn2/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>jbpm</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>jbpm-bpmn2</artifactId>

--- a/jbpm/jbpm-flow-builder/pom.xml
+++ b/jbpm/jbpm-flow-builder/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>jbpm</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>jbpm-flow-builder</artifactId>

--- a/jbpm/jbpm-flow/pom.xml
+++ b/jbpm/jbpm-flow/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>jbpm</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>jbpm-flow</artifactId>

--- a/jbpm/pom.xml
+++ b/jbpm/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-build-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../kogito-build/kogito-build-parent/pom.xml</relativePath>
   </parent>
 

--- a/jbpm/process-serialization-protobuf/pom.xml
+++ b/jbpm/process-serialization-protobuf/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>jbpm</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
 

--- a/jbpm/process-workitems/pom.xml
+++ b/jbpm/process-workitems/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>jbpm</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-workitems</artifactId>

--- a/kogito-bom/pom.xml
+++ b/kogito-bom/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-runtimes</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/kogito-build/kogito-build-parent/pom.xml
+++ b/kogito-build/kogito-build-parent/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.kie.kogito</groupId>
     <!-- The Kogito Dependencies BOM is inherited here to reuse all the version properties defined there and used across our internal modules. -->
     <artifactId>kogito-dependencies-bom</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../kogito-dependencies-bom/pom.xml</relativePath>
   </parent>
 

--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-build</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kogito-build/kogito-ide-config/pom.xml
+++ b/kogito-build/kogito-ide-config/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-runtimes</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/kogito-build/kogito-kie-bom/pom.xml
+++ b/kogito-build/kogito-kie-bom/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-build</artifactId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/kogito-build/pom.xml
+++ b/kogito-build/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-runtimes</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/kogito-codegen-modules/kogito-codegen-api/pom.xml
+++ b/kogito-codegen-modules/kogito-codegen-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-codegen-modules</artifactId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>kogito-codegen-api</artifactId>

--- a/kogito-codegen-modules/kogito-codegen-core/pom.xml
+++ b/kogito-codegen-modules/kogito-codegen-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-codegen-modules</artifactId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>kogito-codegen-core</artifactId>

--- a/kogito-codegen-modules/kogito-codegen-decisions/pom.xml
+++ b/kogito-codegen-modules/kogito-codegen-decisions/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-codegen-modules</artifactId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>kogito-codegen-decisions</artifactId>

--- a/kogito-codegen-modules/kogito-codegen-integration-tests/pom.xml
+++ b/kogito-codegen-modules/kogito-codegen-integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-codegen-modules</artifactId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>kogito-codegen-integration-tests</artifactId>

--- a/kogito-codegen-modules/kogito-codegen-openapi/pom.xml
+++ b/kogito-codegen-modules/kogito-codegen-openapi/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-codegen-modules</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kogito-codegen-modules/kogito-codegen-predictions/pom.xml
+++ b/kogito-codegen-modules/kogito-codegen-predictions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-codegen-modules</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>kogito-codegen-predictions</artifactId>

--- a/kogito-codegen-modules/kogito-codegen-processes/pom.xml
+++ b/kogito-codegen-modules/kogito-codegen-processes/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-codegen-modules</artifactId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>kogito-codegen-processes</artifactId>

--- a/kogito-codegen-modules/kogito-codegen-rules/pom.xml
+++ b/kogito-codegen-modules/kogito-codegen-rules/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-codegen-modules</artifactId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>kogito-codegen-rules</artifactId>

--- a/kogito-codegen-modules/kogito-codegen-sample/kogito-codegen-sample-generator/pom.xml
+++ b/kogito-codegen-modules/kogito-codegen-sample/kogito-codegen-sample-generator/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-codegen-sample</artifactId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>kogito-codegen-sample-generator</artifactId>

--- a/kogito-codegen-modules/kogito-codegen-sample/kogito-codegen-sample-runtime/pom.xml
+++ b/kogito-codegen-modules/kogito-codegen-sample/kogito-codegen-sample-runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-codegen-sample</artifactId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>kogito-codegen-sample-runtime</artifactId>

--- a/kogito-codegen-modules/kogito-codegen-sample/pom.xml
+++ b/kogito-codegen-modules/kogito-codegen-sample/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-codegen-modules</artifactId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-codegen-sample</artifactId>

--- a/kogito-codegen-modules/pom.xml
+++ b/kogito-codegen-modules/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-build-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../kogito-build/kogito-build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kogito-maven-plugin/pom.xml
+++ b/kogito-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
  <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-build-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
    <relativePath>../kogito-build/kogito-build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kogito-serverless-workflow/kogito-jq-expression/pom.xml
+++ b/kogito-serverless-workflow/kogito-jq-expression/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-serverless-workflow</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-jq-expression</artifactId>

--- a/kogito-serverless-workflow/kogito-jsonpath-expression/pom.xml
+++ b/kogito-serverless-workflow/kogito-jsonpath-expression/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-serverless-workflow</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-jsonpath-expression</artifactId>

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/pom.xml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-serverless-workflow</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-serverless-workflow-builder</artifactId>

--- a/kogito-serverless-workflow/kogito-serverless-workflow-runtime/pom.xml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-serverless-workflow</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-serverless-workflow-runtime</artifactId>

--- a/kogito-serverless-workflow/pom.xml
+++ b/kogito-serverless-workflow/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-build-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../kogito-build/kogito-build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kogito-test-utils/pom.xml
+++ b/kogito-test-utils/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-build-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../kogito-build/kogito-build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kogito-workitems/kogito-jackson-utils/pom.xml
+++ b/kogito-workitems/kogito-jackson-utils/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-workitems</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-jackson-utils</artifactId>

--- a/kogito-workitems/kogito-openapi-workitem/pom.xml
+++ b/kogito-workitems/kogito-openapi-workitem/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-workitems</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-openapi-workitem</artifactId>

--- a/kogito-workitems/kogito-rest-workitem/pom.xml
+++ b/kogito-workitems/kogito-rest-workitem/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-workitems</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-rest-workitem</artifactId>

--- a/kogito-workitems/pom.xml
+++ b/kogito-workitems/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-build-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../kogito-build/kogito-build-parent/pom.xml</relativePath>
   </parent>
   <artifactId>kogito-workitems</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.kie.kogito</groupId>
   <artifactId>kogito-runtimes</artifactId>
-  <version>1.14.0-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Kogito Runtimes</name>

--- a/quarkus/addons/common/deployment/pom.xml
+++ b/quarkus/addons/common/deployment/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-common-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/common/pom.xml
+++ b/quarkus/addons/common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/events/decisions/deployment/pom.xml
+++ b/quarkus/addons/events/decisions/deployment/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-events-decisions-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-events-decisions-deployment</artifactId>
   <name>Kogito Add-On Events Decisions - Deployment</name>

--- a/quarkus/addons/events/decisions/pom.xml
+++ b/quarkus/addons/events/decisions/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-events-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-addons-quarkus-events-decisions-parent</artifactId>

--- a/quarkus/addons/events/decisions/runtime/pom.xml
+++ b/quarkus/addons/events/decisions/runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-events-decisions-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-addons-quarkus-events-decisions</artifactId>

--- a/quarkus/addons/events/mongodb/deployment/pom.xml
+++ b/quarkus/addons/events/mongodb/deployment/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-events-mongodb-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-events-mongodb-deployment</artifactId>
   <name>Kogito Add-On Events MongoDB - Deployment</name>

--- a/quarkus/addons/events/mongodb/pom.xml
+++ b/quarkus/addons/events/mongodb/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-events-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-addons-quarkus-events-mongodb-parent</artifactId>

--- a/quarkus/addons/events/mongodb/runtime/pom.xml
+++ b/quarkus/addons/events/mongodb/runtime/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-addons-quarkus-events-mongodb-parent</artifactId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-addons-quarkus-events-mongodb</artifactId>

--- a/quarkus/addons/events/pom.xml
+++ b/quarkus/addons/events/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/events/predictions/deployment/pom.xml
+++ b/quarkus/addons/events/predictions/deployment/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-events-predictions-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-events-predictions-deployment</artifactId>
   <name>Kogito Add-On Events Predictions - Deployment</name>

--- a/quarkus/addons/events/predictions/pom.xml
+++ b/quarkus/addons/events/predictions/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-events-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-addons-quarkus-events-predictions-parent</artifactId>

--- a/quarkus/addons/events/predictions/runtime/pom.xml
+++ b/quarkus/addons/events/predictions/runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-events-predictions-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-addons-quarkus-events-predictions</artifactId>

--- a/quarkus/addons/events/process/deployment/pom.xml
+++ b/quarkus/addons/events/process/deployment/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-events-process-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-events-process-deployment</artifactId>
   <name>Kogito Add-On Events Process - Deployment</name>

--- a/quarkus/addons/events/process/pom.xml
+++ b/quarkus/addons/events/process/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-events-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-addons-quarkus-events-process-parent</artifactId>

--- a/quarkus/addons/events/process/runtime/pom.xml
+++ b/quarkus/addons/events/process/runtime/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-events-process-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-events-process</artifactId>
   <name>Kogito Add-On Events Process</name>

--- a/quarkus/addons/events/rules/deployment/pom.xml
+++ b/quarkus/addons/events/rules/deployment/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-events-rules-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-events-rules-deployment</artifactId>
   <name>Kogito Add-On Events Rules - Deployment</name>

--- a/quarkus/addons/events/rules/pom.xml
+++ b/quarkus/addons/events/rules/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-events-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-addons-quarkus-events-rules-parent</artifactId>

--- a/quarkus/addons/events/rules/runtime/pom.xml
+++ b/quarkus/addons/events/rules/runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-events-rules-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-addons-quarkus-events-rules</artifactId>

--- a/quarkus/addons/explainability/deployment/pom.xml
+++ b/quarkus/addons/explainability/deployment/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-explainability-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-explainability-deployment</artifactId>
   <name>Kogito Add-On Explainability - Deployment</name>

--- a/quarkus/addons/explainability/pom.xml
+++ b/quarkus/addons/explainability/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-addons-quarkus-explainability-parent</artifactId>

--- a/quarkus/addons/explainability/runtime/pom.xml
+++ b/quarkus/addons/explainability/runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>kogito-addons-quarkus-explainability-parent</artifactId>
         <groupId>org.kie.kogito</groupId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/jobs/deployment/pom.xml
+++ b/quarkus/addons/jobs/deployment/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-jobs-management-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-jobs-management-deployment</artifactId>
   <name>Kogito Add-On Jobs Management - Deployment</name>

--- a/quarkus/addons/jobs/pom.xml
+++ b/quarkus/addons/jobs/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-addons-quarkus-jobs-management-parent</artifactId>

--- a/quarkus/addons/jobs/runtime/pom.xml
+++ b/quarkus/addons/jobs/runtime/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-jobs-management-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-jobs-management</artifactId>
   <name>Kogito Add-On Jobs Management</name>

--- a/quarkus/addons/knative/eventing/deployment/pom.xml
+++ b/quarkus/addons/knative/eventing/deployment/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-knative-eventing-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-knative-eventing-deployment</artifactId>
   <name>Kogito Add-On Knative Eventing - Deployment</name>

--- a/quarkus/addons/knative/eventing/pom.xml
+++ b/quarkus/addons/knative/eventing/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-knative-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-addons-quarkus-knative-eventing-parent</artifactId>

--- a/quarkus/addons/knative/eventing/runtime/pom.xml
+++ b/quarkus/addons/knative/eventing/runtime/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-knative-eventing-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/knative/pom.xml
+++ b/quarkus/addons/knative/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/kubernetes/deployment/pom.xml
+++ b/quarkus/addons/kubernetes/deployment/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-kubernetes-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-kubernetes-deployment</artifactId>
   <name>Kogito Add-On Kubernetes - Deployment</name>

--- a/quarkus/addons/kubernetes/pom.xml
+++ b/quarkus/addons/kubernetes/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/kubernetes/runtime/pom.xml
+++ b/quarkus/addons/kubernetes/runtime/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-kubernetes-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/mail/deployment/pom.xml
+++ b/quarkus/addons/mail/deployment/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-mail-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-mail-deployment</artifactId>
   <name>Kogito Add-On Mail - Deployment</name>

--- a/quarkus/addons/mail/pom.xml
+++ b/quarkus/addons/mail/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-addons-quarkus-mail-parent</artifactId>

--- a/quarkus/addons/mail/runtime/pom.xml
+++ b/quarkus/addons/mail/runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-mail-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-mail</artifactId>
   <name>Kogito Add-On Mail</name>

--- a/quarkus/addons/messaging/common/pom.xml
+++ b/quarkus/addons/messaging/common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-messaging-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-messaging-common</artifactId>
   <name>Kogito Add-On Messaging - Common</name>

--- a/quarkus/addons/messaging/deployment/pom.xml
+++ b/quarkus/addons/messaging/deployment/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-messaging-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-messaging-deployment</artifactId>
   <name>Kogito Add-On Messaging - Deployment</name>

--- a/quarkus/addons/messaging/integration-tests/pom.xml
+++ b/quarkus/addons/messaging/integration-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-messaging-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-messaging-it</artifactId>
   <name>Kogito Add-On Messaging - Integration Tests</name>

--- a/quarkus/addons/messaging/pom.xml
+++ b/quarkus/addons/messaging/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-messaging-parent</artifactId>
   <packaging>pom</packaging>

--- a/quarkus/addons/messaging/runtime/pom.xml
+++ b/quarkus/addons/messaging/runtime/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-messaging-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/monitoring/core/pom.xml
+++ b/quarkus/addons/monitoring/core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-monitoring-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>kogito-addons-quarkus-monitoring-core</artifactId>

--- a/quarkus/addons/monitoring/elastic/deployment/pom.xml
+++ b/quarkus/addons/monitoring/elastic/deployment/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-monitoring-elastic-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-monitoring-elastic-deployment</artifactId>
   <name>Kogito Add-On Monitoring Elastic - Deployment</name>

--- a/quarkus/addons/monitoring/elastic/pom.xml
+++ b/quarkus/addons/monitoring/elastic/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-monitoring-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-monitoring-elastic-parent</artifactId>
   <packaging>pom</packaging>

--- a/quarkus/addons/monitoring/elastic/runtime/pom.xml
+++ b/quarkus/addons/monitoring/elastic/runtime/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-monitoring-elastic-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/monitoring/pom.xml
+++ b/quarkus/addons/monitoring/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/monitoring/prometheus/deployment/pom.xml
+++ b/quarkus/addons/monitoring/prometheus/deployment/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-monitoring-prometheus-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-monitoring-prometheus-deployment</artifactId>
   <name>Kogito Add-On Monitoring Prometheus - Deployment</name>

--- a/quarkus/addons/monitoring/prometheus/pom.xml
+++ b/quarkus/addons/monitoring/prometheus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-monitoring-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-monitoring-prometheus-parent</artifactId>
   <packaging>pom</packaging>

--- a/quarkus/addons/monitoring/prometheus/runtime/pom.xml
+++ b/quarkus/addons/monitoring/prometheus/runtime/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-monitoring-prometheus-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/persistence/filesystem/deployment/pom.xml
+++ b/quarkus/addons/persistence/filesystem/deployment/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-persistence-filesystem-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-persistence-filesystem-deployment</artifactId>
   <name>Kogito Add-On Persistence FileSystem - Deployment</name>

--- a/quarkus/addons/persistence/filesystem/pom.xml
+++ b/quarkus/addons/persistence/filesystem/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-persistence-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-persistence-filesystem-parent</artifactId>
   <packaging>pom</packaging>

--- a/quarkus/addons/persistence/filesystem/runtime/pom.xml
+++ b/quarkus/addons/persistence/filesystem/runtime/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-persistence-filesystem-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/persistence/infinispan/deployment/pom.xml
+++ b/quarkus/addons/persistence/infinispan/deployment/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-persistence-infinispan-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-persistence-infinispan-deployment</artifactId>
   <name>Kogito Add-On Persistence Infinispan - Deployment</name>

--- a/quarkus/addons/persistence/infinispan/health/pom.xml
+++ b/quarkus/addons/persistence/infinispan/health/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-persistence-infinispan-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/persistence/infinispan/pom.xml
+++ b/quarkus/addons/persistence/infinispan/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-persistence-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-persistence-infinispan-parent</artifactId>
   <packaging>pom</packaging>

--- a/quarkus/addons/persistence/infinispan/runtime/pom.xml
+++ b/quarkus/addons/persistence/infinispan/runtime/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-persistence-infinispan-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/persistence/jdbc/deployment/pom.xml
+++ b/quarkus/addons/persistence/jdbc/deployment/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-persistence-jdbc-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-persistence-jdbc-deployment</artifactId>
   <name>Kogito Add-On Persistence JDBC - Deployment</name>

--- a/quarkus/addons/persistence/jdbc/pom.xml
+++ b/quarkus/addons/persistence/jdbc/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-persistence-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-persistence-jdbc-parent</artifactId>
   <packaging>pom</packaging>

--- a/quarkus/addons/persistence/jdbc/runtime/pom.xml
+++ b/quarkus/addons/persistence/jdbc/runtime/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-persistence-jdbc-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/persistence/kafka/deployment/pom.xml
+++ b/quarkus/addons/persistence/kafka/deployment/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-persistence-kafka-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-persistence-kafka-deployment</artifactId>
   <name>Kogito Add-On Persistence Kafka Streams - Deployment</name>

--- a/quarkus/addons/persistence/kafka/pom.xml
+++ b/quarkus/addons/persistence/kafka/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-persistence-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-persistence-kafka-parent</artifactId>
   <packaging>pom</packaging>

--- a/quarkus/addons/persistence/kafka/runtime/pom.xml
+++ b/quarkus/addons/persistence/kafka/runtime/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-persistence-kafka-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/persistence/mongodb/deployment/pom.xml
+++ b/quarkus/addons/persistence/mongodb/deployment/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-persistence-mongodb-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-persistence-mongodb-deployment</artifactId>
   <name>Kogito Add-On Persistence MongoDB - Deployment</name>

--- a/quarkus/addons/persistence/mongodb/pom.xml
+++ b/quarkus/addons/persistence/mongodb/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-persistence-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-persistence-mongodb-parent</artifactId>
   <packaging>pom</packaging>

--- a/quarkus/addons/persistence/mongodb/runtime/pom.xml
+++ b/quarkus/addons/persistence/mongodb/runtime/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-persistence-mongodb-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/persistence/pom.xml
+++ b/quarkus/addons/persistence/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/persistence/postgresql/deployment/pom.xml
+++ b/quarkus/addons/persistence/postgresql/deployment/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-persistence-postgresql-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-persistence-postgresql-deployment</artifactId>
   <name>Kogito Add-On Persistence PostgreSQL - Deployment</name>

--- a/quarkus/addons/persistence/postgresql/pom.xml
+++ b/quarkus/addons/persistence/postgresql/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-persistence-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-persistence-postgresql-parent</artifactId>
   <packaging>pom</packaging>

--- a/quarkus/addons/persistence/postgresql/runtime/pom.xml
+++ b/quarkus/addons/persistence/postgresql/runtime/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-persistence-postgresql-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/pom.xml
+++ b/quarkus/addons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-quarkus-bom</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../bom/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/quarkus/addons/process-management/deployment/pom.xml
+++ b/quarkus/addons/process-management/deployment/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-process-management-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-process-management-deployment</artifactId>
   <name>Kogito Add-On Process Management - Deployment</name>

--- a/quarkus/addons/process-management/pom.xml
+++ b/quarkus/addons/process-management/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/process-management/runtime/pom.xml
+++ b/quarkus/addons/process-management/runtime/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-process-management-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-process-management</artifactId>
   <name>Kogito Add-On Process Management</name>

--- a/quarkus/addons/process-svg/deployment/pom.xml
+++ b/quarkus/addons/process-svg/deployment/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-process-svg-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-process-svg-deployment</artifactId>
   <name>Kogito Add-On Process SVG - Deployment</name>

--- a/quarkus/addons/process-svg/pom.xml
+++ b/quarkus/addons/process-svg/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/process-svg/runtime/pom.xml
+++ b/quarkus/addons/process-svg/runtime/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-process-svg-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-process-svg</artifactId>
   <name>Kogito Add-On Process SVG</name>

--- a/quarkus/addons/rest-exception-handler/pom.xml
+++ b/quarkus/addons/rest-exception-handler/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-rest-exception-handler</artifactId>
   <name>Kogito :: Rest Exception Handler :: Quarkus</name>

--- a/quarkus/addons/task-management/deployment/pom.xml
+++ b/quarkus/addons/task-management/deployment/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-task-management-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-task-management-deployment</artifactId>
   <name>Kogito Add-On Task Management - Deployment</name>

--- a/quarkus/addons/task-management/pom.xml
+++ b/quarkus/addons/task-management/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/task-management/runtime/pom.xml
+++ b/quarkus/addons/task-management/runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-task-management-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-task-management</artifactId>
   <name>Kogito Add-On Task Management</name>

--- a/quarkus/addons/task-notification/deployment/pom.xml
+++ b/quarkus/addons/task-notification/deployment/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-task-notification-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-task-notification-deployment</artifactId>
   <name>Kogito Add-On Task Notification - Deployment</name>

--- a/quarkus/addons/task-notification/pom.xml
+++ b/quarkus/addons/task-notification/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/task-notification/runtime/pom.xml
+++ b/quarkus/addons/task-notification/runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-task-notification-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-task-notification</artifactId>
   <name>Kogito Add-On Task Notification</name>

--- a/quarkus/addons/tracing-decision/deployment/pom.xml
+++ b/quarkus/addons/tracing-decision/deployment/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-tracing-decision-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-tracing-decision-deployment</artifactId>
   <name>Kogito Add-On Tracing Decision - Deployment</name>

--- a/quarkus/addons/tracing-decision/pom.xml
+++ b/quarkus/addons/tracing-decision/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/tracing-decision/runtime/pom.xml
+++ b/quarkus/addons/tracing-decision/runtime/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-tracing-decision-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/bom/pom.xml
+++ b/quarkus/bom/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>quarkus</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-quarkus-bom</artifactId>

--- a/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-deployment/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-deployment/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>kogito-quarkus-decisions-extension</artifactId>
         <groupId>org.kie.kogito</groupId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test-hot-reload/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test-hot-reload/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>kogito-quarkus-decisions-extension</artifactId>
         <groupId>org.kie.kogito</groupId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>kogito-quarkus-decisions-extension</artifactId>
         <groupId>org.kie.kogito</groupId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>kogito-quarkus-decisions-extension</artifactId>
         <groupId>org.kie.kogito</groupId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-decisions-extension/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-decisions-extension/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>quarkus-extensions</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>kogito-quarkus-extension-common</artifactId>
         <groupId>org.kie.kogito</groupId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>kogito-quarkus-extension-common</artifactId>
         <groupId>org.kie.kogito</groupId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-extension-common/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-extension-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>quarkus-extensions</artifactId>
         <groupId>org.kie.kogito</groupId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-deployment/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-deployment/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-quarkus-extension</artifactId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-quarkus-deployment</artifactId>

--- a/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-integration-test-maven-devmode/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-integration-test-maven-devmode/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-quarkus-extension</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-quarkus-integration-test-maven-devmode</artifactId>

--- a/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-integration-test/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-integration-test/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-quarkus-extension</artifactId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-quarkus-integration-test</artifactId>

--- a/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-quarkus-extension</artifactId>
-    <version>1.14.0-SNAPSHOT</version>    
+    <version>2.0.0-SNAPSHOT</version>    
   </parent>
 
   <artifactId>kogito-quarkus</artifactId>

--- a/quarkus/extensions/kogito-quarkus-extension/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-extension/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>quarkus-extensions</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions-deployment/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions-deployment/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>kogito-quarkus-predictions-extension</artifactId>
         <groupId>org.kie.kogito</groupId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions-integration-test/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions-integration-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>kogito-quarkus-predictions-extension</artifactId>
         <groupId>org.kie.kogito</groupId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>kogito-quarkus-predictions-extension</artifactId>
         <groupId>org.kie.kogito</groupId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-predictions-extension/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-predictions-extension/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>quarkus-extensions</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-deployment/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-deployment/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-quarkus-processes-extension</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-integration-test-hot-reload/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-integration-test-hot-reload/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-quarkus-processes-extension</artifactId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-quarkus-processes-integration-test-hot-reload</artifactId>

--- a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-integration-test/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-integration-test/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-quarkus-processes-extension</artifactId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-quarkus-processes-integration-test</artifactId>

--- a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-quarkus-processes-extension</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-processes-extension/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-processes-extension/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>quarkus-extensions</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-deployment/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-deployment/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>kogito-quarkus-rules-extension</artifactId>
         <groupId>org.kie.kogito</groupId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test-hot-reload/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test-hot-reload/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>kogito-quarkus-rules-extension</artifactId>
         <groupId>org.kie.kogito</groupId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test-session/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test-session/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>kogito-quarkus-rules-extension</artifactId>
         <groupId>org.kie.kogito</groupId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>kogito-quarkus-rules-extension</artifactId>
         <groupId>org.kie.kogito</groupId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>kogito-quarkus-rules-extension</artifactId>
         <groupId>org.kie.kogito</groupId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-rules-extension/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-rules-extension/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>quarkus-extensions</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-quarkus-serverless-workflow-extension</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-quarkus-serverless-workflow-extension</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-quarkus-serverless-workflow-extension</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>quarkus-extensions</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-test-list/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-test-list/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>quarkus-extensions</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/pom.xml
+++ b/quarkus/extensions/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>quarkus</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>quarkus-extensions</artifactId>

--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-build-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../kogito-build/kogito-build-parent/pom.xml</relativePath>
   </parent>
 

--- a/quarkus/test/pom.xml
+++ b/quarkus/test/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>quarkus</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-quarkus-test-utils</artifactId>

--- a/springboot/addons/events/decisions/pom.xml
+++ b/springboot/addons/events/decisions/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-springboot-events-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-addons-springboot-events-decisions</artifactId>

--- a/springboot/addons/events/kafka/pom.xml
+++ b/springboot/addons/events/kafka/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-springboot-events-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-springboot-events-process-kafka</artifactId>
   <name>Kogito :: Add-Ons :: Events :: SprintBoot :: Process :: Kafka</name>

--- a/springboot/addons/events/mongodb/pom.xml
+++ b/springboot/addons/events/mongodb/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-addons-springboot-events-parent</artifactId>
-        <version>1.14.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/addons/events/pom.xml
+++ b/springboot/addons/events/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-springboot-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/addons/events/predictions/pom.xml
+++ b/springboot/addons/events/predictions/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-springboot-events-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-addons-springboot-events-predictions</artifactId>

--- a/springboot/addons/events/rules/pom.xml
+++ b/springboot/addons/events/rules/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-springboot-events-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-addons-springboot-events-rules</artifactId>

--- a/springboot/addons/explainability/pom.xml
+++ b/springboot/addons/explainability/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-springboot-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/addons/jobs/pom.xml
+++ b/springboot/addons/jobs/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-springboot-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-springboot-jobs-management</artifactId>
   <name>Kogito :: Add-Ons :: Jobs :: Management SprintBoot Addon</name>

--- a/springboot/addons/kubernetes/pom.xml
+++ b/springboot/addons/kubernetes/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-springboot-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/addons/mail/pom.xml
+++ b/springboot/addons/mail/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-springboot-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/addons/messaging/implementation/pom.xml
+++ b/springboot/addons/messaging/implementation/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-springboot-messaging-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-springboot-messaging</artifactId>
   <name>Kogito :: Add-Ons :: Messaging :: Spring Boot</name>

--- a/springboot/addons/messaging/integration-tests/pom.xml
+++ b/springboot/addons/messaging/integration-tests/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-springboot-messaging-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-springboot-messaging-it</artifactId>
   <name>Kogito :: Add-Ons :: Messaging :: Spring Boot (ITs)</name>

--- a/springboot/addons/messaging/pom.xml
+++ b/springboot/addons/messaging/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-springboot-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/addons/monitoring/core/pom.xml
+++ b/springboot/addons/monitoring/core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-springboot-monitoring-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <name>Kogito :: Add-Ons :: Monitoring Core Springboot</name>

--- a/springboot/addons/monitoring/elastic/pom.xml
+++ b/springboot/addons/monitoring/elastic/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-springboot-monitoring-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/addons/monitoring/pom.xml
+++ b/springboot/addons/monitoring/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-springboot-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/addons/monitoring/prometheus/pom.xml
+++ b/springboot/addons/monitoring/prometheus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-springboot-monitoring-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <name>Kogito :: Add-Ons :: Monitoring Prometheus Springboot</name>

--- a/springboot/addons/pom.xml
+++ b/springboot/addons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-spring-boot-bom</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../bom</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/springboot/addons/process-management/pom.xml
+++ b/springboot/addons/process-management/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-springboot-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/addons/process-svg/pom.xml
+++ b/springboot/addons/process-svg/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-springboot-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-springboot-process-svg</artifactId>
   <name>Kogito :: Add-Ons :: Process SVG :: Spring Boot Addon</name>

--- a/springboot/addons/rest-exception-handler/pom.xml
+++ b/springboot/addons/rest-exception-handler/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-springboot-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/addons/task-management/pom.xml
+++ b/springboot/addons/task-management/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-springboot-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/addons/task-notification/pom.xml
+++ b/springboot/addons/task-notification/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-springboot-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/addons/tracing-decision/pom.xml
+++ b/springboot/addons/tracing-decision/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kogito-addons-springboot-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/archetype/pom.xml
+++ b/springboot/archetype/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>springboot</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-spring-boot-archetype</artifactId>
   <packaging>maven-archetype</packaging>

--- a/springboot/bom/pom.xml
+++ b/springboot/bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>springboot</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/pom.xml
+++ b/springboot/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-build-parent</artifactId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../kogito-build/kogito-build-parent/pom.xml</relativePath>
   </parent>
 

--- a/springboot/starters/kogito-decisions-spring-boot-starter/pom.xml
+++ b/springboot/starters/kogito-decisions-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>spring-boot-starters</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/starters/kogito-predictions-spring-boot-starter/pom.xml
+++ b/springboot/starters/kogito-predictions-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>spring-boot-starters</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/starters/kogito-processes-spring-boot-starter/pom.xml
+++ b/springboot/starters/kogito-processes-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>spring-boot-starters</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/starters/kogito-rules-spring-boot-starter/pom.xml
+++ b/springboot/starters/kogito-rules-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>spring-boot-starters</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/starters/kogito-serverless-workflow-spring-boot-starter/pom.xml
+++ b/springboot/starters/kogito-serverless-workflow-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>spring-boot-starters</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/starters/kogito-spring-boot-starter/pom.xml
+++ b/springboot/starters/kogito-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>spring-boot-starters</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/starters/kogito-springboot-starter/pom.xml
+++ b/springboot/starters/kogito-springboot-starter/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>spring-boot-starters</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/starters/pom.xml
+++ b/springboot/starters/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>springboot</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/test/pom.xml
+++ b/springboot/test/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>springboot</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>1.14.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-spring-boot-test-utils</artifactId>


### PR DESCRIPTION
Reverts kiegroup/kogito-runtimes#1715 due to Nexus issues. it will be set back once Nexus issues are solved