### PR TITLE
KOGITO-6272 Ensure Quarkus extensions do not depend on quarkus-jackson

### DIFF
--- a/kogito-codegen-modules/kogito-codegen-core/src/main/java/org/kie/kogito/codegen/core/ApplicationConfigGenerator.java
+++ b/kogito-codegen-modules/kogito-codegen-core/src/main/java/org/kie/kogito/codegen/core/ApplicationConfigGenerator.java
@@ -74,7 +74,7 @@ public class ApplicationConfigGenerator {
 
         generatedFiles.add(generateApplicationConfigDescriptor(configClassNames));
 
-        if (context.hasDI()) {
+        if (context.hasDI() && context.hasRESTGloballyAvailable()) {
             generatedFiles.add(ObjectMapperGenerator.generate(context));
         }
 

--- a/kogito-codegen-modules/kogito-codegen-core/src/main/java/org/kie/kogito/codegen/core/ObjectMapperGenerator.java
+++ b/kogito-codegen-modules/kogito-codegen-core/src/main/java/org/kie/kogito/codegen/core/ObjectMapperGenerator.java
@@ -17,6 +17,7 @@ package org.kie.kogito.codegen.core;
 
 import org.kie.kogito.codegen.api.GeneratedFile;
 import org.kie.kogito.codegen.api.GeneratedFileType;
+import org.kie.kogito.codegen.api.Generator;
 import org.kie.kogito.codegen.api.context.KogitoBuildContext;
 import org.kie.kogito.codegen.api.template.TemplatedGenerator;
 
@@ -25,14 +26,12 @@ public class ObjectMapperGenerator {
     private ObjectMapperGenerator() {
     }
 
-    private static final GeneratedFileType JSON_MAPPER_TYPE = GeneratedFileType.of("JSON_MAPPER", GeneratedFileType.Category.SOURCE);
-
     public static GeneratedFile generate(KogitoBuildContext context) {
         TemplatedGenerator generator = TemplatedGenerator.builder()
                 .withTemplateBasePath("class-templates/config")
                 .build(context, "GlobalObjectMapper");
 
-        return new GeneratedFile(JSON_MAPPER_TYPE,
+        return new GeneratedFile(Generator.REST_TYPE,
                 generator.generatedFilePath(),
                 generator.compilationUnitOrThrow().toString());
     }

--- a/kogito-codegen-modules/kogito-codegen-core/src/main/java/org/kie/kogito/codegen/core/ObjectMapperGenerator.java
+++ b/kogito-codegen-modules/kogito-codegen-core/src/main/java/org/kie/kogito/codegen/core/ObjectMapperGenerator.java
@@ -16,7 +16,6 @@
 package org.kie.kogito.codegen.core;
 
 import org.kie.kogito.codegen.api.GeneratedFile;
-import org.kie.kogito.codegen.api.GeneratedFileType;
 import org.kie.kogito.codegen.api.Generator;
 import org.kie.kogito.codegen.api.context.KogitoBuildContext;
 import org.kie.kogito.codegen.api.template.TemplatedGenerator;

--- a/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common/pom.xml
@@ -57,6 +57,12 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jackson</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>
         </dependency>
 

--- a/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules/pom.xml
@@ -24,6 +24,11 @@
             <groupId>org.kie.kogito</groupId>
             <artifactId>kogito-api-incubation-rules-services</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jackson</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- kogito -->
         <dependency>


### PR DESCRIPTION
While bumping to 2.5.0.CR1 a couple of jackson-related issues were
discovered

1. we were relying on `quarkus-jackson` being a dependency; but it was
transitive from vertx; now vertx removed that dependency and we break
2. ObjectMapperGenerator is always generated even when resteasy is not
present

- fix: add `provided` dependency to `quarkus-jackson`
- ObjectMapperGenerator should be optional (generate only with resteasy present)
- formatting

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](CONTRIBUTING.md)
- [ ] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run all builds</b>  
  Please add comment: <b>Jenkins retest this</b>

* <b>Run (or rerun) specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Run (or rerun) LTS specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Run (or rerun) native specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
