### PR TITLE
FAI-681: Integrate TrustyService with Quarkus DevServices services

### DIFF
--- a/kogito-bom/pom.xml
+++ b/kogito-bom/pom.xml
@@ -2108,6 +2108,17 @@
         <version>${project.version}</version>
         <classifier>sources</classifier>
       </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>runtime-tools-quarkus-extension-deployment</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>runtime-tools-quarkus-extension-deployment</artifactId>
+        <version>${project.version}</version>
+        <classifier>sources</classifier>
+      </dependency>
 
       <!-- Tracing -->
       <dependency>

--- a/kogito-bom/pom.xml
+++ b/kogito-bom/pom.xml
@@ -450,7 +450,6 @@
         <classifier>sources</classifier>
       </dependency>
 
-
       <dependency>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-addons-quarkus-messaging-common</artifactId>
@@ -473,7 +472,6 @@
         <version>${project.version}</version>
         <classifier>sources</classifier>
       </dependency>
-
 
       <dependency>
         <groupId>org.kie.kogito</groupId>
@@ -641,7 +639,6 @@
         <classifier>javadoc</classifier>
       </dependency>
 
-
       <!-- Monitoring addon     -->
       <dependency>
         <groupId>org.kie.kogito</groupId>
@@ -790,7 +787,6 @@
         <version>${project.version}</version>
         <classifier>sources</classifier>
       </dependency>
-
 
       <!-- Grafana API     -->
       <dependency>
@@ -1580,7 +1576,6 @@
         <version>${project.version}</version>
       </dependency>
 
-
       <!-- drools -->
       <dependency>
         <groupId>org.kie.kogito</groupId>
@@ -1917,7 +1912,6 @@
         <classifier>sources</classifier>
       </dependency>
 
-
       <!-- Quarkus extension -->
       <dependency>
         <groupId>org.kie.kogito</groupId>
@@ -2100,6 +2094,19 @@
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-quarkus-extension-spi</artifactId>
         <version>${project.version}</version>
+      </dependency>
+
+      <!-- Quarkus DevUI addon -->
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>runtime-tools-quarkus-extension</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>runtime-tools-quarkus-extension</artifactId>
+        <version>${project.version}</version>
+        <classifier>sources</classifier>
       </dependency>
 
       <!-- Tracing -->

--- a/quarkus/addons/tracing-decision/deployment/pom.xml
+++ b/quarkus/addons/tracing-decision/deployment/pom.xml
@@ -31,15 +31,19 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-reactive-messaging-kafka-deployment</artifactId>
     </dependency>
+
     <!-- Needed to trick DevServices into running a PostgreSQL instance for TrustyService -->
+    <!-- This dependency handles starting up Databases for DevServices in DevMode -->
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-hibernate-orm-deployment</artifactId>
+      <artifactId>quarkus-datasource-deployment</artifactId>
     </dependency>
+    <!-- This dependency handles instantiation of a PostgreSQL instance for DevServices in DevMode -->
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-jdbc-postgresql-deployment</artifactId>
     </dependency>
+
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-vertx-deployment</artifactId>

--- a/quarkus/addons/tracing-decision/deployment/pom.xml
+++ b/quarkus/addons/tracing-decision/deployment/pom.xml
@@ -31,6 +31,15 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-reactive-messaging-kafka-deployment</artifactId>
     </dependency>
+    <!-- Needed to trick DevServices into running a PostgreSQL instance for TrustyService -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-hibernate-orm-deployment</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-jdbc-postgresql-deployment</artifactId>
+    </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-vertx-deployment</artifactId>

--- a/quarkus/addons/tracing-decision/deployment/pom.xml
+++ b/quarkus/addons/tracing-decision/deployment/pom.xml
@@ -9,6 +9,11 @@
   </parent>
   <artifactId>kogito-addons-quarkus-tracing-decision-deployment</artifactId>
   <name>Kogito Add-On Tracing Decision - Deployment</name>
+
+  <properties>
+    <version.kogito.trusty.postgresql.image>1.15.0</version.kogito.trusty.postgresql.image>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.kie.kogito</groupId>
@@ -50,6 +55,12 @@
     </dependency>
   </dependencies>
   <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>

--- a/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/deployment/DevServicesConfig.java
+++ b/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/deployment/DevServicesConfig.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.tracing.decision.quarkus.deployment;
+
+import java.util.Objects;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+public final class DevServicesConfig extends SimpleBuildItem {
+
+    public enum Property {
+
+        QuarkusDataSourceDbKind("quarkus.datasource.db-kind") {
+            @Override
+            public String getEnvironmentVariableName() {
+                return "QUARKUS_DATASOURCE_DB_KIND";
+            }
+        },
+        QuarkusDataSourceUserName("quarkus.datasource.username") {
+            @Override
+            public String getEnvironmentVariableName() {
+                return "QUARKUS_DATASOURCE_USERNAME";
+            }
+        },
+        QuarkusDataSourcePassword("quarkus.datasource.password") {
+            @Override
+            public String getEnvironmentVariableName() {
+                return "QUARKUS_DATASOURCE_PASSWORD";
+            }
+        },
+        QuarkusDataSourceJdbcUrl("quarkus.datasource.jdbc.url") {
+            @Override
+            public String getEnvironmentVariableName() {
+                return "QUARKUS_DATASOURCE_JDBC_URL";
+            }
+        },
+        KafkaBootstrapServers("kafka.bootstrap.servers") {
+            @Override
+            public String getEnvironmentVariableName() {
+                return "KAFKA_BOOTSTRAP_SERVERS";
+            }
+        },
+        HibernateOrmDatabaseGeneration("quarkus.hibernate-orm.database.generation") {
+            @Override
+            public String getEnvironmentVariableName() {
+                return "QUARKUS_HIBERNATE_ORM_DATABASE_GENERATION";
+            }
+        };
+
+        private final String propertyName;
+
+        Property(String propertyName) {
+            this.propertyName = propertyName;
+        }
+
+        public String getPropertyName() {
+            return propertyName;
+        }
+
+        public abstract String getEnvironmentVariableName();
+
+    }
+
+    private String dataSourceUserName;
+    private String dataSourcePassword;
+    private String dataSourceKind;
+    private String dataSourceUrl;
+    private String kafkaBootstrapServer;
+    private String hibernateOrmDatabaseGeneration;
+
+    public String getDataSourceUserName() {
+        return dataSourceUserName;
+    }
+
+    public void setDataSourceUserName(String dataSourceUserName) {
+        this.dataSourceUserName = dataSourceUserName;
+    }
+
+    public String getDataSourcePassword() {
+        return dataSourcePassword;
+    }
+
+    public void setDataSourcePassword(String dataSourcePassword) {
+        this.dataSourcePassword = dataSourcePassword;
+    }
+
+    public String getDataSourceKind() {
+        return dataSourceKind;
+    }
+
+    public void setDataSourceKind(String dataSourceKind) {
+        this.dataSourceKind = dataSourceKind;
+    }
+
+    public String getDataSourceUrl() {
+        return dataSourceUrl;
+    }
+
+    public void setDataSourceUrl(String dataSourceUrl) {
+        this.dataSourceUrl = dataSourceUrl;
+    }
+
+    public String getKafkaBootstrapServer() {
+        return kafkaBootstrapServer;
+    }
+
+    public void setKafkaBootstrapServer(String kafkaBootstrapServer) {
+        this.kafkaBootstrapServer = kafkaBootstrapServer;
+    }
+
+    public String getHibernateOrmDatabaseGeneration() {
+        return hibernateOrmDatabaseGeneration;
+    }
+
+    public void setHibernateOrmDatabaseGeneration(String hibernateOrmDatabaseGeneration) {
+        this.hibernateOrmDatabaseGeneration = hibernateOrmDatabaseGeneration;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DevServicesConfig that = (DevServicesConfig) o;
+        return Objects.equals(dataSourceUserName, that.dataSourceUserName)
+                && Objects.equals(dataSourcePassword, that.dataSourcePassword)
+                && Objects.equals(dataSourceKind, that.dataSourceKind)
+                && Objects.equals(dataSourceUrl, that.dataSourceUrl)
+                && Objects.equals(kafkaBootstrapServer, that.kafkaBootstrapServer)
+                && Objects.equals(hibernateOrmDatabaseGeneration, that.hibernateOrmDatabaseGeneration);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(dataSourceUserName,
+                dataSourcePassword,
+                dataSourceKind,
+                dataSourceUrl,
+                kafkaBootstrapServer,
+                hibernateOrmDatabaseGeneration);
+    }
+}

--- a/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/deployment/DevServicesConfigProcessor.java
+++ b/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/deployment/DevServicesConfigProcessor.java
@@ -46,7 +46,7 @@ public class DevServicesConfigProcessor {
 
         final DevServicesConfig devServicesConfig = new DevServicesConfig();
 
-        LOGGER.info("Extracting Quarkus DevService configurations...");
+        LOGGER.debug("Extracting Quarkus DevService configurations...");
         final Map<String, String> quarkusConfig = configurationItems.getConfig();
         devServicesConfig.setDataSourceKind(quarkusConfig.get(QuarkusDataSourceDbKind.getPropertyName()));
         devServicesConfig.setDataSourceUserName(quarkusConfig.get(QuarkusDataSourceUserName.getPropertyName()));
@@ -55,12 +55,12 @@ public class DevServicesConfigProcessor {
         devServicesConfig.setKafkaBootstrapServer(quarkusConfig.get(KafkaBootstrapServers.getPropertyName()));
         devServicesConfig.setHibernateOrmDatabaseGeneration(quarkusConfig.get(HibernateOrmDatabaseGeneration.getPropertyName()));
 
-        LOGGER.info(String.format("DevServices default DataSource Kind: %s", devServicesConfig.getDataSourceKind()));
-        LOGGER.info(String.format("DevServices default DataSource Username: %s", devServicesConfig.getDataSourceUserName()));
-        LOGGER.info(String.format("DevServices default DataSource Password: %s", devServicesConfig.getDataSourcePassword()));
-        LOGGER.info(String.format("DevServices default DataSource URL: %s", devServicesConfig.getDataSourceUrl()));
-        LOGGER.info(String.format("DevServices Kafka Bootstrap Server: %s", devServicesConfig.getKafkaBootstrapServer()));
-        LOGGER.info(String.format("DevServices Hibernate ORM Database Generation: %s", devServicesConfig.getHibernateOrmDatabaseGeneration()));
+        LOGGER.debug(String.format("DevServices default DataSource Kind: %s", devServicesConfig.getDataSourceKind()));
+        LOGGER.debug(String.format("DevServices default DataSource Username: %s", devServicesConfig.getDataSourceUserName()));
+        LOGGER.debug(String.format("DevServices default DataSource Password: %s", devServicesConfig.getDataSourcePassword()));
+        LOGGER.debug(String.format("DevServices default DataSource URL: %s", devServicesConfig.getDataSourceUrl()));
+        LOGGER.debug(String.format("DevServices Kafka Bootstrap Server: %s", devServicesConfig.getKafkaBootstrapServer()));
+        LOGGER.debug(String.format("DevServices Hibernate ORM Database Generation: %s", devServicesConfig.getHibernateOrmDatabaseGeneration()));
 
         devServicesPostgreSQLConfigBuilder.produce(devServicesConfig);
     }

--- a/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/deployment/DevServicesConfigProcessor.java
+++ b/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/deployment/DevServicesConfigProcessor.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.tracing.decision.quarkus.deployment;
+
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.DevServicesLauncherConfigResultBuildItem;
+
+import static org.kie.kogito.tracing.decision.quarkus.deployment.DevServicesConfig.Property.HibernateOrmDatabaseGeneration;
+import static org.kie.kogito.tracing.decision.quarkus.deployment.DevServicesConfig.Property.KafkaBootstrapServers;
+import static org.kie.kogito.tracing.decision.quarkus.deployment.DevServicesConfig.Property.QuarkusDataSourceDbKind;
+import static org.kie.kogito.tracing.decision.quarkus.deployment.DevServicesConfig.Property.QuarkusDataSourceJdbcUrl;
+import static org.kie.kogito.tracing.decision.quarkus.deployment.DevServicesConfig.Property.QuarkusDataSourcePassword;
+import static org.kie.kogito.tracing.decision.quarkus.deployment.DevServicesConfig.Property.QuarkusDataSourceUserName;
+
+/**
+ * Extracts DevServices properties.
+ */
+public class DevServicesConfigProcessor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DevServicesConfigProcessor.class);
+
+    @SuppressWarnings("unused")
+    @BuildStep(onlyIf = IsDevelopment.class)
+    public void extractDevServicesDefaultDataSourceConfiguration(final DevServicesLauncherConfigResultBuildItem configurationItems,
+            final BuildProducer<DevServicesConfig> devServicesPostgreSQLConfigBuilder) {
+
+        final DevServicesConfig devServicesConfig = new DevServicesConfig();
+
+        LOGGER.info("Extracting Quarkus DevService configurations...");
+        final Map<String, String> quarkusConfig = configurationItems.getConfig();
+        devServicesConfig.setDataSourceKind(quarkusConfig.get(QuarkusDataSourceDbKind.getPropertyName()));
+        devServicesConfig.setDataSourceUserName(quarkusConfig.get(QuarkusDataSourceUserName.getPropertyName()));
+        devServicesConfig.setDataSourcePassword(quarkusConfig.get(QuarkusDataSourcePassword.getPropertyName()));
+        devServicesConfig.setDataSourceUrl(quarkusConfig.get(QuarkusDataSourceJdbcUrl.getPropertyName()));
+        devServicesConfig.setKafkaBootstrapServer(quarkusConfig.get(KafkaBootstrapServers.getPropertyName()));
+        devServicesConfig.setHibernateOrmDatabaseGeneration(quarkusConfig.get(HibernateOrmDatabaseGeneration.getPropertyName()));
+
+        LOGGER.info(String.format("DevServices default DataSource Kind: %s", devServicesConfig.getDataSourceKind()));
+        LOGGER.info(String.format("DevServices default DataSource Username: %s", devServicesConfig.getDataSourceUserName()));
+        LOGGER.info(String.format("DevServices default DataSource Password: %s", devServicesConfig.getDataSourcePassword()));
+        LOGGER.info(String.format("DevServices default DataSource URL: %s", devServicesConfig.getDataSourceUrl()));
+        LOGGER.info(String.format("DevServices Kafka Bootstrap Server: %s", devServicesConfig.getKafkaBootstrapServer()));
+        LOGGER.info(String.format("DevServices Hibernate ORM Database Generation: %s", devServicesConfig.getHibernateOrmDatabaseGeneration()));
+
+        devServicesPostgreSQLConfigBuilder.produce(devServicesConfig);
+    }
+
+}

--- a/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/deployment/DevServicesSetupEnvironmentProcessor.java
+++ b/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/deployment/DevServicesSetupEnvironmentProcessor.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.tracing.decision.quarkus.deployment;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.DevServicesConfigResultBuildItem;
+import io.quarkus.deployment.builditem.DevServicesSharedNetworkBuildItem;
+import io.quarkus.runtime.configuration.ConfigUtils;
+
+import static org.kie.kogito.tracing.decision.quarkus.deployment.DevServicesConfig.Property.HibernateOrmDatabaseGeneration;
+
+/**
+ * Configures DevServices properties.
+ */
+public class DevServicesSetupEnvironmentProcessor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DevServicesSetupEnvironmentProcessor.class);
+    private static final String HIBERNATE_ORM_DATABASE_GENERATION_STRATEGY = "drop-and-create";
+
+    @SuppressWarnings("unused")
+    @BuildStep(onlyIf = IsDevelopment.class)
+    public void extractDevServicesDefaultDataSourceConfiguration(final BuildProducer<DevServicesConfigResultBuildItem> devServicesConfigResultBuilder,
+            final BuildProducer<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItemBuildProducer) {
+
+        LOGGER.info("Checking DevService configuration...");
+        if (!ConfigUtils.isPropertyPresent(HibernateOrmDatabaseGeneration.getPropertyName())) {
+            LOGGER.info(String.format("Setting %s=%s to initialize DevServices managed database",
+                    HibernateOrmDatabaseGeneration.getPropertyName(),
+                    HIBERNATE_ORM_DATABASE_GENERATION_STRATEGY));
+            devServicesConfigResultBuilder.produce(new DevServicesConfigResultBuildItem(
+                    HibernateOrmDatabaseGeneration.getPropertyName(),
+                    HIBERNATE_ORM_DATABASE_GENERATION_STRATEGY));
+        }
+
+        LOGGER.info("Enabling use of TestContainers 'Shared Network' for all containers started by Quarkus.");
+        devServicesSharedNetworkBuildItemBuildProducer.produce(new DevServicesSharedNetworkBuildItem());
+    }
+}

--- a/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/deployment/DevServicesSetupEnvironmentProcessor.java
+++ b/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/deployment/DevServicesSetupEnvironmentProcessor.java
@@ -40,9 +40,9 @@ public class DevServicesSetupEnvironmentProcessor {
     public void extractDevServicesDefaultDataSourceConfiguration(final BuildProducer<DevServicesConfigResultBuildItem> devServicesConfigResultBuilder,
             final BuildProducer<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItemBuildProducer) {
 
-        LOGGER.info("Checking DevService configuration...");
+        LOGGER.debug("Checking DevService configuration...");
         if (!ConfigUtils.isPropertyPresent(HibernateOrmDatabaseGeneration.getPropertyName())) {
-            LOGGER.info(String.format("Setting %s=%s to initialize DevServices managed database",
+            LOGGER.debug(String.format("Setting %s=%s to initialize DevServices managed database",
                     HibernateOrmDatabaseGeneration.getPropertyName(),
                     HIBERNATE_ORM_DATABASE_GENERATION_STRATEGY));
             devServicesConfigResultBuilder.produce(new DevServicesConfigResultBuildItem(
@@ -50,7 +50,7 @@ public class DevServicesSetupEnvironmentProcessor {
                     HIBERNATE_ORM_DATABASE_GENERATION_STRATEGY));
         }
 
-        LOGGER.info("Enabling use of TestContainers 'Shared Network' for all containers started by Quarkus.");
+        LOGGER.debug("Enabling use of TestContainers 'Shared Network' for all containers started by Quarkus.");
         devServicesSharedNetworkBuildItemBuildProducer.produce(new DevServicesSharedNetworkBuildItem());
     }
 }

--- a/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/deployment/KogitoAddOnTracingDecisionProcessor.java
+++ b/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/deployment/KogitoAddOnTracingDecisionProcessor.java
@@ -30,6 +30,7 @@ class KogitoAddOnTracingDecisionProcessor extends RequireCapabilityKogitoAddOnPr
     }
 
     @BuildStep
+    @SuppressWarnings("unused")
     FeatureBuildItem feature() {
         return new FeatureBuildItem(FEATURE);
     }

--- a/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/deployment/KogitoBuildTimeConfig.java
+++ b/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/deployment/KogitoBuildTimeConfig.java
@@ -24,7 +24,7 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 public class KogitoBuildTimeConfig {
 
     /**
-     * Configuration for DevServices. DevServices allows Quarkus to automatically start Data Index in dev and test mode.
+     * Configuration for DevServices. DevServices allows Quarkus to automatically start TrustyService in dev and test mode.
      */
     @ConfigItem
     public KogitoDevServicesBuildTimeConfig devservicesTrusty;

--- a/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/deployment/KogitoBuildTimeConfig.java
+++ b/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/deployment/KogitoBuildTimeConfig.java
@@ -27,5 +27,5 @@ public class KogitoBuildTimeConfig {
      * Configuration for DevServices. DevServices allows Quarkus to automatically start TrustyService in dev and test mode.
      */
     @ConfigItem
-    public KogitoDevServicesBuildTimeConfig devservicesTrusty;
+    public KogitoDevServicesBuildTimeConfig devServicesTrusty;
 }

--- a/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/deployment/KogitoBuildTimeConfig.java
+++ b/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/deployment/KogitoBuildTimeConfig.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.tracing.decision.quarkus.deployment;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(name = "kogito", phase = ConfigPhase.BUILD_TIME)
+public class KogitoBuildTimeConfig {
+
+    /**
+     * Configuration for DevServices. DevServices allows Quarkus to automatically start Data Index in dev and test mode.
+     */
+    @ConfigItem
+    public KogitoDevServicesBuildTimeConfig devservicesTrusty;
+}

--- a/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/deployment/KogitoDevServicesBuildTimeConfig.java
+++ b/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/deployment/KogitoDevServicesBuildTimeConfig.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.tracing.decision.quarkus.deployment;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+@ConfigGroup
+public class KogitoDevServicesBuildTimeConfig {
+
+    /**
+     * If Dev Services for Kogito has been explicitly enabled or disabled. Dev Services are generally enabled
+     * by default, unless there is an existing configuration present.
+     */
+    @ConfigItem
+    public Optional<Boolean> enabled = Optional.empty();
+
+    /**
+     * Optional fixed port the dev service will listen to.
+     * <p>
+     * If not defined, 8081 will be used.
+     */
+    @ConfigItem(defaultValue = "8081")
+    public Optional<Integer> port;
+
+    /**
+     * The TrustyService image to use.
+     */
+    @ConfigItem(defaultValue = "quay.io/kiegroup/kogito-trusty-postgresql:1.14.0")
+    public String imageName;
+
+    /**
+     * Indicates if the TrustyService instance managed by Quarkus DevServices is shared.
+     * When shared, Quarkus looks for running containers using label-based service discovery.
+     * If a matching container is found, it is used, and so a second one is not started.
+     * Otherwise, DevServices starts a new TrustyService instance.
+     * <p>
+     * The discovery uses the {@code kogito-dev-service-trusty-service} label.
+     * The value is configured using the {@code service-name} property.
+     * <p>
+     * Container sharing is only used in dev mode.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean shared;
+
+    /**
+     * The value of the {@code kogito-dev-service-trusty-service} label attached to the started container.
+     * This property is used when {@code shared} is set to {@code true}.
+     * In this case, before starting a container, DevServices looks for a container with the
+     * {@code kogito-dev-service-trusty-service} label set to the configured value. If found, it will use this
+     * container instead of starting a new one. Otherwise, it starts a new container with the
+     * {@code kogito-dev-service-trusty-service} label set to the specified value.
+     */
+    @ConfigItem(defaultValue = "kogito-trusty-service")
+    public String serviceName;
+
+}

--- a/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/deployment/KogitoDevServicesBuildTimeConfig.java
+++ b/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/deployment/KogitoDevServicesBuildTimeConfig.java
@@ -42,7 +42,7 @@ public class KogitoDevServicesBuildTimeConfig {
     /**
      * The TrustyService image to use.
      */
-    @ConfigItem(defaultValue = "quay.io/kiegroup/kogito-trusty-postgresql:1.14.0")
+    @ConfigItem
     public String imageName;
 
     /**

--- a/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/deployment/KogitoDevServicesProcessor.java
+++ b/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/deployment/KogitoDevServicesProcessor.java
@@ -121,8 +121,8 @@ public class KogitoDevServicesProcessor {
                                 .filter(Objects::nonNull)
                                 .findFirst();
                     }
-                    LOGGER.info(String.format("[PostgreSQL] Private Port: %s", port.orElse(0)));
-                    LOGGER.info(String.format("[PostgreSQL] IP Address: %s", ipAddress.orElse("<None>")));
+                    LOGGER.debug(String.format("[PostgreSQL] Private Port: %s", port.orElse(0)));
+                    LOGGER.debug(String.format("[PostgreSQL] IP Address: %s", ipAddress.orElse("<None>")));
                     if (ipAddress.isPresent() && port.isPresent()) {
                         final String jdbcUrl = String.format("jdbc:postgresql://%s:%d/default?loggerLevel=OFF", ipAddress.get(), port.get());
                         devServicesConfig.setDataSourceUrl(jdbcUrl);
@@ -144,7 +144,7 @@ public class KogitoDevServicesProcessor {
                                 .filter(Objects::nonNull)
                                 .findFirst();
                     }
-                    LOGGER.info(String.format("[Kafka] IP Address: %s", ipAddress.orElse("<None>")));
+                    LOGGER.debug(String.format("[Kafka] IP Address: %s", ipAddress.orElse("<None>")));
                     if (ipAddress.isPresent()) {
                         final String kafkaBootstrapServer = String.format("PLAINTEXT://%s:29092", ipAddress.get());
                         devServicesConfig.setKafkaBootstrapServer(kafkaBootstrapServer);
@@ -204,11 +204,11 @@ public class KogitoDevServicesProcessor {
                                 .filter(Objects::nonNull)
                                 .findFirst();
                     }
-                    LOGGER.info(String.format("[TrustyService] Private Port: %s", port.orElse(0)));
-                    LOGGER.info(String.format("[TrustyService] IP Address: %s", ipAddress.orElse("<None>")));
+                    LOGGER.debug(String.format("[TrustyService] Private Port: %s", port.orElse(0)));
+                    LOGGER.debug(String.format("[TrustyService] IP Address: %s", ipAddress.orElse("<None>")));
                     if (ipAddress.isPresent() && port.isPresent()) {
                         final String trustyServiceServer = String.format("http://%s:%s", ipAddress.get(), port.get());
-                        LOGGER.info(String.format("Setting System Property '%s' to '%s'", KOGITO_TRUSTY_SERVICE, trustyServiceServer));
+                        LOGGER.debug(String.format("Setting System Property '%s' to '%s'", KOGITO_TRUSTY_SERVICE, trustyServiceServer));
                         systemProperties.produce(new SystemPropertyBuildItem(KOGITO_TRUSTY_SERVICE, trustyServiceServer));
                     }
                 });
@@ -275,12 +275,12 @@ public class KogitoDevServicesProcessor {
                         launchMode.getLaunchMode() == LaunchMode.DEVELOPMENT ? config.serviceName : null,
                         useSharedNetwork);
 
-                LOGGER.info(String.format("TrustyService DataSource Kind: %s", devServicesConfig.getDataSourceKind()));
-                LOGGER.info(String.format("TrustyService DataSource Username: %s", devServicesConfig.getDataSourceUserName()));
-                LOGGER.info(String.format("TrustyService DataSource Password: %s", devServicesConfig.getDataSourcePassword()));
-                LOGGER.info(String.format("TrustyService DataSource URL: %s", devServicesConfig.getDataSourceUrl()));
-                LOGGER.info(String.format("TrustyService Kafka Bootstrap Server: %s", devServicesConfig.getKafkaBootstrapServer()));
-                LOGGER.info(String.format("TrustyService Hibernate ORM Database Generation: %s", devServicesConfig.getHibernateOrmDatabaseGeneration()));
+                LOGGER.debug(String.format("TrustyService DataSource Kind: %s", devServicesConfig.getDataSourceKind()));
+                LOGGER.debug(String.format("TrustyService DataSource Username: %s", devServicesConfig.getDataSourceUserName()));
+                LOGGER.debug(String.format("TrustyService DataSource Password: %s", devServicesConfig.getDataSourcePassword()));
+                LOGGER.debug(String.format("TrustyService DataSource URL: %s", devServicesConfig.getDataSourceUrl()));
+                LOGGER.debug(String.format("TrustyService Kafka Bootstrap Server: %s", devServicesConfig.getKafkaBootstrapServer()));
+                LOGGER.debug(String.format("TrustyService Hibernate ORM Database Generation: %s", devServicesConfig.getHibernateOrmDatabaseGeneration()));
 
                 //Environment variables used by kogito-images when launching the TrustyService container
                 container.addEnv("SCRIPT_DEBUG", "false");

--- a/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/deployment/KogitoDevServicesProcessor.java
+++ b/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/deployment/KogitoDevServicesProcessor.java
@@ -1,0 +1,373 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.tracing.decision.quarkus.deployment;
+
+import java.io.Closeable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.kie.kogito.tracing.decision.quarkus.devservices.TrustyServiceInMemoryContainer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.utility.DockerImageName;
+
+import com.github.dockerjava.api.model.ContainerNetwork;
+import com.github.dockerjava.api.model.ContainerNetworkSettings;
+import com.github.dockerjava.api.model.ContainerPort;
+
+import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.IsDockerWorking;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.CuratedApplicationShutdownBuildItem;
+import io.quarkus.deployment.builditem.DevServicesSharedNetworkBuildItem;
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
+import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
+import io.quarkus.deployment.console.ConsoleInstalledBuildItem;
+import io.quarkus.deployment.console.StartupLogCompressor;
+import io.quarkus.deployment.dev.devservices.GlobalDevServicesConfig;
+import io.quarkus.deployment.logging.LoggingSetupBuildItem;
+import io.quarkus.devservices.common.ContainerAddress;
+import io.quarkus.devservices.common.ContainerLocator;
+import io.quarkus.runtime.LaunchMode;
+
+import static org.kie.kogito.tracing.decision.TrustyConstants.KOGITO_TRUSTY_SERVICE;
+import static org.kie.kogito.tracing.decision.quarkus.deployment.DevServicesConfig.Property.HibernateOrmDatabaseGeneration;
+import static org.kie.kogito.tracing.decision.quarkus.deployment.DevServicesConfig.Property.KafkaBootstrapServers;
+import static org.kie.kogito.tracing.decision.quarkus.deployment.DevServicesConfig.Property.QuarkusDataSourceDbKind;
+import static org.kie.kogito.tracing.decision.quarkus.deployment.DevServicesConfig.Property.QuarkusDataSourceJdbcUrl;
+import static org.kie.kogito.tracing.decision.quarkus.deployment.DevServicesConfig.Property.QuarkusDataSourcePassword;
+import static org.kie.kogito.tracing.decision.quarkus.deployment.DevServicesConfig.Property.QuarkusDataSourceUserName;
+
+/**
+ * Start a TrustyService instance with PostgreSQL storage as dev service if needed.
+ */
+public class KogitoDevServicesProcessor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(KogitoDevServicesProcessor.class);
+    private static final ContainerLocator LOCATOR = new ContainerLocator(TrustyServiceInMemoryContainer.DEV_SERVICE_LABEL,
+            TrustyServiceInMemoryContainer.PORT);
+
+    static volatile Closeable closeable;
+    static volatile TrustyServiceDevServiceConfig cfg;
+    static volatile boolean first = true;
+
+    private final IsDockerWorking isDockerWorking = new IsDockerWorking(true);
+
+    @SuppressWarnings("unused")
+    @BuildStep(onlyIf = { GlobalDevServicesConfig.Enabled.class, IsDevelopment.class })
+    public void startTrustyServiceDevService(
+            final DevServicesConfig devServicesConfig,
+            final BuildProducer<SystemPropertyBuildItem> systemProperties,
+            final LaunchModeBuildItem launchMode,
+            final KogitoBuildTimeConfig buildTimeConfig,
+            final List<DevServicesSharedNetworkBuildItem> devServicesSharedNetwork,
+            final Optional<ConsoleInstalledBuildItem> consoleInstalled,
+            final CuratedApplicationShutdownBuildItem applicationShutdown,
+            final LoggingSetupBuildItem loggingSetup) {
+
+        LOGGER.info("Docker Containers configuration...");
+        DockerClientFactory.lazyClient().listContainersCmd().exec()
+                .forEach(c -> {
+                    LOGGER.debug("----> Image: " + c.getImage());
+                    LOGGER.debug("----> Ports: " + Arrays.stream(c.getPorts()).map(p -> p.getPrivatePort() + ">>" + p.getPublicPort()).collect(Collectors.joining(", ")));
+                    LOGGER.debug("----> Network: "
+                            + (Objects.isNull(c.getNetworkSettings()) ? ""
+                                    : c.getNetworkSettings()
+                                            .getNetworks()
+                                            .entrySet()
+                                            .stream()
+                                            .map(n -> String.format("%s=%s [%s]", n.getKey(), n.getValue(), n.getValue().getIpAddress())).collect(Collectors.joining(", "))));
+                });
+
+        //Discover PostgreSQL container
+        LOGGER.info("Discovering DevServices PostgreSQL instance...");
+        DockerClientFactory.lazyClient().listContainersCmd().exec()
+                .stream().filter(container -> container.getImage().contains("postgres"))
+                .findFirst()
+                .ifPresent(container -> {
+                    Optional<Integer> port = Optional.empty();
+                    Optional<String> ipAddress = Optional.empty();
+                    final ContainerPort[] containerPorts = container.getPorts();
+                    final ContainerNetworkSettings networkSettings = container.getNetworkSettings();
+                    if (Objects.nonNull(containerPorts)) {
+                        port = Arrays.stream(containerPorts)
+                                .map(ContainerPort::getPrivatePort)
+                                .filter(Objects::nonNull)
+                                .findFirst();
+                    }
+                    if (Objects.nonNull(networkSettings)) {
+                        ipAddress = networkSettings.getNetworks().values().stream()
+                                .map(ContainerNetwork::getIpAddress)
+                                .filter(Objects::nonNull)
+                                .findFirst();
+                    }
+                    LOGGER.info(String.format("[PostgreSQL] Private Port: %s", port.orElse(0)));
+                    LOGGER.info(String.format("[PostgreSQL] IP Address: %s", ipAddress.orElse("<None>")));
+                    if (ipAddress.isPresent() && port.isPresent()) {
+                        final String jdbcUrl = String.format("jdbc:postgresql://%s:%d/default?loggerLevel=OFF", ipAddress.get(), port.get());
+                        devServicesConfig.setDataSourceUrl(jdbcUrl);
+                    }
+                });
+
+        //Discover Kafaka Broker container
+        LOGGER.info("Discovering DevServices Redpanda (Kafka) instance...");
+        DockerClientFactory.lazyClient().listContainersCmd().exec()
+                .stream().filter(container -> container.getImage().contains("vectorized/redpanda"))
+                .findFirst()
+                .ifPresent(container -> {
+                    Optional<String> ipAddress = Optional.empty();
+                    final ContainerPort[] containerPorts = container.getPorts();
+                    final ContainerNetworkSettings networkSettings = container.getNetworkSettings();
+                    if (Objects.nonNull(networkSettings)) {
+                        ipAddress = networkSettings.getNetworks().values().stream()
+                                .map(ContainerNetwork::getIpAddress)
+                                .filter(Objects::nonNull)
+                                .findFirst();
+                    }
+                    LOGGER.info(String.format("[Kafka] IP Address: %s", ipAddress.orElse("<None>")));
+                    if (ipAddress.isPresent()) {
+                        final String kafkaBootstrapServer = String.format("PLAINTEXT://%s:29092", ipAddress.get());
+                        devServicesConfig.setKafkaBootstrapServer(kafkaBootstrapServer);
+                    }
+                });
+
+        final TrustyServiceDevServiceConfig configuration = getConfiguration(buildTimeConfig);
+
+        if (closeable != null) {
+            boolean shouldShutdown = !configuration.equals(cfg);
+            if (!shouldShutdown) {
+                return;
+            }
+            shutdownTrustyService();
+            cfg = null;
+        }
+
+        final StartupLogCompressor compressor = new StartupLogCompressor(
+                (launchMode.isTest() ? "(test) " : "") + "Kogito TrustyService DevService starting:",
+                consoleInstalled,
+                loggingSetup);
+
+        TrustyServiceInstance trustyService = null;
+        try {
+            trustyService = startTrustyService(configuration,
+                    devServicesConfig,
+                    launchMode,
+                    !devServicesSharedNetwork.isEmpty());
+            if (trustyService != null) {
+                closeable = trustyService.getCloseable();
+            }
+            compressor.close();
+        } catch (Throwable t) {
+            compressor.closeAndDumpCaptured();
+            throw new RuntimeException("Failed to start Kogito TrustyService DevServices", t);
+        }
+
+        //Discover TrustyService container
+        LOGGER.info("Discovering TrustyService instance...");
+        DockerClientFactory.lazyClient().listContainersCmd().exec()
+                .stream().filter(container -> container.getImage().toLowerCase(Locale.ROOT).contains("trusty"))
+                .findFirst()
+                .ifPresent(container -> {
+                    Optional<Integer> port = Optional.empty();
+                    Optional<String> ipAddress = Optional.empty();
+                    final ContainerPort[] containerPorts = container.getPorts();
+                    final ContainerNetworkSettings networkSettings = container.getNetworkSettings();
+                    if (Objects.nonNull(containerPorts)) {
+                        port = Arrays.stream(containerPorts)
+                                .map(ContainerPort::getPrivatePort)
+                                .filter(Objects::nonNull)
+                                .findFirst();
+                    }
+                    if (Objects.nonNull(networkSettings)) {
+                        ipAddress = networkSettings.getNetworks().values().stream()
+                                .map(ContainerNetwork::getIpAddress)
+                                .filter(Objects::nonNull)
+                                .findFirst();
+                    }
+                    LOGGER.info(String.format("[TrustyService] Private Port: %s", port.orElse(0)));
+                    LOGGER.info(String.format("[TrustyService] IP Address: %s", ipAddress.orElse("<None>")));
+                    if (ipAddress.isPresent() && port.isPresent()) {
+                        final String trustyServiceServer = String.format("http://%s:%s", ipAddress.get(), port.get());
+                        LOGGER.info(String.format("Setting System Property '%s' to '%s'", KOGITO_TRUSTY_SERVICE, trustyServiceServer));
+                        systemProperties.produce(new SystemPropertyBuildItem(KOGITO_TRUSTY_SERVICE, trustyServiceServer));
+                    }
+                });
+
+        // Configure the watch dog
+        if (first) {
+            first = false;
+            final Runnable closeTask = () -> {
+                if (closeable != null) {
+                    shutdownTrustyService();
+                }
+                first = true;
+                closeable = null;
+                cfg = null;
+            };
+            applicationShutdown.addCloseTask(closeTask, true);
+        }
+        cfg = configuration;
+
+        if (trustyService != null && trustyService.isOwner()) {
+            LOGGER.info(
+                    "DevServices for Kogito TrustyService started at {}",
+                    trustyService.getUrl());
+        }
+    }
+
+    private void shutdownTrustyService() {
+        if (closeable != null) {
+            try {
+                closeable.close();
+            } catch (Throwable e) {
+                LOGGER.error("Failed to stop Kogito Data Index", e);
+            } finally {
+                closeable = null;
+            }
+        }
+    }
+
+    private TrustyServiceInstance startTrustyService(final TrustyServiceDevServiceConfig config,
+            final DevServicesConfig devServicesConfig,
+            final LaunchModeBuildItem launchMode,
+            final boolean useSharedNetwork) {
+        if (!config.devServicesEnabled) {
+            // explicitly disabled
+            LOGGER.info("Not starting DevServices for Kogito, as it has been disabled in the config.");
+            return null;
+        }
+
+        if (!isDockerWorking.getAsBoolean()) {
+            LOGGER.warn("Docker isn't working, unable to start TrustyService image.");
+            return null;
+        }
+
+        final Optional<ContainerAddress> maybeContainerAddress = LOCATOR.locateContainer(config.serviceName,
+                config.shared,
+                launchMode.getLaunchMode());
+
+        // Starting TrustyService
+        final Supplier<TrustyServiceInstance> trustyServiceSupplier = () -> {
+            try {
+                TrustyServiceInMemoryContainer container = new TrustyServiceInMemoryContainer(
+                        DockerImageName.parse(config.imageName),
+                        config.fixedExposedPort,
+                        launchMode.getLaunchMode() == LaunchMode.DEVELOPMENT ? config.serviceName : null,
+                        useSharedNetwork);
+
+                LOGGER.info(String.format("TrustyService DataSource Kind: %s", devServicesConfig.getDataSourceKind()));
+                LOGGER.info(String.format("TrustyService DataSource Username: %s", devServicesConfig.getDataSourceUserName()));
+                LOGGER.info(String.format("TrustyService DataSource Password: %s", devServicesConfig.getDataSourcePassword()));
+                LOGGER.info(String.format("TrustyService DataSource URL: %s", devServicesConfig.getDataSourceUrl()));
+                LOGGER.info(String.format("TrustyService Kafka Bootstrap Server: %s", devServicesConfig.getKafkaBootstrapServer()));
+                LOGGER.info(String.format("TrustyService Hibernate ORM Database Generation: %s", devServicesConfig.getHibernateOrmDatabaseGeneration()));
+
+                //Environment variables used by kogito-images when launching the TrustyService container
+                container.addEnv("SCRIPT_DEBUG", "false");
+                container.addEnv("EXPLAINABILITY_ENABLED", "false");
+
+                //Environment variables used by TrustyService to integrate with other services
+                container.addEnv(QuarkusDataSourceDbKind.getEnvironmentVariableName(), devServicesConfig.getDataSourceKind());
+                container.addEnv(QuarkusDataSourceUserName.getEnvironmentVariableName(), devServicesConfig.getDataSourceUserName());
+                container.addEnv(QuarkusDataSourcePassword.getEnvironmentVariableName(), devServicesConfig.getDataSourcePassword());
+                container.addEnv(QuarkusDataSourceJdbcUrl.getEnvironmentVariableName(), devServicesConfig.getDataSourceUrl());
+                container.addEnv(KafkaBootstrapServers.getEnvironmentVariableName(), devServicesConfig.getKafkaBootstrapServer());
+                container.addEnv(HibernateOrmDatabaseGeneration.getEnvironmentVariableName(), devServicesConfig.getHibernateOrmDatabaseGeneration());
+
+                container.start();
+
+                return new TrustyServiceInstance(container.getUrl(), container::close);
+            } catch (Exception ex) {
+                throw new RuntimeException(ex);
+            }
+        };
+
+        return maybeContainerAddress.map(containerAddress -> new TrustyServiceInstance(containerAddress.getUrl(), null))
+                .orElseGet(trustyServiceSupplier);
+    }
+
+    private TrustyServiceDevServiceConfig getConfiguration(final KogitoBuildTimeConfig cfg) {
+        KogitoDevServicesBuildTimeConfig devServicesConfig = cfg.devservicesTrusty;
+        return new TrustyServiceDevServiceConfig(devServicesConfig);
+    }
+
+    private static class TrustyServiceInstance {
+
+        private final String url;
+        private final Closeable closeable;
+
+        public TrustyServiceInstance(final String url,
+                final Closeable closeable) {
+            this.url = url;
+            this.closeable = closeable;
+        }
+
+        public boolean isOwner() {
+            return closeable != null;
+        }
+
+        public String getUrl() {
+            return url;
+        }
+
+        public Closeable getCloseable() {
+            return closeable;
+        }
+    }
+
+    private static final class TrustyServiceDevServiceConfig {
+
+        private final boolean devServicesEnabled;
+        private final String imageName;
+        private final Integer fixedExposedPort;
+        private final boolean shared;
+        private final String serviceName;
+
+        public TrustyServiceDevServiceConfig(final KogitoDevServicesBuildTimeConfig config) {
+            this.devServicesEnabled = config.enabled.orElse(true);
+            this.imageName = config.imageName;
+            this.fixedExposedPort = config.port.orElse(0);
+            this.shared = config.shared;
+            this.serviceName = config.serviceName;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            TrustyServiceDevServiceConfig that = (TrustyServiceDevServiceConfig) o;
+            return devServicesEnabled == that.devServicesEnabled
+                    && Objects.equals(imageName, that.imageName)
+                    && Objects.equals(fixedExposedPort, that.fixedExposedPort);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(devServicesEnabled, imageName, fixedExposedPort);
+        }
+    }
+}

--- a/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/deployment/KogitoDevServicesProcessor.java
+++ b/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/deployment/KogitoDevServicesProcessor.java
@@ -307,7 +307,7 @@ public class KogitoDevServicesProcessor {
     }
 
     private TrustyServiceDevServiceConfig getConfiguration(final KogitoBuildTimeConfig cfg) {
-        KogitoDevServicesBuildTimeConfig devServicesConfig = cfg.devservicesTrusty;
+        KogitoDevServicesBuildTimeConfig devServicesConfig = cfg.devServicesTrusty;
         return new TrustyServiceDevServiceConfig(devServicesConfig);
     }
 

--- a/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/devservices/TrustyServiceInMemoryContainer.java
+++ b/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/devservices/TrustyServiceInMemoryContainer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.kie.kogito.quarkus.processes.devservices;
+package org.kie.kogito.tracing.decision.quarkus.devservices;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,29 +25,36 @@ import org.testcontainers.utility.DockerImageName;
 import io.quarkus.devservices.common.ConfigureUtil;
 
 /**
- * This container wraps Data Index Service container
+ * This container wraps the TrustyService container
  */
-public class DataIndexInMemoryContainer extends GenericContainer<DataIndexInMemoryContainer> {
+public class TrustyServiceInMemoryContainer extends GenericContainer<TrustyServiceInMemoryContainer> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TrustyServiceInMemoryContainer.class);
 
     public static final int PORT = 8080;
+
     /**
      * This allows other applications to discover the running service and use it instead of starting a new instance.
      */
-    public static final String DEV_SERVICE_LABEL = "kogito-dev-service-data-index";
-    private static final Logger LOGGER = LoggerFactory.getLogger(DataIndexInMemoryContainer.class);
-
+    public static final String DEV_SERVICE_LABEL = "kogito-dev-service-trusty-service";
     private final int fixedExposedPort;
     private final boolean useSharedNetwork;
+
     private String hostName = null;
 
-    public DataIndexInMemoryContainer(DockerImageName dockerImageName, int fixedExposedPort, String serviceName, boolean useSharedNetwork) {
+    public TrustyServiceInMemoryContainer(final DockerImageName dockerImageName,
+            final int fixedExposedPort,
+            final String serviceName,
+            final boolean useSharedNetwork) {
         super(dockerImageName);
         this.fixedExposedPort = fixedExposedPort;
         this.useSharedNetwork = useSharedNetwork;
 
-        if (serviceName != null) { // Only adds the label in dev mode.
+        // Only adds the label in dev mode.
+        if (serviceName != null) {
             withLabel(DEV_SERVICE_LABEL, serviceName);
         }
+
         withPrivilegedMode(true);
         withLogConsumer(new Slf4jLogConsumer(LOGGER));
     }
@@ -57,14 +64,14 @@ public class DataIndexInMemoryContainer extends GenericContainer<DataIndexInMemo
         super.configure();
 
         if (useSharedNetwork) {
-            hostName = ConfigureUtil.configureSharedNetwork(this, "data-index");
+            hostName = ConfigureUtil.configureSharedNetwork(this, "trusty-service");
             return;
         }
 
         if (fixedExposedPort > 0) {
             addFixedExposedPort(fixedExposedPort, PORT);
         } else {
-            addExposedPorts(PORT);
+            addExposedPort(PORT);
         }
     }
 

--- a/quarkus/addons/tracing-decision/deployment/src/main/resources/application.properties
+++ b/quarkus/addons/tracing-decision/deployment/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.kogito.dev-services-trusty.image-name=quay.io/kiegroup/kogito-trusty-postgresql:${version.kogito.trusty.postgresql.image}

--- a/quarkus/addons/tracing-decision/integration-tests/pom.xml
+++ b/quarkus/addons/tracing-decision/integration-tests/pom.xml
@@ -1,0 +1,59 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.kie.kogito</groupId>
+    <artifactId>kogito-addons-quarkus-tracing-decision-parent</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>kogito-addons-quarkus-tracing-decision-it</artifactId>
+  <name>Integration tests for the Tracing Decision Add-On (Quarkus)</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-jackson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-quarkus-decisions</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-addons-quarkus-tracing-decision</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5-internal</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/quarkus/addons/tracing-decision/integration-tests/src/test/java/org/kie/kogito/tracing/QuarkusTracingAddonDevServicesIT.java
+++ b/quarkus/addons/tracing-decision/integration-tests/src/test/java/org/kie/kogito/tracing/QuarkusTracingAddonDevServicesIT.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.tracing;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.http.ContentType;
+import io.restassured.http.Headers;
+import io.restassured.response.Response;
+
+import static io.restassured.RestAssured.given;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class QuarkusTracingAddonDevServicesIT {
+
+    private static final String KOGITO_EXECUTION_ID_HEADER = "X-Kogito-execution-id";
+
+    @RegisterExtension
+    public static QuarkusDevModeTest test = new QuarkusDevModeTest()
+            .withApplicationRoot(jar -> {
+                jar.addAsResource(new StringAsset(loadResource("/application.properties")),
+                        "application.properties");
+                jar.addAsResource(new StringAsset(loadResource("/LoanEligibility.dmn")),
+                        "LoanEligibility.dmn");
+            });
+
+    @Test
+    public void testEvaluateLoanEligibility() {
+        execute().then()
+                .statusCode(200)
+                .header(KOGITO_EXECUTION_ID_HEADER, notNullValue())
+                .body("'Decide'", is(true));
+    }
+
+    @Test
+    public void testExecutionsAreStored() {
+        final List<String> executionIds = new ArrayList<>();
+        executionIds.add(executeAndGetExecutionId());
+        executionIds.add(executeAndGetExecutionId());
+        executionIds.add(executeAndGetExecutionId());
+
+        final String trustyServiceEndpoint = System.getProperty("kogito.trusty.http.url");
+
+        await()
+                .atMost(30, TimeUnit.SECONDS)
+                .pollInterval(500, TimeUnit.MILLISECONDS)
+                .until(() -> {
+                    final Response response = given().when().get(trustyServiceEndpoint + "/executions");
+                    final String json = response.prettyPrint();
+                    return executionIds.stream().allMatch(executionId -> json.contains("\"executionId\": \"" + executionId + "\""));
+                });
+    }
+
+    private Response execute() {
+        return given()
+                .body("{" +
+                        "    \"Client\": {" +
+                        "        \"age\": 43," +
+                        "        \"salary\": 1950," +
+                        "        \"existing payments\": 100" +
+                        "    }," +
+                        "    \"Loan\": {" +
+                        "        \"duration\": 15," +
+                        "        \"installment\": 180" +
+                        "    }," +
+                        "    \"SupremeDirector\" : \"Yes\"," +
+                        "    \"Bribe\": 1000" +
+                        "}")
+                .contentType(ContentType.JSON)
+                .when()
+                .post("/LoanEligibility");
+    }
+
+    private String executeAndGetExecutionId() {
+        final Headers headers = execute().headers();
+
+        assertTrue(headers.hasHeaderWithName(KOGITO_EXECUTION_ID_HEADER));
+        return headers.getValue(KOGITO_EXECUTION_ID_HEADER);
+    }
+
+    private static String loadResource(final String name) {
+        try {
+            final URL url = QuarkusTracingAddonDevServicesIT.class.getResource(name);
+            if (Objects.nonNull(url)) {
+                return Files.readString(Paths.get(url.toURI()), StandardCharsets.UTF_8);
+            }
+        } catch (IOException | URISyntaxException e) {
+            // Swallow as we through an exception if the resource cannot be read
+        }
+        throw new IllegalStateException(String.format("Unable to load '%s'", name));
+    }
+}

--- a/quarkus/addons/tracing-decision/integration-tests/src/test/java/org/kie/kogito/tracing/QuarkusTracingAddonDevServicesIT.java
+++ b/quarkus/addons/tracing-decision/integration-tests/src/test/java/org/kie/kogito/tracing/QuarkusTracingAddonDevServicesIT.java
@@ -110,14 +110,15 @@ public class QuarkusTracingAddonDevServicesIT {
     }
 
     private static String loadResource(final String name) {
+        String resource = null;
         try {
             final URL url = QuarkusTracingAddonDevServicesIT.class.getResource(name);
             if (Objects.nonNull(url)) {
-                return Files.readString(Paths.get(url.toURI()), StandardCharsets.UTF_8);
+                resource = Files.readString(Paths.get(url.toURI()), StandardCharsets.UTF_8);
             }
         } catch (IOException | URISyntaxException e) {
-            // Swallow as we through an exception if the resource cannot be read
+            throw new IllegalStateException(String.format("Unable to load '%s'", name));
         }
-        throw new IllegalStateException(String.format("Unable to load '%s'", name));
+        return resource;
     }
 }

--- a/quarkus/addons/tracing-decision/integration-tests/src/test/java/org/kie/kogito/tracing/QuarkusTracingAddonDevServicesIT.java
+++ b/quarkus/addons/tracing-decision/integration-tests/src/test/java/org/kie/kogito/tracing/QuarkusTracingAddonDevServicesIT.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.kie.kogito.tracing.decision.TrustyConstants;
 
 import io.quarkus.test.QuarkusDevModeTest;
 import io.restassured.http.ContentType;
@@ -69,7 +70,7 @@ public class QuarkusTracingAddonDevServicesIT {
         executionIds.add(executeAndGetExecutionId());
         executionIds.add(executeAndGetExecutionId());
 
-        final String trustyServiceEndpoint = System.getProperty("kogito.trusty.http.url");
+        final String trustyServiceEndpoint = System.getProperty(TrustyConstants.KOGITO_TRUSTY_SERVICE);
 
         await()
                 .atMost(30, TimeUnit.SECONDS)

--- a/quarkus/addons/tracing-decision/integration-tests/src/test/resources/LoanEligibility.dmn
+++ b/quarkus/addons/tracing-decision/integration-tests/src/test/resources/LoanEligibility.dmn
@@ -1,0 +1,432 @@
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="https://github.com/kiegroup/kogito-examples/dmn-quarkus-listener-example" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" id="_DC5AB7D9-7D61-40F7-94C1-2E064A053AC0" name="LoanEligibility" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://github.com/kiegroup/kogito-examples/dmn-quarkus-listener-example">
+  <dmn:extensionElements/>
+  <dmn:itemDefinition id="_AD041308-CE7E-4359-97DA-E03C520A7A70" name="tClient" isCollection="false">
+    <dmn:itemComponent id="_91AB76A9-CDCC-463E-B404-C530AB0AA6B5" name="age" isCollection="false">
+      <dmn:typeRef>number</dmn:typeRef>
+      <dmn:allowedValues kie:constraintType="range" id="_4B686261-D292-4719-BCD7-4122528082CE">
+        <dmn:text>[18..80]</dmn:text>
+      </dmn:allowedValues>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_DDC79E0D-C9A1-40F9-BF5B-FC12B4894DBA" name="salary" isCollection="false">
+      <dmn:typeRef>number</dmn:typeRef>
+      <dmn:allowedValues kie:constraintType="expression" id="_0C9977E2-35D1-4279-A4A0-5A421E9C72B8">
+        <dmn:text>&gt; 0</dmn:text>
+      </dmn:allowedValues>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_73E5A8FE-258A-4E02-B2C8-4C1247AC1173" name="existing payments" isCollection="false">
+      <dmn:typeRef>number</dmn:typeRef>
+      <dmn:allowedValues kie:constraintType="expression" id="_D25C94E0-7BFD-40A4-8F4F-D60398D3B949">
+        <dmn:text>&gt;= 0</dmn:text>
+      </dmn:allowedValues>
+    </dmn:itemComponent>
+  </dmn:itemDefinition>
+  <dmn:itemDefinition id="_D88AFBD5-4920-49E6-BE27-1A43179E51EA" name="tLoan" isCollection="false">
+    <dmn:itemComponent id="_3FECD32E-06B7-4D31-B25D-DA4CCBCFCB6C" name="duration" isCollection="false">
+      <dmn:typeRef>number</dmn:typeRef>
+      <dmn:allowedValues kie:constraintType="expression" id="_124C0712-A0CB-4988-A225-8BBC57AA5963">
+        <dmn:text>&gt; 0</dmn:text>
+      </dmn:allowedValues>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_54CF2415-8CFA-4EAE-9482-F03C4355F218" name="installment" isCollection="false">
+      <dmn:typeRef>number</dmn:typeRef>
+      <dmn:allowedValues kie:constraintType="expression" id="_9B214CD8-4B23-4BD5-8A22-F0D22C2713A6">
+        <dmn:text>&gt; 0</dmn:text>
+      </dmn:allowedValues>
+    </dmn:itemComponent>
+  </dmn:itemDefinition>
+  <dmn:inputData id="_94A72ABB-E455-4F5C-A254-DB4B6D291944" name="Client">
+    <dmn:extensionElements/>
+    <dmn:variable id="_2200B3CC-EF45-40A1-9B29-C4EC77B211C3" name="Client" typeRef="tClient"/>
+  </dmn:inputData>
+  <dmn:inputData id="_A6007998-6106-493C-8728-E1986304B7FC" name="Loan">
+    <dmn:extensionElements/>
+    <dmn:variable id="_8ACB289B-4BCF-4B6D-B0C4-1DE4390CE4B7" name="Loan" typeRef="tLoan"/>
+  </dmn:inputData>
+  <dmn:decision id="_AF3816EA-29BE-417F-A83F-D77A74719369" name="Eligibility">
+    <dmn:extensionElements/>
+    <dmn:question>Is the client eligible for the loan?</dmn:question>
+    <dmn:allowedAnswers>"Yes" "No"</dmn:allowedAnswers>
+    <dmn:variable id="_51474B96-4904-4A5F-911C-C7803178BC31" name="Eligibility" typeRef="string"/>
+    <dmn:informationRequirement id="_3D11E284-712F-4E06-B3B1-E5A9B92999D5">
+      <dmn:requiredInput href="#_94A72ABB-E455-4F5C-A254-DB4B6D291944"/>
+    </dmn:informationRequirement>
+    <dmn:informationRequirement id="_415EBA81-5FDF-45D5-8783-CB97C0485672">
+      <dmn:requiredInput href="#_A6007998-6106-493C-8728-E1986304B7FC"/>
+    </dmn:informationRequirement>
+    <dmn:decisionTable id="_98FE50CB-F4CC-45BB-A7F4-58D97A14A957" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row">
+      <dmn:input id="_CDF02DAD-5492-4BF6-B275-9DD55D1C14C6">
+        <dmn:inputExpression id="_336FE6B0-8A50-4B62-B17A-E851FC1B13CD" typeRef="number">
+          <dmn:text>Client.salary</dmn:text>
+        </dmn:inputExpression>
+      </dmn:input>
+      <dmn:input id="_BA521F15-CED4-4B69-A163-E41684519129">
+        <dmn:inputExpression id="_FDF9C754-1ACD-4808-8364-50A2D03D3E49" typeRef="number">
+          <dmn:text>Client.age + Loan.duration</dmn:text>
+        </dmn:inputExpression>
+      </dmn:input>
+      <dmn:input id="_EF5E6B06-2DFB-4703-9570-861D4F8306EA">
+        <dmn:inputExpression id="_9597291D-FE7E-4FE0-A2F0-0690AB8A439A" typeRef="number">
+          <dmn:text>((Client.existing payments + Loan.installment) / Client.salary) * 100</dmn:text>
+        </dmn:inputExpression>
+      </dmn:input>
+      <dmn:output id="_6919B10D-0B12-4B5E-9DF5-1A90F166CF9A" typeRef="string">
+        <dmn:defaultOutputEntry id="_F19ECF67-98FC-4041-B8A0-E1A39C2BD0D9">
+          <dmn:text>"No"</dmn:text>
+        </dmn:defaultOutputEntry>
+      </dmn:output>
+      <dmn:rule id="_CE3825FE-A003-43F7-B124-FA360BD8CFB8">
+        <dmn:inputEntry id="_6FE7CEAC-E5FF-4298-9575-BF93CFE47E47">
+          <dmn:text>(0..2000]</dmn:text>
+        </dmn:inputEntry>
+        <dmn:inputEntry id="_20AC69B3-B16F-483B-9F04-C55F6809AA80">
+          <dmn:text>&lt;= 80</dmn:text>
+        </dmn:inputEntry>
+        <dmn:inputEntry id="_80AFC97A-047F-4EF5-945E-409A4FB17D03">
+          <dmn:text>&lt;= 20</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_E8F9174B-0F91-4F18-9A24-DEEE48FEB1B2">
+          <dmn:text>"Yes"</dmn:text>
+        </dmn:outputEntry>
+      </dmn:rule>
+      <dmn:rule id="_30A82FBE-4839-4CCD-81D7-E6143B5C266C">
+        <dmn:inputEntry id="_6AD0971D-18F5-402A-8F90-63A4F0AF50B6">
+          <dmn:text>(2000..3000]</dmn:text>
+        </dmn:inputEntry>
+        <dmn:inputEntry id="_FC38A913-9135-41A4-A209-B07C84F485A9">
+          <dmn:text>&lt;= 80</dmn:text>
+        </dmn:inputEntry>
+        <dmn:inputEntry id="_371D1B0A-3730-4B21-9323-05D19D9BB444">
+          <dmn:text>&lt;= 25</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_22C51C0E-A741-4BF2-828C-7CAAB5B3309A">
+          <dmn:text>"Yes"</dmn:text>
+        </dmn:outputEntry>
+      </dmn:rule>
+      <dmn:rule id="_ABF81842-40CE-4195-8E7D-B3313EED4C99">
+        <dmn:inputEntry id="_A6A04F7C-59BD-4E7D-B75A-D650224E9316">
+          <dmn:text>&gt; 3000</dmn:text>
+        </dmn:inputEntry>
+        <dmn:inputEntry id="_23EE5ABD-0906-4244-ABA0-43CD3A5BF77B">
+          <dmn:text>&lt;= 80</dmn:text>
+        </dmn:inputEntry>
+        <dmn:inputEntry id="_6737F418-999A-42E9-B814-1A0E2DB75ABE">
+          <dmn:text>&lt;= 35</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_BC47E642-0629-46CF-ACD2-2AF9737D46CB">
+          <dmn:text>"Yes"</dmn:text>
+        </dmn:outputEntry>
+      </dmn:rule>
+    </dmn:decisionTable>
+  </dmn:decision>
+  <dmn:inputData id="_384E3E0A-C54F-419C-BD8B-2D67438DF75E" name="SupremeDirector">
+    <dmn:extensionElements/>
+    <dmn:variable id="_3A512E33-E6E7-4DD2-BC84-094E17BA2A4F" name="SupremeDirector" typeRef="string"/>
+  </dmn:inputData>
+  <dmn:decision id="_D2E1574D-15A0-4BA7-9F51-C3A08A33B093" name="Judgement">
+    <dmn:extensionElements/>
+    <dmn:question>does the director approve it?</dmn:question>
+    <dmn:allowedAnswers>"yes" , "no"</dmn:allowedAnswers>
+    <dmn:variable id="_F51371F3-D8D8-494D-B31D-2050657C58D3" name="Judgement" typeRef="string"/>
+    <dmn:informationRequirement id="_EE5D79A8-BCA2-4818-9AF1-11068BD4B25C">
+      <dmn:requiredInput href="#_384E3E0A-C54F-419C-BD8B-2D67438DF75E"/>
+    </dmn:informationRequirement>
+    <dmn:informationRequirement id="_96E2003D-D51E-46AA-A1C9-1063E273AA05">
+      <dmn:requiredDecision href="#_AF3816EA-29BE-417F-A83F-D77A74719369"/>
+    </dmn:informationRequirement>
+    <dmn:decisionTable id="_5C30DC02-F116-454A-B87A-71A72DC4887F" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row">
+      <dmn:input id="_41D37F5C-6589-4C5E-A20A-63350D115D51">
+        <dmn:inputExpression id="_0DAEB9A4-90AA-4E69-8999-9AA533937833" typeRef="string">
+          <dmn:text>Eligibility</dmn:text>
+        </dmn:inputExpression>
+      </dmn:input>
+      <dmn:input id="_EDDAB97B-325B-4102-BFFD-2ADF96B7749F">
+        <dmn:inputExpression id="_99FE587F-F85D-4234-99F2-7EADD47D7D48" typeRef="string">
+          <dmn:text>SupremeDirector</dmn:text>
+        </dmn:inputExpression>
+      </dmn:input>
+      <dmn:output id="_6CBC7A80-E485-425E-81F9-570E96A64E2E"/>
+      <dmn:rule id="_E11830D2-F640-4E6B-9680-E28FAF342951">
+        <dmn:inputEntry id="_74F3C294-5DCB-4B9A-9271-4972F1612630">
+          <dmn:text>"Yes"</dmn:text>
+        </dmn:inputEntry>
+        <dmn:inputEntry id="_FA478FC4-0509-47EA-BFB6-552A25ACA9F3">
+          <dmn:text>"No"</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_A90E8962-D2A3-4412-B054-3BC39064E57A">
+          <dmn:text>"No"</dmn:text>
+        </dmn:outputEntry>
+      </dmn:rule>
+      <dmn:rule id="_8E878140-E3D5-4E30-A138-2E4DEAFBB788">
+        <dmn:inputEntry id="_9D2A75E3-7FDF-4E83-A6E0-90CB81016469">
+          <dmn:text>"No"</dmn:text>
+        </dmn:inputEntry>
+        <dmn:inputEntry id="_44EF108E-9EDC-402C-B31A-F6F790F42C73">
+          <dmn:text>"Yes"</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_BC3E4D05-1494-4E87-9CB3-FE0A63CAB8FB">
+          <dmn:text>"Yes"</dmn:text>
+        </dmn:outputEntry>
+      </dmn:rule>
+      <dmn:rule id="_D398F29A-E764-4FC1-8715-2F3C2BD7402C">
+        <dmn:inputEntry id="_DD7EDF09-3836-485C-BD59-193FE8C29B8B">
+          <dmn:text>"No"</dmn:text>
+        </dmn:inputEntry>
+        <dmn:inputEntry id="_6396722B-6A2A-4394-B0DC-D436128A3C96">
+          <dmn:text>"No"</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_025F4EBE-63EA-49D3-8379-8B5C742888CB">
+          <dmn:text>"No"</dmn:text>
+        </dmn:outputEntry>
+      </dmn:rule>
+      <dmn:rule id="_6E28C0EE-D52E-479D-9B6D-AFF8BAB938C2">
+        <dmn:inputEntry id="_E7D161F5-5086-4A17-9883-BDEE48E20BB8">
+          <dmn:text>"Yes"</dmn:text>
+        </dmn:inputEntry>
+        <dmn:inputEntry id="_B9D06AA6-9150-4A0A-8E76-4B257008AD3F">
+          <dmn:text>"Yes"</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_C960F031-2C1B-4307-A3D7-3479F062EBB2">
+          <dmn:text>"Yes"</dmn:text>
+        </dmn:outputEntry>
+      </dmn:rule>
+    </dmn:decisionTable>
+  </dmn:decision>
+  <dmn:inputData id="_62EE020F-ECA8-455A-8E97-8496137E68B4" name="Bribe">
+    <dmn:extensionElements/>
+    <dmn:variable id="_A396BC6B-CEC4-4431-8940-41B57520378E" name="Bribe" typeRef="number"/>
+  </dmn:inputData>
+  <dmn:decision id="_884FEC17-CE43-4C3D-A331-A5D1515D1FD9" name="Is Enough?">
+    <dmn:extensionElements/>
+    <dmn:variable id="_E00D1E77-C93F-4660-BF40-94FDC8262644" name="Is Enough?" typeRef="number"/>
+    <dmn:informationRequirement id="_986FC7F9-E9C0-40C8-BE1B-E9575A95F376">
+      <dmn:requiredInput href="#_62EE020F-ECA8-455A-8E97-8496137E68B4"/>
+    </dmn:informationRequirement>
+    <dmn:decisionTable id="_D2423DE6-2CA9-4D5F-A6BE-27E87A6D21FC" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row">
+      <dmn:input id="_7873EF4E-37E0-4381-9BB0-88E190B6B94E">
+        <dmn:inputExpression id="_F18C0B26-0624-4C34-A8B1-31016DAFD0D3" typeRef="number">
+          <dmn:text>Bribe</dmn:text>
+        </dmn:inputExpression>
+      </dmn:input>
+      <dmn:output id="_AB79DAA1-1365-4310-9C4A-62568955A63A" typeRef="number"/>
+      <dmn:rule id="_4EF36921-0EC0-4B0C-9C64-E8CD3AD508A4">
+        <dmn:inputEntry id="_2B4416F8-E16D-48C5-B32F-0F104953712D">
+          <dmn:text>&lt;= 100</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_3CDD1963-95F8-4DE3-938A-2F053DB8BA52">
+          <dmn:text>0</dmn:text>
+        </dmn:outputEntry>
+      </dmn:rule>
+      <dmn:rule id="_0241A869-8F87-49FB-B394-92179CA6E230">
+        <dmn:inputEntry id="_B4EB2282-3FB7-4C37-9AD7-37F9CBC9B754">
+          <dmn:text>&gt; 100</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_17235367-E58F-4D2F-B86D-2CA71F1A37F6">
+          <dmn:text>100</dmn:text>
+        </dmn:outputEntry>
+      </dmn:rule>
+    </dmn:decisionTable>
+  </dmn:decision>
+  <dmn:decision id="_1A4EF39A-A268-489F-A82D-17BF8DAC8300" name="Decide">
+    <dmn:extensionElements/>
+    <dmn:variable id="_CDE86409-F7F5-4F00-9137-00E92266AB48" name="Decide" typeRef="boolean"/>
+    <dmn:informationRequirement id="_C1DB403E-22F3-431D-AEC1-98F16D57D00A">
+      <dmn:requiredDecision href="#_D2E1574D-15A0-4BA7-9F51-C3A08A33B093"/>
+    </dmn:informationRequirement>
+    <dmn:informationRequirement id="_44E96742-9125-4484-8ABF-1D999EBC32E3">
+      <dmn:requiredDecision href="#_884FEC17-CE43-4C3D-A331-A5D1515D1FD9"/>
+    </dmn:informationRequirement>
+    <dmn:decisionTable id="_6E77FA9A-EB09-4203-A6B3-EE891DC4ADDC" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row">
+      <dmn:input id="_4DB09638-72A4-4D52-91F1-26CC9189F3A1">
+        <dmn:inputExpression id="_5F451E1A-4B8F-4E03-BD2A-7EB29AE36014" typeRef="number">
+          <dmn:text>Is Enough?</dmn:text>
+        </dmn:inputExpression>
+      </dmn:input>
+      <dmn:input id="_FAB42BC6-C21B-4F80-AA1F-06E5E8C4D14F">
+        <dmn:inputExpression id="_E0AF203D-9268-48D6-B19F-1CB6A7CDE5EC" typeRef="string">
+          <dmn:text>Judgement</dmn:text>
+        </dmn:inputExpression>
+      </dmn:input>
+      <dmn:output id="_E4346355-A3C9-4982-AC03-62A9BA707EEF" typeRef="boolean"/>
+      <dmn:rule id="_D514CAC3-693C-48DB-8CA2-507B9EE2118A">
+        <dmn:inputEntry id="_EA171464-55E0-41CD-8774-F08428C75BD8">
+          <dmn:text>100</dmn:text>
+        </dmn:inputEntry>
+        <dmn:inputEntry id="_1F130117-C1E7-4533-B8F1-7E78BB0B99E4">
+          <dmn:text>"Yes"</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_F1B318CF-585B-44F9-8E73-A440B7611E86">
+          <dmn:text>true</dmn:text>
+        </dmn:outputEntry>
+      </dmn:rule>
+      <dmn:rule id="_E697779C-C3DC-45AC-8BAA-B1B2598E1766">
+        <dmn:inputEntry id="_FBA02E03-A091-40A3-B7EE-422E4770DA22">
+          <dmn:text>100</dmn:text>
+        </dmn:inputEntry>
+        <dmn:inputEntry id="_A35EE57C-33C0-4373-AD25-674AA6B2F1DE">
+          <dmn:text>"No"</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_0DAA8AD8-E835-4E17-BF37-A6F78589EFF3">
+          <dmn:text>true</dmn:text>
+        </dmn:outputEntry>
+      </dmn:rule>
+      <dmn:rule id="_90835DFC-A457-42D6-AC95-14BEB9DD92E3">
+        <dmn:inputEntry id="_60C38460-CCE6-443E-B263-200B7DB3A3B1">
+          <dmn:text>0</dmn:text>
+        </dmn:inputEntry>
+        <dmn:inputEntry id="_CD277B6A-D64A-4704-AC6B-A165A14DE24C">
+          <dmn:text>"Yes"</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_AB1C503B-C525-4076-8600-B5158C502159">
+          <dmn:text>true</dmn:text>
+        </dmn:outputEntry>
+      </dmn:rule>
+      <dmn:rule id="_7E6638E5-8CD2-490C-92A6-3FCF45197756">
+        <dmn:inputEntry id="_0333A98F-1F0E-4047-894C-ABCCD25D261E">
+          <dmn:text>0</dmn:text>
+        </dmn:inputEntry>
+        <dmn:inputEntry id="_D296C816-21A1-407C-8C1D-F9A2A7416BFE">
+          <dmn:text>"No"</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_A24188C7-CF10-4163-ABF2-CBA2A84D32B4">
+          <dmn:text>false</dmn:text>
+        </dmn:outputEntry>
+      </dmn:rule>
+    </dmn:decisionTable>
+  </dmn:decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <di:extension>
+        <kie:ComponentsWidthsExtension>
+          <kie:ComponentWidths dmnElementRef="_98FE50CB-F4CC-45BB-A7F4-58D97A14A957">
+            <kie:width>50</kie:width>
+            <kie:width>100</kie:width>
+            <kie:width>100</kie:width>
+            <kie:width>100</kie:width>
+            <kie:width>100</kie:width>
+            <kie:width>100</kie:width>
+          </kie:ComponentWidths>
+          <kie:ComponentWidths dmnElementRef="_5C30DC02-F116-454A-B87A-71A72DC4887F">
+            <kie:width>50</kie:width>
+            <kie:width>100</kie:width>
+            <kie:width>100</kie:width>
+            <kie:width>100</kie:width>
+            <kie:width>100</kie:width>
+          </kie:ComponentWidths>
+          <kie:ComponentWidths dmnElementRef="_D2423DE6-2CA9-4D5F-A6BE-27E87A6D21FC">
+            <kie:width>50</kie:width>
+            <kie:width>100</kie:width>
+            <kie:width>100</kie:width>
+            <kie:width>100</kie:width>
+          </kie:ComponentWidths>
+          <kie:ComponentWidths dmnElementRef="_6E77FA9A-EB09-4203-A6B3-EE891DC4ADDC">
+            <kie:width>50</kie:width>
+            <kie:width>100</kie:width>
+            <kie:width>100</kie:width>
+            <kie:width>100</kie:width>
+            <kie:width>100</kie:width>
+          </kie:ComponentWidths>
+        </kie:ComponentsWidthsExtension>
+      </di:extension>
+      <dmndi:DMNShape id="dmnshape-_94A72ABB-E455-4F5C-A254-DB4B6D291944" dmnElementRef="_94A72ABB-E455-4F5C-A254-DB4B6D291944" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="268" y="670" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-_A6007998-6106-493C-8728-E1986304B7FC" dmnElementRef="_A6007998-6106-493C-8728-E1986304B7FC" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="467" y="670" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-_AF3816EA-29BE-417F-A83F-D77A74719369" dmnElementRef="_AF3816EA-29BE-417F-A83F-D77A74719369" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="368" y="517" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-_384E3E0A-C54F-419C-BD8B-2D67438DF75E" dmnElementRef="_384E3E0A-C54F-419C-BD8B-2D67438DF75E" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="687.2990654205607" y="517.3421052631579" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-_D2E1574D-15A0-4BA7-9F51-C3A08A33B093" dmnElementRef="_D2E1574D-15A0-4BA7-9F51-C3A08A33B093" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="524" y="364" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-_62EE020F-ECA8-455A-8E97-8496137E68B4" dmnElementRef="_62EE020F-ECA8-455A-8E97-8496137E68B4" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="852" y="363.6842105263158" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-_884FEC17-CE43-4C3D-A331-A5D1515D1FD9" dmnElementRef="_884FEC17-CE43-4C3D-A331-A5D1515D1FD9" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="852" y="279.3421052631579" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-_1A4EF39A-A268-489F-A82D-17BF8DAC8300" dmnElementRef="_1A4EF39A-A268-489F-A82D-17BF8DAC8300" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="649" y="152" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="dmnedge-_3D11E284-712F-4E06-B3B1-E5A9B92999D5" dmnElementRef="_3D11E284-712F-4E06-B3B1-E5A9B92999D5">
+        <di:waypoint x="318" y="670"/>
+        <di:waypoint x="418" y="567"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-_415EBA81-5FDF-45D5-8783-CB97C0485672" dmnElementRef="_415EBA81-5FDF-45D5-8783-CB97C0485672">
+        <di:waypoint x="517" y="670"/>
+        <di:waypoint x="418" y="567"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-_EE5D79A8-BCA2-4818-9AF1-11068BD4B25C" dmnElementRef="_EE5D79A8-BCA2-4818-9AF1-11068BD4B25C">
+        <di:waypoint x="737.2990654205607" y="517.3421052631579"/>
+        <di:waypoint x="574" y="414"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-_96E2003D-D51E-46AA-A1C9-1063E273AA05" dmnElementRef="_96E2003D-D51E-46AA-A1C9-1063E273AA05">
+        <di:waypoint x="418" y="517"/>
+        <di:waypoint x="574" y="414"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-_986FC7F9-E9C0-40C8-BE1B-E9575A95F376" dmnElementRef="_986FC7F9-E9C0-40C8-BE1B-E9575A95F376">
+        <di:waypoint x="952" y="388.6842105263158"/>
+        <di:waypoint x="852" y="304.3421052631579"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-_C1DB403E-22F3-431D-AEC1-98F16D57D00A" dmnElementRef="_C1DB403E-22F3-431D-AEC1-98F16D57D00A">
+        <di:waypoint x="624" y="389"/>
+        <di:waypoint x="649" y="177"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-_44E96742-9125-4484-8ABF-1D999EBC32E3" dmnElementRef="_44E96742-9125-4484-8ABF-1D999EBC32E3">
+        <di:waypoint x="902" y="279.3421052631579"/>
+        <di:waypoint x="699" y="202"/>
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</dmn:definitions>

--- a/quarkus/addons/tracing-decision/integration-tests/src/test/resources/application.properties
+++ b/quarkus/addons/tracing-decision/integration-tests/src/test/resources/application.properties
@@ -1,0 +1,11 @@
+# Kafka Tracing
+mp.messaging.outgoing.kogito-tracing-decision.group.id=kogito-runtimes
+mp.messaging.outgoing.kogito-tracing-decision.connector=smallrye-kafka
+mp.messaging.outgoing.kogito-tracing-decision.topic=kogito-tracing-decision
+mp.messaging.outgoing.kogito-tracing-decision.value.serializer=org.apache.kafka.common.serialization.StringSerializer
+
+# Kafka Tracing Model
+mp.messaging.outgoing.kogito-tracing-model.group.id=kogito-runtimes
+mp.messaging.outgoing.kogito-tracing-model.connector=smallrye-kafka
+mp.messaging.outgoing.kogito-tracing-model.topic=kogito-tracing-model
+mp.messaging.outgoing.kogito-tracing-model.value.serializer=org.apache.kafka.common.serialization.StringSerializer

--- a/quarkus/addons/tracing-decision/integration-tests/src/test/resources/application.properties
+++ b/quarkus/addons/tracing-decision/integration-tests/src/test/resources/application.properties
@@ -9,3 +9,5 @@ mp.messaging.outgoing.kogito-tracing-model.group.id=kogito-runtimes
 mp.messaging.outgoing.kogito-tracing-model.connector=smallrye-kafka
 mp.messaging.outgoing.kogito-tracing-model.topic=kogito-tracing-model
 mp.messaging.outgoing.kogito-tracing-model.value.serializer=org.apache.kafka.common.serialization.StringSerializer
+
+quarkus.log.level=INFO

--- a/quarkus/addons/tracing-decision/pom.xml
+++ b/quarkus/addons/tracing-decision/pom.xml
@@ -16,6 +16,7 @@
   <modules>
     <module>deployment</module>
     <module>runtime</module>
+    <module>integration-tests</module>
   </modules>
 
 </project>

--- a/quarkus/addons/tracing-decision/runtime/pom.xml
+++ b/quarkus/addons/tracing-decision/runtime/pom.xml
@@ -21,15 +21,19 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-reactive-messaging-kafka</artifactId>
     </dependency>
+
     <!-- Needed to trick DevServices into running a PostgreSQL instance for TrustyService -->
+    <!-- This dependency handles starting up Databases for DevServices in DevMode -->
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-hibernate-orm</artifactId>
+      <artifactId>quarkus-datasource</artifactId>
     </dependency>
+    <!-- This dependency handles instantiation of a PostgreSQL instance for DevServices in DevMode -->
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-jdbc-postgresql</artifactId>
     </dependency>
+
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-vertx</artifactId>

--- a/quarkus/addons/tracing-decision/runtime/pom.xml
+++ b/quarkus/addons/tracing-decision/runtime/pom.xml
@@ -21,6 +21,15 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-reactive-messaging-kafka</artifactId>
     </dependency>
+    <!-- Needed to trick DevServices into running a PostgreSQL instance for TrustyService -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-hibernate-orm</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-jdbc-postgresql</artifactId>
+    </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-vertx</artifactId>

--- a/quarkus/addons/tracing-decision/runtime/src/main/java/org/kie/kogito/tracing/decision/TrustyConstants.java
+++ b/quarkus/addons/tracing-decision/runtime/src/main/java/org/kie/kogito/tracing/decision/TrustyConstants.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.tracing.decision;
+
+public class TrustyConstants {
+
+    public static final String KOGITO_TRUSTY_SERVICE = "kogito.trusty.http.url";
+}


### PR DESCRIPTION
See https://issues.redhat.com/browse/FAI-681

Part of an ensemble:
- https://github.com/kiegroup/kogito-runtimes/pull/1759
- https://github.com/kiegroup/kogito-apps/pull/1157
- https://github.com/kiegroup/kogito-examples/pull/1032

These PRs contain the changes I've had to implement to have the following running:-

- A `kogito` application running on `localhost:8080`
- This `kogito` application starting a Docker container for a service it needs `TrustyService`.
- This `kogito` application connecting with and using Quarkus' DevServices Redpanda (Kafka) instance.
- `TrustyService` connecting with and using Quarkus' DevServices Redpanda (Kafka) instance.
- `TrustyService` connecting with and using Quarkus' DevServices PostgreSQL instance.

You can run https://github.com/kiegroup/kogito-examples/pull/1032 to see this work.

Then enter `mvn compile quarkus:dev` and wait a bit for things to start.

You can make a model evaluation request:
```
curl -X POST -H 'Accept: application/json' -H 'Content-Type: application/json' -d '{"Bribe": 0,"Client": {"age": 0,"existing payments": 0,"salary": 0},"Loan": {"duration": 0,"installment": 0},"SupremeDirector": "yes"}' http://localhost:8080/LoanEligibility
```
You can also check things are getting processed elsewhere:

**Get PostgreSQL's IP address**
- Run `docker network prune` (it makes a step below easier to explain!)
- Run `docker ps` and make a note of the image `NAME` for `postgres` e.g. `gifted_nobel`.
- Run `docker network ls` and make a note of the `NETWORK ID` for a `bridge` (that does not have the name `bridge`) e.g. `c41e6358dddb`
- Run `docker network inspect c41e6358dddb` (`NETWORK ID` from the previous step) and look at the `Containers` section.
- Find the entry with the `Name` matching that PostgreSQL name you found earlier.
- Make a note of the `IPv4Address` e.g. `192.168.64.3`.

**Run a PostgreSQL client**
- `docker run -it --rm --network XXX jbergknoff/postgresql-client postgresql://quarkus:quarkus@YYY:5432/default`
- Where `XXX` is the `NETWORK ID` above, e.g. `c41e6358dddb`
- Where `YYY` is the IP address above, e.g. `192.168.64.3`

**Inspect stuff***
- In the PostgreSQL client terminal enter `select count(*) from kogito_data_cache;`

**Known issue**
You will see in the Quarkus logs something like:-
```
2021-11-29 12:12:59,359 INFO  [org.kie.kog.tra.dec.qua.dev.TrustyServiceInMemoryContainer] (docker-java-stream--1324434781) STDOUT: 2021-11-29 12:12:59,350 ERROR [org.kie.kog.tru.ser.com.mes.BaseEventConsumer] (ForkJoinPool.commonPool-worker-5) Something unexpected happened during the processing of an Event. The event is discarded.: java.lang.IllegalArgumentException: A model with ID XXX is already present in the storage.
2021-11-29 12:12:59,360 INFO  [org.kie.kog.tra.dec.qua.dev.TrustyServiceInMemoryContainer] (docker-java-stream--1324434781) STDOUT: 	at org.kie.kogito.trusty.service.common.TrustyServiceImpl.storeModel(TrustyServiceImpl.java:187)
2021-11-29 12:12:59,360 INFO  [org.kie.kog.tra.dec.qua.dev.TrustyServiceInMemoryContainer] (docker-java-stream--1324434781) STDOUT: 	at org.kie.kogito.trusty.service.common.TrustyServiceImpl_ClientProxy.storeModel(TrustyServiceImpl_ClientProxy.zig:683)
2021-11-29 12:12:59,361 INFO  [org.kie.kog.tra.dec.qua.dev.TrustyServiceInMemoryContainer] (docker-java-stream--1324434781) STDOUT: 	at org.kie.kogito.trusty.service.common.messaging.incoming.ModelEventConsumer.internalHandleCloudEvent(ModelEventConsumer.java:78)
2021-11-29 12:12:59,361 INFO  [org.kie.kog.tra.dec.qua.dev.TrustyServiceInMemoryContainer] (docker-java-stream--1324434781) STDOUT: 	at org.kie.kogito.trusty.service.common.messaging.incoming.ModelEventConsumer.internalHandleCloudEvent(ModelEventConsumer.java:41)
2021-11-29 12:12:59,362 INFO  [org.kie.kog.tra.dec.qua.dev.TrustyServiceInMemoryContainer] (docker-java-stream--1324434781) STDOUT: 	at org.kie.kogito.trusty.service.common.messaging.BaseEventConsumer.handleCloudEvent(BaseEventConsumer.java:84)
2021-11-29 12:12:59,362 INFO  [org.kie.kog.tra.dec.qua.dev.TrustyServiceInMemoryContainer] (docker-java-stream--1324434781) STDOUT: 	at java.base/java.util.Optional.ifPresent(Optional.java:183)
2021-11-29 12:12:59,362 INFO  [org.kie.kog.tra.dec.qua.dev.TrustyServiceInMemoryContainer] (docker-java-stream--1324434781) STDOUT: 	at org.kie.kogito.trusty.service.common.messaging.BaseEventConsumer.handleMessage(BaseEventConsumer.java:58)
2021-11-29 12:12:59,363 INFO  [org.kie.kog.tra.dec.qua.dev.TrustyServiceInMemoryContainer] (docker-java-stream--1324434781) STDOUT: 	at org.kie.kogito.trusty.service.common.messaging.incoming.ModelEventConsumer.lambda$handleMessage$0(ModelEventConsumer.java:60)
2021-11-29 12:12:59,363 INFO  [org.kie.kog.tra.dec.qua.dev.TrustyServiceInMemoryContainer] (docker-java-stream--1324434781) STDOUT: 	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1736)
2021-11-29 12:12:59,364 INFO  [org.kie.kog.tra.dec.qua.dev.TrustyServiceInMemoryContainer] (docker-java-stream--1324434781) STDOUT: 	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.exec(CompletableFuture.java:1728)
2021-11-29 12:12:59,364 INFO  [org.kie.kog.tra.dec.qua.dev.TrustyServiceInMemoryContainer] (docker-java-stream--1324434781) STDOUT: 	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:2902021-11-29 12:12:59,364 INFO  [org.kie.kog.tra.dec.qua.dev.TrustyServiceInMemoryContainer] (docker-java-stream--1324434781) STDOUT: 	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
2021-11-29 12:12:59,365 INFO  [org.kie.kog.tra.dec.qua.dev.TrustyServiceInMemoryContainer] (docker-java-stream--1324434781) STDOUT: 	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
2021-11-29 12:12:59,365 INFO  [org.kie.kog.tra.dec.qua.dev.TrustyServiceInMemoryContainer] (docker-java-stream--1324434781) STDOUT: 	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
2021-11-29 12:12:59,366 INFO  [org.kie.kog.tra.dec.qua.dev.TrustyServiceInMemoryContainer] (docker-java-stream--1324434781) STDOUT: 	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
```
This is caused by "hot reload" support. When the DMN model is deployed kogito triggers a hot restart of Quarkus. The problem is that a `ModelEvent` was fired when Quarkus started the first time and again following the restart. The PostgreSQL container is not stopped, re-started and cleared for the hot reload... a new JIRA can be created. 

----------------------
Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run all builds</b>  
  Please add comment: <b>Jenkins retest this</b>

* <b>Run (or rerun) specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Run (or rerun) LTS specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Run (or rerun) native specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
