### PR TITLE
Invoker failing to resolve Quarkus dep on local nexus repo on Jenkins CI

### DIFF
--- a/integration-tests/integration-tests-kogito-plugin/pom.xml
+++ b/integration-tests/integration-tests-kogito-plugin/pom.xml
@@ -49,6 +49,12 @@
       <version>${project.version}</version>
       <type>pom</type>
     </dependency>
+    <dependency> <!-- make IT module to depend transitively Quarkus BOM due to Jenkins CI failing to locate Quarkus dependency on the local nexus repo -->
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-bom</artifactId>
+      <version>${version.io.quarkus}</version>
+      <type>pom</type>
+    </dependency>
     <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-addons-quarkus-process-management</artifactId>

--- a/integration-tests/integration-tests-kogito-plugin/pom.xml
+++ b/integration-tests/integration-tests-kogito-plugin/pom.xml
@@ -55,6 +55,12 @@
       <version>${version.io.quarkus}</version>
       <type>pom</type>
     </dependency>
+    <dependency> <!-- make IT module to depend transitively Quarkus BOM due to Jenkins CI failing to locate Quarkus dependency on the local nexus repo -->
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-bootstrap-bom</artifactId>
+      <version>${version.io.quarkus}</version>
+      <type>pom</type>
+    </dependency>
     <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-addons-quarkus-process-management</artifactId>


### PR DESCRIPTION


<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run all builds</b>  
  Please add comment: <b>Jenkins retest this</b>

* <b>Run (or rerun) specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Run (or rerun) LTS specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Run (or rerun) native specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
