### PR TITLE
[KOGITO-6418] Event states filter and merging

### DIFF
--- a/api/kogito-services/src/main/java/org/kie/kogito/services/event/EventConsumerFactory.java
+++ b/api/kogito-services/src/main/java/org/kie/kogito/services/event/EventConsumerFactory.java
@@ -15,6 +15,7 @@
  */
 package org.kie.kogito.services.event;
 
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
 
@@ -23,5 +24,5 @@ import org.kie.kogito.process.ProcessService;
 
 public interface EventConsumerFactory {
 
-    <M extends Model, D> EventConsumer get(ProcessService service, ExecutorService executor, Function<D, M> function, boolean cloudEvents);
+    <M extends Model, D> EventConsumer get(ProcessService service, ExecutorService executor, Optional<Function<D, M>> function, boolean cloudEvents);
 }

--- a/api/kogito-services/src/main/java/org/kie/kogito/services/event/impl/AbstractMessageConsumer.java
+++ b/api/kogito-services/src/main/java/org/kie/kogito/services/event/impl/AbstractMessageConsumer.java
@@ -18,6 +18,7 @@ package org.kie.kogito.services.event.impl;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Function;
 
 import org.kie.kogito.Application;
 import org.kie.kogito.Model;
@@ -78,7 +79,7 @@ public abstract class AbstractMessageConsumer<M extends Model, D, T extends Abst
         this.application = application;
         this.trigger = trigger;
         this.eventConverter = eventConverter;
-        this.eventConsumer = eventConsumerFactory.get(processService, executorService, this::eventToModel, useCloudEvents);
+        this.eventConsumer = eventConsumerFactory.get(processService, executorService, getModelConverter(), useCloudEvents);
         if (useCloudEvents) {
             this.outputClass = cloudEventClass;
             eventReceiver.subscribe(this::consumeCloud, new SubscriptionInfo<>(eventConverter, cloudEventClass, Optional.of(trigger)));
@@ -107,5 +108,7 @@ public abstract class AbstractMessageConsumer<M extends Model, D, T extends Abst
         return result;
     }
 
-    protected abstract M eventToModel(D event);
+    protected Optional<Function<D, M>> getModelConverter() {
+        return Optional.empty();
+    }
 }

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/BoundaryEventNodeVisitor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/BoundaryEventNodeVisitor.java
@@ -15,8 +15,6 @@
  */
 package org.jbpm.compiler.canonical;
 
-import java.util.Map;
-
 import org.jbpm.process.core.context.variable.Variable;
 import org.jbpm.process.core.context.variable.VariableScope;
 import org.jbpm.ruleflow.core.factory.BoundaryEventNodeFactory;
@@ -30,9 +28,6 @@ import static org.jbpm.ruleflow.core.Metadata.EVENT_TYPE;
 import static org.jbpm.ruleflow.core.Metadata.EVENT_TYPE_COMPENSATION;
 import static org.jbpm.ruleflow.core.Metadata.EVENT_TYPE_MESSAGE;
 import static org.jbpm.ruleflow.core.Metadata.EVENT_TYPE_SIGNAL;
-import static org.jbpm.ruleflow.core.Metadata.MESSAGE_TYPE;
-import static org.jbpm.ruleflow.core.Metadata.TRIGGER_REF;
-import static org.jbpm.ruleflow.core.Metadata.TRIGGER_TYPE;
 import static org.jbpm.ruleflow.core.factory.BoundaryEventNodeFactory.METHOD_ADD_COMPENSATION_HANDLER;
 import static org.jbpm.ruleflow.core.factory.BoundaryEventNodeFactory.METHOD_ATTACHED_TO;
 import static org.jbpm.ruleflow.core.factory.EventNodeFactory.METHOD_EVENT_TYPE;
@@ -63,12 +58,7 @@ public class BoundaryEventNodeVisitor extends AbstractNodeVisitor<BoundaryEventN
         if (EVENT_TYPE_SIGNAL.equals(eventType)) {
             metadata.addSignal(node.getType(), variable != null ? variable.getType().getStringType() : null);
         } else if (EVENT_TYPE_MESSAGE.equals(eventType)) {
-            Map<String, Object> nodeMetaData = node.getMetaData();
-            metadata.addTrigger(new TriggerMetaData((String) nodeMetaData.get(TRIGGER_REF),
-                    (String) nodeMetaData.get(TRIGGER_TYPE),
-                    (String) nodeMetaData.get(MESSAGE_TYPE),
-                    node.getVariableName(),
-                    String.valueOf(node.getId())).validate());
+            metadata.addTrigger(TriggerMetaData.of(node, node.getVariableName()));
         } else if (EVENT_TYPE_COMPENSATION.equalsIgnoreCase(eventType) && node.getAttachedToNodeId() != null) {
             body.addStatement(getFactoryMethod(getNodeId(node), METHOD_ADD_COMPENSATION_HANDLER, new StringLiteralExpr(node.getAttachedToNodeId())));
         }

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/EventNodeVisitor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/EventNodeVisitor.java
@@ -16,7 +16,6 @@
 package org.jbpm.compiler.canonical;
 
 import java.text.MessageFormat;
-import java.util.Map;
 
 import org.jbpm.process.core.context.variable.Variable;
 import org.jbpm.process.core.context.variable.VariableScope;
@@ -30,9 +29,6 @@ import com.github.javaparser.ast.stmt.BlockStmt;
 import static org.jbpm.ruleflow.core.Metadata.EVENT_TYPE;
 import static org.jbpm.ruleflow.core.Metadata.EVENT_TYPE_MESSAGE;
 import static org.jbpm.ruleflow.core.Metadata.EVENT_TYPE_SIGNAL;
-import static org.jbpm.ruleflow.core.Metadata.MESSAGE_TYPE;
-import static org.jbpm.ruleflow.core.Metadata.TRIGGER_REF;
-import static org.jbpm.ruleflow.core.Metadata.TRIGGER_TYPE;
 import static org.jbpm.ruleflow.core.factory.EventNodeFactory.METHOD_EVENT_TYPE;
 import static org.jbpm.ruleflow.core.factory.EventNodeFactory.METHOD_VARIABLE_NAME;
 
@@ -57,14 +53,8 @@ public class EventNodeVisitor extends AbstractNodeVisitor<EventNode> {
         if (EVENT_TYPE_SIGNAL.equals(node.getMetaData(EVENT_TYPE))) {
             metadata.addSignal(node.getType(), variable != null ? variable.getType().getStringType() : null);
         } else if (EVENT_TYPE_MESSAGE.equals(node.getMetaData(EVENT_TYPE))) {
-            Map<String, Object> nodeMetaData = node.getMetaData();
             try {
-                TriggerMetaData triggerMetaData = new TriggerMetaData((String) nodeMetaData.get(TRIGGER_REF),
-                        (String) nodeMetaData.get(TRIGGER_TYPE),
-                        (String) nodeMetaData.get(MESSAGE_TYPE),
-                        node.getVariableName(),
-                        String.valueOf(node.getId())).validate();
-                metadata.addTrigger(triggerMetaData);
+                metadata.addTrigger(TriggerMetaData.of(node, node.getVariableName()));
             } catch (IllegalArgumentException e) {
                 throw new IllegalArgumentException(
                         MessageFormat.format(

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/StartNodeVisitor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/StartNodeVisitor.java
@@ -72,11 +72,7 @@ public class StartNodeVisitor extends AbstractNodeVisitor<StartNode> {
     }
 
     private TriggerMetaData buildTriggerMetadata(StartNode node) {
-        return new TriggerMetaData((String) node.getMetaData(TRIGGER_REF),
-                (String) node.getMetaData(TRIGGER_TYPE),
-                (String) node.getMetaData(MESSAGE_TYPE),
-                (String) node.getMetaData(TRIGGER_MAPPING),
-                String.valueOf(node.getId())).validate();
+        return TriggerMetaData.of(node, (String) node.getMetaData(TRIGGER_MAPPING));
     }
 
     protected void handleSignal(StartNode startNode, Map<String, Object> nodeMetaData, BlockStmt body, VariableScope variableScope, ProcessMetaData metadata) {

--- a/jbpm/jbpm-flow/src/main/java/org/kie/kogito/event/impl/CloudEventConsumer.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/kogito/event/impl/CloudEventConsumer.java
@@ -35,11 +35,11 @@ public class CloudEventConsumer<D, M extends Model, T extends AbstractProcessDat
 
     private static final Logger logger = LoggerFactory.getLogger(CloudEventConsumer.class);
 
-    private Function<D, M> function;
+    private Optional<Function<D, M>> function;
     private ProcessService processService;
     private ExecutorService executor;
 
-    public CloudEventConsumer(ProcessService processService, ExecutorService executor, Function<D, M> function) {
+    public CloudEventConsumer(ProcessService processService, ExecutorService executor, Optional<Function<D, M>> function) {
         this.processService = processService;
         this.executor = executor;
         this.function = function;
@@ -48,7 +48,6 @@ public class CloudEventConsumer<D, M extends Model, T extends AbstractProcessDat
     @Override
     public CompletionStage<?> consume(Application application, Process<M> process, Object object, String trigger) {
         T cloudEvent = (T) object;
-        M model = function.apply(cloudEvent.getData());
         String simpleName = cloudEvent.getClass().getSimpleName();
         // currently we filter out messages on the receiving end; for strategy see https://issues.redhat.com/browse/KOGITO-3591
         if (ignoredMessageType(cloudEvent, simpleName) && ignoredMessageType(cloudEvent, trigger)) {
@@ -66,16 +65,20 @@ public class CloudEventConsumer<D, M extends Model, T extends AbstractProcessDat
             Optional<ProcessInstance<M>> instance = process.instances().findById(cloudEvent.getKogitoReferenceId());
             if (instance.isPresent()) {
                 return CompletableFuture.completedFuture(processService.signalProcessInstance((Process) process, cloudEvent.getKogitoReferenceId(), cloudEvent.getData(), "Message-" + trigger));
-            } else {
-                logger.warn("Process instance with id '{}' not found for triggering signal '{}', starting a new one",
+            } else if (function.isPresent()) {
+                logger.info("Process instance with id '{}' not found for triggering signal '{}', starting a new one",
                         cloudEvent.getKogitoReferenceId(),
                         trigger);
-                return startNewInstance(process, model, cloudEvent, trigger);
+                return startNewInstance(process, function.get().apply(cloudEvent.getData()), cloudEvent, trigger);
+            } else {
+                return CompletableFuture.failedStage(new IllegalArgumentException("Process instance with id " + cloudEvent.getKogitoReferenceId() + " not found for triggering signal " + trigger));
             }
+
+        } else if (function.isPresent()) {
+            logger.debug("Received message without reference id, starting new process instance with trigger '{}'", trigger);
+            return startNewInstance(process, function.get().apply(cloudEvent.getData()), cloudEvent, trigger);
         } else {
-            logger.debug("Received message without reference id, starting new process instance with trigger '{}'",
-                    trigger);
-            return startNewInstance(process, model, cloudEvent, trigger);
+            return CompletableFuture.failedStage(new IllegalArgumentException("Received not start event without kogito referecence id for trigger " + trigger));
         }
     }
 

--- a/jbpm/jbpm-flow/src/main/java/org/kie/kogito/event/impl/DataEventConsumer.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/kogito/event/impl/DataEventConsumer.java
@@ -15,6 +15,7 @@
  */
 package org.kie.kogito.event.impl;
 
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutorService;
@@ -25,20 +26,16 @@ import org.kie.kogito.Model;
 import org.kie.kogito.process.Process;
 import org.kie.kogito.process.ProcessService;
 import org.kie.kogito.services.event.EventConsumer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class DataEventConsumer<D, M extends Model> implements EventConsumer<M> {
 
-    private static final Logger logger = LoggerFactory.getLogger(DataEventConsumer.class);
-
-    private Function<D, M> function;
+    private Optional<Function<D, M>> function;
 
     private ProcessService processService;
 
     private ExecutorService executorService;
 
-    public DataEventConsumer(ProcessService processService, ExecutorService executorService, Function<D, M> function) {
+    public DataEventConsumer(ProcessService processService, ExecutorService executorService, Optional<Function<D, M>> function) {
         this.processService = processService;
         this.executorService = executorService;
         this.function = function;
@@ -46,7 +43,8 @@ public class DataEventConsumer<D, M extends Model> implements EventConsumer<M> {
 
     @Override
     public CompletionStage<Void> consume(Application application, Process<M> process, Object eventData, String trigger) {
-        return CompletableFuture.runAsync(() -> processService.createProcessInstance(process, function.apply((D) eventData), null, trigger, null), executorService);
+        //TODO right now it is only possible to start a new process instance when not using cloudevent
+        return CompletableFuture.runAsync(() -> processService.createProcessInstance(process, function.get().apply((D) eventData), null, trigger, null), executorService);
     }
 
 }

--- a/jbpm/jbpm-flow/src/main/java/org/kie/kogito/event/impl/DefaultEventConsumerFactory.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/kogito/event/impl/DefaultEventConsumerFactory.java
@@ -15,6 +15,7 @@
  */
 package org.kie.kogito.event.impl;
 
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
 
@@ -26,7 +27,7 @@ import org.kie.kogito.services.event.EventConsumerFactory;
 public class DefaultEventConsumerFactory implements EventConsumerFactory {
 
     @Override
-    public <M extends Model, D> EventConsumer<M> get(ProcessService processService, ExecutorService executorService, Function<D, M> function, boolean cloudEvents) {
+    public <M extends Model, D> EventConsumer<M> get(ProcessService processService, ExecutorService executorService, Optional<Function<D, M>> function, boolean cloudEvents) {
         return cloudEvents
                 ? new CloudEventConsumer<>(processService, executorService, function)
                 : new DataEventConsumer<>(processService, executorService, function);

--- a/jbpm/jbpm-flow/src/test/java/org/kie/kogito/event/impl/EventImplTest.java
+++ b/jbpm/jbpm-flow/src/test/java/org/kie/kogito/event/impl/EventImplTest.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.function.Function;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -152,9 +153,13 @@ public class EventImplTest {
         executor.shutdown();
     }
 
+    private Optional<Function<DummyEvent, DummyModel>> getConvertedMethod() {
+        return Optional.of(DummyModel::new);
+    }
+
     @Test
     void testSigCloudEvent() {
-        EventConsumer<DummyModel> consumer = factory.get(processService, executor, DummyModel::new, true);
+        EventConsumer<DummyModel> consumer = factory.get(processService, executor, getConvertedMethod(), true);
         final String trigger = "dummyTopic";
         consumer.consume(application, process, new DummyCloudEvent(new DummyEvent("pepe"), "1"), trigger);
         ArgumentCaptor<String> signal = ArgumentCaptor.forClass(String.class);
@@ -167,7 +172,7 @@ public class EventImplTest {
     @Test
     void testCloudEvent() {
         EventConsumer<DummyModel> consumer =
-                factory.get(processService, executor, DummyModel::new, true);
+                factory.get(processService, executor, getConvertedMethod(), true);
         final String trigger = "dummyTopic";
         consumer.consume(application, process, new DummyCloudEvent(new DummyEvent("pepe")), trigger);
         ArgumentCaptor<String> signal = ArgumentCaptor.forClass(String.class);
@@ -181,7 +186,7 @@ public class EventImplTest {
     @Test
     void testDataEvent() {
         EventConsumer<DummyModel> consumer =
-                factory.get(processService, executor, DummyModel::new, false);
+                factory.get(processService, executor, getConvertedMethod(), false);
         final String trigger = "dummyTopic";
         consumer.consume(application, process, new DummyEvent("pepe"), trigger);
         ArgumentCaptor<String> signal = ArgumentCaptor.forClass(String.class);
@@ -207,7 +212,7 @@ public class EventImplTest {
 
     @Test
     void testEventPayloadException() {
-        EventConsumer<DummyModel> consumer = factory.get(processService, executor, DummyModel::new, true);
+        EventConsumer<DummyModel> consumer = factory.get(processService, executor, getConvertedMethod(), true);
         final String trigger = "dummyTopic";
         final String payload = "{ a = b }";
         assertThrows(ClassCastException.class, () -> consumer.consume(application, process, payload, trigger));

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/MessageConsumerJavaTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/MessageConsumerJavaTemplate.java
@@ -25,9 +25,10 @@ import org.kie.kogito.process.Process;
 import org.kie.kogito.process.ProcessService;
 import org.kie.kogito.process.impl.ProcessServiceImpl;
 import org.kie.kogito.services.event.EventConsumerFactory;
+import org.kie.kogito.services.event.impl.AbstractMessageConsumer;
 import org.kie.kogito.event.impl.DefaultEventConsumerFactory;
 
-public class $Type$MessageConsumer {
+public class $Type$MessageConsumer extends AbstractMessageConsumer<$Type$, $DataType$, $DataEventType$> {
 
     Process<$Type$> process;
 
@@ -44,15 +45,5 @@ public class $Type$MessageConsumer {
     public void configure() {
         eventConsumerFactory = new DefaultEventConsumerFactory();
         service = new ProcessServiceImpl(application);
-    }
-
-    public void consume($DataType$ payload) {
-        eventConsumerFactory
-            .<$Type$,$DataType$>get(service, executor, event -> {
-                $Type$ model = new $Type$();
-                model.set$DataType$(event);
-                return model;
-            }, useCloudEvents)
-            .consume(application, process, payload, "$Trigger$");
     }
 }

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/MessageConsumerQuarkusTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/MessageConsumerQuarkusTemplate.java
@@ -73,9 +73,4 @@ public class $Type$MessageConsumer extends AbstractMessageConsumer<$Type$, $Data
 
     }
 
-    protected $Type$ eventToModel($DataType$ event) {
-        $Type$ model = new $Type$();
-        model.set$DataType$(event);
-        return model;
-    }
 }

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/MessageConsumerSpringTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/MessageConsumerSpringTemplate.java
@@ -54,9 +54,4 @@ public class $Type$MessageConsumer extends AbstractMessageConsumer<$Type$, $Data
               eventConverter);
     }
 
-    protected $Type$ eventToModel($DataType$ event) {
-        $Type$ model = new $Type$();
-        model.set$DataType$(event);
-        return model;
-    }
 }

--- a/kogito-serverless-workflow/kogito-jq-expression/src/main/java/org/kie/kogito/expr/jq/JqExpression.java
+++ b/kogito-serverless-workflow/kogito-jq-expression/src/main/java/org/kie/kogito/expr/jq/JqExpression.java
@@ -26,7 +26,6 @@ import org.kie.kogito.serverless.workflow.utils.ExpressionHandlerUtils;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import net.thisptr.jackson.jq.JsonQuery;
 import net.thisptr.jackson.jq.Output;
@@ -157,7 +156,7 @@ public class JqExpression implements Expression {
 
     @Override
     public void assign(Object context, Object value) {
-        ExpressionHandlerUtils.assign((ObjectNode) context, eval(context, JsonNode.class), (JsonNode) value, expr);
+        ExpressionHandlerUtils.assign((JsonNode) context, eval(context, JsonNode.class), (JsonNode) value, expr);
     }
 
     private void compile() throws JsonQueryException {

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/CallbackHandler.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/CallbackHandler.java
@@ -24,8 +24,6 @@ import io.serverlessworkflow.api.Workflow;
 import io.serverlessworkflow.api.filters.EventDataFilter;
 import io.serverlessworkflow.api.states.CallbackState;
 
-import static org.kie.kogito.serverless.workflow.parser.ServerlessWorkflowParser.DEFAULT_WORKFLOW_VAR;
-
 public class CallbackHandler extends CompositeContextNodeHandler<CallbackState> {
 
     protected CallbackHandler(CallbackState state, Workflow workflow, ParserContext parserContext) {
@@ -51,8 +49,8 @@ public class CallbackHandler extends CompositeContextNodeHandler<CallbackState> 
             dataExpr = eventFilter.getData();
             toExpr = eventFilter.getToStateData();
         }
-        currentNode = connect(currentNode, consumeEventNode(embeddedSubProcess, state.getEventRef(), DEFAULT_WORKFLOW_VAR, DEFAULT_WORKFLOW_VAR));
-        //      filterAndMergeNode(embeddedSubProcess, state.getEventRef(), dataExpr, toExpr, (f, inputVar, outputVar) -> consumeEventNode(f, state.getEventRef(), inputVar, outputVar)));
+        currentNode = connect(currentNode,
+                filterAndMergeNode(embeddedSubProcess, state.getEventRef(), dataExpr, toExpr, (f, inputVar, outputVar) -> consumeEventNode(f, state.getEventRef(), inputVar, outputVar)));
         connect(currentNode, embeddedSubProcess.endNode(parserContext.newId()).name("EmbeddedEnd").terminate(true)).done();
         return new MakeNodeResult(embeddedSubProcess);
     }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/EventHandler.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/EventHandler.java
@@ -30,8 +30,6 @@ import io.serverlessworkflow.api.events.OnEvents;
 import io.serverlessworkflow.api.filters.EventDataFilter;
 import io.serverlessworkflow.api.states.EventState;
 
-import static org.kie.kogito.serverless.workflow.parser.ServerlessWorkflowParser.DEFAULT_WORKFLOW_VAR;
-
 public class EventHandler extends CompositeContextNodeHandler<EventState> {
 
     protected EventHandler(EventState state, Workflow workflow, ParserContext parserContext) {
@@ -61,13 +59,11 @@ public class EventHandler extends CompositeContextNodeHandler<EventState> {
         }
 
         if (onEventRefs.size() == 1) {
-            startFactory = messageStartNode(factory, onEventRefs.get(0), DEFAULT_WORKFLOW_VAR, DEFAULT_WORKFLOW_VAR);
-            // TODO filterAndMergeNode(factory, state.getName(), dataExpr, toExpr, (f, inputVar, outputVar) -> messageStartNode(f, onEventRefs.get(0), inputVar, outputVar)).getOutgoingNode();
+            startFactory = filterAndMergeNode(factory, state.getName(), dataExpr, toExpr, (f, inputVar, outputVar) -> messageStartNode(f, onEventRefs.get(0), inputVar, outputVar)).getOutgoingNode();
         } else {
             startFactory = factory.joinNode(parserContext.newId()).name(state.getName() + "Split").type(Join.TYPE_XOR);
             for (String onEventRef : onEventRefs) {
-                connect(messageStartNode(factory, onEventRef, DEFAULT_WORKFLOW_VAR, DEFAULT_WORKFLOW_VAR),
-                        // TODO support merge for events filterAndMergeNode(factory, state.getName(), dataExpr, toExpr, (f, inputVar, outputVar) -> messageStartNode(f, onEventRef, inputVar, outputVar)).getOutgoingNode(),
+                connect(filterAndMergeNode(factory, state.getName(), dataExpr, toExpr, (f, inputVar, outputVar) -> messageStartNode(f, onEventRef, inputVar, outputVar)).getOutgoingNode(),
                         startFactory);
             }
         }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/SwitchHandler.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/SwitchHandler.java
@@ -37,8 +37,6 @@ import io.serverlessworkflow.api.switchconditions.DataCondition;
 import io.serverlessworkflow.api.switchconditions.EventCondition;
 import io.serverlessworkflow.api.transitions.Transition;
 
-import static org.kie.kogito.serverless.workflow.parser.ServerlessWorkflowParser.DEFAULT_WORKFLOW_VAR;
-
 public class SwitchHandler extends StateHandler<SwitchState> {
 
     private static final String XORSPLITDEFAULT = "Default";
@@ -94,12 +92,10 @@ public class SwitchHandler extends StateHandler<SwitchState> {
                 toExpr = eventFilter.getToStateData();
 
             }
-            // TODO MakeNodeResult filteredNode =
-            //        filterAndMergeNode(factory, eventCondition.getName(), dataExpr, toExpr, (f, inputVar, outputVar) -> consumeEventNode(f, eventCondition.getEventRef(), inputVar, outputVar));
-
-            NodeFactory<?, ?> eventNode = consumeEventNode(factory, eventCondition.getEventRef(), DEFAULT_WORKFLOW_VAR, DEFAULT_WORKFLOW_VAR);
-            eventNode.done().connection(startNode.getNode().getId(), eventNode.getNode().getId());
-            targetState.connect(factory, eventNode.getNode().getId());
+            MakeNodeResult eventNode =
+                    filterAndMergeNode(factory, eventCondition.getName(), dataExpr, toExpr, (f, inputVar, outputVar) -> consumeEventNode(f, eventCondition.getEventRef(), inputVar, outputVar));
+            factory.connection(startNode.getNode().getId(), eventNode.getIncomingNode().getNode().getId());
+            targetState.connect(factory, eventNode.getOutgoingNode().getNode().getId());
         }
     }
 

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/java/org/kie/kogito/serverless/workflow/ServerlessWorkflowParsingTest.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/java/org/kie/kogito/serverless/workflow/ServerlessWorkflowParsingTest.java
@@ -213,7 +213,7 @@ public class ServerlessWorkflowParsingTest {
         assertEquals("org.kie.kogito.serverless", process.getPackageName());
         assertEquals(RuleFlowProcess.PUBLIC_VISIBILITY, process.getVisibility());
 
-        assertEquals(3, process.getNodes().length);
+        assertEquals(4, process.getNodes().length);
 
         Node node = process.getNodes()[2];
         assertTrue(node instanceof StartNode);
@@ -249,7 +249,7 @@ public class ServerlessWorkflowParsingTest {
         assertEquals("org.kie.kogito.serverless", process.getPackageName());
         assertEquals(RuleFlowProcess.PUBLIC_VISIBILITY, process.getVisibility());
 
-        assertEquals(5, process.getNodes().length);
+        assertEquals(7, process.getNodes().length);
 
         Node node = process.getNodes()[0];
         assertTrue(node instanceof EndNode);
@@ -259,7 +259,7 @@ public class ServerlessWorkflowParsingTest {
         assertTrue(node instanceof Join);
         node = process.getNodes()[3];
         assertTrue(node instanceof StartNode);
-        node = process.getNodes()[4];
+        node = process.getNodes()[5];
         assertTrue(node instanceof StartNode);
 
         // now check the composite one to see what nodes it has
@@ -547,7 +547,7 @@ public class ServerlessWorkflowParsingTest {
         assertEquals("org.kie.kogito.serverless", process.getPackageName());
         assertEquals(RuleFlowProcess.PUBLIC_VISIBILITY, process.getVisibility());
 
-        assertEquals(10, process.getNodes().length);
+        assertEquals(12, process.getNodes().length);
 
         Node node = process.getNodes()[0];
         assertTrue(node instanceof StartNode);
@@ -567,7 +567,7 @@ public class ServerlessWorkflowParsingTest {
         assertTrue(node instanceof ActionNode);
         node = process.getNodes()[8];
         assertTrue(node instanceof EventNode);
-        node = process.getNodes()[9];
+        node = process.getNodes()[10];
         assertTrue(node instanceof EventNode);
 
         Split split = (Split) process.getNodes()[4];
@@ -576,11 +576,9 @@ public class ServerlessWorkflowParsingTest {
 
         EventNode firstEventNode = (EventNode) process.getNodes()[8];
         assertEquals("visaApprovedEvent", firstEventNode.getName());
-        assertEquals("workflowdata", firstEventNode.getVariableName());
 
-        EventNode secondEventNode = (EventNode) process.getNodes()[9];
+        EventNode secondEventNode = (EventNode) process.getNodes()[10];
         assertEquals("visaDeniedEvent", secondEventNode.getName());
-        assertEquals("workflowdata", secondEventNode.getVariableName());
     }
 
     @ParameterizedTest
@@ -593,7 +591,7 @@ public class ServerlessWorkflowParsingTest {
         assertEquals("org.kie.kogito.serverless", process.getPackageName());
         assertEquals(RuleFlowProcess.PUBLIC_VISIBILITY, process.getVisibility());
 
-        assertEquals(9, process.getNodes().length);
+        assertEquals(11, process.getNodes().length);
 
         Node node = process.getNodes()[0];
         assertTrue(node instanceof CompositeContextNode);
@@ -601,25 +599,25 @@ public class ServerlessWorkflowParsingTest {
         assertTrue(node instanceof Join);
         node = process.getNodes()[2];
         assertTrue(node instanceof StartNode);
-        node = process.getNodes()[3];
-        assertTrue(node instanceof StartNode);
         node = process.getNodes()[4];
-        assertTrue(node instanceof Split);
-        node = process.getNodes()[5];
-        assertTrue(node instanceof Split);
+        assertTrue(node instanceof StartNode);
         node = process.getNodes()[6];
-        assertTrue(node instanceof ActionNode);
+        assertTrue(node instanceof Split);
         node = process.getNodes()[7];
-        assertTrue(node instanceof EndNode);
+        assertTrue(node instanceof Split);
         node = process.getNodes()[8];
+        assertTrue(node instanceof ActionNode);
+        node = process.getNodes()[9];
+        assertTrue(node instanceof EndNode);
+        node = process.getNodes()[10];
         assertTrue(node instanceof EndNode);
 
-        Split split = (Split) process.getNodes()[4];
+        Split split = (Split) process.getNodes()[6];
         assertEquals("CheckBackend", split.getName());
         assertEquals(2, split.getType());
         assertEquals(2, split.getConstraints().size());
 
-        Split split2 = (Split) process.getNodes()[5];
+        Split split2 = (Split) process.getNodes()[7];
         assertEquals("CheckFrontend", split2.getName());
         assertEquals(2, split2.getType());
         assertEquals(2, split2.getConstraints().size());

--- a/kogito-serverless-workflow/kogito-serverless-workflow-utils/src/main/java/org/kie/kogito/serverless/workflow/utils/ExpressionHandlerUtils.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-utils/src/main/java/org/kie/kogito/serverless/workflow/utils/ExpressionHandlerUtils.java
@@ -19,7 +19,6 @@ import java.util.Optional;
 
 import org.kie.kogito.jackson.utils.JsonObjectUtils;
 import org.kie.kogito.jackson.utils.MergeUtils;
-import org.kie.kogito.jackson.utils.ObjectMapperFactory;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -29,13 +28,10 @@ public class ExpressionHandlerUtils {
     private ExpressionHandlerUtils() {
     }
 
-    public static void assign(ObjectNode context, JsonNode target, JsonNode value, String expr) {
-        if (target == null || target.isNull()) {
-            target = value.isArray() ? ObjectMapperFactory.get().createArrayNode() : ObjectMapperFactory.get().createObjectNode();
-        }
+    public static void assign(JsonNode context, JsonNode target, JsonNode value, String expr) {
         Optional<String> varName = fallbackVarToName(expr);
-        if (varName.isPresent()) {
-            JsonObjectUtils.addToNode(varName.get(), MergeUtils.merge(value, target), context);
+        if (varName.isPresent() && context.isObject()) {
+            JsonObjectUtils.addToNode(varName.get(), MergeUtils.merge(value, target), (ObjectNode) context);
         }
     }
 

--- a/kogito-workitems/kogito-jackson-utils/src/main/java/org/kie/kogito/jackson/utils/MergeUtils.java
+++ b/kogito-workitems/kogito-jackson-utils/src/main/java/org/kie/kogito/jackson/utils/MergeUtils.java
@@ -60,7 +60,7 @@ public class MergeUtils {
                 JsonNode found = target.get(entry.getKey());
                 target.set(entry.getKey(), found != null ? merge(entry.getValue(), found, skipDuplicates) : entry.getValue());
             }
-        } else {
+        } else if (!src.isNull()) {
             target.set("response", src);
         }
         return target;

--- a/quarkus/addons/knative/eventing/deployment/src/test/java/org/kie/kogito/addons/quarkus/knative/eventing/deployment/KogitoProcessKnativeEventingProcessorTest.java
+++ b/quarkus/addons/knative/eventing/deployment/src/test/java/org/kie/kogito/addons/quarkus/knative/eventing/deployment/KogitoProcessKnativeEventingProcessorTest.java
@@ -16,10 +16,15 @@
 package org.kie.kogito.addons.quarkus.knative.eventing.deployment;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.jbpm.compiler.canonical.TriggerMetaData;
+import org.jbpm.ruleflow.core.Metadata;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.kie.api.definition.process.Node;
 import org.kie.kogito.codegen.process.events.ProcessCloudEventMeta;
 import org.kie.kogito.codegen.process.events.ProcessCloudEventMetaBuilder;
 import org.kie.kogito.quarkus.extensions.spi.deployment.KogitoProcessContainerGeneratorBuildItem;
@@ -35,6 +40,20 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class KogitoProcessKnativeEventingProcessorTest {
+
+    private static TriggerMetaData triggerMetadata;
+
+    @BeforeAll
+    static void setupClass() {
+        Node node = mock(Node.class);
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put(Metadata.TRIGGER_REF, "myType");
+        metadata.put(Metadata.MAPPING_VARIABLE, "myVar");
+        metadata.put(Metadata.TRIGGER_TYPE, "ProduceMessage");
+        metadata.put(Metadata.MESSAGE_TYPE, "myDataType");
+        when(node.getMetaData()).thenReturn(metadata);
+        triggerMetadata = TriggerMetaData.of(node);
+    }
 
     @Test
     void checkNotBuiltMetadataIfNoCEs() {
@@ -60,7 +79,7 @@ public class KogitoProcessKnativeEventingProcessorTest {
         when(processor.selectDeploymentTarget(null, kubernetesMetaBuildItems)).thenCallRealMethod();
         when(processor.getCloudEventMetaBuilder()).thenReturn(mockedCEBuilder);
         when(mockedCEBuilder.build(containerGeneratorBuildItem.getProcessContainerGenerators()))
-                .thenReturn(Collections.singleton(new ProcessCloudEventMeta("123", new TriggerMetaData("mtyTrigger", "ProduceMessage", "myType", "", ""))));
+                .thenReturn(Collections.singleton(new ProcessCloudEventMeta("123", triggerMetadata)));
 
         processor.buildMetadata(containerGeneratorBuildItem, null, kubernetesMetaBuildItems, metadata);
 
@@ -81,7 +100,7 @@ public class KogitoProcessKnativeEventingProcessorTest {
         when(processor.selectDeploymentTarget(deploymentTargets, kubernetesMetaBuildItems)).thenCallRealMethod();
         when(processor.getCloudEventMetaBuilder()).thenReturn(mockedCEBuilder);
         when(mockedCEBuilder.build(containerGeneratorBuildItem.getProcessContainerGenerators()))
-                .thenReturn(Collections.singleton(new ProcessCloudEventMeta("123", new TriggerMetaData("mtyTrigger", "ProduceMessage", "myType", "", ""))));
+                .thenReturn(Collections.singleton(new ProcessCloudEventMeta("123", triggerMetadata)));
 
         processor.buildMetadata(containerGeneratorBuildItem, deploymentTargets, kubernetesMetaBuildItems, metadata);
 


### PR DESCRIPTION
This add filter and merge support for SWF event states. 
In order to achieve that, code generator was slightly changed, so `eventToModel` method is only generated is the target node is a start one. This step is required to not force events to carry the whole model, as was kind of assumed before this change. 
The presence of that optional method has an additional benefit.  It allow us to identify at runtime if the target of the event is start node, so an attempt to start a process should be done or the targer is an intermediate event and a signal method should be called. This allow us to prevent what was happning with https://issues.redhat.com/browse/KOGITO-6356 
To round up this set of changes, name of classes generated for events in a subprocess are now guaranteed to be unique (which was not the case before)  
Finally, I feel we are lacking a way to signal a bunch of active process, we probable need another method to` ProcesService` interface, since right now we only have the one that accepts a process intance Id. I have opened  https://issues.redhat.com/browse/KOGITO-6468 and assigned to @evacchi to evaluate that need, since it affects the process API. 
Callback modified example at https://github.com/kiegroup/kogito-examples/pull/1055
As part of the testing of the examples, some improvements in JsonPathExpression were added. 