### PR TITLE
KOGITO-6448 async findById processInstance used by CloudEventConsumer

### DIFF
--- a/jbpm/jbpm-flow/src/main/java/org/kie/kogito/event/impl/CloudEventConsumer.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/kogito/event/impl/CloudEventConsumer.java
@@ -62,30 +62,39 @@ public class CloudEventConsumer<D, M extends Model, T extends AbstractProcessDat
             logger.debug("Received message with reference id '{}' going to use it to send signal '{}'",
                     cloudEvent.getKogitoReferenceId(),
                     trigger);
-            Optional<ProcessInstance<M>> instance = process.instances().findById(cloudEvent.getKogitoReferenceId());
-            if (instance.isPresent()) {
-                return CompletableFuture.completedFuture(processService.signalProcessInstance((Process) process, cloudEvent.getKogitoReferenceId(), cloudEvent.getData(), "Message-" + trigger));
-            } else if (function.isPresent()) {
-                logger.info("Process instance with id '{}' not found for triggering signal '{}', starting a new one",
-                        cloudEvent.getKogitoReferenceId(),
-                        trigger);
-                return startNewInstance(process, function.get().apply(cloudEvent.getData()), cloudEvent, trigger);
-            } else {
-                logger.info("Process instance with id {} not found for triggering signal {}", cloudEvent.getKogitoReferenceId(), trigger);
-                return CompletableFuture.completedFuture(null);
-            }
-
+            return CompletableFuture.supplyAsync(() -> {
+                Optional<ProcessInstance<M>> instance = findProcessInstance(process, cloudEvent);
+                if (instance.isPresent()) {
+                    return signalProcessInstance(process, trigger, cloudEvent);
+                } else if (function.isPresent()) {
+                    logger.info("Process instance with id '{}' not found for triggering signal '{}', starting a new one",
+                            cloudEvent.getKogitoReferenceId(),
+                            trigger);
+                    return startNewInstance(process, function.get().apply(cloudEvent.getData()), cloudEvent, trigger);
+                } else {
+                    logger.info("Process instance with id {} not found for triggering signal {}", cloudEvent.getKogitoReferenceId(), trigger);
+                    return null;
+                }
+            }, executor);
         } else if (function.isPresent()) {
             logger.debug("Received message without reference id, starting new process instance with trigger '{}'", trigger);
-            return startNewInstance(process, function.get().apply(cloudEvent.getData()), cloudEvent, trigger);
+            return CompletableFuture.supplyAsync(() -> startNewInstance(process, function.get().apply(cloudEvent.getData()), cloudEvent, trigger), executor);
         } else {
             logger.warn("Received not start event without kogito referecence id for trigger {}", trigger);
             return CompletableFuture.completedFuture(null);
         }
     }
 
-    private CompletionStage<Void> startNewInstance(Process<M> process, M model, T cloudEvent, String trigger) {
-        return CompletableFuture.runAsync(() -> processService.createProcessInstance(process, model, cloudEvent.getKogitoStartFromNode(), trigger, cloudEvent.getKogitoProcessinstanceId()), executor);
+    private Optional<M> signalProcessInstance(Process process, String trigger, T cloudEvent) {
+        return processService.signalProcessInstance(process, cloudEvent.getKogitoReferenceId(), cloudEvent.getData(), "Message-" + trigger);
+    }
+
+    private Optional<ProcessInstance<M>> findProcessInstance(Process<M> process, T cloudEvent) {
+        return process.instances().findById(cloudEvent.getKogitoReferenceId());
+    }
+
+    private ProcessInstance<M> startNewInstance(Process<M> process, M model, T cloudEvent, String trigger) {
+        return processService.createProcessInstance(process, model, cloudEvent.getKogitoStartFromNode(), trigger, cloudEvent.getKogitoProcessinstanceId());
     }
 
     private boolean ignoredMessageType(T cloudEvent, String type) {

--- a/jbpm/jbpm-flow/src/test/java/org/kie/kogito/event/impl/EventImplTest.java
+++ b/jbpm/jbpm-flow/src/test/java/org/kie/kogito/event/impl/EventImplTest.java
@@ -158,10 +158,11 @@ public class EventImplTest {
     }
 
     @Test
-    void testSigCloudEvent() {
+    void testSigCloudEvent() throws Exception {
         EventConsumer<DummyModel> consumer = factory.get(processService, executor, getConvertedMethod(), true);
         final String trigger = "dummyTopic";
-        consumer.consume(application, process, new DummyCloudEvent(new DummyEvent("pepe"), "1"), trigger);
+        consumer.consume(application, process, new DummyCloudEvent(new DummyEvent("pepe"), "1"), trigger).toCompletableFuture().get();
+
         ArgumentCaptor<String> signal = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<String> processInstanceId = ArgumentCaptor.forClass(String.class);
         verify(processService, times(1)).signalProcessInstance(Mockito.any(Process.class), processInstanceId.capture(), Mockito.any(DummyEvent.class), signal.capture());
@@ -170,11 +171,11 @@ public class EventImplTest {
     }
 
     @Test
-    void testCloudEvent() {
+    void testCloudEvent() throws Exception {
         EventConsumer<DummyModel> consumer =
                 factory.get(processService, executor, getConvertedMethod(), true);
         final String trigger = "dummyTopic";
-        consumer.consume(application, process, new DummyCloudEvent(new DummyEvent("pepe")), trigger);
+        consumer.consume(application, process, new DummyCloudEvent(new DummyEvent("pepe")), trigger).toCompletableFuture().get();
         ArgumentCaptor<String> signal = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<String> processInstanceId = ArgumentCaptor.forClass(String.class);
         verify(processService, timeout(1500L).times(1)).createProcessInstance(Mockito.any(Process.class), Mockito.any(DummyModel.class), Mockito.isNull(), signal.capture(),
@@ -184,11 +185,11 @@ public class EventImplTest {
     }
 
     @Test
-    void testDataEvent() {
+    void testDataEvent() throws Exception {
         EventConsumer<DummyModel> consumer =
                 factory.get(processService, executor, getConvertedMethod(), false);
         final String trigger = "dummyTopic";
-        consumer.consume(application, process, new DummyEvent("pepe"), trigger);
+        consumer.consume(application, process, new DummyEvent("pepe"), trigger).toCompletableFuture().get();
         ArgumentCaptor<String> signal = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<String> processInstanceId = ArgumentCaptor.forClass(String.class);
         verify(processService, timeout(1500L).times(1)).createProcessInstance(Mockito.any(Process.class), Mockito.any(DummyModel.class), Mockito.isNull(), signal.capture(), Mockito.isNull());
@@ -215,6 +216,6 @@ public class EventImplTest {
         EventConsumer<DummyModel> consumer = factory.get(processService, executor, getConvertedMethod(), true);
         final String trigger = "dummyTopic";
         final String payload = "{ a = b }";
-        assertThrows(ClassCastException.class, () -> consumer.consume(application, process, payload, trigger));
+        assertThrows(ClassCastException.class, () -> consumer.consume(application, process, payload, trigger).toCompletableFuture().get());
     }
 }


### PR DESCRIPTION
Async findById in ProcessInstances used by CloudEventConsumero avoid Thread Blocked Exception.
This issue was noticed using the latest PostgreSQL 14+ with the reactive client.
https://issues.redhat.com/browse/KOGITO-6448


Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](CONTRIBUTING.md)
- [ ] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run all builds</b>  
  Please add comment: <b>Jenkins retest this</b>

* <b>Run (or rerun) specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Run (or rerun) LTS specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Run (or rerun) native specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
