### PR TITLE
FAI-694: Quarkus: runtime-tools-quarkus-extension: Make UI features pluggable

### DIFF
--- a/quarkus/addons/common/deployment/src/main/java/org/kie/kogito/quarkus/addons/common/deployment/TrustyServiceAvailableBuildItem.java
+++ b/quarkus/addons/common/deployment/src/main/java/org/kie/kogito/quarkus/addons/common/deployment/TrustyServiceAvailableBuildItem.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.quarkus.addons.common.deployment;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * Signals that a Trusty Service instance is available.
+ */
+public final class TrustyServiceAvailableBuildItem extends SimpleBuildItem {
+
+}

--- a/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/deployment/KogitoDevServicesProcessor.java
+++ b/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/deployment/KogitoDevServicesProcessor.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import org.kie.kogito.quarkus.addons.common.deployment.TrustyServiceAvailableBuildItem;
 import org.kie.kogito.tracing.decision.quarkus.devservices.TrustyServiceInMemoryContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -78,6 +79,7 @@ public class KogitoDevServicesProcessor {
     public void startTrustyServiceDevService(
             final DevServicesConfig devServicesConfig,
             final BuildProducer<SystemPropertyBuildItem> systemProperties,
+            final BuildProducer<TrustyServiceAvailableBuildItem> trustyServiceAvailableBuildItemBuildProducer,
             final LaunchModeBuildItem launchMode,
             final KogitoBuildTimeConfig buildTimeConfig,
             final List<DevServicesSharedNetworkBuildItem> devServicesSharedNetwork,
@@ -110,6 +112,8 @@ public class KogitoDevServicesProcessor {
         if (closeable != null) {
             boolean shouldShutdown = !configuration.equals(cfg);
             if (!shouldShutdown) {
+                // Signal the service is (still) available when DevServices may have restarted but the service not
+                trustyServiceAvailableBuildItemBuildProducer.produce(new TrustyServiceAvailableBuildItem());
                 return;
             }
             shutdownTrustyService();
@@ -128,6 +132,8 @@ public class KogitoDevServicesProcessor {
                     launchMode,
                     !devServicesSharedNetwork.isEmpty());
             if (trustyService != null) {
+                // Signal the service is available
+                trustyServiceAvailableBuildItemBuildProducer.produce(new TrustyServiceAvailableBuildItem());
                 closeable = trustyService.getCloseable();
             }
             compressor.close();

--- a/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoDataIndexServiceAvailableBuildItem.java
+++ b/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoDataIndexServiceAvailableBuildItem.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.quarkus.common.deployment;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * Signals that a Data Index Service instance is available.
+ */
+public final class KogitoDataIndexServiceAvailableBuildItem extends SimpleBuildItem {
+
+}


### PR DESCRIPTION
See https://issues.redhat.com/browse/FAI-694

This PR adds two new `BuildItem`'s signalling when a back-end service is available.

They determine what UI components are visible in the DevUI console. 

This is part of an ensemble:
- https://github.com/kiegroup/kogito-runtimes/pull/1818
- https://github.com/kiegroup/kogito-apps/pull/1176

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run all builds</b>  
  Please add comment: <b>Jenkins retest this</b>

* <b>Run (or rerun) specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Run (or rerun) LTS specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Run (or rerun) native specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
