### PR TITLE
KOGITO-6319 LocalDates are supported in the ObjectMapper (processes) 

### DIFF
--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/transformation/JsonResolver.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/transformation/JsonResolver.java
@@ -31,6 +31,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 public class JsonResolver {
 
@@ -48,6 +49,7 @@ public class JsonResolver {
                 .setSerializationInclusion(JsonInclude.Include.NON_NULL)
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
                 .configure(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT, true)
+                .registerModule(new JavaTimeModule())
                 .setPropertyNamingStrategy(PropertyNamingStrategies.LOWER_CAMEL_CASE));
     }
 

--- a/jbpm/jbpm-flow/src/test/java/org/jbpm/process/core/transformation/JsonResolverTest.java
+++ b/jbpm/jbpm-flow/src/test/java/org/jbpm/process/core/transformation/JsonResolverTest.java
@@ -15,7 +15,9 @@
  */
 package org.jbpm.process.core.transformation;
 
+import java.time.LocalDate;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -199,5 +201,12 @@ public class JsonResolverTest {
         assertThat(output.get("child")).isInstanceOf(Map.class);
         assertThat(output.get("child2")).isInstanceOf(Map.class);
         assertThat(output.get("string")).isEqualTo("value");
+    }
+
+    @Test
+    void testDate() {
+        LocalDate localDate = LocalDate.of(2021, 12, 21);
+        Map<String, Object> r = resolver.resolveAll(Map.of("date", localDate));
+        assertThat(r.get("date")).isEqualTo(List.of(2021, 12, 21));
     }
 }


### PR DESCRIPTION
cherry-pick:
- KOGITO-6319 LocalDates are supported in the ObjectMapper (processes) (#1762)
