### PR TITLE
[BAPL-2051]-Certify Spring Boot 2.4.x

### DIFF
--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -18,7 +18,7 @@
     <!-- this version property is used in plugins but also in dependencies too -->
     <version.io.quarkus>2.6.0.Final</version.io.quarkus>
     <version.io.quarkus.quarkus-test-maven>2.6.0.Final</version.io.quarkus.quarkus-test-maven>
-    <version.org.springframework.boot>2.3.10.RELEASE</version.org.springframework.boot>
+    <version.org.springframework.boot>2.4.9</version.org.springframework.boot>
 
     <!-- dependencies versions -->
     <version.com.fasterxml.jackson>2.12.5</version.com.fasterxml.jackson>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/BAPL-2051
Upgraded version of Spring Boot to align with Red Hat supported Spring Boot 2.4.9 version.