### PR TITLE
KOGITO-6489 Removed from EventFlowIT the dependency on KafkaTestClient

### DIFF
--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/application.properties
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/application.properties
@@ -2,11 +2,8 @@
 org.kogito.openapi.client.multiplication.base_path=http://localhost:9090
 org.kogito.openapi.client.subtraction.base_path=http://localhost:9191
 
-kafka.bootstrap.servers=localhost:9092
+mp.messaging.incoming.move.connector=quarkus-http
+mp.messaging.incoming.move.path=/move
 
-mp.messaging.incoming.move.connector=smallrye-kafka
-mp.messaging.incoming.move.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
-
-mp.messaging.incoming.quiet.connector=smallrye-kafka
-mp.messaging.incoming.quiet.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
-
+mp.messaging.incoming.quiet.connector=quarkus-http
+mp.messaging.incoming.quiet.path=/quiet


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/KOGITO-6489

Quarkus 2.6.x uses Kafka 3, which is incompatible with vertx-kafka-client:4.2.2.
That makes necessary stop using vertx-kafka-client classes directly and use MicroProfile Reactive Messaging if possible.