### PR TITLE
[KOGITO-6331] Implementing eventRef for actions

### DIFF
--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ExpressionSupplier.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ExpressionSupplier.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.compiler.canonical;
+
+import org.kie.kogito.internal.process.runtime.KogitoNode;
+
+import com.github.javaparser.ast.expr.Expression;
+
+public interface ExpressionSupplier {
+
+    public Expression get(KogitoNode node, ProcessMetaData metadata);
+}

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ForEachNodeVisitor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ForEachNodeVisitor.java
@@ -19,7 +19,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Supplier;
 
 import org.jbpm.process.core.context.variable.VariableScope;
 import org.jbpm.process.core.datatype.impl.type.ObjectDataType;
@@ -31,7 +30,6 @@ import org.jbpm.workflow.core.node.ForEachNode;
 
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.BooleanLiteralExpr;
-import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.LongLiteralExpr;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
@@ -104,8 +102,8 @@ public class ForEachNodeVisitor extends AbstractCompositeNodeVisitor<ForEachNode
             body.addStatement(getFactoryMethod(getNodeId(node), "expressionLanguage", new StringLiteralExpr(node.getExpressionLanguage())));
         }
 
-        if (node.getCompletionAction() instanceof Supplier) {
-            body.addStatement(getFactoryMethod(getNodeId(node), "completionAction", ((Supplier<Expression>) node.getCompletionAction()).get()));
+        if (node.getCompletionAction() instanceof ExpressionSupplier) {
+            body.addStatement(getFactoryMethod(getNodeId(node), "completionAction", ((ExpressionSupplier) node.getCompletionAction()).get(node, metadata)));
         }
 
         // visit nodes

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/actions/ProduceEventAction.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/actions/ProduceEventAction.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.process.instance.impl.actions;
+
+import java.io.Serializable;
+import java.util.function.Supplier;
+
+import org.drools.core.common.InternalKnowledgeRuntime;
+import org.jbpm.process.instance.InternalProcessRuntime;
+import org.jbpm.process.instance.impl.Action;
+import org.kie.kogito.internal.process.runtime.KogitoProcessContext;
+import org.kie.kogito.internal.process.runtime.KogitoProcessInstance;
+import org.kie.kogito.services.event.impl.AbstractMessageProducer;
+
+public class ProduceEventAction<T> implements Action, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String varName;
+    private final String triggerName;
+    private final Supplier<AbstractMessageProducer<T, ?>> supplier;
+
+    public ProduceEventAction(String triggerName, String varName, Supplier<AbstractMessageProducer<T, ?>> supplier) {
+        this.triggerName = triggerName;
+        this.varName = varName;
+        this.supplier = supplier;
+    }
+
+    @Override
+    public void execute(KogitoProcessContext context) throws Exception {
+        Object object = context.getVariable(varName);
+        KogitoProcessInstance pi = context.getProcessInstance();
+        InternalKnowledgeRuntime runtime = (InternalKnowledgeRuntime) context.getKieRuntime();
+        InternalProcessRuntime process = (InternalProcessRuntime) runtime.getProcessRuntime();
+        process.getProcessEventSupport().fireOnMessage(pi, context.getNodeInstance(), runtime, triggerName, object);
+        supplier.get().produce(pi, getObject(object));
+    }
+
+    protected T getObject(Object object) {
+        return (T) object;
+    }
+}

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/factory/ActionNodeFactory.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/factory/ActionNodeFactory.java
@@ -22,7 +22,7 @@ import org.jbpm.workflow.core.NodeContainer;
 import org.jbpm.workflow.core.impl.DroolsConsequenceAction;
 import org.jbpm.workflow.core.node.ActionNode;
 
-public class ActionNodeFactory<T extends RuleFlowNodeContainerFactory<T, ?>> extends NodeFactory<ActionNodeFactory<T>, T> {
+public class ActionNodeFactory<T extends RuleFlowNodeContainerFactory<T, ?>> extends NodeFactory<ActionNodeFactory<T>, T> implements SupportsAction<ActionNodeFactory<T>, T> {
 
     public static final String METHOD_ACTION = "action";
 
@@ -60,6 +60,7 @@ public class ActionNodeFactory<T extends RuleFlowNodeContainerFactory<T, ?>> ext
         return this;
     }
 
+    @Override
     public ActionNodeFactory<T> action(Action action) {
         DroolsAction droolsAction = new DroolsAction();
         droolsAction.setMetaData("Action", action);

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/factory/EndNodeFactory.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/factory/EndNodeFactory.java
@@ -27,7 +27,7 @@ import org.jbpm.workflow.core.node.EndNode;
 
 import static org.jbpm.ruleflow.core.Metadata.ACTION;
 
-public class EndNodeFactory<T extends RuleFlowNodeContainerFactory<T, ?>> extends NodeFactory<EndNodeFactory<T>, T> {
+public class EndNodeFactory<T extends RuleFlowNodeContainerFactory<T, ?>> extends NodeFactory<EndNodeFactory<T>, T> implements SupportsAction<EndNodeFactory<T>, T> {
 
     public static final String METHOD_TERMINATE = "terminate";
     public static final String METHOD_ACTION = "action";
@@ -45,6 +45,7 @@ public class EndNodeFactory<T extends RuleFlowNodeContainerFactory<T, ?>> extend
         return this;
     }
 
+    @Override
     public EndNodeFactory<T> action(Action action) {
         DroolsAction droolsAction = new DroolsAction();
         droolsAction.setMetaData(ACTION, action);

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/factory/SupportsAction.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/factory/SupportsAction.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.ruleflow.core.factory;
+
+import org.jbpm.process.instance.impl.Action;
+import org.jbpm.ruleflow.core.RuleFlowNodeContainerFactory;
+
+public interface SupportsAction<T extends NodeFactory<T, P>, P extends RuleFlowNodeContainerFactory<P, ?>> {
+    T action(Action action);
+}

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/MessageProducerJavaTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/resources/class-templates/MessageProducerJavaTemplate.java
@@ -18,15 +18,15 @@ package com.myspace.demo;
 import java.util.Optional;
 
 import org.kie.kogito.internal.process.runtime.KogitoProcessInstance;
+import org.kie.kogito.services.event.AbstractProcessDataEvent;
 import org.kie.kogito.services.event.impl.StringEventMarshaller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.kie.kogito.event.EventMarshaller;
 
-public class MessageProducer {
+public class MessageProducer extends org.kie.kogito.services.event.impl.AbstractMessageProducer<java.lang.String,AbstractProcessDataEvent<String>>{
 
-    Object emitter;
 
     Optional<Boolean> useCloudEvents = Optional.of(true);
 
@@ -50,5 +50,10 @@ public class MessageProducer {
                 pi.getRootProcessId(),
                 String.valueOf(pi.getState()),
                 pi.getReferenceId() == null || pi.getReferenceId().trim().isEmpty() ? null : pi.getReferenceId()): eventData);
+    }
+    
+    @Override
+    protected  AbstractProcessDataEvent<String>  dataEventTypeConstructor(String e, KogitoProcessInstance pi, String trigger)  {
+        return null;
     }
 }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/ServerlessWorkflowParser.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/ServerlessWorkflowParser.java
@@ -132,14 +132,15 @@ public class ServerlessWorkflowParser {
                 .defaultContext(variableScope);
     }
 
-    public static <T extends NodeFactory<T, P>, P extends RuleFlowNodeContainerFactory<P, ?>> T sendEventNode(T actionNode,
-            EventDefinition eventDefinition) {
+    public static <T extends NodeFactory<T, P>, P extends RuleFlowNodeContainerFactory<P, ?>> T sendEventNode(NodeFactory<T, P> actionNode,
+            EventDefinition eventDefinition, String inputVar) {
         return actionNode
                 .name(eventDefinition.getName())
-                .metaData(Metadata.TRIGGER_TYPE, "ProduceMessage")
-                .metaData(Metadata.MAPPING_VARIABLE, DEFAULT_WORKFLOW_VAR)
+                .metaData(Metadata.EVENT_TYPE, "message")
+                .metaData(Metadata.MAPPING_VARIABLE, inputVar)
                 .metaData(Metadata.TRIGGER_REF, eventDefinition.getType())
-                .metaData(Metadata.MESSAGE_TYPE, JSON_NODE);
+                .metaData(Metadata.MESSAGE_TYPE, JSON_NODE)
+                .metaData(Metadata.TRIGGER_TYPE, "ProduceMessage");
     }
 
     public static <T extends NodeFactory<T, P>, P extends RuleFlowNodeContainerFactory<P, ?>> T messageNode(T nodeFactory, EventDefinition eventDefinition, String inputVar) {
@@ -150,6 +151,5 @@ public class ServerlessWorkflowParser {
                 .metaData(Metadata.TRIGGER_REF, eventDefinition.getType())
                 .metaData(Metadata.MESSAGE_TYPE, JSON_NODE)
                 .metaData(Metadata.TRIGGER_TYPE, "ConsumeMessage");
-
     }
 }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/SwitchHandler.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/SwitchHandler.java
@@ -26,7 +26,6 @@ import org.jbpm.ruleflow.core.factory.NodeFactory;
 import org.jbpm.ruleflow.core.factory.SplitFactory;
 import org.jbpm.workflow.core.node.Split;
 import org.kie.kogito.serverless.workflow.parser.ParserContext;
-import org.kie.kogito.serverless.workflow.parser.ServerlessWorkflowParser;
 import org.kie.kogito.serverless.workflow.utils.ServerlessWorkflowUtils;
 
 import io.serverlessworkflow.api.Workflow;
@@ -35,6 +34,8 @@ import io.serverlessworkflow.api.states.SwitchState;
 import io.serverlessworkflow.api.switchconditions.DataCondition;
 import io.serverlessworkflow.api.switchconditions.EventCondition;
 import io.serverlessworkflow.api.transitions.Transition;
+
+import static org.kie.kogito.serverless.workflow.parser.ServerlessWorkflowParser.DEFAULT_WORKFLOW_VAR;
 
 public class SwitchHandler extends StateHandler<SwitchState> {
 
@@ -138,7 +139,7 @@ public class SwitchHandler extends StateHandler<SwitchState> {
     private void addConstraint(NodeFactory<?, ?> startNode, long targetId, DataCondition condition) {
         ((SplitFactory<?>) startNode).constraintBuilder(targetId, concatId(startNode.getNode().getId(), targetId),
                 "DROOLS_DEFAULT", workflow.getExpressionLang(), ServerlessWorkflowUtils.conditionScript(condition.getCondition())).withDefault(isDefaultCondition(state, condition))
-                .metadata(Metadata.VARIABLE, ServerlessWorkflowParser.DEFAULT_WORKFLOW_VAR);
+                .metadata(Metadata.VARIABLE, DEFAULT_WORKFLOW_VAR);
     }
 
     private EndNodeFactory<?> endNodeFactory(RuleFlowNodeContainerFactory<?, ?> factory, List<ProduceEvent> produceEvents) {
@@ -146,7 +147,7 @@ public class SwitchHandler extends StateHandler<SwitchState> {
         if (produceEvents == null || produceEvents.isEmpty()) {
             endNodeFactory.terminate(true);
         } else {
-            ServerlessWorkflowParser.sendEventNode(endNodeFactory, eventDefinition(produceEvents.get(0).getEventRef()));
+            sendEventNode(endNodeFactory, produceEvents.get(0));
         }
         return endNodeFactory;
     }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/suppliers/CollectorActionSupplier.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/suppliers/CollectorActionSupplier.java
@@ -15,14 +15,15 @@
  */
 package org.kie.kogito.serverless.workflow.suppliers;
 
-import java.util.function.Supplier;
-
+import org.jbpm.compiler.canonical.ExpressionSupplier;
+import org.jbpm.compiler.canonical.ProcessMetaData;
 import org.jbpm.compiler.canonical.descriptors.SupplierUtils;
+import org.kie.kogito.internal.process.runtime.KogitoNode;
 import org.kie.kogito.serverless.workflow.actions.CollectorAction;
 
 import com.github.javaparser.ast.expr.Expression;
 
-public class CollectorActionSupplier extends CollectorAction implements Supplier<Expression> {
+public class CollectorActionSupplier extends CollectorAction implements ExpressionSupplier {
 
     private Expression expression;
 
@@ -32,7 +33,7 @@ public class CollectorActionSupplier extends CollectorAction implements Supplier
     }
 
     @Override
-    public Expression get() {
+    public Expression get(KogitoNode node, ProcessMetaData metadata) {
         return expression;
     }
 

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/suppliers/CompensationActionSupplier.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/suppliers/CompensationActionSupplier.java
@@ -15,14 +15,15 @@
  */
 package org.kie.kogito.serverless.workflow.suppliers;
 
-import java.util.function.Supplier;
-
+import org.jbpm.compiler.canonical.ExpressionSupplier;
+import org.jbpm.compiler.canonical.ProcessMetaData;
 import org.jbpm.compiler.canonical.descriptors.SupplierUtils;
 import org.jbpm.process.instance.impl.actions.ProcessInstanceCompensationAction;
+import org.kie.kogito.internal.process.runtime.KogitoNode;
 
 import com.github.javaparser.ast.expr.Expression;
 
-public class CompensationActionSupplier extends ProcessInstanceCompensationAction implements Supplier<Expression> {
+public class CompensationActionSupplier extends ProcessInstanceCompensationAction implements ExpressionSupplier {
 
     private static final long serialVersionUID = 1L;
 
@@ -31,7 +32,7 @@ public class CompensationActionSupplier extends ProcessInstanceCompensationActio
     }
 
     @Override
-    public Expression get() {
+    public Expression get(KogitoNode node, ProcessMetaData metadata) {
         return SupplierUtils.getExpression(ProcessInstanceCompensationAction.class, getActivityRef());
     }
 }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/suppliers/ExpressionActionSupplier.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/suppliers/ExpressionActionSupplier.java
@@ -15,20 +15,20 @@
  */
 package org.kie.kogito.serverless.workflow.suppliers;
 
-import java.util.function.Supplier;
-
+import org.jbpm.compiler.canonical.ExpressionSupplier;
+import org.jbpm.compiler.canonical.ProcessMetaData;
 import org.jbpm.compiler.canonical.descriptors.SupplierUtils;
+import org.kie.kogito.internal.process.runtime.KogitoNode;
 import org.kie.kogito.serverless.workflow.actions.ExpressionAction;
 import org.kie.kogito.serverless.workflow.parser.ServerlessWorkflowParser;
 
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
 
-public class ExpressionActionSupplier extends ExpressionAction implements Supplier<Expression> {
+public class ExpressionActionSupplier extends ExpressionAction implements ExpressionSupplier {
 
     public static Builder of(String lang, String expr) {
         return new Builder(lang, expr);
-
     }
 
     public static class Builder {
@@ -80,7 +80,7 @@ public class ExpressionActionSupplier extends ExpressionAction implements Suppli
     }
 
     @Override
-    public Expression get() {
+    public Expression get(KogitoNode node, ProcessMetaData metadata) {
         return expression;
     }
 }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/suppliers/InjectActionSupplier.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/suppliers/InjectActionSupplier.java
@@ -15,9 +15,10 @@
  */
 package org.kie.kogito.serverless.workflow.suppliers;
 
-import java.util.function.Supplier;
-
+import org.jbpm.compiler.canonical.ExpressionSupplier;
+import org.jbpm.compiler.canonical.ProcessMetaData;
 import org.jbpm.compiler.canonical.descriptors.SupplierUtils;
+import org.kie.kogito.internal.process.runtime.KogitoNode;
 import org.kie.kogito.jackson.utils.ObjectMapperFactory;
 import org.kie.kogito.serverless.workflow.actions.InjectAction;
 
@@ -25,16 +26,16 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.javaparser.ast.expr.Expression;
 
-public class InjectActionSupplier extends InjectAction implements Supplier<Expression> {
+public class InjectActionSupplier extends InjectAction implements ExpressionSupplier {
 
     public InjectActionSupplier(JsonNode node) {
         super(node);
     }
 
     @Override
-    public Expression get() {
+    public Expression get(KogitoNode kogitoNode, ProcessMetaData metadata) {
         try {
-            return SupplierUtils.getExpression(InjectAction.class, ObjectMapperFactory.get().writeValueAsString(node).replace("\"", "\\\""));
+            return SupplierUtils.getExpression(InjectAction.class, ObjectMapperFactory.get().writeValueAsString(this.node).replace("\"", "\\\""));
         } catch (JsonProcessingException e) {
             throw new IllegalStateException(e);
         }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/suppliers/MergeActionSupplier.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/suppliers/MergeActionSupplier.java
@@ -15,14 +15,15 @@
  */
 package org.kie.kogito.serverless.workflow.suppliers;
 
-import java.util.function.Supplier;
-
+import org.jbpm.compiler.canonical.ExpressionSupplier;
+import org.jbpm.compiler.canonical.ProcessMetaData;
 import org.jbpm.compiler.canonical.descriptors.SupplierUtils;
+import org.kie.kogito.internal.process.runtime.KogitoNode;
 import org.kie.kogito.serverless.workflow.actions.MergeAction;
 
 import com.github.javaparser.ast.expr.Expression;
 
-public class MergeActionSupplier extends MergeAction implements Supplier<Expression> {
+public class MergeActionSupplier extends MergeAction implements ExpressionSupplier {
 
     private Expression expression;
 
@@ -33,7 +34,7 @@ public class MergeActionSupplier extends MergeAction implements Supplier<Express
     }
 
     @Override
-    public Expression get() {
+    public Expression get(KogitoNode node, ProcessMetaData metadata) {
         return expression;
 
     }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/suppliers/ProduceEventActionSupplier.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/suppliers/ProduceEventActionSupplier.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.serverless.workflow.suppliers;
+
+import org.jbpm.compiler.canonical.AbstractNodeVisitor;
+import org.jbpm.compiler.canonical.ExpressionSupplier;
+import org.jbpm.compiler.canonical.ProcessMetaData;
+import org.jbpm.compiler.canonical.TriggerMetaData;
+import org.jbpm.process.instance.impl.Action;
+import org.kie.kogito.internal.process.runtime.KogitoNode;
+import org.kie.kogito.internal.process.runtime.KogitoProcessContext;
+import org.kie.kogito.serverless.workflow.actions.SWFProduceEventAction;
+import org.slf4j.LoggerFactory;
+
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.NullLiteralExpr;
+import com.github.javaparser.ast.expr.StringLiteralExpr;
+
+import static com.github.javaparser.StaticJavaParser.parseClassOrInterfaceType;
+
+public class ProduceEventActionSupplier implements ExpressionSupplier, Action {
+
+    private final String exprLang;
+    private final String data;
+
+    public ProduceEventActionSupplier(String exprLang, String data) {
+        this.exprLang = exprLang;
+        this.data = data;
+    }
+
+    @Override
+    public Expression get(KogitoNode node, ProcessMetaData metadata) {
+        return AbstractNodeVisitor.buildProducerAction(parseClassOrInterfaceType(SWFProduceEventAction.class.getCanonicalName()), TriggerMetaData.of(node), metadata)
+                .addArgument(new StringLiteralExpr(exprLang))
+                .addArgument(data != null ? new StringLiteralExpr(data) : new NullLiteralExpr());
+    }
+
+    @Override
+    public void execute(KogitoProcessContext context) throws Exception {
+        LoggerFactory.getLogger(ProduceEventActionSupplier.class).warn("Code generation step is needed for event production");
+    }
+
+}

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/suppliers/SysoutActionSupplier.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/suppliers/SysoutActionSupplier.java
@@ -15,14 +15,15 @@
  */
 package org.kie.kogito.serverless.workflow.suppliers;
 
-import java.util.function.Supplier;
-
+import org.jbpm.compiler.canonical.ExpressionSupplier;
+import org.jbpm.compiler.canonical.ProcessMetaData;
 import org.jbpm.compiler.canonical.descriptors.SupplierUtils;
+import org.kie.kogito.internal.process.runtime.KogitoNode;
 import org.kie.kogito.serverless.workflow.actions.SysoutAction;
 
 import com.github.javaparser.ast.expr.Expression;
 
-public class SysoutActionSupplier extends SysoutAction implements Supplier<Expression> {
+public class SysoutActionSupplier extends SysoutAction implements ExpressionSupplier {
 
     private final Expression expression;
 
@@ -32,7 +33,7 @@ public class SysoutActionSupplier extends SysoutAction implements Supplier<Expre
     }
 
     @Override
-    public Expression get() {
+    public Expression get(KogitoNode node, ProcessMetaData metadata) {
         return expression;
     }
 

--- a/kogito-serverless-workflow/kogito-serverless-workflow-runtime/src/main/java/org/kie/kogito/serverless/workflow/actions/SWFProduceEventAction.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-runtime/src/main/java/org/kie/kogito/serverless/workflow/actions/SWFProduceEventAction.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.serverless.workflow.actions;
+
+import java.util.function.Supplier;
+
+import org.jbpm.process.instance.impl.actions.ProduceEventAction;
+import org.kie.kogito.jackson.utils.JsonObjectUtils;
+import org.kie.kogito.jackson.utils.ObjectMapperFactory;
+import org.kie.kogito.process.workitems.impl.expr.Expression;
+import org.kie.kogito.process.workitems.impl.expr.ExpressionHandlerFactory;
+import org.kie.kogito.services.event.impl.AbstractMessageProducer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class SWFProduceEventAction extends ProduceEventAction<JsonNode> {
+    private static final long serialVersionUID = 1L;
+
+    private Expression expr;
+    private JsonNode value;
+
+    public SWFProduceEventAction(String triggerName, String varName, Supplier<AbstractMessageProducer<JsonNode, ?>> supplier, String exprLang, String data) {
+        super(triggerName, varName, supplier);
+        if (data != null) {
+            this.expr = ExpressionHandlerFactory.get(exprLang, data);
+            if (!expr.isValid()) {
+                try {
+                    this.value = ObjectMapperFactory.get().readTree(data);
+                } catch (JsonProcessingException e) {
+                    throw new IllegalArgumentException("Data " + data + " is not valid json not valid expression");
+                }
+            }
+        }
+    }
+
+    @Override
+    public JsonNode getObject(Object object) {
+        if (value != null) {
+            return value;
+        } else if (expr != null) {
+            return expr.eval(object, JsonNode.class);
+        } else {
+            return JsonObjectUtils.fromValue(object);
+        }
+    }
+
+}


### PR DESCRIPTION
This PR add support for this part of the spec  https://github.com/serverlessworkflow/specification/blob/0.6.x/specification.md#eventref-definition. This will allow sending events from an action
Note that we are not implementing resultEventRef, fire&wait scenarios can be implemented using an action that publish an event inside a callback state. 
To implement this, ActionNodeVisitor has been heavily refactor, so we can reuse already generated code that publish events. 
New inteface ExpressionSupplier has been created inside flow-builder. This allow passing node information to SWF action supplier (which is needed to get the proper id for the event producer) 
See examples at https://github.com/kiegroup/kogito-examples/pull/1082