### PR TITLE
KOGITO-6531 Broken Swagger-UI Quarkus for DMN OpenAPI references

### DIFF
--- a/integration-tests/integration-tests-quarkus-decisions/src/test/java/org/kie/kogito/integrationtests/quarkus/OASIT.java
+++ b/integration-tests/integration-tests-quarkus-decisions/src/test/java/org/kie/kogito/integrationtests/quarkus/OASIT.java
@@ -62,6 +62,23 @@ class OASIT {
     }
 
     @Test
+    public void testOASisSwaggerUICompatible() {
+        String url = rootUrl.toString() + "/q/openapi"; // default location since Quarkus v1.10
+        ParseOptions parseOptions = new ParseOptions();
+        parseOptions.setResolve(false); // we want the actual OAS file (something ~like http://localhost:8080/q/openapi) as read by the Swagger UI on fetch.
+        SwaggerParseResult result = new OpenAPIV3Parser().readLocation(url, null, parseOptions);
+        assertThat(result.getMessages()).isEmpty();
+
+        final String DMN_MODEL_NAME = "basicAdd";
+
+        OpenAPI openAPI = result.getOpenAPI();
+        PathItem p1 = openAPI.getPaths().get("/" + DMN_MODEL_NAME);
+        assertThat(p1).isNotNull();
+        assertThat(p1.getPost().getRequestBody().getContent().get("application/json").getSchema().get$ref()).startsWith("/dmnDefinitions.json#");
+        assertThat(p1.getPost().getResponses().getDefault().getContent().get("application/json").getSchema().get$ref()).startsWith("/dmnDefinitions.json#");
+    }
+
+    @Test
     public void testOASdmnDefinitions() {
         RestAssured.given()
                 .get("/dmnDefinitions.json")

--- a/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/test/java/org/kie/kogito/integrationtests/springboot/OASTest.java
+++ b/integration-tests/integration-tests-springboot/src/it/integration-tests-springboot-it/src/test/java/org/kie/kogito/integrationtests/springboot/OASTest.java
@@ -59,6 +59,25 @@ class OASTest extends BaseRestTest {
         assertThat(p2).isNotNull();
         assertThat(p2.getPost()).isNotNull(); // only POST for ../dmnresult expected.
     }
+    
+    @Test
+    public void testOASisSwaggerUICompatible() {
+        String url = RestAssured.baseURI + ":" + RestAssured.port + "/v3/api-docs"; // default location from org.springdoc:springdoc-openapi-ui as used in archetype
+        ParseOptions parseOptions = new ParseOptions();
+        parseOptions.setResolve(false); // we want the actual OAS file (something ~like http://localhost:8080/v3/api-docs) as read by the Swagger UI on fetch.
+        SwaggerParseResult result = new OpenAPIV3Parser().readLocation(url, null, parseOptions);
+
+        List<String> messages = result.getMessages();
+        assertThat(messages).isEmpty();
+
+        final String DMN_MODEL_NAME = "basicAdd";
+
+        OpenAPI openAPI = result.getOpenAPI();
+        PathItem p1 = openAPI.getPaths().get("/" + DMN_MODEL_NAME);
+        assertThat(p1).isNotNull();
+        assertThat(p1.getPost().getRequestBody().getContent().get("application/json").getSchema().get$ref()).startsWith("/dmnDefinitions.json#");
+        assertThat(p1.getPost().getResponses().getDefault().getContent().get("application/json").getSchema().get$ref()).startsWith("/dmnDefinitions.json#");
+    }
 
     @Test
     public void testOASdmnDefinitions() {

--- a/kogito-codegen-modules/kogito-codegen-decisions/src/main/java/org/kie/kogito/codegen/decision/DecisionRestResourceGenerator.java
+++ b/kogito-codegen-modules/kogito-codegen-decisions/src/main/java/org/kie/kogito/codegen/decision/DecisionRestResourceGenerator.java
@@ -58,6 +58,7 @@ import com.github.javaparser.ast.stmt.Statement;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 
 import static com.github.javaparser.StaticJavaParser.parseStatement;
+import static java.util.function.Predicate.not;
 
 public class DecisionRestResourceGenerator {
 
@@ -201,7 +202,7 @@ public class DecisionRestResourceGenerator {
         }
         final String DMN_DEFINITIONS_JSON = "/dmnDefinitions.json";
         // MP / Quarkus
-        final String Q_CTX_PATH = context.getApplicationProperty("quarkus.http.root-path").orElse("");
+        final String Q_CTX_PATH = context.getApplicationProperty("quarkus.http.root-path").filter(not("/"::equals)).orElse("");
         processAnnForRef(dmnMethod,
                 "org.eclipse.microprofile.openapi.annotations.parameters.RequestBody",
                 "org.eclipse.microprofile.openapi.annotations.media.Schema",
@@ -213,7 +214,7 @@ public class DecisionRestResourceGenerator {
                 Q_CTX_PATH + DMN_DEFINITIONS_JSON + outputRef,
                 !mpAnnPresent);
         // io.swagger / SB
-        final String SB_CTX_PATH = context.getApplicationProperty("server.servlet.context-path").orElse("");
+        final String SB_CTX_PATH = context.getApplicationProperty("server.servlet.context-path").filter(not("/"::equals)).orElse("");
         processAnnForRef(dmnMethod,
                 "io.swagger.v3.oas.annotations.parameters.RequestBody",
                 "io.swagger.v3.oas.annotations.media.Schema",


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-6531

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run all builds</b>  
  Please add comment: <b>Jenkins retest this</b>

* <b>Run (or rerun) specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Run (or rerun) LTS specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Run (or rerun) native specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
