### PR TITLE
[DROOLS-6646] move ClassFieldAccessorStore out of drools-core

### DIFF
--- a/jbpm/jbpm-flow-builder/src/test/java/org/jbpm/compiler/PackageBuilderTest.java
+++ b/jbpm/jbpm-flow-builder/src/test/java/org/jbpm/compiler/PackageBuilderTest.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.drools.core.definitions.InternalKnowledgePackage;
-import org.drools.core.definitions.impl.KnowledgePackageImpl;
+import org.drools.core.reteoo.CoreComponentFactory;
 import org.drools.core.util.DroolsStreamUtils;
 import org.drools.drl.ast.descr.PackageDescr;
 import org.jbpm.process.core.Context;
@@ -116,7 +116,7 @@ public class PackageBuilderTest extends AbstractBaseTest {
 
     @Test
     public void testPackageRuleFlows() throws Exception {
-        InternalKnowledgePackage pkg = new KnowledgePackageImpl("boo");
+        InternalKnowledgePackage pkg = CoreComponentFactory.get().createKnowledgePackage("boo");
         Process rf = new MockRuleFlow("1");
         pkg.addProcess(rf);
         assertTrue(pkg.getRuleFlows().containsKey("1"));

--- a/jbpm/jbpm-flow-builder/src/test/java/org/jbpm/process/builder/JavaActionBuilderTest.java
+++ b/jbpm/jbpm-flow-builder/src/test/java/org/jbpm/process/builder/JavaActionBuilderTest.java
@@ -22,7 +22,7 @@ import java.util.List;
 import org.drools.compiler.builder.impl.KnowledgeBuilderImpl;
 import org.drools.compiler.compiler.DialectCompiletimeRegistry;
 import org.drools.core.definitions.InternalKnowledgePackage;
-import org.drools.core.definitions.impl.KnowledgePackageImpl;
+import org.drools.core.reteoo.CoreComponentFactory;
 import org.drools.drl.ast.descr.ActionDescr;
 import org.drools.drl.ast.descr.ProcessDescr;
 import org.drools.mvel.java.JavaDialect;
@@ -45,7 +45,7 @@ public class JavaActionBuilderTest extends AbstractBaseTest {
 
     @Test
     public void testSimpleAction() throws Exception {
-        final InternalKnowledgePackage pkg = new KnowledgePackageImpl("pkg1");
+        final InternalKnowledgePackage pkg = CoreComponentFactory.get().createKnowledgePackage("pkg1");
 
         ActionDescr actionDescr = new ActionDescr();
         actionDescr.setText("list.add( \"hello world\" );");

--- a/jbpm/jbpm-flow-builder/src/test/java/org/jbpm/process/builder/JavaReturnValueConstraintEvaluatorBuilderTest.java
+++ b/jbpm/jbpm-flow-builder/src/test/java/org/jbpm/process/builder/JavaReturnValueConstraintEvaluatorBuilderTest.java
@@ -21,7 +21,7 @@ import org.drools.compiler.builder.impl.KnowledgeBuilderImpl;
 import org.drools.compiler.compiler.DialectCompiletimeRegistry;
 import org.drools.core.common.InternalKnowledgeRuntime;
 import org.drools.core.definitions.InternalKnowledgePackage;
-import org.drools.core.definitions.impl.KnowledgePackageImpl;
+import org.drools.core.reteoo.CoreComponentFactory;
 import org.drools.drl.ast.descr.ProcessDescr;
 import org.drools.drl.ast.descr.ReturnValueDescr;
 import org.drools.mvel.java.JavaDialect;
@@ -43,7 +43,7 @@ public class JavaReturnValueConstraintEvaluatorBuilderTest extends AbstractBaseT
 
     @Test
     public void testSimpleReturnValueConstraintEvaluator() throws Exception {
-        final InternalKnowledgePackage pkg = new KnowledgePackageImpl("pkg1");
+        final InternalKnowledgePackage pkg = CoreComponentFactory.get().createKnowledgePackage("pkg1");
 
         ProcessDescr processDescr = new ProcessDescr();
         processDescr.setClassName("Process1");

--- a/jbpm/jbpm-flow-builder/src/test/java/org/jbpm/process/builder/MVELActionBuilderTest.java
+++ b/jbpm/jbpm-flow-builder/src/test/java/org/jbpm/process/builder/MVELActionBuilderTest.java
@@ -23,7 +23,7 @@ import org.drools.compiler.builder.impl.KnowledgeBuilderImpl;
 import org.drools.compiler.compiler.DialectCompiletimeRegistry;
 import org.drools.compiler.rule.builder.PackageBuildContext;
 import org.drools.core.definitions.InternalKnowledgePackage;
-import org.drools.core.definitions.impl.KnowledgePackageImpl;
+import org.drools.core.reteoo.CoreComponentFactory;
 import org.drools.drl.ast.descr.ActionDescr;
 import org.drools.mvel.MVELDialectRuntimeData;
 import org.drools.mvel.builder.MVELDialect;
@@ -45,7 +45,7 @@ public class MVELActionBuilderTest extends AbstractBaseTest {
 
     @Test
     public void testSimpleAction() throws Exception {
-        final InternalKnowledgePackage pkg = new KnowledgePackageImpl("pkg1");
+        final InternalKnowledgePackage pkg = CoreComponentFactory.get().createKnowledgePackage("pkg1");
 
         ActionDescr actionDescr = new ActionDescr();
         actionDescr.setText("list.add( 'hello world' )");

--- a/jbpm/jbpm-flow-builder/src/test/java/org/jbpm/process/builder/MVELDecisionBuilderTest.java
+++ b/jbpm/jbpm-flow-builder/src/test/java/org/jbpm/process/builder/MVELDecisionBuilderTest.java
@@ -23,7 +23,7 @@ import org.drools.compiler.builder.impl.KnowledgeBuilderImpl;
 import org.drools.compiler.compiler.PackageRegistry;
 import org.drools.compiler.rule.builder.PackageBuildContext;
 import org.drools.core.definitions.InternalKnowledgePackage;
-import org.drools.core.definitions.impl.KnowledgePackageImpl;
+import org.drools.core.reteoo.CoreComponentFactory;
 import org.drools.drl.ast.descr.ActionDescr;
 import org.drools.mvel.MVELDialectRuntimeData;
 import org.drools.mvel.builder.MVELDialect;
@@ -45,7 +45,7 @@ public class MVELDecisionBuilderTest extends AbstractBaseTest {
 
     @Test
     public void testSimpleAction() throws Exception {
-        final InternalKnowledgePackage pkg = new KnowledgePackageImpl("pkg1");
+        final InternalKnowledgePackage pkg = CoreComponentFactory.get().createKnowledgePackage("pkg1");
 
         ActionDescr actionDescr = new ActionDescr();
         actionDescr.setText("list.add( 'hello world' )");

--- a/jbpm/jbpm-flow-builder/src/test/java/org/jbpm/process/builder/MVELReturnValueConstraintEvaluatorBuilderTest.java
+++ b/jbpm/jbpm-flow-builder/src/test/java/org/jbpm/process/builder/MVELReturnValueConstraintEvaluatorBuilderTest.java
@@ -22,7 +22,7 @@ import org.drools.compiler.compiler.DialectCompiletimeRegistry;
 import org.drools.compiler.rule.builder.PackageBuildContext;
 import org.drools.core.common.InternalKnowledgeRuntime;
 import org.drools.core.definitions.InternalKnowledgePackage;
-import org.drools.core.definitions.impl.KnowledgePackageImpl;
+import org.drools.core.reteoo.CoreComponentFactory;
 import org.drools.drl.ast.descr.ReturnValueDescr;
 import org.drools.mvel.MVELDialectRuntimeData;
 import org.drools.mvel.builder.MVELDialect;
@@ -42,7 +42,7 @@ public class MVELReturnValueConstraintEvaluatorBuilderTest extends AbstractBaseT
 
     @Test
     public void testSimpleReturnValueConstraintEvaluator() throws Exception {
-        final InternalKnowledgePackage pkg = new KnowledgePackageImpl("pkg1");
+        final InternalKnowledgePackage pkg = CoreComponentFactory.get().createKnowledgePackage("pkg1");
 
         ReturnValueDescr descr = new ReturnValueDescr();
         descr.setText("return value");


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/DROOLS-6646

Related PRs
https://github.com/kiegroup/drools/pull/4116
https://github.com/kiegroup/kogito-runtimes/pull/1862