### PR TITLE
[KOGITO-6456] Implementing recognition of children exceptions

### DIFF
--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/ErrorEventTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/ErrorEventTest.java
@@ -358,7 +358,7 @@ public class ErrorEventTest extends JbpmBpmn2TestCase {
         kruntime.getKogitoWorkItemManager().registerWorkItemHandler("Human Task", handler);
 
         KogitoProcessInstance processInstance = kruntime.startProcess("com.sample.bpmn.hello");
-        assertEquals(KogitoProcessInstance.STATE_ERROR, processInstance.getState());
+        assertEquals(KogitoProcessInstance.STATE_COMPLETED, processInstance.getState());
     }
 
     @Test

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/context/exception/ExceptionHandlerPolicy.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/context/exception/ExceptionHandlerPolicy.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.process.core.context.exception;
+
+import java.util.function.BiPredicate;
+
+public interface ExceptionHandlerPolicy extends BiPredicate<String, Throwable> {
+
+}

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/context/exception/ExceptionHandlerPolicyFactory.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/context/exception/ExceptionHandlerPolicyFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.process.core.context.exception;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class ExceptionHandlerPolicyFactory {
+
+    private ExceptionHandlerPolicyFactory() {
+    }
+
+    private static Collection<ExceptionHandlerPolicy> policies = new ArrayList<>();
+
+    static {
+        policies.add(new SubclassExceptionPolicy());
+        policies.add(new RootCauseExceptionPolicy());
+    }
+
+    public static Collection<ExceptionHandlerPolicy> getHandlerPolicies() {
+        return policies;
+    }
+}

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/context/exception/RootCauseExceptionPolicy.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/context/exception/RootCauseExceptionPolicy.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.process.core.context.exception;
+
+public class RootCauseExceptionPolicy implements ExceptionHandlerPolicy {
+    @Override
+    public boolean test(String className, Throwable exception) {
+        boolean found = false;
+        Throwable rootCause = exception.getCause();
+        while (!found && rootCause != null) {
+            found = className.equals(rootCause.getClass().getName());
+            rootCause = rootCause.getCause();
+        }
+        return found;
+    }
+
+}

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/context/exception/SubclassExceptionPolicy.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/context/exception/SubclassExceptionPolicy.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.process.core.context.exception;
+
+public class SubclassExceptionPolicy implements ExceptionHandlerPolicy {
+
+    @Override
+    public boolean test(String className, Throwable exception) {
+        boolean found = false;
+        Class<?> exceptionClass = exception.getClass().getSuperclass();
+        while (!found && !exceptionClass.equals(Object.class)) {
+            found = className.equals(exceptionClass.getName());
+            exceptionClass = exceptionClass.getSuperclass();
+        }
+        return found;
+    }
+
+}

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/context/exception/ExceptionScopeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/context/exception/ExceptionScopeInstance.java
@@ -24,12 +24,22 @@ public abstract class ExceptionScopeInstance extends AbstractContextInstance {
 
     private static final long serialVersionUID = 510l;
 
+    @Override
     public String getContextType() {
         return ExceptionScope.EXCEPTION_SCOPE;
     }
 
     public ExceptionScope getExceptionScope() {
         return (ExceptionScope) getContext();
+    }
+
+    public void handleException(Throwable exception, KogitoProcessContext params) {
+        ExceptionHandler handler = getExceptionScope().getExceptionHandler(exception);
+        if (handler == null) {
+            throw new IllegalArgumentException(
+                    "Could not find ExceptionHandler for " + exception);
+        }
+        handleException(handler, exception.getClass().getCanonicalName(), params);
     }
 
     public void handleException(String exception, KogitoProcessContext params) {

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/NodeInstanceImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/NodeInstanceImpl.java
@@ -252,13 +252,12 @@ public abstract class NodeInstanceImpl implements org.jbpm.workflow.instance.Nod
         try {
             action.execute(context);
         } catch (Exception e) {
-            String exceptionName = e.getClass().getName();
-            ExceptionScopeInstance exceptionScopeInstance = (ExceptionScopeInstance) resolveContextInstance(ExceptionScope.EXCEPTION_SCOPE, exceptionName);
+            ExceptionScopeInstance exceptionScopeInstance = (ExceptionScopeInstance) resolveContextInstance(ExceptionScope.EXCEPTION_SCOPE, e);
             if (exceptionScopeInstance == null) {
                 throw new WorkflowRuntimeException(this, getProcessInstance(), "Unable to execute Action: " + e.getMessage(), e);
             }
             context.getContextData().put("Exception", e);
-            exceptionScopeInstance.handleException(exceptionName, context);
+            exceptionScopeInstance.handleException(e, context);
             cancel();
         }
     }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/StateBasedNodeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/StateBasedNodeInstance.java
@@ -33,6 +33,7 @@ import org.jbpm.process.core.timer.Timer;
 import org.jbpm.process.instance.InternalProcessRuntime;
 import org.jbpm.process.instance.ProcessInstance;
 import org.jbpm.process.instance.impl.Action;
+import org.jbpm.util.ContextFactory;
 import org.jbpm.workflow.core.DroolsAction;
 import org.jbpm.workflow.core.node.StateBasedNode;
 import org.jbpm.workflow.instance.impl.ExtendedNodeInstanceImpl;
@@ -43,6 +44,7 @@ import org.kie.api.runtime.rule.Match;
 import org.kie.kogito.drools.core.common.KogitoInternalAgenda;
 import org.kie.kogito.internal.process.event.KogitoEventListener;
 import org.kie.kogito.internal.process.runtime.KogitoNodeInstance;
+import org.kie.kogito.internal.process.runtime.KogitoProcessContext;
 import org.kie.kogito.internal.process.runtime.KogitoProcessInstance;
 import org.kie.kogito.internal.process.runtime.KogitoProcessRuntime;
 import org.kie.kogito.jobs.DurationExpirationTime;
@@ -439,5 +441,11 @@ public abstract class StateBasedNodeInstance extends ExtendedNodeInstanceImpl im
         }
 
         return null;
+    }
+
+    protected final KogitoProcessContext getProcessContext(Throwable e) {
+        KogitoProcessContext context = ContextFactory.fromNode(this);
+        context.getContextData().put("Exception", e);
+        return context;
     }
 }

--- a/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/data/HelloService.java
+++ b/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/java/org/kie/kogito/codegen/data/HelloService.java
@@ -74,8 +74,8 @@ public class HelloService {
             System.out.println("Mocking Throw Error1 (IllegalArgumentException)");
             throw new IllegalArgumentException();
         } else if ("error2".equals(errorType)) {
-            System.out.println("Mocking Throw Error2 (RuntimeException)");
-            throw new RuntimeException();
+            System.out.println("Mocking Throw Error2 (IllegalStateException)");
+            throw new IllegalStateException();
         }
         System.out.println("Mocking Throw Generic Error (UnsupportedOperationException)");
         throw new UnsupportedOperationException();

--- a/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/resources/error/BoundaryError.bpmn2
+++ b/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/resources/error/BoundaryError.bpmn2
@@ -1,7 +1,7 @@
 <bpmn2:definitions xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" xmlns:xsi="xsi" id="_RpDLAKSEEDmxZ-6bQS7TiA" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
   <bpmn2:itemDefinition id="_errorTypeItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__CCE02051-D053-41D9-927C-1F2506139CE7_errorTypeInputXItem" structureRef="String"/>
-  <bpmn2:error id="java.lang.RuntimeException" errorCode="java.lang.RuntimeException"/>
+  <bpmn2:error id="java.lang.RuntimeException" errorCode="java.lang.IllegalStateException"/>
   <bpmn2:interface id="_CCE02051-D053-41D9-927C-1F2506139CE7_ServiceInterface" name="org.kie.kogito.codegen.data.HelloService" implementationRef="org.kie.kogito.codegen.data.HelloService">
     <bpmn2:operation id="_CCE02051-D053-41D9-927C-1F2506139CE7_ServiceOperation" name="error" implementationRef="error"/>
   </bpmn2:interface>


### PR DESCRIPTION
This will allow to use more generic exception in this example 
https://github.com/kiegroup/kogito-examples/blob/stable/serverless-workflow-error-quarkus/src/main/resources/error.sw.json#L43
After this change, it will also work with java.lang.RuntimeException
