### PR TITLE
FAI-698: trusty-service-postgresql: Create docker images locally

### DIFF
--- a/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/deployment/KogitoDevServicesProcessor.java
+++ b/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/deployment/KogitoDevServicesProcessor.java
@@ -67,9 +67,6 @@ public class KogitoDevServicesProcessor {
     private static final ContainerLocator LOCATOR = new ContainerLocator(TrustyServiceInMemoryContainer.DEV_SERVICE_LABEL,
             TrustyServiceInMemoryContainer.PORT);
 
-    private static final String IMAGE_NAME_POSTGRESQL = "postgres";
-    private static final String IMAGE_NAME_KAFKA = "vectorized/redpanda";
-
     static volatile Closeable closeable;
     static volatile TrustyServiceDevServiceConfig cfg;
     static volatile boolean first = true;
@@ -92,6 +89,12 @@ public class KogitoDevServicesProcessor {
         DockerClientFactory.lazyClient().listContainersCmd().exec()
                 .forEach(c -> {
                     LOGGER.debug("----> Image: " + c.getImage());
+                    if (Objects.nonNull(c.getNames())) {
+                        Arrays.stream(c.getNames()).forEach(n -> LOGGER.debug(String.format("----> Name: %s", n)));
+                    }
+                    if (Objects.nonNull(c.getLabels())) {
+                        c.getLabels().forEach((key, value) -> LOGGER.debug(String.format("----> Label: [%s]=[%s]", key, value)));
+                    }
                     LOGGER.debug("----> Ports: " + Arrays.stream(c.getPorts()).map(p -> p.getPrivatePort() + ">>" + p.getPublicPort()).collect(Collectors.joining(", ")));
                     LOGGER.debug("----> Network: "
                             + (Objects.isNull(c.getNetworkSettings()) ? ""
@@ -100,58 +103,6 @@ public class KogitoDevServicesProcessor {
                                             .entrySet()
                                             .stream()
                                             .map(n -> String.format("%s=%s [%s]", n.getKey(), n.getValue(), n.getValue().getIpAddress())).collect(Collectors.joining(", "))));
-                });
-
-        //Discover PostgreSQL container
-        LOGGER.info("Discovering DevServices PostgreSQL instance...");
-        DockerClientFactory.lazyClient().listContainersCmd().exec()
-                .stream().filter(this::isPostgresImage)
-                .findFirst()
-                .ifPresent(container -> {
-                    Optional<Integer> port = Optional.empty();
-                    Optional<String> ipAddress = Optional.empty();
-                    final ContainerPort[] containerPorts = container.getPorts();
-                    final ContainerNetworkSettings networkSettings = container.getNetworkSettings();
-                    if (Objects.nonNull(containerPorts)) {
-                        port = Arrays.stream(containerPorts)
-                                .map(ContainerPort::getPrivatePort)
-                                .filter(Objects::nonNull)
-                                .findFirst();
-                    }
-                    if (Objects.nonNull(networkSettings)) {
-                        ipAddress = networkSettings.getNetworks().values().stream()
-                                .map(ContainerNetwork::getIpAddress)
-                                .filter(Objects::nonNull)
-                                .findFirst();
-                    }
-                    LOGGER.debug(String.format("[PostgreSQL] Private Port: %s", port.orElse(0)));
-                    LOGGER.debug(String.format("[PostgreSQL] IP Address: %s", ipAddress.orElse("<None>")));
-                    if (ipAddress.isPresent() && port.isPresent()) {
-                        final String jdbcUrl = String.format("jdbc:postgresql://%s:%d/default?loggerLevel=OFF", ipAddress.get(), port.get());
-                        devServicesConfig.setDataSourceUrl(jdbcUrl);
-                    }
-                });
-
-        //Discover Kafaka Broker container
-        LOGGER.info("Discovering DevServices Redpanda (Kafka) instance...");
-        DockerClientFactory.lazyClient().listContainersCmd().exec()
-                .stream().filter(this::isKafkaImage)
-                .findFirst()
-                .ifPresent(container -> {
-                    Optional<String> ipAddress = Optional.empty();
-                    final ContainerPort[] containerPorts = container.getPorts();
-                    final ContainerNetworkSettings networkSettings = container.getNetworkSettings();
-                    if (Objects.nonNull(networkSettings)) {
-                        ipAddress = networkSettings.getNetworks().values().stream()
-                                .map(ContainerNetwork::getIpAddress)
-                                .filter(Objects::nonNull)
-                                .findFirst();
-                    }
-                    LOGGER.debug(String.format("[Kafka] IP Address: %s", ipAddress.orElse("<None>")));
-                    if (ipAddress.isPresent()) {
-                        final String kafkaBootstrapServer = String.format("PLAINTEXT://%s:29092", ipAddress.get());
-                        devServicesConfig.setKafkaBootstrapServer(kafkaBootstrapServer);
-                    }
                 });
 
         final TrustyServiceDevServiceConfig configuration = getConfiguration(buildTimeConfig);
@@ -236,16 +187,6 @@ public class KogitoDevServicesProcessor {
                     "DevServices for Kogito TrustyService started at {}",
                     trustyService.getUrl());
         }
-    }
-
-    private boolean isPostgresImage(final Container container) {
-        final String name = container.getImage();
-        return IMAGE_NAME_POSTGRESQL.equals(name);
-    }
-
-    private boolean isKafkaImage(final Container container) {
-        final String name = container.getImage();
-        return IMAGE_NAME_KAFKA.equals(name);
     }
 
     private boolean isTrustyServiceImage(final Container container,

--- a/quarkus/addons/tracing-decision/integration-tests/src/test/resources/application.properties
+++ b/quarkus/addons/tracing-decision/integration-tests/src/test/resources/application.properties
@@ -10,4 +10,5 @@ mp.messaging.outgoing.kogito-tracing-model.connector=smallrye-kafka
 mp.messaging.outgoing.kogito-tracing-model.topic=kogito-tracing-model
 mp.messaging.outgoing.kogito-tracing-model.value.serializer=org.apache.kafka.common.serialization.StringSerializer
 
-quarkus.log.level=INFO
+quarkus.kogito.dev-services-trusty.image-name=quay.io/kiegroup/kogito-trusty-postgresql:latest
+#quarkus.kogito.dev-services-trusty.image-name=org.kie.kogito/trusty-service-postgresql:2.0.0-SNAPSHOT


### PR DESCRIPTION
See https://issues.redhat.com/browse/FAI-698

This allows use of a locally built `trusty-service-postgresql` to be used for the DevUI extension, if needed.

Part of an ensemble:
- https://github.com/kiegroup/kogito-runtimes/pull/1883
- https://github.com/kiegroup/kogito-apps/pull/1198

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run all builds</b>  
  Please add comment: <b>Jenkins retest this</b>

* <b>Run (or rerun) specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Run (or rerun) LTS specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Run (or rerun) native specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
