### PR TITLE
KOGITO-6609 Bump AssertJ to 3.22.0

### DIFF
--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -77,7 +77,7 @@
     <version.org.mongo.springboot>4.1.0</version.org.mongo.springboot> <!-- https://issues.redhat.com/browse/KOGITO-5031 -->
     <version.org.mozilla.rhino>1.7.13</version.org.mozilla.rhino>
 
-    <version.org.assertj>3.21.0</version.org.assertj>
+    <version.org.assertj>3.22.0</version.org.assertj>
     <version.org.json-unit-assertj>2.9.0</version.org.json-unit-assertj>
     <version.org.hamcrest>1.3</version.org.hamcrest> <!-- else old version coming from Mockito wins and breaks tests -->
     <version.org.junit.minor>8.0</version.org.junit.minor> <!-- so that org.junit.platform and org.junit can share the same minor version -->


### PR DESCRIPTION
needed to fix ecosystem CI ([see zulip thread](https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/Codestart.20test.20framework/near/268817427))