### PR TITLE
KOGITO-6522: OpenAPI on Windows generates wrong path during executiontime

### DIFF
--- a/kogito-codegen-modules/kogito-codegen-openapi/src/main/java/org/kie/kogito/codegen/openapi/client/OpenApiSpecDescriptor.java
+++ b/kogito-codegen-modules/kogito-codegen-openapi/src/main/java/org/kie/kogito/codegen/openapi/client/OpenApiSpecDescriptor.java
@@ -18,7 +18,6 @@ package org.kie.kogito.codegen.openapi.client;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Paths;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.HashSet;
@@ -43,11 +42,11 @@ public class OpenApiSpecDescriptor {
     public OpenApiSpecDescriptor(final String resource) {
         try {
             this.uri = new URI(resource);
-            this.resourceName = Paths.get(this.uri.getPath()).getFileName().toString();
+            this.resourceName = getFileName(uri.toString());
             this.id = generateId(this.uri.toString(), resourceName);
             this.requiredOperations = new HashSet<>();
         } catch (URISyntaxException e) {
-            throw new OpenApiClientException("Fail to parse given resource into URI" + resource, e);
+            throw new OpenApiClientException("Fail to parse given resource into URI " + resource, e);
         }
     }
 
@@ -124,5 +123,9 @@ public class OpenApiSpecDescriptor {
                 ", uri=" + uri +
                 ", id='" + id + '\'' +
                 '}';
+    }
+
+    private static String getFileName(String resource) {
+        return resource.substring(resource.lastIndexOf('/') + 1);
     }
 }

--- a/kogito-codegen-modules/kogito-codegen-openapi/src/main/java/org/kie/kogito/codegen/openapi/client/di/ServicesConfigurationHandler.java
+++ b/kogito-codegen-modules/kogito-codegen-openapi/src/main/java/org/kie/kogito/codegen/openapi/client/di/ServicesConfigurationHandler.java
@@ -30,7 +30,7 @@ import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
  */
 public class ServicesConfigurationHandler extends AbstractDependencyInjectionHandler {
 
-    private final static String API_CLIENT_PARAMETER = "ApiClient";
+    private static final String API_CLIENT_PARAMETER = "ApiClient";
 
     protected ServicesConfigurationHandler(KogitoBuildContext context) {
         super(context);
@@ -68,7 +68,7 @@ public class ServicesConfigurationHandler extends AbstractDependencyInjectionHan
             if (canonicalClassName == null || canonicalClassName.isEmpty()) {
                 return false;
             }
-            return file.getPath().endsWith(canonicalClassName.replace(".", "/") + JAVA_EXTENSION);
+            return file.toURI().toString().endsWith(canonicalClassName.replace(".", "/") + JAVA_EXTENSION);
         }
     }
 }


### PR DESCRIPTION
Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [X] You have read the [contributors guide](CONTRIBUTING.md)
- [X] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [X] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [X] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [X] Pull Request contains link to the JIRA issue
- [X] Pull Request contains link to any dependent or related Pull Request
- [X] Pull Request contains description of the issue
- [X] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run all builds</b>  
  Please add comment: <b>Jenkins retest this</b>

* <b>Run (or rerun) specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Run (or rerun) LTS specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Run (or rerun) native specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
