### PR TITLE
[KOGITO-6581] Use a temporary location to generate intermediate openapi files

### DIFF
--- a/kogito-codegen-modules/kogito-codegen-api/src/main/java/org/kie/kogito/codegen/api/context/impl/AbstractKogitoBuildContext.java
+++ b/kogito-codegen-modules/kogito-codegen-api/src/main/java/org/kie/kogito/codegen/api/context/impl/AbstractKogitoBuildContext.java
@@ -18,6 +18,7 @@ package org.kie.kogito.codegen.api.context.impl;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.text.MessageFormat;
 import java.util.Collection;
 import java.util.Collections;
@@ -220,7 +221,7 @@ public abstract class AbstractKogitoBuildContext implements KogitoBuildContext {
         protected ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         protected Predicate<String> classAvailabilityResolver = this::hasClass;
         // default fallback value (usually overridden)
-        protected AppPaths appPaths = AppPaths.fromProjectDir(new File(".").toPath());
+        protected AppPaths appPaths = AppPaths.fromProjectDir(new File(".").toPath(), Path.of(".", AppPaths.TARGET_DIR));
         protected KogitoGAV gav;
 
         protected AbstractBuilder() {

--- a/kogito-codegen-modules/kogito-codegen-api/src/main/java/org/kie/kogito/codegen/api/utils/AppPaths.java
+++ b/kogito-codegen-modules/kogito-codegen-api/src/main/java/org/kie/kogito/codegen/api/utils/AppPaths.java
@@ -39,12 +39,13 @@ public class AppPaths {
 
     private final boolean isJar;
     private final Path resourcesPath;
+    private final Path outputTarget;
 
-    public static AppPaths fromProjectDir(Path projectDir) {
-        return new AppPaths(Collections.singleton(projectDir), Collections.emptyList(), false, BuildTool.MAVEN, "main");
+    public static AppPaths fromProjectDir(Path projectDir, Path outputTarget) {
+        return new AppPaths(Collections.singleton(projectDir), Collections.emptyList(), false, BuildTool.MAVEN, "main", outputTarget);
     }
 
-    public static AppPaths fromQuarkus(Iterable<Path> paths, BuildTool bt) {
+    public static AppPaths fromQuarkus(Path outputTarget, Iterable<Path> paths, BuildTool bt) {
         Set<Path> projectPaths = new LinkedHashSet<>();
         Collection<Path> classesPaths = new ArrayList<>();
         boolean isJar = false;
@@ -69,17 +70,17 @@ public class AppPaths {
                     break;
             }
         }
-        return new AppPaths(projectPaths, classesPaths, isJar, bt, "main");
+        return new AppPaths(projectPaths, classesPaths, isJar, bt, "main", outputTarget);
     }
 
     /**
      * Builder to be used only for tests, where <b>all</b> resources must be present in "src/test/resources" directory
-     * 
+     *
      * @param projectDir
      * @return
      */
     public static AppPaths fromTestDir(Path projectDir) {
-        return new AppPaths(Collections.singleton(projectDir), Collections.emptyList(), false, BuildTool.MAVEN, "test");
+        return new AppPaths(Collections.singleton(projectDir), Collections.emptyList(), false, BuildTool.MAVEN, "test", Paths.get(projectDir.toString(), TARGET_DIR));
     }
 
     private static PathType getPathType(Path archiveLocation) {
@@ -113,10 +114,11 @@ public class AppPaths {
      * @param resourcesBasePath "main" or "test"
      */
     private AppPaths(Set<Path> projectPaths, Collection<Path> classesPaths, boolean isJar, BuildTool bt,
-            String resourcesBasePath) {
+            String resourcesBasePath, Path outputTarget) {
         this.isJar = isJar;
         this.projectPaths.addAll(projectPaths);
         this.classesPaths.addAll(classesPaths);
+        this.outputTarget = outputTarget;
         if (bt == BuildTool.GRADLE) {
             resourcesPath = Paths.get(""); // no prefix required
         } else {
@@ -134,18 +136,6 @@ public class AppPaths {
 
     public Path getFirstProjectPath() {
         return projectPaths.iterator().next();
-    }
-
-    public boolean hasProjectPaths() {
-        return !this.projectPaths.isEmpty();
-    }
-
-    public Path getFirstClassesPath() {
-        return classesPaths.iterator().next();
-    }
-
-    public boolean hasClassesPaths() {
-        return !this.classesPaths.isEmpty();
     }
 
     private Path[] getJarPaths() {
@@ -167,12 +157,12 @@ public class AppPaths {
         return transformPaths(projectPaths, p -> p.resolve("src"));
     }
 
-    public Collection<Path> getProjectPaths() {
-        return Collections.unmodifiableCollection(projectPaths);
-    }
-
     public Collection<Path> getClassesPaths() {
         return Collections.unmodifiableCollection(classesPaths);
+    }
+
+    public Path getOutputTarget() {
+        return outputTarget;
     }
 
     private Path[] transformPaths(Collection<Path> paths, UnaryOperator<Path> f) {

--- a/kogito-codegen-modules/kogito-codegen-openapi/src/main/java/org/kie/kogito/codegen/openapi/client/OpenApiClientCodegen.java
+++ b/kogito-codegen-modules/kogito-codegen-openapi/src/main/java/org/kie/kogito/codegen/openapi/client/OpenApiClientCodegen.java
@@ -166,6 +166,6 @@ public class OpenApiClientCodegen extends AbstractGenerator {
      * @return the final path where to generate the OpenAPI Client project
      */
     private String getOutputDirForOpenAPIGen(final OpenApiSpecDescriptor resource) {
-        return Paths.get(OpenApiUtils.getTempDirLocation(), GEN_BASE_PATH, resource.getId()).toString();
+        return Paths.get(OpenApiUtils.getTempDirLocation(this.context()), GEN_BASE_PATH, resource.getId()).toString();
     }
 }

--- a/kogito-codegen-modules/kogito-codegen-openapi/src/main/java/org/kie/kogito/codegen/openapi/client/OpenApiClientCodegen.java
+++ b/kogito-codegen-modules/kogito-codegen-openapi/src/main/java/org/kie/kogito/codegen/openapi/client/OpenApiClientCodegen.java
@@ -166,6 +166,6 @@ public class OpenApiClientCodegen extends AbstractGenerator {
      * @return the final path where to generate the OpenAPI Client project
      */
     private String getOutputDirForOpenAPIGen(final OpenApiSpecDescriptor resource) {
-        return Paths.get(OpenApiUtils.getEndUserTargetDir(this.context()), GEN_BASE_PATH, resource.getId()).toString();
+        return Paths.get(OpenApiUtils.getTempDirLocation(), GEN_BASE_PATH, resource.getId()).toString();
     }
 }

--- a/kogito-codegen-modules/kogito-codegen-openapi/src/main/java/org/kie/kogito/codegen/openapi/client/OpenApiClientException.java
+++ b/kogito-codegen-modules/kogito-codegen-openapi/src/main/java/org/kie/kogito/codegen/openapi/client/OpenApiClientException.java
@@ -17,10 +17,6 @@ package org.kie.kogito.codegen.openapi.client;
 
 public class OpenApiClientException extends RuntimeException {
 
-    public OpenApiClientException(Throwable cause) {
-        super(cause);
-    }
-
     public OpenApiClientException(String s, Throwable e) {
         super(s, e);
     }

--- a/kogito-codegen-modules/kogito-codegen-openapi/src/main/java/org/kie/kogito/codegen/openapi/client/OpenApiUtils.java
+++ b/kogito-codegen-modules/kogito-codegen-openapi/src/main/java/org/kie/kogito/codegen/openapi/client/OpenApiUtils.java
@@ -15,9 +15,7 @@
  */
 package org.kie.kogito.codegen.openapi.client;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
+import org.kie.kogito.codegen.api.context.KogitoBuildContext;
 
 import static java.util.Objects.requireNonNull;
 
@@ -27,14 +25,10 @@ public final class OpenApiUtils {
     }
 
     /**
-     * Creates a temporary location in the file system and return its string form
+     * Abstraction of the user's project temporary location
      */
-    public static String getTempDirLocation() {
-        try {
-            return Files.createTempDirectory("kogito-openapi-").toFile().getAbsolutePath();
-        } catch (IOException e) {
-            throw new UncheckedIOException("Unable to create temporary directory: ", e);
-        }
+    public static String getTempDirLocation(KogitoBuildContext context) {
+        return context.getAppPaths().getOutputTarget().toString();
     }
 
     public static void requireValidSpecURI(final OpenApiSpecDescriptor resource) {

--- a/kogito-codegen-modules/kogito-codegen-openapi/src/main/java/org/kie/kogito/codegen/openapi/client/OpenApiUtils.java
+++ b/kogito-codegen-modules/kogito-codegen-openapi/src/main/java/org/kie/kogito/codegen/openapi/client/OpenApiUtils.java
@@ -15,11 +15,9 @@
  */
 package org.kie.kogito.codegen.openapi.client;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
-
-import org.kie.kogito.codegen.api.context.KogitoBuildContext;
-import org.kie.kogito.codegen.api.utils.AppPaths;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
 
 import static java.util.Objects.requireNonNull;
 
@@ -28,17 +26,15 @@ public final class OpenApiUtils {
     private OpenApiUtils() {
     }
 
-    public static String getEndUserTargetDir(final KogitoBuildContext context) {
-        if (context.getAppPaths().hasClassesPaths()) {
-            final Path classesPath = context.getAppPaths().getFirstClassesPath();
-            if (classesPath.endsWith(Paths.get(AppPaths.TARGET_DIR))) {
-                return classesPath.toString();
-            }
+    /**
+     * Creates a temporary location in the file system and return its string form
+     */
+    public static String getTempDirLocation() {
+        try {
+            return Files.createTempDirectory("kogito-openapi-").toFile().getAbsolutePath();
+        } catch (IOException e) {
+            throw new UncheckedIOException("Unable to create temporary directory: ", e);
         }
-        if (context.getAppPaths().hasProjectPaths()) {
-            return context.getAppPaths().getFirstProjectPath().resolve(AppPaths.TARGET_DIR).toString();
-        }
-        throw new IllegalStateException("No valid paths found in the current application path: " + context.getAppPaths());
     }
 
     public static void requireValidSpecURI(final OpenApiSpecDescriptor resource) {

--- a/kogito-codegen-modules/kogito-codegen-openapi/src/main/java/org/kie/kogito/codegen/openapi/client/io/AbstractPathResolver.java
+++ b/kogito-codegen-modules/kogito-codegen-openapi/src/main/java/org/kie/kogito/codegen/openapi/client/io/AbstractPathResolver.java
@@ -43,7 +43,7 @@ public abstract class AbstractPathResolver implements PathResolver {
     }
 
     private String getOutputPath() {
-        final Path outputPath = Paths.get(OpenApiUtils.getTempDirLocation(), BASE_PATH);
+        final Path outputPath = Paths.get(OpenApiUtils.getTempDirLocation(this.context), BASE_PATH);
         if (Files.notExists(outputPath)) {
             try {
                 Files.createDirectories(outputPath);

--- a/kogito-codegen-modules/kogito-codegen-openapi/src/main/java/org/kie/kogito/codegen/openapi/client/io/AbstractPathResolver.java
+++ b/kogito-codegen-modules/kogito-codegen-openapi/src/main/java/org/kie/kogito/codegen/openapi/client/io/AbstractPathResolver.java
@@ -18,6 +18,7 @@ package org.kie.kogito.codegen.openapi.client.io;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Files;
@@ -25,7 +26,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.kie.kogito.codegen.api.context.KogitoBuildContext;
-import org.kie.kogito.codegen.openapi.client.OpenApiClientException;
 import org.kie.kogito.codegen.openapi.client.OpenApiSpecDescriptor;
 import org.kie.kogito.codegen.openapi.client.OpenApiUtils;
 
@@ -43,12 +43,12 @@ public abstract class AbstractPathResolver implements PathResolver {
     }
 
     private String getOutputPath() {
-        final Path outputPath = Paths.get(OpenApiUtils.getEndUserTargetDir(this.context), BASE_PATH);
+        final Path outputPath = Paths.get(OpenApiUtils.getTempDirLocation(), BASE_PATH);
         if (Files.notExists(outputPath)) {
             try {
                 Files.createDirectories(outputPath);
             } catch (IOException e) {
-                throw new OpenApiClientException("Failed to create output path for OpenAPI spec files at " + outputPath, e);
+                throw new UncheckedIOException("Failed to create output path for OpenAPI spec files at " + outputPath, e);
             }
         }
         return outputPath.toString();
@@ -61,7 +61,7 @@ public abstract class AbstractPathResolver implements PathResolver {
             output.getChannel().transferFrom(channel, 0, Integer.MAX_VALUE);
             return outputPath;
         } catch (IOException e) {
-            throw new OpenApiClientException("Fail to resolve remote file: " + resource.getURI().toString(), e);
+            throw new UncheckedIOException("Fail to resolve remote file: " + resource.getURI().toString(), e);
         }
     }
 }

--- a/kogito-codegen-modules/kogito-codegen-openapi/src/main/java/org/kie/kogito/codegen/openapi/client/io/HTTPResolver.java
+++ b/kogito-codegen-modules/kogito-codegen-openapi/src/main/java/org/kie/kogito/codegen/openapi/client/io/HTTPResolver.java
@@ -17,10 +17,10 @@ package org.kie.kogito.codegen.openapi.client.io;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.net.URL;
 
 import org.kie.kogito.codegen.api.context.KogitoBuildContext;
-import org.kie.kogito.codegen.openapi.client.OpenApiClientException;
 import org.kie.kogito.codegen.openapi.client.OpenApiSpecDescriptor;
 import org.kie.kogito.codegen.openapi.client.OpenApiUtils;
 
@@ -43,7 +43,7 @@ public class HTTPResolver extends AbstractPathResolver {
                 return this.saveFileToTempLocation(resource, is);
             }
         } catch (IOException e) {
-            throw new OpenApiClientException("Fail to resolve remote file: " + resource.getURI().toString(), e);
+            throw new UncheckedIOException("Fail to resolve remote file: " + resource.getURI().toString(), e);
         }
     }
 }

--- a/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/AbstractKieMojo.java
+++ b/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/AbstractKieMojo.java
@@ -93,7 +93,7 @@ public abstract class AbstractKieMojo extends AbstractMojo {
     }
 
     protected KogitoBuildContext discoverKogitoRuntimeContext(ClassLoader classLoader) {
-        AppPaths appPaths = AppPaths.fromProjectDir(projectDir.toPath());
+        AppPaths appPaths = AppPaths.fromProjectDir(projectDir.toPath(), outputDirectory.toPath());
         KogitoBuildContext context = contextBuilder()
                 .withClassAvailabilityResolver(this::hasClassOnClasspath)
                 .withApplicationProperties(appPaths.getResourceFiles())

--- a/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoAssetsProcessor.java
+++ b/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoAssetsProcessor.java
@@ -51,6 +51,7 @@ import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.index.IndexingUtil;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
+import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
 import io.quarkus.maven.dependency.ResolvedDependency;
 import io.quarkus.resteasy.reactive.spi.GeneratedJaxRsResourceBuildItem;
 import io.quarkus.vertx.http.deployment.spi.AdditionalStaticResourceBuildItem;
@@ -78,11 +79,17 @@ public class KogitoAssetsProcessor {
     CurateOutcomeBuildItem curateOutcomeBuildItem;
     @Inject
     CombinedIndexBuildItem combinedIndexBuildItem;
+    @Inject
+    OutputTargetBuildItem outputTargetBuildItem;
 
     @BuildStep
     public KogitoBuildContextBuildItem generateKogitoBuildContext() {
         // configure the application generator
-        KogitoBuildContext context = kogitoBuildContext(root.getPaths(), combinedIndexBuildItem.getIndex(), curateOutcomeBuildItem.getApplicationModel().getAppArtifact());
+        KogitoBuildContext context =
+                kogitoBuildContext(outputTargetBuildItem.getOutputDirectory(),
+                        root.getPaths(),
+                        combinedIndexBuildItem.getIndex(),
+                        curateOutcomeBuildItem.getApplicationModel().getAppArtifact());
         return new KogitoBuildContextBuildItem(context);
     }
 

--- a/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoQuarkusResourceUtils.java
+++ b/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoQuarkusResourceUtils.java
@@ -76,7 +76,7 @@ public class KogitoQuarkusResourceUtils {
                     System.getProperty("kogito.codegen.resources.directory", "target/generated-resources/kogito/"),
                     "target/generated-sources/kogito/");
 
-    public static KogitoBuildContext kogitoBuildContext(Iterable<Path> paths, IndexView index, Dependency appArtifact) {
+    public static KogitoBuildContext kogitoBuildContext(Path outputTarget, Iterable<Path> paths, IndexView index, Dependency appArtifact) {
         // scan and parse paths
         AppPaths.BuildTool buildTool;
         if (System.getProperty("org.gradle.appname") == null) {
@@ -84,7 +84,7 @@ public class KogitoQuarkusResourceUtils {
         } else {
             buildTool = AppPaths.BuildTool.GRADLE;
         }
-        AppPaths appPaths = AppPaths.fromQuarkus(paths, buildTool);
+        AppPaths appPaths = AppPaths.fromQuarkus(outputTarget, paths, buildTool);
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         KogitoBuildContext context = QuarkusKogitoBuildContext.builder()
                 .withApplicationPropertyProvider(new KogitoQuarkusApplicationPropertiesProvider())


### PR DESCRIPTION
We don't need the output Maven target dir to generate these files since it's an intermediary process handled by the inner openapi library.

cc @aloubyansky 

see: https://issues.redhat.com/browse/KOGITO-6581

Signed-off-by: Ricardo Zanini <zanini@redhat.com>

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run all builds</b>  
  Please add comment: <b>Jenkins retest this</b>

* <b>Run (or rerun) specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Run (or rerun) LTS specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Run (or rerun) native specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
