### PR TITLE
KOGITO-6682 Force maven version to 3.8.1+

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 **JIRA Issues:** https://issues.jboss.org/projects/KOGITO
 
 ## Requirements
-- [Maven](https://maven.apache.org/) 3.6.3 or later
+- [Maven](https://maven.apache.org/) 3.8.1 or later
 - [Java](https://openjdk.java.net/install/) 11 or later (devel package)
 - optional: Docker installation for running integration tests
 

--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -94,7 +94,7 @@
     <version.org.reflections>0.9.11</version.org.reflections>
     <version.org.slf4j>1.7.30</version.org.slf4j>
 
-    <version.maven>3.6.3</version.maven>
+    <version.maven>3.8.1</version.maven>
     <version.maven.plugin>3.6.0</version.maven.plugin>
 
     <version.plexus>1.6</version.plexus>


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-6682

Related PRs:
- https://github.com/kiegroup/drools/pull/4174
- https://github.com/kiegroup/kogito-runtimes/pull/1962
- https://github.com/kiegroup/optaplanner/pull/1820
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/647
- https://github.com/kiegroup/optaplanner-quickstarts/pull/277
- https://github.com/kiegroup/kogito-apps/pull/1227
- https://github.com/kiegroup/kogito-examples/pull/1109