### PR TITLE
KOGITO-6170 Remove forced maven dependencies for Codestart

### DIFF
--- a/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test/pom.xml
@@ -16,24 +16,6 @@
         <!-- excluded because of https://issues.redhat.com/browse/KOGITO-6392 -->
         <quarkus.test.list.include>false</quarkus.test.list.include>
     </properties>
-    
-    <dependencyManagement>
-        <!-- see https://github.com/quarkusio/quarkus/pull/20933 -->
-        <dependencies>
-          <dependency>
-              <groupId>org.apache.maven.resolver</groupId>
-              <artifactId>maven-resolver-api</artifactId>
-              <version>1.6.2</version>
-              <scope>test</scope>
-          </dependency>
-          <dependency>
-              <groupId>org.apache.maven.resolver</groupId>
-              <artifactId>maven-resolver-util</artifactId>
-              <version>1.6.2</version>
-              <scope>test</scope>
-          </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -61,17 +43,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-devtools-testing</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <!-- see https://github.com/quarkusio/quarkus/pull/20933 -->
-        <dependency>
-            <groupId>org.apache.maven.resolver</groupId>
-            <artifactId>maven-resolver-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.resolver</groupId>
-            <artifactId>maven-resolver-util</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-6170

follow-up of:
- https://github.com/kiegroup/kogito-runtimes/pull/1668#issuecomment-948478908
- https://github.com/quarkusio/quarkus/pull/20933

with
- https://github.com/kiegroup/kogito-runtimes/pull/1446

now available,

these versions can be removed; showing local test:

<img width="3134" alt="Screenshot 2022-02-02 at 09 20 42" src="https://user-images.githubusercontent.com/1699252/152118297-f7df5992-1b5b-4600-b3d2-327dce21cf0a.png">


<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run all builds</b>  
  Please add comment: <b>Jenkins retest this</b>

* <b>Run (or rerun) specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Run (or rerun) LTS specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Run (or rerun) native specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
