### PR TITLE
[KOGITO-6661] Implementing useData and useResult

### DIFF
--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/CompositeContextNodeHandler.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/CompositeContextNodeHandler.java
@@ -111,19 +111,21 @@ public abstract class CompositeContextNodeHandler<S extends State> extends State
         String fromExpr = null;
         String resultExpr = null;
         String toExpr = null;
+        boolean useData = true;
         if (actionFilter != null) {
             fromExpr = actionFilter.getFromStateData();
             resultExpr = actionFilter.getResults();
             toExpr = actionFilter.getToStateData();
+            useData = actionFilter.isUseResults();
         }
         if (action.getFunctionRef() != null) {
-            return filterAndMergeNode(embeddedSubProcess, fromExpr, resultExpr, toExpr,
+            return filterAndMergeNode(embeddedSubProcess, fromExpr, resultExpr, toExpr, useData,
                     (factory, inputVar, outputVar) -> getActionNode(factory, action.getFunctionRef(), inputVar, outputVar, collectVar, extraVariables));
         } else if (action.getEventRef() != null) {
-            return filterAndMergeNode(embeddedSubProcess, fromExpr, resultExpr, toExpr,
+            return filterAndMergeNode(embeddedSubProcess, fromExpr, resultExpr, toExpr, useData,
                     (factory, inputVar, outputVar) -> getActionNode(factory, action.getEventRef(), inputVar));
         } else if (action.getSubFlowRef() != null) {
-            return filterAndMergeNode(embeddedSubProcess, fromExpr, resultExpr, toExpr,
+            return filterAndMergeNode(embeddedSubProcess, fromExpr, resultExpr, toExpr, useData,
                     (factory, inputVar, outputVar) -> getActionNode(factory, action.getSubFlowRef(), inputVar, outputVar));
         } else {
             throw new IllegalArgumentException("Action node " + action.getName() + " of state " + state.getName() + " does not have function or event defined");

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/eventMultiple.sw.json
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/eventMultiple.sw.json
@@ -51,6 +51,9 @@
             "moveEvent",
             "quietEvent"
           ],
+          "eventDataFilter" : {
+             "useData": false
+          },
           "actions": [ 
           {
             "name": "printAfterEvent",

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/expression.sw.json
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/expression.sw.json
@@ -31,6 +31,11 @@
       "operation": ".message |=.+\\\" and in my native language dog is translated to $CONST.dog.castellano\\\""
     },
     {
+      "name": "discardedResult",
+      "type": "expression",
+      "operation": ".discardedResult |=\\\"This string won't be added to the data\\\""
+    },
+    {
       "name": "printMessage",
       "type": "custom",
       "operation": "sysout"
@@ -81,7 +86,16 @@
               "message": ".result"
             }
           }
-        }
+         },
+         {
+           "name": "discardedResultAction",
+           "functionRef" : {
+             "refName" : "discardedResult"
+            },
+            "actionDataFilter" : {
+              "useResults" : false 
+            }
+         }  
       ],
       "end": {
         "terminate": "true"

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/ExpressionRestIT.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/ExpressionRestIT.java
@@ -38,6 +38,7 @@ class ExpressionRestIT {
                 .statusCode(201)
                 .body("workflowdata.result", is(4))
                 .body("workflowdata.number", nullValue())
-                .body("workflowdata.message", is("my name is javierito and in my native language dog is translated to perro"));
+                .body("workflowdata.message", is("my name is javierito and in my native language dog is translated to perro"))
+                .body("workflowdata.discardedResult", nullValue());
     }
 }


### PR DESCRIPTION
Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](CONTRIBUTING.md)
- [ ] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run all builds</b>  
  Please add comment: <b>Jenkins retest this</b>

* <b>Run (or rerun) specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Run (or rerun) LTS specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Run (or rerun) native specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
