### PR TITLE
[KOGITO-6706] Polishing exception handling

### DIFF
--- a/api/kogito-api/src/main/java/org/kie/kogito/internal/process/runtime/KogitoWorkflowProcessInstance.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/internal/process/runtime/KogitoWorkflowProcessInstance.java
@@ -17,6 +17,7 @@ package org.kie.kogito.internal.process.runtime;
 
 import java.util.Collection;
 import java.util.Date;
+import java.util.Optional;
 
 import org.kie.api.runtime.process.WorkflowProcessInstance;
 import org.kie.kogito.process.flexible.AdHocFragment;
@@ -50,7 +51,6 @@ public interface KogitoWorkflowProcessInstance extends WorkflowProcessInstance, 
      * Returns error message associated with this process instance in case it is in an error
      * state. It will consists of
      * <ul>
-     * <li>unique error id (uuid)</li>
      * <li>fully qualified class name of the root cause</li>
      * <li>error message of the root cause</li>
      * </ul>
@@ -58,6 +58,13 @@ public interface KogitoWorkflowProcessInstance extends WorkflowProcessInstance, 
      * @return error message
      */
     String getErrorMessage();
+
+    /**
+     * Returns the throwable originating the error, if available
+     * 
+     * @return
+     */
+    Optional<Throwable> getErrorCause();
 
     /**
      * Returns optional correlation key assigned to process instance

--- a/api/kogito-api/src/main/java/org/kie/kogito/process/ProcessError.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/process/ProcessError.java
@@ -21,6 +21,10 @@ public interface ProcessError {
 
     String errorMessage();
 
+    default Throwable errorCause() {
+        return null;
+    }
+
     void retrigger();
 
     void skip();

--- a/api/kogito-api/src/main/java/org/kie/kogito/process/ProcessInstance.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/process/ProcessInstance.java
@@ -212,7 +212,7 @@ public interface ProcessInstance<T> {
     default ProcessInstance<T> checkError() {
         Optional<ProcessError> error = error();
         if (error.isPresent()) {
-            throw new ProcessInstanceExecutionException(id(), error.get().failedNodeId(), error.get().errorMessage());
+            throw new ProcessInstanceExecutionException(id(), error.get().failedNodeId(), error.get().errorMessage(), error.get().errorCause());
         }
         return this;
     }

--- a/api/kogito-api/src/main/java/org/kie/kogito/process/ProcessInstanceExecutionException.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/process/ProcessInstanceExecutionException.java
@@ -29,7 +29,11 @@ public class ProcessInstanceExecutionException extends RuntimeException {
     private String errorMessage;
 
     public ProcessInstanceExecutionException(String processInstanceId, String failedNodeId, String errorMessage) {
-        super("Process instance with id " + processInstanceId + " not found");
+        this(processInstanceId, failedNodeId, errorMessage, null);
+    }
+
+    public ProcessInstanceExecutionException(String processInstanceId, String failedNodeId, String errorMessage, Throwable rootCause) {
+        super("Process instance with id " + processInstanceId + " failed becuase of " + errorMessage, rootCause);
         this.processInstanceId = processInstanceId;
         this.failedNodeId = failedNodeId;
         this.errorMessage = errorMessage;

--- a/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcessInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcessInstance.java
@@ -16,8 +16,16 @@
 package org.kie.kogito.process.impl;
 
 import java.lang.reflect.Field;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -578,6 +586,7 @@ public abstract class AbstractProcessInstance<T extends Model> implements Proces
 
         final String errorMessage = pi.getErrorMessage();
         final String nodeInError = pi.getNodeIdInError();
+        final Throwable errorCause = pi.getErrorCause().orElse(null);
         return new ProcessError() {
 
             @Override
@@ -588,6 +597,11 @@ public abstract class AbstractProcessInstance<T extends Model> implements Proces
             @Override
             public String errorMessage() {
                 return errorMessage;
+            }
+
+            @Override
+            public Throwable errorCause() {
+                return errorCause;
             }
 
             @Override

--- a/kogito-serverless-workflow/kogito-serverless-workflow-runtime/src/main/java/org/kie/kogito/serverless/workflow/actions/DataInputSchemaAction.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-runtime/src/main/java/org/kie/kogito/serverless/workflow/actions/DataInputSchemaAction.java
@@ -48,10 +48,9 @@ public class DataInputSchemaAction implements Action {
             SchemaLoader.load(mapper.readValue(URIContentLoaderFactory.runtimeLoader(schema).toBytes(), JSONObject.class))
                     .validate(mapper.convertValue(getWorkflowData(context), JSONObject.class));
         } catch (ValidationException ex) {
+            logger.warn("There are validation errors {}", ex.getCausingExceptions());
             if (failOnValidationErrors) {
-                throw ex;
-            } else {
-                logger.warn("There are validation errors {}", ex.getCausingExceptions());
+                throw new IllegalArgumentException("Error validating input schema", ex);
             }
         }
 

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/ExpressionRestIT.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/ExpressionRestIT.java
@@ -23,7 +23,6 @@ import io.restassured.http.ContentType;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
 @QuarkusIntegrationTest
 class ExpressionRestIT {
@@ -51,6 +50,6 @@ class ExpressionRestIT {
                 .body("{\"workflowdata\":{\"numbers\":[{\"x\":\"abcdedf\", \"y\": 1},{\"x\":4, \"y\": 3}]}}").when()
                 .post("/expression")
                 .then()
-                .statusCode(greaterThanOrEqualTo(400));
+                .statusCode(is(400));
     }
 }

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/pom.xml
@@ -22,6 +22,12 @@
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-quarkus-processes</artifactId>
     </dependency>
+    
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-addons-quarkus-rest-exception-handler</artifactId>
+    </dependency>
+    
 
     <dependency>
       <groupId>org.graalvm.nativeimage</groupId>


### PR DESCRIPTION
Target of the changes performed with this PR was to obtain the output shown in the attaching image of a REST request to start a workflow with invalid parameters
![Screenshot from 2022-02-11 11-53-38](https://user-images.githubusercontent.com/65240126/153579473-c1f2e873-7e47-4a58-8ae1-dfd437db1458.png)
In order to achieve that, basically following steps were done:
- Rest Exception handler addon was added to Serveless workflow dependencies
- Root cause of ProcessIntanceExecutionException is now properly set, which implies slightly modifying WorkFlowProcessInstanceImpl
- `BaseExceptionHandler`in the addon was modified to properly deal with ProcessInstanceExecutionException root cause. 

