### PR TITLE
[KOGITO-6768] Be able to rename default channel

### DIFF
--- a/api/kogito-events-api/src/main/java/org/kie/kogito/event/KogitoEventStreams.java
+++ b/api/kogito-events-api/src/main/java/org/kie/kogito/event/KogitoEventStreams.java
@@ -18,10 +18,6 @@ package org.kie.kogito.event;
 public class KogitoEventStreams {
     public static final String INCOMING = "kogito_incoming_stream";
     public static final String OUTGOING = "kogito_outgoing_stream";
-    public static final String PUBLISHER = "kogito_event_publisher";
-    public static final String WORKER_THREAD = "kogito-event-worker";
-    public static final String DEFAULT_OUTGOING_BEAN_NAME = OUTGOING + "_eventEmitter";
-    public static final String DEFAULT_INCOMING_BEAN_NAME = INCOMING + "_eventReceiver";
 
     private KogitoEventStreams() {
     }

--- a/quarkus/addons/messaging/common/src/main/java/org/kie/kogito/addon/quarkus/messaging/common/QuarkusTopicDiscovery.java
+++ b/quarkus/addons/messaging/common/src/main/java/org/kie/kogito/addon/quarkus/messaging/common/QuarkusTopicDiscovery.java
@@ -25,7 +25,6 @@ import javax.enterprise.context.ApplicationScoped;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.kie.kogito.addon.cloudevents.AbstractTopicDiscovery;
 import org.kie.kogito.event.ChannelType;
-import org.kie.kogito.event.KogitoEventStreams;
 import org.kie.kogito.event.Topic;
 
 @ApplicationScoped
@@ -36,11 +35,12 @@ public class QuarkusTopicDiscovery extends AbstractTopicDiscovery {
     private static final String INCOMING_PREFIX = "mp.messaging.incoming.";
     private static final String TOPIC_SUFFIX = ".topic";
 
+    @Override
     protected List<Topic> getTopics() {
         final List<Topic> topics = new ArrayList<>();
         ConfigProvider.getConfig().getPropertyNames().forEach(n -> {
             if (n.startsWith(OUTGOING_PREFIX)) {
-                final String topicName = this.extractChannelName(n, OUTGOING_PREFIX, KogitoEventStreams.OUTGOING);
+                final String topicName = this.extractChannelName(n, OUTGOING_PREFIX);
                 if (topics.stream().noneMatch(t -> t.getName().equals(topicName) && t.getType() == ChannelType.OUTGOING)) {
                     final Topic topic = new Topic();
                     topic.setType(ChannelType.OUTGOING);
@@ -48,7 +48,7 @@ public class QuarkusTopicDiscovery extends AbstractTopicDiscovery {
                     topics.add(topic);
                 }
             } else if (n.startsWith(INCOMING_PREFIX)) {
-                final String topicName = this.extractChannelName(n, INCOMING_PREFIX, KogitoEventStreams.INCOMING);
+                final String topicName = this.extractChannelName(n, INCOMING_PREFIX);
                 if (topics.stream().noneMatch(t -> t.getName().equals(topicName) && t.getType() == ChannelType.INCOMING)) {
                     final Topic topic = new Topic();
                     topic.setType(ChannelType.INCOMING);
@@ -60,10 +60,7 @@ public class QuarkusTopicDiscovery extends AbstractTopicDiscovery {
         return topics;
     }
 
-    private String extractChannelName(String property, String prefix, String defaultChannel) {
-        if (property.length() <= prefix.length()) {
-            return defaultChannel;
-        }
+    private String extractChannelName(String property, String prefix) {
         String channelName = property.substring(prefix.length());
         if (channelName.contains(".")) {
             channelName = channelName.substring(0, channelName.indexOf("."));

--- a/quarkus/addons/messaging/deployment/src/main/java/org/kie/kogito/addon/cloudevents/quarkus/deployment/ChannelInfo.java
+++ b/quarkus/addons/messaging/deployment/src/main/java/org/kie/kogito/addon/cloudevents/quarkus/deployment/ChannelInfo.java
@@ -22,11 +22,13 @@ public class ChannelInfo {
     private final String channelName;
     private final String className;
     private final boolean isInput;
+    private final boolean isDefault;
 
-    public ChannelInfo(String channelName, String className, boolean isInput) {
+    public ChannelInfo(String channelName, String className, boolean isInput, boolean isDefault) {
         this.className = className;
         this.channelName = channelName;
         this.isInput = isInput;
+        this.isDefault = isDefault;
     }
 
     public String getChannelName() {
@@ -39,10 +41,6 @@ public class ChannelInfo {
 
     public boolean isInput() {
         return isInput;
-    }
-
-    public boolean isOutput() {
-        return !isInput;
     }
 
     @Override
@@ -59,5 +57,17 @@ public class ChannelInfo {
         ChannelInfo other = (ChannelInfo) obj;
         return Objects.equals(channelName, other.channelName) && Objects.equals(className, other.className) &&
                 isInput == other.isInput;
+    }
+
+    public boolean isDefault() {
+        return isDefault;
+    }
+
+    public boolean isInputDefault() {
+        return isInput && isDefault;
+    }
+
+    public boolean isOutputDefault() {
+        return !isInput && isDefault;
     }
 }

--- a/quarkus/addons/messaging/deployment/src/main/java/org/kie/kogito/addon/cloudevents/quarkus/deployment/EventGenerator.java
+++ b/quarkus/addons/messaging/deployment/src/main/java/org/kie/kogito/addon/cloudevents/quarkus/deployment/EventGenerator.java
@@ -22,7 +22,6 @@ import org.drools.core.util.StringUtils;
 import org.kie.kogito.codegen.api.context.KogitoBuildContext;
 import org.kie.kogito.codegen.api.template.InvalidTemplateException;
 import org.kie.kogito.codegen.api.template.TemplatedGenerator;
-import org.kie.kogito.event.KogitoEventStreams;
 
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
@@ -52,7 +51,7 @@ public class EventGenerator implements ClassGenerator {
         ClassOrInterfaceDeclaration clazz = generator.findFirst(ClassOrInterfaceDeclaration.class).orElseThrow(() -> new InvalidTemplateException(template, "Cannot find class declaration"));
         clazz.setName(className);
         String annotationName = null;
-        if (!channelInfo.getChannelName().equals(KogitoEventStreams.INCOMING) && !channelInfo.getChannelName().equals(KogitoEventStreams.OUTGOING)) {
+        if (!channelInfo.isDefault()) {
             annotationName = StringUtils.ucFirst(polishClassName(channelInfo, "Qualifier"));
         }
         this.annotationName = Optional.ofNullable(annotationName);


### PR DESCRIPTION
The properties to rename channel are 
`kogito.addon.messaging.incoming.defaultName` and` kogito.addon.messaging.outgoing.defaultName`
See example at https://github.com/kiegroup/kogito-examples/pull/1126