### PR TITLE
[KOGITO-6638] Enhancing error message when message has not association

### DIFF
--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/MessageHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/MessageHandler.java
@@ -22,8 +22,14 @@ import java.util.Map;
 import org.drools.core.xml.BaseAbstractHandler;
 import org.drools.core.xml.ExtensibleXmlParser;
 import org.drools.core.xml.Handler;
-import org.jbpm.bpmn2.core.*;
+import org.jbpm.bpmn2.core.DataStore;
+import org.jbpm.bpmn2.core.Definitions;
 import org.jbpm.bpmn2.core.Error;
+import org.jbpm.bpmn2.core.Escalation;
+import org.jbpm.bpmn2.core.Interface;
+import org.jbpm.bpmn2.core.ItemDefinition;
+import org.jbpm.bpmn2.core.Message;
+import org.jbpm.bpmn2.core.Signal;
 import org.jbpm.compiler.xml.ProcessBuildData;
 import org.jbpm.ruleflow.core.RuleFlowProcess;
 import org.xml.sax.Attributes;
@@ -52,6 +58,7 @@ public class MessageHandler extends BaseAbstractHandler implements Handler {
         }
     }
 
+    @Override
     @SuppressWarnings("unchecked")
     public Object start(final String uri, final String localName,
             final Attributes attrs, final ExtensibleXmlParser parser)
@@ -81,21 +88,20 @@ public class MessageHandler extends BaseAbstractHandler implements Handler {
             buildData.setMetaData("Messages", messages);
         }
         Message message = new Message(id);
-        message.setType(itemDefinition.getStructureRef());
+        message.setType(itemDefinition.getStructureRef() == null || itemDefinition.getStructureRef().isEmpty() ? "Object" : itemDefinition.getStructureRef());
         message.setName(name);
-
-        if (message.getType() != null && !message.getType().isEmpty()) {
-            messages.put(id, message);
-        }
+        messages.put(id, message);
         return message;
     }
 
+    @Override
     public Object end(final String uri, final String localName,
             final ExtensibleXmlParser parser) throws SAXException {
         parser.endElementBuilder();
         return parser.getCurrent();
     }
 
+    @Override
     public Class<?> generateNodeFor() {
         return Message.class;
     }

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/TriggerMetaData.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/TriggerMetaData.java
@@ -99,17 +99,26 @@ public class TriggerMetaData {
     }
 
     private TriggerMetaData validate() {
+        StringBuilder errorMsg = new StringBuilder();
         if (TriggerType.ConsumeMessage.equals(type) || TriggerType.ProduceMessage.equals(type)) {
 
-            if (StringUtils.isEmpty(name) ||
-                    StringUtils.isEmpty(dataType) ||
-                    StringUtils.isEmpty(modelRef)) {
-                throw new IllegalArgumentException("Message Trigger information is not complete " + this);
+            if (StringUtils.isEmpty(name)) {
+                errorMsg.append(" It does not contain name.");
+            }
+
+            if (StringUtils.isEmpty(dataType)) {
+                errorMsg.append(" It does not contain dataType.");
+            }
+
+            if (StringUtils.isEmpty(modelRef)) {
+                errorMsg.append(" It does not contain modelRef.");
             }
         } else if (TriggerType.Signal.equals(type) && StringUtils.isEmpty(name)) {
-            throw new IllegalArgumentException("Signal Trigger information is not complete " + this);
+            errorMsg.append(" Signal should contain a name.");
         }
-
+        if (errorMsg.length() > 0) {
+            throw new IllegalArgumentException("Error validating metadata trigger " + this + errorMsg);
+        }
         return this;
     }
 

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/descriptors/ServiceTaskDescriptor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/descriptors/ServiceTaskDescriptor.java
@@ -73,7 +73,6 @@ public class ServiceTaskDescriptor extends AbstractServiceTaskDescriptor {
     protected ServiceTaskDescriptor(WorkItemNode workItemNode, ClassLoader contextClassLoader) {
         super(workItemNode);
         mangledName = mangledHandlerName(interfaceName, operationName, String.valueOf(workItemNode.getId()));
-        this.parameters = extractTaskParameters();
         try {
             cls = contextClassLoader.loadClass(interfaceName);
         } catch (ClassNotFoundException e) {
@@ -84,6 +83,7 @@ public class ServiceTaskDescriptor extends AbstractServiceTaskDescriptor {
                                     workItemNode.getName(),
                                     interfaceName));
         }
+        this.parameters = extractTaskParameters();
         try {
             method = ReflectionUtils.getMethod(contextClassLoader, cls, operationName, parameters.stream().map(Argument::getType).collect(Collectors.toList()));
         } catch (ReflectiveOperationException ex) {

--- a/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/resources/servicetask/MultiParamServiceProcessNoOutput.bpmn2
+++ b/kogito-codegen-modules/kogito-codegen-integration-tests/src/test/resources/servicetask/MultiParamServiceProcessNoOutput.bpmn2
@@ -14,23 +14,11 @@
   <bpmn2:itemDefinition id="_ageItem"
     structureRef="Integer" />
   <bpmn2:itemDefinition
-    id="_750337AF-3A39-4B58-9CA6-947FCE6E61DB_InMessageType"
-    structureRef="" />
-  <bpmn2:itemDefinition
-    id="_750337AF-3A39-4B58-9CA6-947FCE6E61DB_OutMessageType"
-    structureRef="" />
-  <bpmn2:itemDefinition
     id="__750337AF-3A39-4B58-9CA6-947FCE6E61DB_nameInputXItem"
     structureRef="String" />
   <bpmn2:itemDefinition
     id="__750337AF-3A39-4B58-9CA6-947FCE6E61DB_ageInputXItem"
     structureRef="Integer" />
-  <bpmn2:message
-    id="_750337AF-3A39-4B58-9CA6-947FCE6E61DB_InMessage"
-    itemRef="_750337AF-3A39-4B58-9CA6-947FCE6E61DB_InMessageType" />
-  <bpmn2:message
-    id="_750337AF-3A39-4B58-9CA6-947FCE6E61DB_OutMessage"
-    itemRef="_750337AF-3A39-4B58-9CA6-947FCE6E61DB_OutMessageType" />
   <bpmn2:interface
     id="_750337AF-3A39-4B58-9CA6-947FCE6E61DB_ServiceInterface"
     name="org.kie.kogito.codegen.data.HelloService"
@@ -38,8 +26,6 @@
     <bpmn2:operation
       id="_750337AF-3A39-4B58-9CA6-947FCE6E61DB_ServiceOperation"
       name="helloNoOutput" implementationRef="helloNoOutput">
-      <bpmn2:inMessageRef>_750337AF-3A39-4B58-9CA6-947FCE6E61DB_InMessage</bpmn2:inMessageRef>
-      <bpmn2:outMessageRef>_750337AF-3A39-4B58-9CA6-947FCE6E61DB_OutMessage</bpmn2:outMessageRef>
     </bpmn2:operation>
   </bpmn2:interface>
   <bpmn2:process id="MultiParamServiceProcessNoOutput" drools:version="1.0"


### PR DESCRIPTION
As part of the issue described in the JIRA, it is clear that, although a message with dataoutput association is not expected to work in Kogito, users deserve a clearer message of our expectation regarding the bmpn definition, so here is my proposal
Some test failed, need to look at them
There is actually an issue if the message is included in the map. Some bpmns messed up and resolve the wrong parameters in the service. 
Also, cogeden is expecting the message to be linked with tthe model (which is not the case if the message has no output connection, I mean the message is just there for waiting), so this is greater than intially expected and I will postpone due to the other priorities