### PR TITLE
KOGITO-6744: [SW] Implement Callback state eventTimeout

### DIFF
--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/ServerlessWorkflowParser.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/ServerlessWorkflowParser.java
@@ -28,10 +28,15 @@ import org.jbpm.process.core.datatype.impl.type.ObjectDataType;
 import org.jbpm.ruleflow.core.Metadata;
 import org.jbpm.ruleflow.core.RuleFlowNodeContainerFactory;
 import org.jbpm.ruleflow.core.RuleFlowProcessFactory;
+import org.jbpm.ruleflow.core.factory.JoinFactory;
 import org.jbpm.ruleflow.core.factory.NodeFactory;
+import org.jbpm.ruleflow.core.factory.SplitFactory;
 import org.jbpm.ruleflow.core.factory.SubProcessNodeFactory;
+import org.jbpm.ruleflow.core.factory.TimerNodeFactory;
 import org.jbpm.workflow.core.impl.DataAssociation;
 import org.jbpm.workflow.core.impl.DataDefinition;
+import org.jbpm.workflow.core.node.Join;
+import org.jbpm.workflow.core.node.Split;
 import org.kie.kogito.codegen.api.GeneratedInfo;
 import org.kie.kogito.codegen.api.context.KogitoBuildContext;
 import org.kie.kogito.internal.process.runtime.KogitoWorkflowProcess;
@@ -46,6 +51,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.serverlessworkflow.api.Workflow;
 import io.serverlessworkflow.api.events.EventDefinition;
 import io.serverlessworkflow.api.workflow.Constants;
+
+import static org.jbpm.process.core.timer.Timer.TIME_DURATION;
+import static org.jbpm.ruleflow.core.Metadata.UNIQUE_ID;
 
 public class ServerlessWorkflowParser {
 
@@ -160,5 +168,29 @@ public class ServerlessWorkflowParser {
                 .metaData(Metadata.TRIGGER_REF, eventDefinition.getType())
                 .metaData(Metadata.MESSAGE_TYPE, JSON_NODE)
                 .metaData(Metadata.TRIGGER_TYPE, "ConsumeMessage");
+    }
+
+    public static <T extends RuleFlowNodeContainerFactory<T, ?>> SplitFactory<T> eventBasedExclusiveSplitNode(T nodeFactory, long nodeId) {
+        return nodeFactory.splitNode(nodeId)
+                .name("ExclusiveSplit_" + nodeId)
+                .type(Split.TYPE_XAND)
+                .metaData(UNIQUE_ID, Long.toString(nodeId))
+                .metaData("EventBased", "true");
+    }
+
+    public static <T extends RuleFlowNodeContainerFactory<T, ?>> JoinFactory<T> joinExclusiveNode(T nodeFactory, long nodeId) {
+        return nodeFactory.joinNode(nodeId)
+                .name("ExclusiveJoin_" + nodeId)
+                .type(Join.TYPE_XOR)
+                .metaData(UNIQUE_ID, Long.toString(nodeId));
+    }
+
+    public static <T extends RuleFlowNodeContainerFactory<T, ?>> TimerNodeFactory<T> timerNode(T nodeFactory, long nodeId, String duration) {
+        return nodeFactory.timerNode(nodeId)
+                .name("TimerNode_" + nodeId)
+                .type(TIME_DURATION)
+                .delay(duration)
+                .metaData(UNIQUE_ID, Long.toString(nodeId))
+                .metaData("EventType", "Timer");
     }
 }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/CallbackHandler.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/CallbackHandler.java
@@ -17,11 +17,17 @@ package org.kie.kogito.serverless.workflow.parser.handlers;
 
 import org.jbpm.ruleflow.core.RuleFlowNodeContainerFactory;
 import org.jbpm.ruleflow.core.factory.CompositeContextNodeFactory;
+import org.jbpm.ruleflow.core.factory.JoinFactory;
 import org.jbpm.ruleflow.core.factory.NodeFactory;
+import org.jbpm.ruleflow.core.factory.SplitFactory;
 import org.kie.kogito.serverless.workflow.parser.ParserContext;
+import org.kie.kogito.serverless.workflow.parser.ServerlessWorkflowParser;
 
 import io.serverlessworkflow.api.Workflow;
 import io.serverlessworkflow.api.states.CallbackState;
+
+import static org.kie.kogito.serverless.workflow.parser.ServerlessWorkflowParser.eventBasedExclusiveSplitNode;
+import static org.kie.kogito.serverless.workflow.parser.ServerlessWorkflowParser.joinExclusiveNode;
 
 public class CallbackHandler extends CompositeContextNodeHandler<CallbackState> {
 
@@ -41,8 +47,32 @@ public class CallbackHandler extends CompositeContextNodeHandler<CallbackState> 
         if (state.getAction() != null) {
             currentNode = connect(currentNode, getActionNode(embeddedSubProcess, state.getAction()));
         }
-        currentNode = connect(currentNode,
-                filterAndMergeNode(embeddedSubProcess, state.getEventDataFilter(), (f, inputVar, outputVar) -> consumeEventNode(f, state.getEventRef(), inputVar, outputVar)));
+        String eventTimeout = getEventTimeout();
+        if (eventTimeout != null && !eventTimeout.isEmpty()) {
+            // Create the event based exclusive split node.
+            SplitFactory<?> splitNode = eventBasedExclusiveSplitNode(embeddedSubProcess, parserContext.newId());
+            // Create the join node for joining the event fired and the timer fired branches.
+            JoinFactory<?> joinNode = joinExclusiveNode(embeddedSubProcess, parserContext.newId());
+            // Connect the currentNode with the split
+            connect(currentNode, splitNode);
+            // Create the event fired branch, normal path if the event arrives in time.
+            NodeFactory<?, ?> eventFiredBranchLastNode = connect(splitNode,
+                    filterAndMergeNode(embeddedSubProcess, state.getEventDataFilter(), (f, inputVar, outputVar) -> consumeEventNode(f, state.getEventRef(), inputVar, outputVar)));
+            // Connect the event fired branch last node with the join node.
+            connect(eventFiredBranchLastNode, joinNode);
+            // Create the timer fired branch
+            org.jbpm.ruleflow.core.factory.TimerNodeFactory<?> eventTimeoutTimerNode = ServerlessWorkflowParser.timerNode(embeddedSubProcess, parserContext.newId(), eventTimeout);
+            connect(splitNode, eventTimeoutTimerNode);
+            // Connect the timer fired branch last node with the join node
+            connect(eventTimeoutTimerNode, joinNode);
+            currentNode = joinNode;
+        } else {
+            // No timeouts, standard case.
+            currentNode = connect(currentNode,
+                    filterAndMergeNode(embeddedSubProcess, state.getEventDataFilter(), (f, inputVar, outputVar) -> consumeEventNode(f, state.getEventRef(), inputVar, outputVar)));
+
+        }
+        // Finally, connect with the End event
         connect(currentNode, embeddedSubProcess.endNode(parserContext.newId()).name("EmbeddedEnd").terminate(true)).done();
         return new MakeNodeResult(embeddedSubProcess);
     }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/StateHandler.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/StateHandler.java
@@ -61,7 +61,6 @@ import io.serverlessworkflow.api.transitions.Transition;
 
 import static org.kie.kogito.serverless.workflow.parser.ServerlessWorkflowParser.DEFAULT_WORKFLOW_VAR;
 import static org.kie.kogito.serverless.workflow.utils.ServerlessWorkflowUtils.processResourceFile;
-import static org.kie.kogito.serverless.workflow.utils.TimeoutsConfigResolver.resolveEventTimeout;
 
 public abstract class StateHandler<S extends State> {
 
@@ -468,9 +467,5 @@ public abstract class StateHandler<S extends State> {
         void onIdTarget(long targetId);
 
         void onEmptyTarget();
-    }
-
-    protected String getEventTimeout() {
-        return resolveEventTimeout(state, workflow);
     }
 }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/StateHandler.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/StateHandler.java
@@ -61,6 +61,7 @@ import io.serverlessworkflow.api.transitions.Transition;
 
 import static org.kie.kogito.serverless.workflow.parser.ServerlessWorkflowParser.DEFAULT_WORKFLOW_VAR;
 import static org.kie.kogito.serverless.workflow.utils.ServerlessWorkflowUtils.processResourceFile;
+import static org.kie.kogito.serverless.workflow.utils.TimeoutsConfigResolver.resolveEventTimeout;
 
 public abstract class StateHandler<S extends State> {
 
@@ -467,5 +468,9 @@ public abstract class StateHandler<S extends State> {
         void onIdTarget(long targetId);
 
         void onEmptyTarget();
+    }
+
+    protected String getEventTimeout() {
+        return resolveEventTimeout(state, workflow);
     }
 }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/utils/TimeoutsConfigResolver.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/utils/TimeoutsConfigResolver.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.serverless.workflow.utils;
+
+import java.time.Duration;
+import java.time.format.DateTimeParseException;
+
+import io.serverlessworkflow.api.Workflow;
+import io.serverlessworkflow.api.interfaces.State;
+import io.serverlessworkflow.api.timeouts.TimeoutsDefinition;
+
+public class TimeoutsConfigResolver {
+
+    private static final String NON_NEGATIVE_DURATION_MUST_BE_PROVIDED = "A positive ISO 8601 duration must be provided when it is configured.";
+
+    private static final String INVALID_EVENT_TIMEOUT_FOR_STATE_ERROR = "An invalid \"eventTimeout\": \"%s\" configuration was provided for the state \"%s\" in the serverless workflow: \"%s\". " +
+            NON_NEGATIVE_DURATION_MUST_BE_PROVIDED;
+
+    private static final String INVALID_EVENT_TIMEOUT_FOR_WORKFLOW_ERROR = "An invalid \"eventTimeout\": \"%s\" configuration was provided for the serverless workflow: \"%s\". " +
+            NON_NEGATIVE_DURATION_MUST_BE_PROVIDED;
+
+    private TimeoutsConfigResolver() {
+    }
+
+    public static String resolveEventTimeout(State state, Workflow workflow) {
+        TimeoutsDefinition timeouts = state.getTimeouts();
+        if (timeouts != null && timeouts.getEventTimeout() != null) {
+            validateStateTimeoutValue(state, workflow, timeouts.getEventTimeout());
+            return timeouts.getEventTimeout();
+        } else {
+            timeouts = workflow.getTimeouts();
+            if (timeouts != null && timeouts.getEventTimeout() != null) {
+                validateWorkflowTimeoutValue(workflow, timeouts.getEventTimeout());
+                return timeouts.getEventTimeout();
+            }
+        }
+        return null;
+    }
+
+    private static void validateStateTimeoutValue(State state, Workflow workflow, String timeoutValue) {
+        if (isInvalidDuration(timeoutValue)) {
+            throw new IllegalArgumentException(String.format(INVALID_EVENT_TIMEOUT_FOR_STATE_ERROR, timeoutValue, state.getName(), workflow.getName()));
+        }
+    }
+
+    private static void validateWorkflowTimeoutValue(Workflow workflow, String timeoutValue) {
+        if (isInvalidDuration(timeoutValue)) {
+            throw new IllegalArgumentException(String.format(INVALID_EVENT_TIMEOUT_FOR_WORKFLOW_ERROR, timeoutValue, workflow.getName()));
+        }
+    }
+
+    private static boolean isInvalidDuration(String value) {
+        Duration duration = parseOrIgnoreException(value);
+        return duration == null || duration.isNegative() || duration.isZero();
+    }
+
+    private static Duration parseOrIgnoreException(String duration) {
+        try {
+            return Duration.parse(duration);
+        } catch (DateTimeParseException ignored) {
+            return null;
+        }
+    }
+}

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/java/org/kie/kogito/serverless/workflow/AbstractServerlessWorkflowParsingTest.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/java/org/kie/kogito/serverless/workflow/AbstractServerlessWorkflowParsingTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.serverless.workflow;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Objects;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.kie.api.definition.process.Process;
+import org.kie.kogito.codegen.api.context.impl.JavaKogitoBuildContext;
+import org.kie.kogito.serverless.workflow.parser.ServerlessWorkflowParser;
+
+public abstract class AbstractServerlessWorkflowParsingTest {
+
+    @BeforeAll
+    public static void init() {
+        System.setProperty("jbpm.enable.multi.con", "true");
+    }
+
+    @AfterAll
+    public static void cleanup() {
+        System.clearProperty("jbpm.enable.multi.con");
+    }
+
+    protected Process getWorkflowParser(String workflowLocation) throws IOException {
+        String format = workflowLocation.endsWith(".sw.json") ? "json" : "yml";
+        ServerlessWorkflowParser parser = ServerlessWorkflowParser.of(
+                new InputStreamReader(Objects.requireNonNull(this.getClass().getResourceAsStream(workflowLocation),
+                        "Required resource was no found: " + workflowLocation)),
+                format,
+                JavaKogitoBuildContext.builder().build());
+        return parser.getProcessInfo().info();
+    }
+}

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/java/org/kie/kogito/serverless/workflow/CallbackStateServerlessWorkflowParsingTest.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/java/org/kie/kogito/serverless/workflow/CallbackStateServerlessWorkflowParsingTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.serverless.workflow;
+
+import org.jbpm.ruleflow.core.RuleFlowProcess;
+import org.jbpm.workflow.core.node.ActionNode;
+import org.jbpm.workflow.core.node.BoundaryEventNode;
+import org.jbpm.workflow.core.node.CompositeContextNode;
+import org.jbpm.workflow.core.node.EndNode;
+import org.jbpm.workflow.core.node.EventNode;
+import org.jbpm.workflow.core.node.Join;
+import org.jbpm.workflow.core.node.Split;
+import org.jbpm.workflow.core.node.StartNode;
+import org.jbpm.workflow.core.node.TimerNode;
+import org.jbpm.workflow.core.node.WorkItemNode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.kie.kogito.serverless.workflow.WorkflowTestUtils.assertClassAndGetNode;
+import static org.kie.kogito.serverless.workflow.WorkflowTestUtils.assertHasName;
+import static org.kie.kogito.serverless.workflow.WorkflowTestUtils.assertHasNodesSize;
+import static org.kie.kogito.serverless.workflow.WorkflowTestUtils.assertIsConnected;
+import static org.kie.kogito.serverless.workflow.WorkflowTestUtils.assertProcessMainParams;
+
+class CallbackStateServerlessWorkflowParsingTest extends AbstractServerlessWorkflowParsingTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = { "/exec/callback-state.sw.json", "/exec/callback-state.sw.yml" })
+    void produceCallbackState(String workflowLocation) throws Exception {
+        RuleFlowProcess process = (RuleFlowProcess) getWorkflowParser(workflowLocation);
+        // assert the process main parameters
+        assertProcessMainParams(process,
+                "callback_state",
+                "Callback State",
+                "1.0",
+                "org.kie.kogito.serverless",
+                RuleFlowProcess.PUBLIC_VISIBILITY);
+
+        // assert the main process structure
+        assertCallbackProcessMainStructure(process);
+
+        // assert the CallbackState internal structure for the no timeouts case
+        CompositeContextNode callbackState = assertClassAndGetNode(process, 3, CompositeContextNode.class);
+        assertHasNodesSize(callbackState, 6);
+        StartNode stateStartNode = assertClassAndGetNode(callbackState, 0, StartNode.class);
+        assertHasName(stateStartNode, "EmbeddedStart");
+        WorkItemNode stateActionNode = assertClassAndGetNode(callbackState, 1, WorkItemNode.class);
+        assertHasName(stateActionNode, "callbackFunction");
+        ActionNode afterStateActionMergeNode = assertClassAndGetNode(callbackState, 2, ActionNode.class);
+        EventNode stateEventNode = assertClassAndGetNode(callbackState, 3, EventNode.class);
+        assertHasName(stateEventNode, "callbackEvent");
+        ActionNode afterStateEventMergeNode = assertClassAndGetNode(callbackState, 4, ActionNode.class);
+        EndNode stateEndNode = assertClassAndGetNode(callbackState, 5, EndNode.class);
+        assertHasName(stateEndNode, "EmbeddedEnd");
+
+        assertIsConnected(stateStartNode, stateActionNode);
+        assertIsConnected(stateActionNode, afterStateActionMergeNode);
+        assertIsConnected(afterStateActionMergeNode, stateEventNode);
+        assertIsConnected(stateEventNode, afterStateEventMergeNode);
+        assertIsConnected(afterStateEventMergeNode, stateEndNode);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "/exec/callback-state-timeouts.sw.json", "/exec/callback-state-timeouts.sw.yml" })
+    void produceCallbackStateWithTimeouts(String workflowLocation) throws Exception {
+        RuleFlowProcess process = (RuleFlowProcess) getWorkflowParser(workflowLocation);
+        // assert the process main parameters
+        assertProcessMainParams(process,
+                "callback_state_timeouts",
+                "Callback State Timeouts",
+                "1.0",
+                "org.kie.kogito.serverless",
+                RuleFlowProcess.PUBLIC_VISIBILITY);
+
+        // assert the main process structure
+        assertCallbackProcessMainStructure(process);
+
+        // assert the CallbackState internal structure for the timeouts case
+        CompositeContextNode callbackState = assertClassAndGetNode(process, 3, CompositeContextNode.class);
+        assertHasNodesSize(callbackState, 9);
+        StartNode stateStartNode = assertClassAndGetNode(callbackState, 0, StartNode.class);
+        assertHasName(stateStartNode, "EmbeddedStart");
+        WorkItemNode stateActionNode = assertClassAndGetNode(callbackState, 1, WorkItemNode.class);
+        assertHasName(stateActionNode, "callbackFunction");
+        ActionNode afterStateActionMergeNode = assertClassAndGetNode(callbackState, 2, ActionNode.class);
+        Split stateSplitNode = assertClassAndGetNode(callbackState, 3, Split.class);
+        assertHasName(stateSplitNode, "ExclusiveSplit_" + stateSplitNode.getId());
+        Join stateJoinNode = assertClassAndGetNode(callbackState, 4, Join.class);
+        assertHasName(stateJoinNode, "ExclusiveJoin_" + stateJoinNode.getId());
+        EventNode stateEventNode = assertClassAndGetNode(callbackState, 5, EventNode.class);
+        assertHasName(stateEventNode, "callbackEvent");
+        ActionNode afterStateEventMergeNode = assertClassAndGetNode(callbackState, 6, ActionNode.class);
+        TimerNode stateTimerNode = assertClassAndGetNode(callbackState, 7, TimerNode.class);
+        assertHasName(stateTimerNode, "TimerNode_" + stateTimerNode.getId());
+        assertThat(stateTimerNode.getTimer().getDelay()).isEqualTo("PT1M");
+        assertThat(stateTimerNode.getTimer().getTimeType()).isEqualTo(1);
+        EndNode stateEndNode = assertClassAndGetNode(callbackState, 8, EndNode.class);
+        assertHasName(stateEndNode, "EmbeddedEnd");
+
+        assertIsConnected(stateStartNode, stateActionNode);
+        assertIsConnected(stateActionNode, afterStateActionMergeNode);
+        assertIsConnected(afterStateActionMergeNode, stateSplitNode);
+        assertIsConnected(stateSplitNode, stateEventNode);
+        assertIsConnected(stateEventNode, afterStateEventMergeNode);
+        assertIsConnected(afterStateEventMergeNode, stateJoinNode);
+        assertIsConnected(stateSplitNode, stateTimerNode);
+        assertIsConnected(stateTimerNode, stateJoinNode);
+        assertIsConnected(stateJoinNode, stateEndNode);
+    }
+
+    private void assertCallbackProcessMainStructure(RuleFlowProcess process) {
+        assertHasNodesSize(process, 7);
+        StartNode processStartNode = assertClassAndGetNode(process, 0, StartNode.class);
+        EndNode processEndNode1 = assertClassAndGetNode(process, 1, EndNode.class);
+        EndNode processEndNode2 = assertClassAndGetNode(process, 2, EndNode.class);
+        CompositeContextNode callbackState = assertClassAndGetNode(process, 3, CompositeContextNode.class);
+        assertHasName(callbackState, "CallbackState");
+        ActionNode processFinalizeSuccessfulState = assertClassAndGetNode(process, 4, ActionNode.class);
+        assertHasName(processFinalizeSuccessfulState, "FinalizeSuccessful");
+        ActionNode processFinalizeWithErrorState = assertClassAndGetNode(process, 5, ActionNode.class);
+        assertHasName(processFinalizeWithErrorState, "FinalizeWithError");
+        BoundaryEventNode callbackStateErrorBoundaryEvent = assertClassAndGetNode(process, 6, BoundaryEventNode.class);
+        assertHasName(callbackStateErrorBoundaryEvent, "Error-CallbackState-java.lang.Exception");
+
+        assertIsConnected(processStartNode, callbackState);
+        assertIsConnected(callbackState, processFinalizeSuccessfulState);
+        assertIsConnected(processFinalizeSuccessfulState, processEndNode1);
+        assertIsConnected(processFinalizeWithErrorState, processEndNode2);
+    }
+}

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/java/org/kie/kogito/serverless/workflow/ServerlessWorkflowParsingTest.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/java/org/kie/kogito/serverless/workflow/ServerlessWorkflowParsingTest.java
@@ -16,7 +16,6 @@
 package org.kie.kogito.serverless.workflow;
 
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.util.Collections;
 
 import org.jbpm.ruleflow.core.Metadata;
@@ -31,8 +30,6 @@ import org.jbpm.workflow.core.node.Split;
 import org.jbpm.workflow.core.node.StartNode;
 import org.jbpm.workflow.core.node.TimerNode;
 import org.jbpm.workflow.core.node.WorkItemNode;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -52,17 +49,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ServerlessWorkflowParsingTest {
-
-    @BeforeAll
-    public static void init() {
-        System.setProperty("jbpm.enable.multi.con", "true");
-    }
-
-    @AfterAll
-    public static void cleanup() {
-        System.clearProperty("jbpm.enable.multi.con");
-    }
+public class ServerlessWorkflowParsingTest extends AbstractServerlessWorkflowParsingTest {
 
     @ParameterizedTest
     @ValueSource(strings = { "/exec/single-operation.sw.json", "/exec/single-operation.sw.yml" })
@@ -720,14 +707,5 @@ public class ServerlessWorkflowParsingTest {
         assertEquals(ServerlessWorkflowParser.DEFAULT_NAME, process.getName());
         assertEquals(ServerlessWorkflowParser.DEFAULT_VERSION, process.getVersion());
         assertEquals(ServerlessWorkflowParser.DEFAULT_PACKAGE, process.getPackageName());
-    }
-
-    private Process getWorkflowParser(String workflowLocation) throws IOException {
-        String format = workflowLocation.endsWith(".sw.json") ? "json" : "yml";
-        ServerlessWorkflowParser parser = ServerlessWorkflowParser.of(
-                new InputStreamReader(this.getClass().getResourceAsStream(workflowLocation)),
-                format,
-                JavaKogitoBuildContext.builder().build());
-        return parser.getProcessInfo().info();
     }
 }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/java/org/kie/kogito/serverless/workflow/utils/TimeoutsConfigResolverTest.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/java/org/kie/kogito/serverless/workflow/utils/TimeoutsConfigResolverTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.serverless.workflow.utils;
+
+import java.util.stream.Stream;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.serverlessworkflow.api.Workflow;
+import io.serverlessworkflow.api.interfaces.State;
+import io.serverlessworkflow.api.timeouts.TimeoutsDefinition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+class TimeoutsConfigResolverTest {
+
+    private static final String STATE_NAME = "STATE_NAME";
+    private static final String WORKFLOW_NAME = "WORKFLOW_NAME";
+    private static final String VALID_STATE_TIMEOUT_DURATION = "PT1M";
+    private static final String VALID_WORKFLOW_TIMEOUT_DURATION = "PT8M";
+    private static final String INVALID_STATE_TIMEOUT_DURATION = "INVALID_STATE_TIMEOUT_DURATION";
+    private static final String EMPTY_STATE_TIMEOUT_DURATION = "";
+    private static final String INVALID_WORKFLOW_TIMEOUT_DURATION = "INVALID_WORKFLOW_TIMEOUT_DURATION";
+    private static final String EMPTY_WORKFLOW_TIMEOUT_DURATION = "";
+
+    @ParameterizedTest
+    @MethodSource("successfulCaseParams")
+    void resolveEventTimeoutSuccessful(State state, Workflow workflow, String expectedTimeout) {
+        assertThat(TimeoutsConfigResolver.resolveEventTimeout(state, workflow)).isEqualTo(expectedTimeout);
+    }
+
+    static Stream<Arguments> successfulCaseParams() {
+        return Stream.of(
+                Arguments.of(mockState(STATE_NAME), mockWorkflow(WORKFLOW_NAME), null),
+                Arguments.of(mockState(STATE_NAME, null), mockWorkflow(WORKFLOW_NAME, null), null),
+                Arguments.of(mockState(STATE_NAME, VALID_STATE_TIMEOUT_DURATION), mockWorkflow(WORKFLOW_NAME), VALID_STATE_TIMEOUT_DURATION),
+                Arguments.of(mockState(STATE_NAME, VALID_STATE_TIMEOUT_DURATION), mockWorkflow(WORKFLOW_NAME, null), VALID_STATE_TIMEOUT_DURATION),
+                Arguments.of(mockState(STATE_NAME, VALID_STATE_TIMEOUT_DURATION), mockWorkflow(WORKFLOW_NAME, VALID_WORKFLOW_TIMEOUT_DURATION), VALID_STATE_TIMEOUT_DURATION),
+                Arguments.of(mockState(STATE_NAME), mockWorkflow(WORKFLOW_NAME, VALID_WORKFLOW_TIMEOUT_DURATION), VALID_WORKFLOW_TIMEOUT_DURATION),
+                Arguments.of(mockState(STATE_NAME, null), mockWorkflow(WORKFLOW_NAME, VALID_WORKFLOW_TIMEOUT_DURATION), VALID_WORKFLOW_TIMEOUT_DURATION));
+    }
+
+    @ParameterizedTest
+    @MethodSource("unsuccessfulCaseParams")
+    void resolveEventTimeoutUnsuccessful(State state, Workflow workflow, String expectedMessagePart) {
+        Assertions.assertThatThrownBy(() -> TimeoutsConfigResolver.resolveEventTimeout(state, workflow))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(expectedMessagePart);
+    }
+
+    static Stream<Arguments> unsuccessfulCaseParams() {
+        return Stream.of(
+                Arguments.of(mockState(STATE_NAME, INVALID_STATE_TIMEOUT_DURATION), mockWorkflow(WORKFLOW_NAME), INVALID_STATE_TIMEOUT_DURATION),
+                Arguments.of(mockState(STATE_NAME, EMPTY_STATE_TIMEOUT_DURATION), mockWorkflow(WORKFLOW_NAME), EMPTY_STATE_TIMEOUT_DURATION),
+                Arguments.of(mockState(STATE_NAME, INVALID_STATE_TIMEOUT_DURATION), mockWorkflow(WORKFLOW_NAME, null), INVALID_STATE_TIMEOUT_DURATION),
+                Arguments.of(mockState(STATE_NAME, INVALID_STATE_TIMEOUT_DURATION), mockWorkflow(WORKFLOW_NAME, INVALID_WORKFLOW_TIMEOUT_DURATION), INVALID_STATE_TIMEOUT_DURATION),
+                Arguments.of(mockState(STATE_NAME, INVALID_STATE_TIMEOUT_DURATION), mockWorkflow(WORKFLOW_NAME, VALID_WORKFLOW_TIMEOUT_DURATION), INVALID_STATE_TIMEOUT_DURATION),
+                Arguments.of(mockState(STATE_NAME), mockWorkflow(WORKFLOW_NAME, INVALID_WORKFLOW_TIMEOUT_DURATION), INVALID_WORKFLOW_TIMEOUT_DURATION),
+                Arguments.of(mockState(STATE_NAME), mockWorkflow(WORKFLOW_NAME, EMPTY_WORKFLOW_TIMEOUT_DURATION), EMPTY_WORKFLOW_TIMEOUT_DURATION),
+                Arguments.of(mockState(STATE_NAME, null), mockWorkflow(WORKFLOW_NAME, INVALID_WORKFLOW_TIMEOUT_DURATION), INVALID_WORKFLOW_TIMEOUT_DURATION),
+                Arguments.of(mockState(STATE_NAME, null), mockWorkflow(WORKFLOW_NAME, INVALID_WORKFLOW_TIMEOUT_DURATION), INVALID_WORKFLOW_TIMEOUT_DURATION));
+    }
+
+    private static State mockState(String name) {
+        State state = mock(State.class);
+        doReturn(name).when(state).getName();
+        return state;
+    }
+
+    private static State mockState(String name, String eventTimeout) {
+        State state = mockState(name);
+        TimeoutsDefinition timeoutsDefinition = mockTimeoutsDefinition(eventTimeout);
+        doReturn(timeoutsDefinition).when(state).getTimeouts();
+        return state;
+    }
+
+    private static Workflow mockWorkflow(String name) {
+        Workflow workflow = mock(Workflow.class);
+        doReturn(name).when(workflow).getName();
+        return workflow;
+    }
+
+    private static Workflow mockWorkflow(String name, String eventTimeout) {
+        Workflow workflow = mockWorkflow(name);
+        TimeoutsDefinition timeoutsDefinition = mockTimeoutsDefinition(eventTimeout);
+        doReturn(timeoutsDefinition).when(workflow).getTimeouts();
+        return workflow;
+    }
+
+    private static TimeoutsDefinition mockTimeoutsDefinition(String eventTimeout) {
+        TimeoutsDefinition timeoutsDefinition = mock(TimeoutsDefinition.class);
+        doReturn(eventTimeout).when(timeoutsDefinition).getEventTimeout();
+        return timeoutsDefinition;
+    }
+}

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/callback-state-timeouts.sw.json
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/callback-state-timeouts.sw.json
@@ -1,0 +1,70 @@
+{
+  "id": "callback_state_timeouts",
+  "version": "1.0",
+  "name": "Callback State Timeouts",
+  "expressionLang": "jsonpath",
+  "description": "Callback State Timeouts Test",
+  "start": "CallbackState",
+  "events": [
+    {
+      "name": "callbackEvent",
+      "source": "",
+      "type": "callback_state_timeouts_event_type"
+    }
+  ],
+  "errors": [
+    {
+      "name": "callbackError",
+      "code": "java.lang.Exception"
+    }
+  ],
+  "functions": [
+    {
+      "name": "callbackFunction",
+      "type": "rest",
+      "operation": "specs/external-service.yaml#sendRequest"
+    }
+  ],
+  "states": [
+    {
+      "name": "CallbackState",
+      "type": "callback",
+      "action": {
+        "name": "callbackAction",
+        "functionRef": {
+          "refName": "callbackFunction",
+          "arguments": {
+            "callbackRequest": { "query" : "$.query" }
+          }
+        }
+      },
+      "eventRef": "callbackEvent",
+      "transition": "FinalizeSuccessful",
+      "onErrors": [
+        {
+          "errorRef": "callbackError",
+          "transition": "FinalizeWithError"
+        }
+      ],
+      "timeouts": {
+        "eventTimeout": "PT1M"
+      }
+    },
+    {
+      "name": "FinalizeSuccessful",
+      "type": "inject",
+      "data": {
+        "lastExecutedState": "FinalizeSuccessful"
+      },
+      "end": true
+    },
+    {
+      "name": "FinalizeWithError",
+      "type": "inject",
+      "data": {
+        "lastExecutedState": "FinalizeWithError"
+      },
+      "end": true
+    }
+  ]
+}

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/callback-state-timeouts.sw.yml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/callback-state-timeouts.sw.yml
@@ -1,0 +1,43 @@
+id: callback_state_timeouts
+version: 1.0
+name: Callback State Timeouts
+expressionLang: jsonpath
+description: Callback State Timeouts Test
+start: CallbackState
+events:
+  - name: callbackEvent
+    source:
+    type: callback_state_timeouts_event_type
+errors:
+  - name: callbackError
+    code: java.lang.Exception
+functions:
+  - name: callbackFunction
+    type: rest
+    operation: specs/external-service.yaml#sendRequest
+states:
+  - name: CallbackState
+    type: callback
+    action:
+      name: callbackAction
+      functionRef:
+        refName: callbackFunction
+        arguments:
+          callbackRequest: { "query": "$.query" }
+    eventRef: callbackEvent
+    transition: FinalizeSuccessful
+    onErrors:
+      - errorRef: callbackError
+        transition: FinalizeWithError
+    timeouts:
+      eventTimeout: PT1M
+  - name: FinalizeSuccessful
+    type: inject
+    data:
+      lastExecutedState": FinalizeSuccessful"
+    end: true
+  - name: FinalizeWithError
+    type: inject
+    data:
+      lastExecutedState: FinalizeWithError
+    end: true

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/callback-state.sw.json
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/callback-state.sw.json
@@ -1,0 +1,67 @@
+{
+  "id": "callback_state",
+  "version": "1.0",
+  "name": "Callback State",
+  "expressionLang": "jsonpath",
+  "description": "Callback State Test",
+  "start": "CallbackState",
+  "events": [
+    {
+      "name": "callbackEvent",
+      "source": "",
+      "type": "callback_state_event_type"
+    }
+  ],
+  "errors": [
+    {
+      "name": "callbackError",
+      "code": "java.lang.Exception"
+    }
+  ],
+  "functions": [
+    {
+      "name": "callbackFunction",
+      "type": "rest",
+      "operation": "specs/external-service.yaml#sendRequest"
+    }
+  ],
+  "states": [
+    {
+      "name": "CallbackState",
+      "type": "callback",
+      "action": {
+        "name": "callbackAction",
+        "functionRef": {
+          "refName": "callbackFunction",
+          "arguments": {
+            "callbackRequest": { "query" : "$.query" }
+          }
+        }
+      },
+      "eventRef": "callbackEvent",
+      "transition": "FinalizeSuccessful",
+      "onErrors": [
+        {
+          "errorRef": "callbackError",
+          "transition": "FinalizeWithError"
+        }
+      ]
+    },
+    {
+      "name": "FinalizeSuccessful",
+      "type": "inject",
+      "data": {
+        "lastExecutedState": "FinalizeSuccessful"
+      },
+      "end": true
+    },
+    {
+      "name": "FinalizeWithError",
+      "type": "inject",
+      "data": {
+        "lastExecutedState": "FinalizeWithError"
+      },
+      "end": true
+    }
+  ]
+}

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/callback-state.sw.yml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/callback-state.sw.yml
@@ -1,0 +1,41 @@
+id: callback_state
+version: 1.0
+name: Callback State
+expressionLang: jsonpath
+description: Callback State Test
+start: CallbackState
+events:
+  - name: callbackEvent
+    source:
+    type: callback_state_event_type
+errors:
+  - name: callbackError
+    code: java.lang.Exception
+functions:
+  - name: callbackFunction
+    type: rest
+    operation: specs/external-service.yaml#sendRequest
+states:
+  - name: CallbackState
+    type: callback
+    action:
+      name: callbackAction
+      functionRef:
+        refName: callbackFunction
+        arguments:
+          callbackRequest: { "query": "$.query" }
+    eventRef: callbackEvent
+    transition: FinalizeSuccessful
+    onErrors:
+      - errorRef: callbackError
+        transition: FinalizeWithError
+  - name: FinalizeSuccessful
+    type: inject
+    data:
+      lastExecutedState": FinalizeSuccessful"
+    end: true
+  - name: FinalizeWithError
+    type: inject
+    data:
+      lastExecutedState: FinalizeWithError
+    end: true

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/pom.xml
@@ -14,6 +14,9 @@
 
   <properties>
     <quarkus.test.list.include>true</quarkus.test.list.include>
+    <!-- base path for serverless workflow files that are being used for testing the parsing specific unit tests, and
+    that we also want to use for testing them executing. -->
+    <shared.test.resources.dir>${project.root.dir}/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources</shared.test.resources.dir>
   </properties>
 
   <dependencies>
@@ -34,7 +37,7 @@
       <artifactId>quarkus-junit5</artifactId>
       <scope>test</scope>
     </dependency>
-     <dependency>
+    <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-quarkus-test-utils</artifactId>
       <scope>test</scope>
@@ -65,6 +68,11 @@
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
       <artifactId>wiremock-jre8</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -119,7 +127,40 @@
             <kogito.version>${project.version}</kogito.version>
           </systemPropertyVariables>
         </configuration>
-        </plugin>
+      </plugin>
+      <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.basedir}/src/main/resources/shared</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${shared.test.resources.dir}/exec</directory>
+                  <includes>
+                    <include>callback-state.sw.json</include>
+                    <include>callback-state-timeouts.sw.json</include>
+                  </includes>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+      <artifactId>maven-clean-plugin</artifactId>
+      <configuration>
+        <filesets>
+          <fileset>
+            <directory>${project.basedir}/src/main/resources/shared</directory>
+          </fileset>
+        </filesets>
+      </configuration>
+    </plugin>
     </plugins>
   </build>
 

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/application.properties
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/application.properties
@@ -2,6 +2,9 @@
 org.kogito.openapi.client.multiplication.base_path=http://localhost:9090
 org.kogito.openapi.client.subtraction.base_path=http://localhost:9191
 
+# OpenApi client properties to access the general purpose external-service, which is mocked by the ExternalServiceMock
+org.kogito.openapi.client.externalservice.base_path=http://localhost:9292
+
 mp.messaging.incoming.move.connector=quarkus-http
 mp.messaging.incoming.move.path=/move
 
@@ -12,3 +15,14 @@ mp.messaging.incoming.never.connector=quarkus-http
 mp.messaging.incoming.never.path=/never
 
 my_name=javierito
+
+kafka.bootstrap.servers=localhost:9092
+# kafka configurations for the CallbackStateIT test.
+mp.messaging.incoming.callback_state_event_type.connector=smallrye-kafka
+mp.messaging.incoming.callback_state_event_type.topic=callback_state_event_type
+mp.messaging.incoming.callback_state_event_type.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
+
+# kafka configurations for the CallbackStateTimeoutsIT test.
+mp.messaging.incoming.callback_state_timeouts_event_type.connector=smallrye-kafka
+mp.messaging.incoming.callback_state_timeouts_event_type.topic=callback_state_timeouts_event_type
+mp.messaging.incoming.callback_state_timeouts_event_type.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/specs/external-service.yaml
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/specs/external-service.yaml
@@ -1,0 +1,24 @@
+---
+openapi: 3.0.3
+info:
+  title: external-service API
+  version: 2.0.0-SNAPSHOT
+paths:
+  /external-service/sendRequest:
+    post:
+      operationId: sendRequest
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QueryRequest'
+      responses:
+        "200":
+          description: OK
+components:
+  schemas:
+    QueryRequest:
+      type: object
+      properties:
+        query:
+          type: string

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/AbstractCallbackStateIT.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/AbstractCallbackStateIT.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.quarkus.workflows;
+
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.kie.kogito.test.quarkus.kafka.KafkaTestClient;
+import org.kie.kogito.testcontainers.quarkus.KafkaQuarkusTestResource;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import io.cloudevents.core.builder.CloudEventBuilder;
+import io.cloudevents.jackson.JsonCloudEventData;
+import io.cloudevents.jackson.JsonFormat;
+import io.restassured.path.json.JsonPath;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.kie.kogito.quarkus.workflows.ExternalServiceMock.GENERATE_ERROR_QUERY;
+import static org.kie.kogito.quarkus.workflows.ExternalServiceMock.SUCCESSFUL_QUERY;
+import static org.kie.kogito.quarkus.workflows.WorkflowTestUtils.assertProcessInstanceExists;
+import static org.kie.kogito.quarkus.workflows.WorkflowTestUtils.assertProcessInstanceHasFinished;
+import static org.kie.kogito.quarkus.workflows.WorkflowTestUtils.assertProcessInstanceNotExists;
+import static org.kie.kogito.quarkus.workflows.WorkflowTestUtils.newProcessInstance;
+import static org.kie.kogito.quarkus.workflows.WorkflowTestUtils.newProcessInstanceAndGetId;
+
+abstract class AbstractCallbackStateIT {
+
+    static final String ANSWER = "ANSWER";
+
+    @ConfigProperty(name = KafkaQuarkusTestResource.KOGITO_KAFKA_PROPERTY)
+    String kafkaBootstrapServers;
+
+    ObjectMapper objectMapper;
+
+    KafkaTestClient kafkaClient;
+
+    @BeforeEach
+    void setup() {
+        kafkaClient = new KafkaTestClient(kafkaBootstrapServers);
+        objectMapper = new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .registerModule(JsonFormat.getCloudEventJacksonModule())
+                .disable(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    }
+
+    void executeCallbackStateSuccessfulPath(String callbackProcessPostUrl,
+            String callbackProcessGetByIdUrl,
+            String answer,
+            String callbackEventType,
+            String callbackEventTopic) throws Exception {
+        // start a new process instance by sending the post query and collect the process instance id.
+        String processInput = buildProcessInput(SUCCESSFUL_QUERY);
+        String processInstanceId = newProcessInstanceAndGetId(callbackProcessPostUrl, processInput);
+
+        // double check that the process instance is there.
+        assertProcessInstanceExists(callbackProcessGetByIdUrl, processInstanceId);
+
+        // prepare and send the response to the created process via kafka
+        String response = objectMapper.writeValueAsString(CloudEventBuilder.v1()
+                .withId(UUID.randomUUID().toString())
+                .withSource(URI.create(""))
+                .withType(callbackEventType)
+                .withTime(OffsetDateTime.now())
+                .withExtension(
+                        "kogitoprocrefid", processInstanceId)
+                .withData(JsonCloudEventData.wrap(objectMapper.createObjectNode().put("answer", answer)))
+                .build());
+        kafkaClient.produce(response, callbackEventTopic);
+
+        // give some time for the event to be processed and the process to finish.
+        assertProcessInstanceHasFinished(callbackProcessGetByIdUrl, processInstanceId, 1, 180);
+    }
+
+    void executeCallbackStateWithErrorPath(String callbackProcessPostUrl, String callbackProcessGetByIdUrl) {
+        // start a new process instance and collect the results.
+        String processInput = buildProcessInput(GENERATE_ERROR_QUERY);
+        JsonPath result = newProcessInstance(callbackProcessPostUrl, processInput);
+        String processInstanceId = result.get("id");
+        // ensure the process has failed as expected since GENERATE_ERROR_QUERY was used.
+        String lastExecutedState = result.getString("workflowdata.lastExecutedState");
+        assertThat(lastExecutedState).isEqualTo("FinalizeWithError");
+        // the process instance should not be there since an end state was reached.
+        assertProcessInstanceNotExists(callbackProcessGetByIdUrl, processInstanceId);
+    }
+
+    @AfterEach
+    void cleanUp() {
+        kafkaClient.shutdown();
+    }
+
+    protected static String buildProcessInput(String query) {
+        return "{\"workflowdata\": {\"query\": \"" + query + "\"} }";
+    }
+}

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/CallbackStateIT.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/CallbackStateIT.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.quarkus.workflows;
+
+import org.junit.jupiter.api.Test;
+import org.kie.kogito.testcontainers.quarkus.KafkaQuarkusTestResource;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusTestResource(KafkaQuarkusTestResource.class)
+@QuarkusTestResource(ExternalServiceMock.class)
+@QuarkusIntegrationTest
+class CallbackStateIT extends AbstractCallbackStateIT {
+
+    private static final String CALLBACK_STATE_SERVICE_URL = "/callback_state";
+    private static final String CALLBACK_STATE_SERVICE_GET_BY_ID_URL = CALLBACK_STATE_SERVICE_URL + "/{id}";
+    private static final String CALLBACK_STATE_EVENT_TYPE = "callback_state_event_type";
+    private static final String CALLBACK_STATE_EVENT_TOPIC = "callback_state_event_type";
+
+    @Test
+    @SuppressWarnings("squid:S2699")
+    void callbackStateSuccessful() throws Exception {
+        executeCallbackStateSuccessfulPath(CALLBACK_STATE_SERVICE_URL,
+                CALLBACK_STATE_SERVICE_GET_BY_ID_URL,
+                ANSWER,
+                CALLBACK_STATE_EVENT_TYPE,
+                CALLBACK_STATE_EVENT_TOPIC);
+    }
+
+    @Test
+    @SuppressWarnings("squid:S2699")
+    void callbackStateWithError() {
+        executeCallbackStateWithErrorPath(CALLBACK_STATE_SERVICE_URL, CALLBACK_STATE_SERVICE_GET_BY_ID_URL);
+    }
+}

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/CallbackStateTimeoutsIT.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/CallbackStateTimeoutsIT.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.quarkus.workflows;
+
+import org.junit.jupiter.api.Test;
+import org.kie.kogito.testcontainers.quarkus.KafkaQuarkusTestResource;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+import static org.kie.kogito.quarkus.workflows.ExternalServiceMock.SUCCESSFUL_QUERY;
+import static org.kie.kogito.quarkus.workflows.WorkflowTestUtils.assertProcessInstanceExists;
+import static org.kie.kogito.quarkus.workflows.WorkflowTestUtils.assertProcessInstanceHasFinished;
+import static org.kie.kogito.quarkus.workflows.WorkflowTestUtils.newProcessInstanceAndGetId;
+
+@QuarkusTestResource(KafkaQuarkusTestResource.class)
+@QuarkusTestResource(ExternalServiceMock.class)
+@QuarkusIntegrationTest
+class CallbackStateTimeoutsIT extends AbstractCallbackStateIT {
+
+    private static final String CALLBACK_STATE_TIMEOUTS_SERVICE_URL = "/callback_state_timeouts";
+    private static final String CALLBACK_STATE_TIMEOUTS_GET_BY_ID_URL = CALLBACK_STATE_TIMEOUTS_SERVICE_URL + "/{id}";
+    private static final String CALLBACK_STATE_TIMEOUTS_EVENT_TYPE = "callback_state_timeouts_event_type";
+    private static final String CALLBACK_STATE_TIMEOUTS_TOPIC = "callback_state_timeouts_event_type";
+
+    @Test
+    @SuppressWarnings("squid:S2699")
+    void callbackStateTimeoutsSuccessful() throws Exception {
+        executeCallbackStateSuccessfulPath(CALLBACK_STATE_TIMEOUTS_SERVICE_URL,
+                CALLBACK_STATE_TIMEOUTS_GET_BY_ID_URL,
+                ANSWER,
+                CALLBACK_STATE_TIMEOUTS_EVENT_TYPE,
+                CALLBACK_STATE_TIMEOUTS_TOPIC);
+    }
+
+    @Test
+    void callbackStateTimeoutsExceeded() {
+        // start a new process instance by sending a query and collect the process instance id.
+        String processInput = buildProcessInput(SUCCESSFUL_QUERY);
+        String processInstanceId = newProcessInstanceAndGetId(CALLBACK_STATE_TIMEOUTS_SERVICE_URL, processInput);
+        // assert the process instance is there
+        assertProcessInstanceExists(CALLBACK_STATE_TIMEOUTS_GET_BY_ID_URL, processInstanceId);
+        // do nothing more and wait until eventTimeout is fired and the process instance finalizes.
+        assertProcessInstanceHasFinished(CALLBACK_STATE_TIMEOUTS_GET_BY_ID_URL, processInstanceId, 1, 180);
+    }
+
+    @Test
+    @SuppressWarnings("squid:S2699")
+    void callbackStateWithError() {
+        executeCallbackStateWithErrorPath(CALLBACK_STATE_TIMEOUTS_SERVICE_URL, CALLBACK_STATE_TIMEOUTS_GET_BY_ID_URL);
+    }
+}

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/ExternalServiceMock.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/ExternalServiceMock.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.quarkus.workflows;
+
+import java.util.Collections;
+import java.util.Map;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.http.Fault;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.configureFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+public class ExternalServiceMock implements QuarkusTestResourceLifecycleManager {
+
+    public static final String SUCCESSFUL_QUERY = "SUCCESSFUL_QUERY";
+    public static final String GENERATE_ERROR_QUERY = "GENERATE_ERROR_QUERY";
+
+    private WireMockServer wireMockServer;
+
+    @Override
+    public Map<String, String> start() {
+        wireMockServer = new WireMockServer(9292);
+        wireMockServer.start();
+        configureFor(wireMockServer.port());
+
+        // mock a successful invocation
+        stubFor(post("/external-service/sendRequest")
+                .withHeader(CONTENT_TYPE, equalTo(APPLICATION_JSON))
+                .withRequestBody(equalToJson("{\"query\" : \"" + SUCCESSFUL_QUERY + "\"}"))
+                .willReturn(aResponse()
+                        .withHeader(CONTENT_TYPE, APPLICATION_JSON)
+                        .withBody("{}")));
+
+        // mock a failing invocation
+        stubFor(post("/external-service/sendRequest")
+                .withHeader(CONTENT_TYPE, equalTo(APPLICATION_JSON))
+                .withRequestBody(equalToJson("{\"query\" : \"" + GENERATE_ERROR_QUERY + "\"}"))
+                .willReturn(aResponse()
+                        .withHeader(CONTENT_TYPE, APPLICATION_JSON)
+                        .withFault(Fault.CONNECTION_RESET_BY_PEER)));
+
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public void stop() {
+        if (wireMockServer != null) {
+            wireMockServer.stop();
+        }
+    }
+}

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/WorkflowTestUtils.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/WorkflowTestUtils.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.quarkus.workflows;
+
+import io.restassured.http.ContentType;
+import io.restassured.path.json.JsonPath;
+
+import static io.restassured.RestAssured.given;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
+
+public class WorkflowTestUtils {
+
+    private WorkflowTestUtils() {
+    }
+
+    /**
+     * Start a new process instance by sending a post request to the processUrl and passing the processInput as
+     * the post body. Assertions are made to ensure the process was properly created.
+     *
+     * @param processUrl the url to send the post request.
+     * @param processInput a String containing a json value that will be the process parameter.
+     * @return the id of the created process.
+     */
+    public static String newProcessInstanceAndGetId(String processUrl, String processInput) {
+        return newProcessInstance(processUrl, processInput).get("id");
+    }
+
+    /**
+     * Start a new process instance by sending a post request to the processUrl and passing the processInput as
+     * the post body. Assertions are made to ensure the process was properly created.
+     *
+     * @param processUrl the url to send the post request.
+     * @param processInput a String containing a json value that will be the process parameter.
+     * @return a JsonPath with the result.
+     */
+    public static JsonPath newProcessInstance(String processUrl, String processInput) {
+        JsonPath result = given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .body(processInput)
+                .post(processUrl)
+                .then()
+                .statusCode(201)
+                .extract()
+                .jsonPath();
+        String processInstanceId = result.get("id");
+        assertThat(processInstanceId).isNotBlank();
+        return result;
+    }
+
+    /**
+     * Asserts that a process instance exists by executing the get getProcessByIdQuery.
+     *
+     * @param getProcessByIdQuery a query in the form /my-process/{id}.
+     * @param processInstanceId the id of the process instance to find
+     */
+    public static void assertProcessInstanceExists(String getProcessByIdQuery, String processInstanceId) {
+        given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .when()
+                .get(getProcessByIdQuery, processInstanceId)
+                .then()
+                .statusCode(200);
+    }
+
+    /**
+     * Asserts that a process instance not exists by executing the getProcessByIdQuery.
+     * 
+     * @param getProcessByIdQuery a query in the form /my-process/{id}.
+     * @param processInstanceId the id of the process instance to find
+     */
+    public static void assertProcessInstanceNotExists(String getProcessByIdQuery, String processInstanceId) {
+        given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .when()
+                .get(getProcessByIdQuery, processInstanceId)
+                .then()
+                .statusCode(404);
+    }
+
+    /**
+     * Asserts that a process instance has finished by executing the getProcessById query during the specified interval
+     * of time. If the http status code 404 is not returned during that time the timeout condition is raised and the
+     * assertion fails.
+     *
+     * @param getProcessByIdQuery a query in the form /my-process/{id}.
+     * @param processInstanceId the id of the process to find.
+     * @param atLeastTimeoutInSeconds minimum time to wait.
+     * @param atMostTimeoutInSeconds maximum time to wait. (the timeout condition is raised when surpassed)
+     */
+    public static void assertProcessInstanceHasFinished(String getProcessByIdQuery,
+            String processInstanceId,
+            long atLeastTimeoutInSeconds,
+            long atMostTimeoutInSeconds) {
+        await()
+                .atLeast(atLeastTimeoutInSeconds, SECONDS)
+                .atMost(atMostTimeoutInSeconds, SECONDS)
+                .with().pollInterval(1, SECONDS)
+                .untilAsserted(() -> given()
+                        .contentType(ContentType.JSON)
+                        .accept(ContentType.JSON)
+                        .get(getProcessByIdQuery, processInstanceId)
+                        .then()
+                        .statusCode(404));
+    }
+}


### PR DESCRIPTION
Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [X] You have read the [contributors guide](CONTRIBUTING.md)
- [X] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [X] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [X] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [X] Pull Request contains link to the JIRA issue
- [X] Pull Request contains link to any dependent or related Pull Request
- [X] Pull Request contains description of the issue
- [X] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run all builds</b>  
  Please add comment: <b>Jenkins retest this</b>

* <b>Run (or rerun) specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Run (or rerun) LTS specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Run (or rerun) native specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
