### PR TITLE
KOGITO-6813 - Kogito Spring Boot Archetype doesn't include any exampl…

### DIFF
--- a/springboot/archetype/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/springboot/archetype/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -114,7 +114,7 @@ def addDependenciesToPOM(String starters, String addons) {
  * Remove the resources that requires a specific starter
  */
 def removeUnneededResources(String starters, String appPackage) {
-    if (starters == "" || starters == null) {
+    if (starters == "_UNDEFINED_" || starters == "" || starters == null) {
         // in this case we will have all starters in the project, let's include everything in the final project
         return
     }

--- a/springboot/archetype/src/test/resources/projects/it-basic/verify.groovy
+++ b/springboot/archetype/src/test/resources/projects/it-basic/verify.groovy
@@ -19,12 +19,12 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 
-// Check the generated resources - no resources should be added in the basic-project
+// Check the generated resources - all resources should be added in the basic-project
 Path projectPath = basedir.toPath().resolve("project/basic-project")
-assert !Files.exists(projectPath.resolve("src/main/resources/test-process.bpmn2"))
-assert !Files.exists(projectPath.resolve("src/test/java/it/pkg/GreetingsTest.java"))
-assert !Files.exists(projectPath.resolve("src/main/resources/TrafficViolation.dmn"))
-assert !Files.exists(projectPath.resolve("src/test/java/it/pkg/TrafficViolationTest.java"))
+assert Files.exists(projectPath.resolve("src/main/resources/test-process.bpmn2"))
+assert Files.exists(projectPath.resolve("src/test/java/it/pkg/GreetingsTest.java"))
+assert Files.exists(projectPath.resolve("src/main/resources/TrafficViolation.dmn"))
+assert Files.exists(projectPath.resolve("src/test/java/it/pkg/TrafficViolationTest.java"))
 
 // Check starters in pom.xml - no starters specified, so kogito-spring-boot-starter should be added in the basic-project
 String pomContent = Files.readString(projectPath.resolve("pom.xml"))


### PR DESCRIPTION
…es with grouping starter

[KOGITO-6813](https://issues.redhat.com/browse/KOGITO-6813)

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run all builds</b>  
  Please add comment: <b>Jenkins retest this</b>

* <b>Run (or rerun) specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Run (or rerun) LTS specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Run (or rerun) native specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
