### PR TITLE
[KOGITO-6763] User internal tag for temporary variables

### DIFF
--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/factory/ForEachNodeFactory.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/factory/ForEachNodeFactory.java
@@ -20,6 +20,7 @@ import org.jbpm.process.instance.impl.Action;
 import org.jbpm.ruleflow.core.RuleFlowNodeContainerFactory;
 import org.jbpm.workflow.core.NodeContainer;
 import org.jbpm.workflow.core.impl.DataDefinition;
+import org.jbpm.workflow.core.node.CompositeContextNode;
 import org.jbpm.workflow.core.node.ForEachNode;
 
 public class ForEachNodeFactory<T extends RuleFlowNodeContainerFactory<T, ?>> extends AbstractCompositeNodeFactory<ForEachNodeFactory<T>, T> {
@@ -45,6 +46,12 @@ public class ForEachNodeFactory<T extends RuleFlowNodeContainerFactory<T, ?>> ex
         return this;
     }
 
+    @Override
+    protected CompositeContextNode getCompositeNode() {
+        return getForEachNode().getCompositeNode();
+    }
+
+    @Override
     public ForEachNodeFactory<T> variable(String variableName, DataType dataType) {
         return variable(variableName, variableName, dataType);
     }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/ForEachStateHandler.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/ForEachStateHandler.java
@@ -36,8 +36,7 @@ public class ForEachStateHandler extends CompositeContextNodeHandler<ForEachStat
 
     protected ForEachStateHandler(ForEachState state, Workflow workflow, ParserContext parserContext) {
         super(state, workflow, parserContext);
-        outputVarName = parserContext.getContext().getApplicationProperty(ServerlessWorkflowUtils.APP_PROPERTIES_BASE + ServerlessWorkflowUtils.APP_PROPERTIES_STATES_BASE + "foreach.outputVarName")
-                .orElse("_swf_eval_temp");
+        outputVarName = ServerlessWorkflowUtils.getForEachVarName(parserContext.getContext());
     }
 
     @Override

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/utils/ServerlessWorkflowUtils.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/utils/ServerlessWorkflowUtils.java
@@ -40,9 +40,9 @@ public class ServerlessWorkflowUtils {
 
     public static final String DEFAULT_WORKFLOW_FORMAT = "json";
     public static final String ALTERNATE_WORKFLOW_FORMAT = "yml";
-    public static final String APP_PROPERTIES_BASE = "kogito.sw.";
+    private static final String APP_PROPERTIES_BASE = "kogito.sw.";
     private static final String APP_PROPERTIES_FUNCTIONS_BASE = "functions.";
-    public static final String APP_PROPERTIES_STATES_BASE = "states.";
+    private static final String APP_PROPERTIES_STATES_BASE = "states.";
     public static final String OPENAPI_OPERATION_SEPARATOR = "#";
 
     private ServerlessWorkflowUtils() {
@@ -64,6 +64,10 @@ public class ServerlessWorkflowUtils {
             logger.warn("Error converting {} to number", value, ex);
             return null;
         }
+    }
+
+    public static String getForEachVarName(KogitoBuildContext context) {
+        return context.getApplicationProperty(APP_PROPERTIES_BASE + APP_PROPERTIES_STATES_BASE + "foreach.outputVarName").orElse("_swf_eval_temp");
     }
 
     public static String resolveFunctionMetadata(FunctionDefinition function, String metadataKey, KogitoBuildContext context, String defaultValue) {


### PR DESCRIPTION
Declaring temporary variables as internal prevents them to be visible outside the process (they are not longer included in the model)