### PR TITLE
KOGITO-6849 Fixed CloudEvent lacking of "Content-Type" header

### DIFF
--- a/api/kogito-events-api/src/main/java/org/kie/kogito/event/AbstractDataEvent.java
+++ b/api/kogito-events-api/src/main/java/org/kie/kogito/event/AbstractDataEvent.java
@@ -152,7 +152,7 @@ public abstract class AbstractDataEvent<T> implements DataEvent<T> {
         if (this.type == null || this.type.isEmpty()) {
             this.type = TYPE_PREFIX;
         }
-        if (this.source == null) {
+        if (this.source == null || this.source.toString().isEmpty()) {
             this.source = URI.create(String.format(SOURCE_FORMAT, kogitoProcessId));
         }
     }

--- a/quarkus/addons/messaging/common/src/main/java/org/kie/kogito/addon/quarkus/messaging/common/message/CloudEventHttpOutgoingDecorator.java
+++ b/quarkus/addons/messaging/common/src/main/java/org/kie/kogito/addon/quarkus/messaging/common/message/CloudEventHttpOutgoingDecorator.java
@@ -15,10 +15,10 @@
  */
 package org.kie.kogito.addon.quarkus.messaging.common.message;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.ws.rs.core.HttpHeaders;
 
 import org.eclipse.microprofile.reactive.messaging.Message;
-import org.eclipse.microprofile.reactive.messaging.Metadata;
 
 import io.quarkus.arc.properties.IfBuildProperty;
 import io.quarkus.reactivemessaging.http.runtime.OutgoingHttpMetadata;
@@ -27,6 +27,7 @@ import io.quarkus.reactivemessaging.http.runtime.OutgoingHttpMetadata;
  * Decorators for Http CloudEvents outgoing messages
  */
 @IfBuildProperty(name = "kogito.messaging.as-cloudevents", stringValue = "true")
+@ApplicationScoped
 public final class CloudEventHttpOutgoingDecorator implements MessageDecorator {
 
     // Note: this constant is also declared in cloudevents-json-jackson.
@@ -36,13 +37,13 @@ public final class CloudEventHttpOutgoingDecorator implements MessageDecorator {
     /**
      * Metadata to include content-type for structured CloudEvents messages
      */
-    static final Metadata HTTP_RESPONSE_METADATA =
-            Metadata.of(new OutgoingHttpMetadata.Builder().addHeader(HttpHeaders.CONTENT_TYPE, CLOUD_EVENTS_CONTENT_TYPE).build());
+    static final OutgoingHttpMetadata HTTP_RESPONSE_METADATA =
+            new OutgoingHttpMetadata.Builder().addHeader(HttpHeaders.CONTENT_TYPE, CLOUD_EVENTS_CONTENT_TYPE).build();
 
     /**
      * Decorates a given payload with custom metadata needed by Http Outgoing processing
      *
-     * @param payload of the given message
+     * @param message of the given message
      * @param <T> Payload type
      */
     @Override

--- a/quarkus/addons/messaging/common/src/test/java/org/kie/kogito/addon/quarkus/messaging/common/message/CloudEventHttpOutgoingDecoratorTest.java
+++ b/quarkus/addons/messaging/common/src/test/java/org/kie/kogito/addon/quarkus/messaging/common/message/CloudEventHttpOutgoingDecoratorTest.java
@@ -20,20 +20,28 @@ import javax.inject.Inject;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.reactivemessaging.http.runtime.OutgoingHttpMetadata;
 import io.quarkus.test.junit.QuarkusTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @QuarkusTest
-class MessageMessageDecoratorFactoryTest {
+class CloudEventHttpOutgoingDecoratorTest {
 
     @Inject
     MessageDecoratorProvider provider;
 
     @Test
-    void verifyCloudEventHttpIsOnClasspath() {
+    void verifyOutgoingHttpMetadataIsSet() {
         Message<String> message = Message.of("pepe");
         message = provider.decorate(message);
-        assertThat(message.getMetadata(CloudEventHttpOutgoingDecorator.class)).isNotNull();
+        assertThat(message.getMetadata(OutgoingHttpMetadata.class)).isNotEmpty();
+
+        /*
+         * It would be nice to check if the Content-Type header has the value "application/cloudevents+json".
+         * But as far as we know, there's no way to test the actual headers, since OutgoingHttpMetadata#getHeaders is not public.
+         * 
+         * https://quarkusio.zulipchat.com/#narrow/stream/294206-smallrye/topic/OutgoingHttpMetadata.20has.20no.20public.20methods/near/274438268
+         */
     }
 }

--- a/quarkus/addons/messaging/common/src/test/resources/application.properties
+++ b/quarkus/addons/messaging/common/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+kogito.messaging.as-cloudevents=true


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/KOGITO-6849
https://github.com/kiegroup/kogito-examples/pull/1165 depends on this PR.

* Fixes the lack of "Content-Type" header and "source" attribute.
* Improves the test for CloudEventHttpOutgoingDecorator.

-------

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run all builds</b>  
  Please add comment: <b>Jenkins retest this</b>

* <b>Run (or rerun) specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Run (or rerun) LTS specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Run (or rerun) native specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
