### PR TITLE
[KOGITO-6853] Data conditions based switch state fails when the defaultCondition points to a state not present in the dataConditions

### DIFF
--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/StateHandler.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/StateHandler.java
@@ -16,7 +16,8 @@
 package org.kie.kogito.serverless.workflow.parser.handlers;
 
 import java.net.URI;
-import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.NoSuchElementException;
@@ -78,7 +79,7 @@ public abstract class StateHandler<S extends State> {
     protected final boolean isStartState;
 
     private JoinFactory<?> join;
-    private List<Long> incomingConnections = new ArrayList<>();
+    private Collection<Long> incomingConnections = new LinkedHashSet<>();
 
     protected StateHandler(S state, Workflow workflow, ParserContext parserContext) {
         this.workflow = workflow;
@@ -467,10 +468,13 @@ public abstract class StateHandler<S extends State> {
     }
 
     protected interface HandleTransitionCallBack {
-        void onStateTarget(StateHandler<?> targetState);
+        default void onStateTarget(StateHandler<?> targetState) {
+        }
 
-        void onIdTarget(long targetId);
+        default void onIdTarget(long targetId) {
+        }
 
-        void onEmptyTarget();
+        default void onEmptyTarget() {
+        }
     }
 }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/java/org/kie/kogito/serverless/workflow/ServerlessWorkflowParsingTest.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/java/org/kie/kogito/serverless/workflow/ServerlessWorkflowParsingTest.java
@@ -559,7 +559,32 @@ public class ServerlessWorkflowParsingTest extends AbstractServerlessWorkflowPar
         assertEquals("org.kie.kogito.serverless", process.getPackageName());
         assertEquals(RuleFlowProcess.PUBLIC_VISIBILITY, process.getVisibility());
 
-        assertEquals(15, process.getNodes().length);
+        assertEquals(16, process.getNodes().length);
+
+        Split split = (Split) process.getNodes()[4];
+        assertEquals("ChooseOnAge", split.getName());
+        assertEquals(2, split.getType());
+        assertEquals(2, split.getConstraints().size());
+
+        boolean haveDefaultConstraint = false;
+        for (Constraint constraint : split.getConstraints().values()) {
+            haveDefaultConstraint = haveDefaultConstraint || constraint.isDefault();
+        }
+
+        assertTrue(haveDefaultConstraint);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = "/exec/switch-state-produce-events-default.sw.json")
+    public void testSwitchProduceEventsDefaultOnTransitionWorkflow(String workflowLocation) throws Exception {
+        RuleFlowProcess process = (RuleFlowProcess) getWorkflowParser(workflowLocation);
+        assertEquals("switchworkflow", process.getId());
+        assertEquals("switch-wf", process.getName());
+        assertEquals("1.0", process.getVersion());
+        assertEquals("org.kie.kogito.serverless", process.getPackageName());
+        assertEquals(RuleFlowProcess.PUBLIC_VISIBILITY, process.getVisibility());
+
+        assertEquals(17, process.getNodes().length);
 
         Split split = (Split) process.getNodes()[4];
         assertEquals("ChooseOnAge", split.getName());

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/switch-state-produce-events-default.sw.json
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/switch-state-produce-events-default.sw.json
@@ -1,0 +1,112 @@
+{
+  "id": "switchworkflow",
+  "name": "switch-wf",
+  "expressionLang": "jsonpath",
+  "version": "1.0",
+  "start": "AddInfo",
+  "events": [
+    {
+      "name": "TestKafkaEvent",
+      "source": "testtopic",
+      "type": "kafka"
+    },
+    {
+      "name": "TestKafkaEvent2",
+      "source": "testtopic",
+      "type": "kafka"
+    },
+    {
+      "name": "TestKafkaEvent3",
+      "source": "testtopic",
+      "type": "kafka"
+    },
+    {
+      "name": "TestKafkaEvent4",
+      "source": "testtopic",
+      "type": "kafka"
+    }
+  ],
+  "states": [
+    {
+      "name": "AddInfo",
+      "type": "inject",
+      "data": {
+        "name": "john",
+        "age": "20"
+      },
+      "transition": "ChooseOnAge"
+    },
+    {
+      "name": "ChooseOnAge",
+      "type": "switch",
+      "dataConditions": [
+        {
+          "condition": "{{ $.[?(@.age  >= 18)] }}",
+          "transition": {
+            "nextState": "Approve",
+            "produceEvents": [
+              {
+                "eventRef": "TestKafkaEvent"
+              },
+              {
+                "eventRef": "TestKafkaEvent2"
+              },
+              {
+                "eventRef": "TestKafkaEvent3"
+              },
+              {
+                "eventRef": "TestKafkaEvent4"
+              }
+            ]
+          }
+        },
+        {
+          "condition": "{{ $.[?(@.age  < 18)] }}",
+          "transition": {
+            "nextState": "Deny",
+            "produceEvents": [
+              {
+                "eventRef": "TestKafkaEvent"
+              },
+              {
+                "eventRef": "TestKafkaEvent2"
+              },
+              {
+                "eventRef": "TestKafkaEvent3"
+              },
+              {
+                "eventRef": "TestKafkaEvent4"
+              }
+            ]
+          }
+        }
+      ],
+      "defaultCondition": {
+        "transition": {
+            "nextState": "Approve",
+            "produceEvents": [
+              {
+                "eventRef": "TestKafkaEvent"
+              }
+            ]
+          }
+      }
+    },
+    {
+      "name": "Approve",
+      "type": "inject",
+      "data": {
+        "decision": "Approve"
+      },
+      "end": true
+    },
+    {
+      "name": "Deny",
+      "type": "inject",
+      "data": {
+        "decision": "Denied"
+      },
+      "end": true
+    }
+  ]
+}

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/greetUnknown.sw.json
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/greetUnknown.sw.json
@@ -1,5 +1,5 @@
 {
-  "id": "greet",
+  "id": "greetUnknown",
   "version": "1.0",
   "name": "Greeting workflow",
   "expressionLang": "jsonpath",
@@ -32,7 +32,7 @@
         }
       ],
       "defaultCondition": {
-        "transition": "GreetInEnglish"
+        "transition": "NoGreet"
       }
     },
     {
@@ -48,6 +48,14 @@
       "type": "inject",
       "data": {
         "greeting": "Saludos desde JSON Workflow,"
+      },
+      "transition": "GreetPerson"
+    },
+    {
+      "name": "NoGreet",
+      "type": "inject",
+      "data": {
+        "greeting": "I'm not familiar with your language,"
       },
       "transition": "GreetPerson"
     },

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/GreetRestIT.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/GreetRestIT.java
@@ -21,38 +21,47 @@ import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.restassured.http.ContentType;
 
 import static io.restassured.RestAssured.given;
-import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
 
 @QuarkusIntegrationTest
 class GreetRestIT {
 
     @Test
     void testGreetRest() {
+        assertIt("greet", "Hello from JSON Workflow,");
+    }
+
+    @Test
+    void testGreetUnknownRest() {
+        assertIt("greetUnknown", "I'm not familiar with your language,");
+    }
+
+    private void assertIt(String flowName, String unknownMessage) {
         given()
                 .contentType(ContentType.JSON)
                 .accept(ContentType.JSON)
                 .body("{\"workflowdata\" : {\"name\" : \"John\", \"language\":\"English\"}}").when()
-                .post("/greet")
+                .post("/" + flowName)
                 .then()
                 .statusCode(201)
-                .body("workflowdata.greeting", containsString("Hello"));
-
-        given()
-                .contentType(ContentType.JSON)
-                .accept(ContentType.JSON)
-                .body("{\"workflowdata\" : {\"name\" : \"John\", \"language\":\"Unknown\"}}").when()
-                .post("/greet")
-                .then()
-                .statusCode(201)
-                .body("workflowdata.greeting", containsString("Hello"));
+                .body("workflowdata.greeting", is("Hello from JSON Workflow,"));
 
         given()
                 .contentType(ContentType.JSON)
                 .accept(ContentType.JSON)
                 .body("{\"workflowdata\" : {\"name\" : \"Javierito\", \"language\":\"Spanish\"}}").when()
-                .post("/greet")
+                .post("/" + flowName)
                 .then()
                 .statusCode(201)
-                .body("workflowdata.greeting", containsString("Saludos"));
+                .body("workflowdata.greeting", is("Saludos desde JSON Workflow,"));
+
+        given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .body("{\"workflowdata\" : {\"name\" : \"John\", \"language\":\"Unknown\"}}").when()
+                .post("/" + flowName)
+                .then()
+                .statusCode(201)
+                .body("workflowdata.greeting", is(unknownMessage));
     }
 }


### PR DESCRIPTION
Default condition transitions should be handled as any other transition. 
The callback should add the default metadata base on the right input node. 
Added integration test with default condition not present in existing conditions based on previous existing one. 