### PR TITLE
Ignore SW files copied from another module

### DIFF
--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/.gitignore
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/.gitignore
@@ -1,0 +1,1 @@
+src/main/resources/shared/*

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/pom.xml
@@ -137,6 +137,7 @@
               <goal>copy-resources</goal>
             </goals>
             <configuration>
+              <skip>${skipTests}</skip>
               <outputDirectory>${project.basedir}/src/main/resources/shared</outputDirectory>
               <resources>
                 <resource>


### PR DESCRIPTION
Ignoring shared folder as files were considered as not added do GIT and skip copying files when tests disabled.