### PR TITLE
Ecosystem CI + Jenkins: maven plugin version should be updated

### DIFF
--- a/.ci/jenkins/Jenkinsfile.quarkus
+++ b/.ci/jenkins/Jenkinsfile.quarkus
@@ -251,6 +251,7 @@ MavenCommand getMavenCommand(String directory, boolean addQuarkusVersion=true) {
                 .inDirectory(directory)
     if (addQuarkusVersion) {
         mvnCmd.withProperty('version.io.quarkus', '999-SNAPSHOT')
+        mvnCmd.withProperty('version.io.quarkus.quarkus-test-maven', '999-SNAPSHOT')
     }
     return mvnCmd
 }

--- a/.github/quarkus-ecosystem-test
+++ b/.github/quarkus-ecosystem-test
@@ -3,14 +3,14 @@ set -e
 
 # update Quarkus dependencies
 mvn versions:compare-dependencies \
-    -pl :kogito-build-parent \
+    -pl :kogito-dependencies-bom \
     -DremotePom=io.quarkus:quarkus-bom:${QUARKUS_VERSION} \
     -DupdatePropertyVersions=true \
     -DupdateDependencies=true \
     -DgenerateBackupPoms=false
 
 # update Quarkus version
-mvn versions:set-property -pl :kogito-build-parent -Dproperty=version.io.quarkus -DnewVersion=${QUARKUS_VERSION} -DgenerateBackupPoms=false
+mvn versions:set-property -pl :kogito-dependencies-bom -Dproperty=version.io.quarkus -DnewVersion=${QUARKUS_VERSION} -DgenerateBackupPoms=false
 
 # run the tests
 mvn --settings .github/quarkus-ecosystem-maven-settings.xml -B --fail-at-end clean install -Dnative -Dquarkus.native.container-build=true -Dquarkus.bootstrap.effective-model-builder=true

--- a/.github/quarkus-ecosystem-test
+++ b/.github/quarkus-ecosystem-test
@@ -12,5 +12,7 @@ mvn versions:compare-dependencies \
 # update Quarkus version
 mvn versions:set-property -pl :kogito-dependencies-bom -Dproperty=version.io.quarkus -DnewVersion=${QUARKUS_VERSION} -DgenerateBackupPoms=false
 
+mvn versions:set-property -pl :kogito-dependencies-bom -Dproperty=version.io.quarkus-test-maven -DnewVersion=${QUARKUS_VERSION} -DgenerateBackupPoms=false
+
 # run the tests
 mvn --settings .github/quarkus-ecosystem-maven-settings.xml -B --fail-at-end clean install -Dnative -Dquarkus.native.container-build=true -Dquarkus.bootstrap.effective-model-builder=true


### PR DESCRIPTION
- Ecosystem CI script is updating the wrong BOM
- Ecosystem CI script is missing a version property
- Add version property to Jenkins CI too
