### PR TITLE
KOGITO-6890 Code Start test is picking up AssertJ version from the environment

### DIFF
--- a/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test/src/test/filtered-resources/project.properties
+++ b/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test/src/test/filtered-resources/project.properties
@@ -1,2 +1,3 @@
 version=${project.version}
 artifactId=${project.artifactId}
+version.assertj=3.22.0

--- a/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test/src/test/java/org/kie/kogito/quarkus/dmn/KogitoDMNCodeCodestartIT.java
+++ b/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test/src/test/java/org/kie/kogito/quarkus/dmn/KogitoDMNCodeCodestartIT.java
@@ -29,21 +29,30 @@ import static io.quarkus.devtools.codestarts.quarkus.QuarkusCodestartCatalog.Lan
 
 public class KogitoDMNCodeCodestartIT {
 
-    public static String projectVersion() {
+    static final Properties properties = new Properties();
+    static {
         try {
-            final Properties properties = new Properties();
             properties.load(KogitoDMNCodeCodestartIT.class.getClassLoader().getResourceAsStream("project.properties"));
-            return properties.getProperty("version");
         } catch (Exception e) {
-            return "<project.properties version unknown>";
+            throw new RuntimeException("project.properties version unknown");
         }
     }
+
+    public static String projectVersion() {
+        return properties.getProperty("version");
+    }
+
+    public static String assertjVersion() {
+        return properties.getProperty("version.assertj");
+    }
+
 
     @RegisterExtension
     public static QuarkusCodestartTest codestartTest = QuarkusCodestartTest.builder()
             .standaloneExtensionCatalog()
             .extension(ArtifactCoords.pom("io.quarkus", "quarkus-resteasy-jackson", null)) // account for KOGITO-5817
             .extension(ArtifactCoords.fromString("org.kie.kogito:kogito-quarkus-decisions:" + projectVersion()))
+            .extension(ArtifactCoords.fromString("org.assertj:assertj-core:" + assertjVersion()))
             .putData(QuarkusDataKey.APP_CONFIG, Map.of("quarkus.http.test-port", "0"))
             .languages(JAVA)
             .build();

--- a/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test/src/test/java/org/kie/kogito/quarkus/dmn/KogitoDMNCodeCodestartIT.java
+++ b/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test/src/test/java/org/kie/kogito/quarkus/dmn/KogitoDMNCodeCodestartIT.java
@@ -46,7 +46,6 @@ public class KogitoDMNCodeCodestartIT {
         return properties.getProperty("version.assertj");
     }
 
-
     @RegisterExtension
     public static QuarkusCodestartTest codestartTest = QuarkusCodestartTest.builder()
             .standaloneExtensionCatalog()


### PR DESCRIPTION
use of old assertJ API. I think we are erroneously depending on the AssertJ version that is shipping with Quarkus somehow

```
2022-03-18T06:00:41.7516065Z [ERROR] Tests run: 2, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 29.376 s <<< FAILURE! - in org.kie.kogito.quarkus.dmn.KogitoDMNCodeCodestartIT
2022-03-18T06:00:41.7519047Z [ERROR] org.kie.kogito.quarkus.dmn.KogitoDMNCodeCodestartIT.testContent  Time elapsed: 0.104 s  <<< ERROR!
2022-03-18T06:00:41.7520044Z java.lang.NoSuchMethodError: 'org.assertj.core.api.AbstractAssert org.assertj.core.api.AbstractPathAssert.satisfies(java.util.function.Consumer[])'
2022-03-18T06:00:41.7521037Z 	at org.kie.kogito.quarkus.dmn.KogitoDMNCodeCodestartIT.testContent(KogitoDMNCodeCodestartIT.java:53)
Failing test is in /quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test/
```

The simplest way to fix is to add an override at src/test/java/org/kie/kogito/quarkus/dmn/KogitoDMNCodeCodestartIT.java:

            .extension(ArtifactCoords.fromString("org.assertj:assertj-core:" + assertjVersion())) 
where assertjVersion is 3.22.0

disable this override when the version will be globally updated. We cannot do that right now, because in Quarkus 2.7.3 a bump to assertJ 3.22.0 (current 3.21.0) will cause the quick start framework to error out at the same point. The issue is a subtle API change

```
java.util.function.Consumer vs java.util.function.Consumer[]
```