### PR TITLE
[KOGITO-6895] Add support for query and header params

### DIFF
--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/descriptors/SupplierUtils.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/descriptors/SupplierUtils.java
@@ -15,6 +15,11 @@
  */
 package org.jbpm.compiler.canonical.descriptors;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.NullLiteralExpr;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
@@ -30,6 +35,22 @@ public class SupplierUtils {
             result.addArgument(arg == null ? new NullLiteralExpr() : new StringLiteralExpr().setString(arg));
         }
         return result;
+    }
+
+    public static MethodCallExpr getCollectionCreationExpr(Collection<?> collection) {
+        if (collection.isEmpty()) {
+            return getStaticMethodCall(Collections.class, "emptyList");
+        } else {
+            MethodCallExpr expr = getStaticMethodCall(Arrays.class, "asList");
+            for (Object item : collection) {
+                expr.addArgument(AbstractServiceTaskDescriptor.getLiteralExpr(item));
+            }
+            return expr;
+        }
+    }
+
+    public static MethodCallExpr getStaticMethodCall(Class<?> clazz, String methodName) {
+        return new MethodCallExpr(clazz.getCanonicalName() + "." + methodName);
     }
 
 }

--- a/kogito-serverless-workflow/kogito-jq-expression/src/test/java/org/kie/kogito/expr/jq/JqExpressionHandlerTest.java
+++ b/kogito-serverless-workflow/kogito-jq-expression/src/test/java/org/kie/kogito/expr/jq/JqExpressionHandlerTest.java
@@ -17,6 +17,7 @@ package org.kie.kogito.expr.jq;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.kie.kogito.internal.process.runtime.KogitoProcessContext;
@@ -37,6 +38,7 @@ class JqExpressionHandlerTest {
     @Test
     void testStringExpression() {
         Expression parsedExpression = ExpressionHandlerFactory.get("jq", ".foo");
+        assertTrue(parsedExpression.isValid(Optional.ofNullable(context)));
         JsonNode node = new ObjectMapper().createObjectNode().put("foo", "javierito");
         assertEquals("javierito", parsedExpression.eval(node, String.class, context));
     }
@@ -44,6 +46,7 @@ class JqExpressionHandlerTest {
     @Test
     void testBooleanExpression() {
         Expression parsedExpression = ExpressionHandlerFactory.get("jq", ".foo");
+        assertTrue(parsedExpression.isValid(Optional.ofNullable(context)));
         JsonNode node = new ObjectMapper().createObjectNode().put("foo", true);
         assertTrue(parsedExpression.eval(node, Boolean.class, context));
     }
@@ -51,6 +54,7 @@ class JqExpressionHandlerTest {
     @Test
     void testNumericExpression() {
         Expression parsedExpression = ExpressionHandlerFactory.get("jq", ".number*.number");
+        assertTrue(parsedExpression.isValid(Optional.ofNullable(context)));
         JsonNode node = new ObjectMapper().createObjectNode().put("number", 2);
         assertEquals(4, parsedExpression.eval(node, JsonNode.class, context).asInt());
     }
@@ -58,6 +62,7 @@ class JqExpressionHandlerTest {
     @Test
     void testNumericAssignment() {
         Expression parsedExpression = ExpressionHandlerFactory.get("jq", "{\"result\" : .number*.number}");
+        assertTrue(parsedExpression.isValid(Optional.ofNullable(context)));
         JsonNode node = new ObjectMapper().createObjectNode().put("number", 2);
         assertEquals(4, parsedExpression.eval(node, JsonNode.class, context).get("result").asInt());
     }
@@ -65,6 +70,7 @@ class JqExpressionHandlerTest {
     @Test
     void testJsonNodeExpression() {
         Expression parsedExpression = ExpressionHandlerFactory.get("jq", ".foo");
+        assertTrue(parsedExpression.isValid(Optional.ofNullable(context)));
         ObjectMapper mapper = new ObjectMapper();
         JsonNode node = mapper.createObjectNode().set("foo", mapper.createObjectNode().put("name", "Javierito"));
         assertEquals("Javierito", parsedExpression.eval(node, ObjectNode.class, context).get("name").asText());
@@ -73,6 +79,7 @@ class JqExpressionHandlerTest {
     @Test
     void testMultiExpression() {
         Expression parsedExpression = ExpressionHandlerFactory.get("jq", ".foo,.main,.another");
+        assertTrue(parsedExpression.isValid(Optional.ofNullable(context)));
         JsonNode node = new ObjectMapper().createObjectNode().put("foo", "Javierito").put("main", "Pepito").put("another", "Fulanito");
         assertEquals("Javierito Pepito Fulanito", parsedExpression.eval(node, String.class, context));
     }
@@ -80,6 +87,7 @@ class JqExpressionHandlerTest {
     @Test
     void testCollection() {
         Expression parsedExpression = ExpressionHandlerFactory.get("jq", ".foo");
+        assertTrue(parsedExpression.isValid(Optional.ofNullable(context)));
         ObjectMapper objectMapper = new ObjectMapper();
         JsonNode node = objectMapper.createObjectNode().set("foo", objectMapper.createArrayNode().add("pepe").add(false).add(3).add(objectMapper.createArrayNode().add(1.1).add(1.2).add(1.3)));
         assertEquals(Arrays.asList("pepe", false, 3, Arrays.asList(1.1, 1.2, 1.3)), parsedExpression.eval(node, Collection.class, context));

--- a/kogito-serverless-workflow/kogito-jsonpath-expression/src/test/java/org/kie/kogito/expr/jsonpath/JsonPathExpressionHandlerTest.java
+++ b/kogito-serverless-workflow/kogito-jsonpath-expression/src/test/java/org/kie/kogito/expr/jsonpath/JsonPathExpressionHandlerTest.java
@@ -17,6 +17,7 @@ package org.kie.kogito.expr.jsonpath;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.kie.kogito.internal.process.runtime.KogitoProcessContext;
@@ -37,6 +38,7 @@ class JsonPathExpressionHandlerTest {
     @Test
     void testStringExpression() {
         Expression parsedExpression = ExpressionHandlerFactory.get("jsonpath", "$.foo");
+        assertTrue(parsedExpression.isValid(Optional.ofNullable(context)));
         JsonNode node = new ObjectMapper().createObjectNode().put("foo", "javierito");
         assertEquals("javierito", parsedExpression.eval(node, String.class, context));
     }
@@ -44,6 +46,7 @@ class JsonPathExpressionHandlerTest {
     @Test
     void testBooleanExpression() {
         Expression parsedExpression = ExpressionHandlerFactory.get("jsonpath", "$.foo");
+        assertTrue(parsedExpression.isValid(Optional.ofNullable(context)));
         JsonNode node = new ObjectMapper().createObjectNode().put("foo", true);
         assertTrue(parsedExpression.eval(node, Boolean.class, context));
     }
@@ -51,6 +54,7 @@ class JsonPathExpressionHandlerTest {
     @Test
     void testJsonNodeExpression() {
         Expression parsedExpression = ExpressionHandlerFactory.get("jsonpath", "$.foo");
+        assertTrue(parsedExpression.isValid(Optional.ofNullable(context)));
         ObjectMapper mapper = new ObjectMapper();
         JsonNode compositeNode = mapper.createObjectNode().put("name", "Javierito");
         JsonNode node = mapper.createObjectNode().set("foo", compositeNode);
@@ -60,6 +64,7 @@ class JsonPathExpressionHandlerTest {
     @Test
     void testCollection() {
         Expression parsedExpression = ExpressionHandlerFactory.get("jsonpath", "$.foo");
+        assertTrue(parsedExpression.isValid(Optional.ofNullable(context)));
         ObjectMapper objectMapper = new ObjectMapper();
         JsonNode node = objectMapper.createObjectNode().set("foo", objectMapper.createArrayNode().add("pepe").add(false).add(3).add(objectMapper.createArrayNode().add(1.1).add(1.2).add(1.3)));
         assertEquals(Arrays.asList("pepe", false, 3, Arrays.asList(1.1, 1.2, 1.3)), parsedExpression.eval(node, Collection.class, context));

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/CompositeContextNodeHandler.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/CompositeContextNodeHandler.java
@@ -346,7 +346,7 @@ public abstract class CompositeContextNodeHandler<S extends State> extends State
                                             new MethodCallExpr(ConversionUtils.class.getCanonicalName() + ".concatPaths")
                                                     .addArgument(new NameExpr("calculatedKey")).addArgument(new StringLiteralExpr(openAPIDescriptor.getPath()))))))
                     .workParameter(RestWorkItemHandler.METHOD, openAPIDescriptor.getMethod())
-                    .workParameter(RestWorkItemHandler.PARAM_DECORATOR, new CollectionParamsDecoratorSupplier(openAPIDescriptor.getHeaderParams(), openAPIDescriptor.getQueryParams()));
+                    .workParameter(RestWorkItemHandler.PARAMS_DECORATOR, new CollectionParamsDecoratorSupplier(openAPIDescriptor.getHeaderParams(), openAPIDescriptor.getQueryParams()));
         } catch (IOException e) {
             throw new IllegalArgumentException("Problem retrieving uri " + uri);
         }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/OpenAPIDescriptor.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/OpenAPIDescriptor.java
@@ -80,7 +80,6 @@ class OpenAPIDescriptor {
     private final String path;
     private final Set<String> pathParams = new HashSet<>();
     private final Set<String> queryParams = new HashSet<>();
-    private final Set<String> bodyParams = new HashSet<>();
     private final Set<String> headerParams = new HashSet<>();
 
     private OpenAPIDescriptor(HttpMethod method, String path, Operation operation) {
@@ -102,8 +101,6 @@ class OpenAPIDescriptor {
             case "header":
                 headerParams.add(parameter.getName());
                 break;
-            case "body":
-                bodyParams.add(parameter.getName());
         }
     }
 
@@ -121,10 +118,6 @@ class OpenAPIDescriptor {
 
     public Set<String> getQueryParams() {
         return queryParams;
-    }
-
-    public Set<String> getBodyParams() {
-        return bodyParams;
     }
 
     public Set<String> getHeaderParams() {

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/suppliers/CollectionParamsDecoratorSupplier.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/suppliers/CollectionParamsDecoratorSupplier.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.serverless.workflow.suppliers;
+
+import java.util.Collection;
+import java.util.function.Supplier;
+
+import org.kogito.workitem.rest.decorators.CollectionParamsDecorator;
+
+import com.github.javaparser.ast.expr.Expression;
+
+import static org.jbpm.compiler.canonical.descriptors.SupplierUtils.getCollectionCreationExpr;
+import static org.jbpm.compiler.canonical.descriptors.SupplierUtils.getExpression;
+
+public class CollectionParamsDecoratorSupplier extends CollectionParamsDecorator implements Supplier<Expression> {
+
+    private final Expression expression;
+
+    public CollectionParamsDecoratorSupplier(Collection<String> headerParams, Collection<String> queryParams) {
+        super(headerParams, queryParams);
+        expression = getExpression(CollectionParamsDecorator.class).addArgument(getCollectionCreationExpr(headerParams)).addArgument(getCollectionCreationExpr(queryParams));
+    }
+
+    @Override
+    public Expression get() {
+        return expression;
+    }
+}

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/suppliers/ConfigWorkItemSupplier.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/suppliers/ConfigWorkItemSupplier.java
@@ -42,7 +42,7 @@ public class ConfigWorkItemSupplier<T> extends ConfigWorkItemResolver<T> impleme
         return expression;
     }
 
-    protected static final ObjectCreationExpr createExpression(Class<? extends ConfigWorkItemResolver> objectClass, String key, Class<?> clazz, Object defaultValue) {
+    protected static final <T, V extends ConfigWorkItemResolver<T>> ObjectCreationExpr createExpression(Class<V> objectClass, String key, Class<T> clazz, T defaultValue) {
         return new ObjectCreationExpr().setType(parseClassOrInterfaceType(objectClass.getCanonicalName()).setTypeArguments(StaticJavaParser.parseClassOrInterfaceType(clazz.getCanonicalName())))
                 .addArgument(new StringLiteralExpr(key))
                 .addArgument(new ClassExpr(parseClassOrInterfaceType(clazz.getCanonicalName()))).addArgument(

--- a/kogito-serverless-workflow/kogito-serverless-workflow-runtime/src/test/java/org/kie/kogito/serverless/workflow/JsonNodeJqResolverTest.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-runtime/src/test/java/org/kie/kogito/serverless/workflow/JsonNodeJqResolverTest.java
@@ -26,8 +26,10 @@ import org.kie.kogito.internal.process.runtime.KogitoNodeInstance;
 import org.kie.kogito.internal.process.runtime.KogitoWorkItem;
 import org.kie.kogito.jackson.utils.ObjectMapperFactory;
 import org.kie.kogito.serverless.workflow.workitemparams.JsonNodeResolver;
+import org.kie.kogito.serverless.workflow.workitemparams.ObjectResolver;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -97,4 +99,12 @@ class JsonNodeJqResolverTest {
         assertThat(processedNode.findValue("leftElement").asText(), equalTo(".fahrenheit"));
     }
 
+    @Test
+    void verifyStringNode() throws JsonMappingException, JsonProcessingException {
+        final JsonNode inputModel = mapper.readTree("{ \"fahrenheit\": \"32\", \"subtractValue\": \"3\" }");
+        when(workItem.getParameter("pepe")).thenReturn(inputModel);
+        assertThat(new ObjectResolver("jq", "pepa", "pepe").apply(workItem).toString(), equalTo("pepa"));
+        assertThat(new ObjectResolver("jq", "pepa_1", "pepe").apply(workItem).toString(), equalTo("pepa_1"));
+        assertThat(new ObjectResolver("jq", "pepa.1", "pepe").apply(workItem).toString(), equalTo("pepa.1"));
+    }
 }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-runtime/src/test/java/org/kie/kogito/serverless/workflow/JsonNodeJsonPathResolverTest.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-runtime/src/test/java/org/kie/kogito/serverless/workflow/JsonNodeJsonPathResolverTest.java
@@ -26,8 +26,10 @@ import org.kie.kogito.internal.process.runtime.KogitoNodeInstance;
 import org.kie.kogito.internal.process.runtime.KogitoWorkItem;
 import org.kie.kogito.jackson.utils.ObjectMapperFactory;
 import org.kie.kogito.serverless.workflow.workitemparams.JsonNodeResolver;
+import org.kie.kogito.serverless.workflow.workitemparams.ObjectResolver;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -86,5 +88,13 @@ class JsonNodeJsonPathResolverTest {
         final JsonNode processedNode = (JsonNode) resolver.apply(workItem);
         assertTrue(processedNode.isValueNode());
         assertThat(processedNode.asText(), equalTo("\"$.fahrenheit\""));
+    }
+
+    @Test
+    void verifyStringNode() throws JsonMappingException, JsonProcessingException {
+        final JsonNode inputModel = mapper.readTree("{ \"fahrenheit\": \"32\", \"subtractValue\": \"3\" }");
+        when(workItem.getParameter("pepe")).thenReturn(inputModel);
+        final ObjectResolver resolver = new ObjectResolver("jsonpath", "pepa", "pepe");
+        assertThat(resolver.apply(workItem).toString(), equalTo("pepa"));
     }
 }

--- a/kogito-workitems/kogito-jackson-utils/src/test/java/org/kie/kogito/jackson/utils/JsonNodeVisitorTest.java
+++ b/kogito-workitems/kogito-jackson-utils/src/test/java/org/kie/kogito/jackson/utils/JsonNodeVisitorTest.java
@@ -43,4 +43,9 @@ public class JsonNodeVisitorTest {
                 ObjectMapperFactory.get().createObjectNode().set("embedded", ObjectMapperFactory.get().createArrayNode().add(ObjectMapperFactory.get().createObjectNode().put("name", "javierito"))),
                 JsonNodeVisitor.transformTextNode(source, n -> JsonObjectUtils.fromValue("javierito")));
     }
+
+    @Test
+    void testStringNodeVisitor() {
+        assertEquals("pepa", JsonNodeVisitor.transformTextNode(JsonObjectUtils.fromValue("pepa"), p -> p).asText());
+    }
 }

--- a/kogito-workitems/kogito-rest-workitem/src/main/java/org/kogito/workitem/rest/RestWorkItemHandler.java
+++ b/kogito-workitems/kogito-rest-workitem/src/main/java/org/kogito/workitem/rest/RestWorkItemHandler.java
@@ -70,18 +70,18 @@ public class RestWorkItemHandler implements KogitoWorkItemHandler {
     public static final String PORT = "Port";
     public static final String RESULT_HANDLER = "ResultHandler";
     public static final String BODY_BUILDER = "BodyBuilder";
-    public static final String PARAM_DECORATOR = "ParamDecorator";
+    public static final String PARAMS_DECORATOR = "ParamsDecorator";
     public static final String PATH_PARAM_RESOLVER = "PathParamResolver";
 
     private static final Logger logger = LoggerFactory.getLogger(RestWorkItemHandler.class);
     private static final RestWorkItemHandlerResult DEFAULT_RESULT_HANDLER = new DefaultRestWorkItemHandlerResult();
     private static final RestWorkItemHandlerBodyBuilder DEFAULT_BODY_BUILDER = new DefaultWorkItemHandlerBodyBuilder();
-    private static final ParamsDecorator DEFAULT_PARAM_DECORATOR = new PrefixParamsDecorator();
+    private static final ParamsDecorator DEFAULT_PARAMS_DECORATOR = new PrefixParamsDecorator();
     private static final PathParamResolver DEFAULT_PATH_PARAM_RESOLVER = new DefaultPathParamResolver();
-    private static final Map<String, RestWorkItemHandlerResult> RESULT_HANDLERS = new ConcurrentHashMap<>();
-    private static final Map<String, RestWorkItemHandlerBodyBuilder> BODY_BUILDERS = new ConcurrentHashMap<>();
-    private static final Map<String, ParamsDecorator> PARAM_DECORATORS = new ConcurrentHashMap<>();
-    private static final Map<String, PathParamResolver> PATH_PARAM_RESOLVERS = new ConcurrentHashMap<>();
+    private static final Map<String, RestWorkItemHandlerResult> resultHandlers = new ConcurrentHashMap<>();
+    private static final Map<String, RestWorkItemHandlerBodyBuilder> bodyBuilders = new ConcurrentHashMap<>();
+    private static final Map<String, ParamsDecorator> paramsDecorators = new ConcurrentHashMap<>();
+    private static final Map<String, PathParamResolver> pathParamsResolvers = new ConcurrentHashMap<>();
 
     private WebClient client;
     private Collection<RequestDecorator> requestDecorators;
@@ -106,10 +106,10 @@ public class RestWorkItemHandler implements KogitoWorkItemHandler {
         HttpMethod method = getParam(parameters, METHOD, HttpMethod.class, HttpMethod.GET);
         String hostProp = getParam(parameters, HOST, String.class, "localhost");
         int portProp = getParam(parameters, PORT, Integer.class, 8080);
-        RestWorkItemHandlerResult resultHandler = getClassParam(parameters, RESULT_HANDLER, RestWorkItemHandlerResult.class, DEFAULT_RESULT_HANDLER, RESULT_HANDLERS);
-        RestWorkItemHandlerBodyBuilder bodyBuilder = getClassParam(parameters, BODY_BUILDER, RestWorkItemHandlerBodyBuilder.class, DEFAULT_BODY_BUILDER, BODY_BUILDERS);
-        ParamsDecorator paramsDecorator = getClassParam(parameters, PARAM_DECORATOR, ParamsDecorator.class, DEFAULT_PARAM_DECORATOR, PARAM_DECORATORS);
-        PathParamResolver pathParamResolver = getClassParam(parameters, PATH_PARAM_RESOLVER, PathParamResolver.class, DEFAULT_PATH_PARAM_RESOLVER, PATH_PARAM_RESOLVERS);
+        RestWorkItemHandlerResult resultHandler = getClassParam(parameters, RESULT_HANDLER, RestWorkItemHandlerResult.class, DEFAULT_RESULT_HANDLER, resultHandlers);
+        RestWorkItemHandlerBodyBuilder bodyBuilder = getClassParam(parameters, BODY_BUILDER, RestWorkItemHandlerBodyBuilder.class, DEFAULT_BODY_BUILDER, bodyBuilders);
+        ParamsDecorator paramsDecorator = getClassParam(parameters, PARAMS_DECORATOR, ParamsDecorator.class, DEFAULT_PARAMS_DECORATOR, paramsDecorators);
+        PathParamResolver pathParamResolver = getClassParam(parameters, PATH_PARAM_RESOLVER, PathParamResolver.class, DEFAULT_PATH_PARAM_RESOLVER, pathParamsResolvers);
 
         logger.debug("Filtered parameters are {}", parameters);
         // create request

--- a/kogito-workitems/kogito-rest-workitem/src/main/java/org/kogito/workitem/rest/RestWorkItemHandler.java
+++ b/kogito-workitems/kogito-rest-workitem/src/main/java/org/kogito/workitem/rest/RestWorkItemHandler.java
@@ -20,12 +20,9 @@ import java.net.URL;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.ServiceLoader;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -41,7 +38,11 @@ import org.kie.kogito.internal.process.runtime.KogitoWorkItemHandler;
 import org.kie.kogito.internal.process.runtime.KogitoWorkItemManager;
 import org.kogito.workitem.rest.bodybuilders.DefaultWorkItemHandlerBodyBuilder;
 import org.kogito.workitem.rest.bodybuilders.RestWorkItemHandlerBodyBuilder;
+import org.kogito.workitem.rest.decorators.ParamsDecorator;
+import org.kogito.workitem.rest.decorators.PrefixParamsDecorator;
 import org.kogito.workitem.rest.decorators.RequestDecorator;
+import org.kogito.workitem.rest.pathresolvers.DefaultPathParamResolver;
+import org.kogito.workitem.rest.pathresolvers.PathParamResolver;
 import org.kogito.workitem.rest.resulthandlers.DefaultRestWorkItemHandlerResult;
 import org.kogito.workitem.rest.resulthandlers.RestWorkItemHandlerResult;
 import org.slf4j.Logger;
@@ -53,6 +54,7 @@ import io.vertx.mutiny.ext.web.client.HttpRequest;
 import io.vertx.mutiny.ext.web.client.HttpResponse;
 import io.vertx.mutiny.ext.web.client.WebClient;
 
+import static org.kogito.workitem.rest.RestWorkItemHandlerUtils.getClassParam;
 import static org.kogito.workitem.rest.RestWorkItemHandlerUtils.getParam;
 
 public class RestWorkItemHandler implements KogitoWorkItemHandler {
@@ -68,11 +70,18 @@ public class RestWorkItemHandler implements KogitoWorkItemHandler {
     public static final String PORT = "Port";
     public static final String RESULT_HANDLER = "ResultHandler";
     public static final String BODY_BUILDER = "BodyBuilder";
+    public static final String PARAM_DECORATOR = "ParamDecorator";
+    public static final String PATH_PARAM_RESOLVER = "PathParamResolver";
 
     private static final Logger logger = LoggerFactory.getLogger(RestWorkItemHandler.class);
     private static final RestWorkItemHandlerResult DEFAULT_RESULT_HANDLER = new DefaultRestWorkItemHandlerResult();
     private static final RestWorkItemHandlerBodyBuilder DEFAULT_BODY_BUILDER = new DefaultWorkItemHandlerBodyBuilder();
+    private static final ParamsDecorator DEFAULT_PARAM_DECORATOR = new PrefixParamsDecorator();
+    private static final PathParamResolver DEFAULT_PATH_PARAM_RESOLVER = new DefaultPathParamResolver();
+    private static final Map<String, RestWorkItemHandlerResult> RESULT_HANDLERS = new ConcurrentHashMap<>();
     private static final Map<String, RestWorkItemHandlerBodyBuilder> BODY_BUILDERS = new ConcurrentHashMap<>();
+    private static final Map<String, ParamsDecorator> PARAM_DECORATORS = new ConcurrentHashMap<>();
+    private static final Map<String, PathParamResolver> PATH_PARAM_RESOLVERS = new ConcurrentHashMap<>();
 
     private WebClient client;
     private Collection<RequestDecorator> requestDecorators;
@@ -80,7 +89,6 @@ public class RestWorkItemHandler implements KogitoWorkItemHandler {
     public RestWorkItemHandler(WebClient client) {
         this.client = client;
         this.requestDecorators = StreamSupport.stream(ServiceLoader.load(RequestDecorator.class).spliterator(), false).collect(Collectors.toList());
-
     }
 
     @Override
@@ -91,7 +99,6 @@ public class RestWorkItemHandler implements KogitoWorkItemHandler {
         Map<String, Object> parameters = new HashMap<>(workItem.getParameters());
         //removing unnecessary parameter
         parameters.remove("TaskName");
-
         String endPoint = getParam(parameters, URL, String.class, null);
         if (endPoint == null) {
             throw new IllegalArgumentException("Missing required parameter " + URL);
@@ -99,52 +106,23 @@ public class RestWorkItemHandler implements KogitoWorkItemHandler {
         HttpMethod method = getParam(parameters, METHOD, HttpMethod.class, HttpMethod.GET);
         String hostProp = getParam(parameters, HOST, String.class, "localhost");
         int portProp = getParam(parameters, PORT, Integer.class, 8080);
-
-        RestWorkItemHandlerResult resultHandler = getParam(parameters, RESULT_HANDLER, RestWorkItemHandlerResult.class,
-                DEFAULT_RESULT_HANDLER);
-        RestWorkItemHandlerBodyBuilder bodyBuilder = getBodyBuilder(parameters);
+        RestWorkItemHandlerResult resultHandler = getClassParam(parameters, RESULT_HANDLER, RestWorkItemHandlerResult.class, DEFAULT_RESULT_HANDLER, RESULT_HANDLERS);
+        RestWorkItemHandlerBodyBuilder bodyBuilder = getClassParam(parameters, BODY_BUILDER, RestWorkItemHandlerBodyBuilder.class, DEFAULT_BODY_BUILDER, BODY_BUILDERS);
+        ParamsDecorator paramsDecorator = getClassParam(parameters, PARAM_DECORATOR, ParamsDecorator.class, DEFAULT_PARAM_DECORATOR, PARAM_DECORATORS);
+        PathParamResolver pathParamResolver = getClassParam(parameters, PATH_PARAM_RESOLVER, PathParamResolver.class, DEFAULT_PATH_PARAM_RESOLVER, PATH_PARAM_RESOLVERS);
 
         logger.debug("Filtered parameters are {}", parameters);
         // create request
-        endPoint = resolvePathParams(endPoint, parameters);
+        endPoint = pathParamResolver.apply(endPoint, parameters);
         Optional<URL> url = getUrl(endPoint);
         String host = url.map(java.net.URL::getHost).orElse(hostProp);
         int port = url.map(java.net.URL::getPort).orElse(portProp);
         String path = url.map(java.net.URL::getPath).orElse(endPoint).replace(" ", "%20");//fix issue with spaces in the path
-
         HttpRequest<Buffer> request = client.request(method, port, host, path);
         requestDecorators.forEach(d -> d.decorate(workItem, parameters, request));
+        paramsDecorator.decorate(workItem, parameters, request);
         HttpResponse<Buffer> response = method.equals(HttpMethod.POST) || method.equals(HttpMethod.PUT) ? request.sendJsonAndAwait(bodyBuilder.apply(parameters)) : request.sendAndAwait();
         manager.completeWorkItem(workItem.getStringId(), Collections.singletonMap(RESULT, resultHandler.apply(response, targetInfo)));
-    }
-
-    public RestWorkItemHandlerBodyBuilder getBodyBuilder(Map<String, Object> parameters) {
-        Object param = parameters.remove(BODY_BUILDER);
-        //in case the body builder is not set as an input, just use the default
-        if (Objects.isNull(param)) {
-            return DEFAULT_BODY_BUILDER;
-        }
-        //check if an instance of RestWorkItemHandlerBodyBuilder was set and just return it
-        if (param instanceof RestWorkItemHandlerBodyBuilder) {
-            return (RestWorkItemHandlerBodyBuilder) param;
-        }
-        //in case of String, try to load an instance by the FQN of a RestWorkItemHandlerBodyBuilder
-        if (param instanceof String) {
-            return BODY_BUILDERS.computeIfAbsent(param.toString(), this::loadBodyBuilder);
-        }
-        throw new IllegalArgumentException("Invalid body builder instance " + param);
-    }
-
-    private RestWorkItemHandlerBodyBuilder loadBodyBuilder(String className) {
-        try {
-            return getClassLoader().loadClass(className).asSubclass(RestWorkItemHandlerBodyBuilder.class).getConstructor().newInstance();
-        } catch (ReflectiveOperationException | ClassCastException e) {
-            throw new IllegalArgumentException("Invalid RestWorkItemHandlerBodyBuilder Class " + className, e);
-        }
-    }
-
-    private ClassLoader getClassLoader() {
-        return Thread.currentThread().getContextClassLoader();
     }
 
     private Optional<URL> getUrl(String endPoint) {
@@ -184,29 +162,4 @@ public class RestWorkItemHandler implements KogitoWorkItemHandler {
         // rest item handler does not support abort
     }
 
-    //  package scoped to allow unit test
-    static String resolvePathParams(String endPoint, Map<String, Object> parameters) {
-        Set<String> toRemove = new HashSet<>();
-        int start = endPoint.indexOf('{');
-        if (start == -1) {
-            return endPoint;
-        }
-        StringBuilder sb = new StringBuilder(endPoint);
-        while (start != -1) {
-            int end = sb.indexOf("}", start);
-            if (end == -1) {
-                throw new IllegalArgumentException("malformed endpoint should contain enclosing '}' " + endPoint);
-            }
-            final String key = sb.substring(start + 1, end);
-            final Object value = parameters.get(key);
-            if (value == null) {
-                throw new IllegalArgumentException("missing parameter " + key);
-            }
-            toRemove.add(key);
-            sb.replace(start, end + 1, value.toString());
-            start = sb.indexOf("{", end);
-        }
-        parameters.keySet().removeAll(toRemove);
-        return sb.toString();
-    }
 }

--- a/kogito-workitems/kogito-rest-workitem/src/main/java/org/kogito/workitem/rest/RestWorkItemHandlerUtils.java
+++ b/kogito-workitems/kogito-rest-workitem/src/main/java/org/kogito/workitem/rest/RestWorkItemHandlerUtils.java
@@ -16,6 +16,7 @@
 package org.kogito.workitem.rest;
 
 import java.util.Map;
+import java.util.Objects;
 
 import io.vertx.mutiny.core.Vertx;
 
@@ -38,5 +39,30 @@ public class RestWorkItemHandlerUtils {
     public static <T> T getParam(Map<String, Object> parameters, String paramName, Class<T> type, T defaultValue) {
         Object value = parameters.remove(paramName);
         return value == null ? defaultValue : convert(value, type, v -> v.toString().toUpperCase());
+    }
+
+    public static <T> T getClassParam(Map<String, Object> parameters, String paramName, Class<T> clazz, T defaultValue, Map<String, T> instances) {
+        Object param = parameters.remove(paramName);
+        //in case the body builder is not set as an input, just use the default
+        if (Objects.isNull(param)) {
+            return defaultValue;
+        }
+        //check if an instance of RestWorkItemHandlerBodyBuilder was set and just return it
+        else if (clazz.isAssignableFrom(param.getClass())) {
+            return clazz.cast(param);
+        }
+        //in case of String, try to load an instance by the FQN of a RestWorkItemHandlerBodyBuilder
+        else if (param instanceof String) {
+            return instances.computeIfAbsent(param.toString(), k -> loadClass(k, clazz));
+        }
+        throw new IllegalArgumentException(param + " is not a valid instance of class " + clazz + " Check value of argument " + paramName);
+    }
+
+    private static <T> T loadClass(String className, Class<T> clazz) {
+        try {
+            return Thread.currentThread().getContextClassLoader().loadClass(className).asSubclass(clazz).getConstructor().newInstance();
+        } catch (ReflectiveOperationException | ClassCastException e) {
+            throw new IllegalArgumentException("Problem loading class " + className, e);
+        }
     }
 }

--- a/kogito-workitems/kogito-rest-workitem/src/main/java/org/kogito/workitem/rest/decorators/AbstractParamsDecorator.java
+++ b/kogito-workitems/kogito-rest-workitem/src/main/java/org/kogito/workitem/rest/decorators/AbstractParamsDecorator.java
@@ -32,13 +32,21 @@ public abstract class AbstractParamsDecorator implements ParamsDecorator {
             Entry<String, Object> entry = iter.next();
             String key = entry.getKey();
             if (isHeaderParameter(key)) {
+                request.putHeader(toHeaderKey(key), entry.getValue().toString());
                 iter.remove();
-                request.putHeader(key, entry.getValue().toString());
             } else if (isQueryParameter(key)) {
+                request.addQueryParam(toQueryKey(key), entry.getValue().toString());
                 iter.remove();
-                request.setQueryParam(key, entry.getValue().toString());
             }
         }
+    }
+
+    protected String toHeaderKey(String key) {
+        return key;
+    }
+
+    protected String toQueryKey(String key) {
+        return key;
     }
 
     protected abstract boolean isHeaderParameter(String key);

--- a/kogito-workitems/kogito-rest-workitem/src/main/java/org/kogito/workitem/rest/decorators/CollectionParamsDecorator.java
+++ b/kogito-workitems/kogito-rest-workitem/src/main/java/org/kogito/workitem/rest/decorators/CollectionParamsDecorator.java
@@ -15,17 +15,25 @@
  */
 package org.kogito.workitem.rest.decorators;
 
-import java.util.Map;
+import java.util.Collection;
 
-import org.kie.kogito.internal.process.runtime.KogitoWorkItem;
-import org.kie.kogito.process.meta.ProcessMeta;
+public class CollectionParamsDecorator extends AbstractParamsDecorator {
 
-import io.vertx.mutiny.ext.web.client.HttpRequest;
+    private final Collection<String> headerParams;
+    private final Collection<String> queryParams;
 
-public class HeaderMetadataDecorator implements RequestDecorator {
+    public CollectionParamsDecorator(Collection<String> headerParams, Collection<String> queryParams) {
+        this.headerParams = headerParams;
+        this.queryParams = queryParams;
+    }
 
     @Override
-    public void decorate(KogitoWorkItem item, Map<String, Object> parameters, HttpRequest<?> request) {
-        ProcessMeta.fromKogitoWorkItem(item).asMap().forEach(request::putHeader);
+    protected boolean isHeaderParameter(String key) {
+        return headerParams.contains(key);
+    }
+
+    @Override
+    protected boolean isQueryParameter(String key) {
+        return queryParams.contains(key);
     }
 }

--- a/kogito-workitems/kogito-rest-workitem/src/main/java/org/kogito/workitem/rest/decorators/ParamsDecorator.java
+++ b/kogito-workitems/kogito-rest-workitem/src/main/java/org/kogito/workitem/rest/decorators/ParamsDecorator.java
@@ -15,17 +15,6 @@
  */
 package org.kogito.workitem.rest.decorators;
 
-import java.util.Map;
+public interface ParamsDecorator extends RequestDecorator {
 
-import org.kie.kogito.internal.process.runtime.KogitoWorkItem;
-import org.kie.kogito.process.meta.ProcessMeta;
-
-import io.vertx.mutiny.ext.web.client.HttpRequest;
-
-public class HeaderMetadataDecorator implements RequestDecorator {
-
-    @Override
-    public void decorate(KogitoWorkItem item, Map<String, Object> parameters, HttpRequest<?> request) {
-        ProcessMeta.fromKogitoWorkItem(item).asMap().forEach(request::putHeader);
-    }
 }

--- a/kogito-workitems/kogito-rest-workitem/src/main/java/org/kogito/workitem/rest/decorators/PrefixParamsDecorator.java
+++ b/kogito-workitems/kogito-rest-workitem/src/main/java/org/kogito/workitem/rest/decorators/PrefixParamsDecorator.java
@@ -15,17 +15,15 @@
  */
 package org.kogito.workitem.rest.decorators;
 
-import java.util.Map;
-
-import org.kie.kogito.internal.process.runtime.KogitoWorkItem;
-import org.kie.kogito.process.meta.ProcessMeta;
-
-import io.vertx.mutiny.ext.web.client.HttpRequest;
-
-public class HeaderMetadataDecorator implements RequestDecorator {
+public class PrefixParamsDecorator extends AbstractParamsDecorator {
 
     @Override
-    public void decorate(KogitoWorkItem item, Map<String, Object> parameters, HttpRequest<?> request) {
-        ProcessMeta.fromKogitoWorkItem(item).asMap().forEach(request::putHeader);
+    protected boolean isHeaderParameter(String key) {
+        return key.startsWith("HEADER_");
+    }
+
+    @Override
+    protected boolean isQueryParameter(String key) {
+        return key.startsWith("QUERY_");
     }
 }

--- a/kogito-workitems/kogito-rest-workitem/src/main/java/org/kogito/workitem/rest/decorators/PrefixParamsDecorator.java
+++ b/kogito-workitems/kogito-rest-workitem/src/main/java/org/kogito/workitem/rest/decorators/PrefixParamsDecorator.java
@@ -17,13 +17,26 @@ package org.kogito.workitem.rest.decorators;
 
 public class PrefixParamsDecorator extends AbstractParamsDecorator {
 
+    private static final String HEADER_PREFIX = "HEADER_";
+    private static final String QUERY_PREFIX = "QUERY_";
+
     @Override
     protected boolean isHeaderParameter(String key) {
-        return key.startsWith("HEADER_");
+        return key.startsWith(HEADER_PREFIX);
     }
 
     @Override
     protected boolean isQueryParameter(String key) {
-        return key.startsWith("QUERY_");
+        return key.startsWith(QUERY_PREFIX);
+    }
+
+    @Override
+    protected String toHeaderKey(String key) {
+        return key.substring(HEADER_PREFIX.length());
+    }
+
+    @Override
+    protected String toQueryKey(String key) {
+        return key.substring(QUERY_PREFIX.length());
     }
 }

--- a/kogito-workitems/kogito-rest-workitem/src/main/java/org/kogito/workitem/rest/pathresolvers/DefaultPathParamResolver.java
+++ b/kogito-workitems/kogito-rest-workitem/src/main/java/org/kogito/workitem/rest/pathresolvers/DefaultPathParamResolver.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kogito.workitem.rest.pathresolvers;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class DefaultPathParamResolver implements PathParamResolver {
+
+    @Override
+    public String apply(String endPoint, Map<String, Object> parameters) {
+        Set<String> toRemove = new HashSet<>();
+        int start = endPoint.indexOf('{');
+        if (start == -1) {
+            return endPoint;
+        }
+        StringBuilder sb = new StringBuilder(endPoint);
+        while (start != -1) {
+            int end = sb.indexOf("}", start);
+            if (end == -1) {
+                throw new IllegalArgumentException("malformed endpoint should contain enclosing '}' " + endPoint);
+            }
+            final String key = sb.substring(start + 1, end);
+            final Object value = parameters.get(key);
+            if (value == null) {
+                throw new IllegalArgumentException("missing parameter " + key);
+            }
+            toRemove.add(key);
+            sb.replace(start, end + 1, value.toString());
+            start = sb.indexOf("{", end);
+        }
+        parameters.keySet().removeAll(toRemove);
+        return sb.toString();
+    }
+}

--- a/kogito-workitems/kogito-rest-workitem/src/main/java/org/kogito/workitem/rest/pathresolvers/PathParamResolver.java
+++ b/kogito-workitems/kogito-rest-workitem/src/main/java/org/kogito/workitem/rest/pathresolvers/PathParamResolver.java
@@ -13,19 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.kogito.workitem.rest.decorators;
+package org.kogito.workitem.rest.pathresolvers;
 
 import java.util.Map;
+import java.util.function.BiFunction;
 
-import org.kie.kogito.internal.process.runtime.KogitoWorkItem;
-import org.kie.kogito.process.meta.ProcessMeta;
-
-import io.vertx.mutiny.ext.web.client.HttpRequest;
-
-public class HeaderMetadataDecorator implements RequestDecorator {
-
-    @Override
-    public void decorate(KogitoWorkItem item, Map<String, Object> parameters, HttpRequest<?> request) {
-        ProcessMeta.fromKogitoWorkItem(item).asMap().forEach(request::putHeader);
-    }
+public interface PathParamResolver extends BiFunction<String, Map<String, Object>, String> {
 }

--- a/kogito-workitems/kogito-rest-workitem/src/test/java/org/kogito/workitem/rest/RestWorkItemHandlerTest.java
+++ b/kogito-workitems/kogito-rest-workitem/src/test/java/org/kogito/workitem/rest/RestWorkItemHandlerTest.java
@@ -16,7 +16,6 @@
 package org.kogito.workitem.rest;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -36,7 +35,6 @@ import org.kie.kogito.internal.process.runtime.KogitoWorkItemManager;
 import org.kie.kogito.jackson.utils.ObjectMapperFactory;
 import org.kie.kogito.process.workitems.impl.KogitoWorkItemImpl;
 import org.kogito.workitem.rest.bodybuilders.DefaultWorkItemHandlerBodyBuilder;
-import org.kogito.workitem.rest.pathresolvers.DefaultPathParamResolver;
 import org.kogito.workitem.rest.resulthandlers.DefaultRestWorkItemHandlerResult;
 import org.kogito.workitem.rest.resulthandlers.RestWorkItemHandlerResult;
 import org.mockito.ArgumentCaptor;
@@ -58,7 +56,6 @@ import io.vertx.mutiny.ext.web.client.WebClient;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.kogito.workitem.rest.RestWorkItemHandler.BODY_BUILDER;
 import static org.mockito.ArgumentMatchers.any;
@@ -152,64 +149,6 @@ public class RestWorkItemHandlerTest {
         when(ioSpecification.getOutputMappingBySources()).thenReturn(outputMapping);
 
         handler = new RestWorkItemHandler(webClient);
-    }
-
-    @Test
-    public void testReplaceTemplateTrivial() {
-        Map<String, Object> parameters = Collections.emptyMap();
-        String endPoint = "http://pepe:password@www.google.com/results/id/?user=pepe#at_point";
-        assertEquals(
-                "http://pepe:password@www.google.com/results/id/?user=pepe#at_point",
-                new DefaultPathParamResolver().apply(endPoint, parameters));
-    }
-
-    @Test
-    public void testReplaceTemplate() {
-        Map<String, Object> parameters = new HashMap<>();
-        // no use singletonMap here since the map must be mutable
-        parameters.put("id", "pepe");
-        String endPoint = "http://pepe:password@www.google.com/results/{id}/?user=pepe#at_point";
-        assertEquals(
-                "http://pepe:password@www.google.com/results/pepe/?user=pepe#at_point",
-                new DefaultPathParamResolver().apply(endPoint, parameters));
-    }
-
-    @Test
-    public void testReplaceTemplateMultiple() {
-        Map<String, Object> parameters = new HashMap<>();
-        parameters.put("id", 26);
-        parameters.put("name", "pepe");
-        String endPoint = "http://pepe:password@www.google.com/results/{id}/names/{name}/?user=pepe#at_point";
-        assertEquals(
-                "http://pepe:password@www.google.com/results/26/names/pepe/?user=pepe#at_point",
-                new DefaultPathParamResolver().apply(endPoint, parameters));
-    }
-
-    @Test
-    public void testReplaceTemplateMissing() {
-        Map<String, Object> parameters = new HashMap<>();
-        parameters.put("id", 26);
-        String endPoint = "http://pepe:password@www.google.com/results/{id}/names/{name}/?user=pepe#at_point";
-        assertTrue(
-                assertThrows(
-                        IllegalArgumentException.class,
-                        () -> new DefaultPathParamResolver().apply(endPoint, parameters))
-                                .getMessage()
-                                .contains("name"));
-    }
-
-    @Test
-    public void testReplaceTemplateBadEndpoint() {
-        Map<String, Object> parameters = new HashMap<>();
-        parameters.put("id", 26);
-        parameters.put("name", "pepe");
-        String endPoint = "http://pepe:password@www.google.com/results/{id}/names/{name/?user=pepe#at_point";
-        assertTrue(
-                assertThrows(
-                        IllegalArgumentException.class,
-                        () -> new DefaultPathParamResolver().apply(endPoint, parameters))
-                                .getMessage()
-                                .contains("}"));
     }
 
     @Test

--- a/kogito-workitems/kogito-rest-workitem/src/test/java/org/kogito/workitem/rest/RestWorkItemHandlerTest.java
+++ b/kogito-workitems/kogito-rest-workitem/src/test/java/org/kogito/workitem/rest/RestWorkItemHandlerTest.java
@@ -36,6 +36,7 @@ import org.kie.kogito.internal.process.runtime.KogitoWorkItemManager;
 import org.kie.kogito.jackson.utils.ObjectMapperFactory;
 import org.kie.kogito.process.workitems.impl.KogitoWorkItemImpl;
 import org.kogito.workitem.rest.bodybuilders.DefaultWorkItemHandlerBodyBuilder;
+import org.kogito.workitem.rest.pathresolvers.DefaultPathParamResolver;
 import org.kogito.workitem.rest.resulthandlers.DefaultRestWorkItemHandlerResult;
 import org.kogito.workitem.rest.resulthandlers.RestWorkItemHandlerResult;
 import org.mockito.ArgumentCaptor;
@@ -159,7 +160,7 @@ public class RestWorkItemHandlerTest {
         String endPoint = "http://pepe:password@www.google.com/results/id/?user=pepe#at_point";
         assertEquals(
                 "http://pepe:password@www.google.com/results/id/?user=pepe#at_point",
-                RestWorkItemHandler.resolvePathParams(endPoint, parameters));
+                new DefaultPathParamResolver().apply(endPoint, parameters));
     }
 
     @Test
@@ -170,7 +171,7 @@ public class RestWorkItemHandlerTest {
         String endPoint = "http://pepe:password@www.google.com/results/{id}/?user=pepe#at_point";
         assertEquals(
                 "http://pepe:password@www.google.com/results/pepe/?user=pepe#at_point",
-                RestWorkItemHandler.resolvePathParams(endPoint, parameters));
+                new DefaultPathParamResolver().apply(endPoint, parameters));
     }
 
     @Test
@@ -181,7 +182,7 @@ public class RestWorkItemHandlerTest {
         String endPoint = "http://pepe:password@www.google.com/results/{id}/names/{name}/?user=pepe#at_point";
         assertEquals(
                 "http://pepe:password@www.google.com/results/26/names/pepe/?user=pepe#at_point",
-                RestWorkItemHandler.resolvePathParams(endPoint, parameters));
+                new DefaultPathParamResolver().apply(endPoint, parameters));
     }
 
     @Test
@@ -192,7 +193,7 @@ public class RestWorkItemHandlerTest {
         assertTrue(
                 assertThrows(
                         IllegalArgumentException.class,
-                        () -> RestWorkItemHandler.resolvePathParams(endPoint, parameters))
+                        () -> new DefaultPathParamResolver().apply(endPoint, parameters))
                                 .getMessage()
                                 .contains("name"));
     }
@@ -206,7 +207,7 @@ public class RestWorkItemHandlerTest {
         assertTrue(
                 assertThrows(
                         IllegalArgumentException.class,
-                        () -> RestWorkItemHandler.resolvePathParams(endPoint, parameters))
+                        () -> new DefaultPathParamResolver().apply(endPoint, parameters))
                                 .getMessage()
                                 .contains("}"));
     }

--- a/kogito-workitems/kogito-rest-workitem/src/test/java/org/kogito/workitem/rest/decorators/ParamsDecoratorTest.java
+++ b/kogito-workitems/kogito-rest-workitem/src/test/java/org/kogito/workitem/rest/decorators/ParamsDecoratorTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kogito.workitem.rest.decorators;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.kie.kogito.internal.process.runtime.KogitoWorkItem;
+
+import io.vertx.mutiny.ext.web.client.HttpRequest;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class ParamsDecoratorTest {
+
+    @Test
+    void testPrefixParamsDecorator() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("HEADER_pepe", "pepa");
+        parameters.put("QUERY_javierito", "real betis balompie");
+        testParamDecorator(new PrefixParamsDecorator(), parameters);
+    }
+
+    @Test
+    void testCollectionParamsDecorator() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("pepe", "pepa");
+        parameters.put("javierito", "real betis balompie");
+        testParamDecorator(new CollectionParamsDecorator(Collections.singleton("pepe"), Collections.singleton("javierito")), parameters);
+    }
+
+    private void testParamDecorator(ParamsDecorator decorator, Map<String, Object> parameters) {
+        HttpRequest<?> request = mock(HttpRequest.class);
+        decorator.decorate(mock(KogitoWorkItem.class), parameters, request);
+        verify(request).addQueryParam("javierito", "real betis balompie");
+        verify(request).putHeader("pepe", "pepa");
+    }
+
+}

--- a/kogito-workitems/kogito-rest-workitem/src/test/java/org/kogito/workitem/rest/pathresolvers/DefaultPathParamResolverTest.java
+++ b/kogito-workitems/kogito-rest-workitem/src/test/java/org/kogito/workitem/rest/pathresolvers/DefaultPathParamResolverTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kogito.workitem.rest.pathresolvers;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DefaultPathParamResolverTest {
+
+    private static DefaultPathParamResolver pathParamResolver;
+
+    @BeforeAll
+    static void setup() {
+        pathParamResolver = new DefaultPathParamResolver();
+    }
+
+    @Test
+    public void testReplaceTemplateTrivial() {
+        Map<String, Object> parameters = Collections.emptyMap();
+        String endPoint = "http://pepe:password@www.google.com/results/id/?user=pepe#at_point";
+        assertEquals(
+                "http://pepe:password@www.google.com/results/id/?user=pepe#at_point",
+                pathParamResolver.apply(endPoint, parameters));
+    }
+
+    @Test
+    public void testReplaceTemplate() {
+        Map<String, Object> parameters = new HashMap<>();
+        // no use singletonMap here since the map must be mutable
+        parameters.put("id", "pepe");
+        String endPoint = "http://pepe:password@www.google.com/results/{id}/?user=pepe#at_point";
+        assertEquals(
+                "http://pepe:password@www.google.com/results/pepe/?user=pepe#at_point",
+                pathParamResolver.apply(endPoint, parameters));
+    }
+
+    @Test
+    public void testReplaceTemplateMultiple() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("id", 26);
+        parameters.put("name", "pepe");
+        String endPoint = "http://pepe:password@www.google.com/results/{id}/names/{name}/?user=pepe#at_point";
+        assertEquals(
+                "http://pepe:password@www.google.com/results/26/names/pepe/?user=pepe#at_point",
+                pathParamResolver.apply(endPoint, parameters));
+    }
+
+    @Test
+    public void testReplaceTemplateMissing() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("id", 26);
+        String endPoint = "http://pepe:password@www.google.com/results/{id}/names/{name}/?user=pepe#at_point";
+        assertTrue(
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> pathParamResolver.apply(endPoint, parameters))
+                                .getMessage()
+                                .contains("name"));
+    }
+
+    @Test
+    public void testReplaceTemplateBadEndpoint() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("id", 26);
+        parameters.put("name", "pepe");
+        String endPoint = "http://pepe:password@www.google.com/results/{id}/names/{name/?user=pepe#at_point";
+        assertTrue(
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> pathParamResolver.apply(endPoint, parameters))
+                                .getMessage()
+                                .contains("}"));
+    }
+
+}

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/fahrenheit-to-celsius.sw.json
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/fahrenheit-to-celsius.sw.json
@@ -34,16 +34,15 @@
           "name": "subtract",
           "functionRef": {
             "refName": "subtraction",
-            "arguments": {
-             "leftElement": "${.fahrenheit}", "rightElement": "${.subtractValue}"
-            }
+            "arguments": "{leftElement: .fahrenheit, rightElement : .subtractValue}"
+            
           }
         },
         {
           "name": "multiply",
           "functionRef": {
             "refName": "multiplication",
-            "arguments": "${{ leftElement: .subtraction.difference, rightElement: .multiplyValue }}"
+            "arguments": { "pepe":"pepa", "leftElement": ".subtraction.difference", "rightElement": ".multiplyValue" }
           }
         }
       ],

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/specs/multiplication.yaml
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/specs/multiplication.yaml
@@ -7,6 +7,12 @@ paths:
   /:
     post:
       operationId: doOperation
+      parameters:
+        - in: header
+          name: pepe
+          schema: 
+            type: string
+          required: true
       requestBody:
         content:
           application/json:

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/OperationsMockService.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/OperationsMockService.java
@@ -17,8 +17,11 @@ package org.kie.kogito.quarkus.workflows;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.function.UnaryOperator;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.MappingBuilder;
+import com.github.tomakehurst.wiremock.matching.EqualToPattern;
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
@@ -35,10 +38,10 @@ public class OperationsMockService implements QuarkusTestResourceLifecycleManage
     public Map<String, String> start() {
         multiplicationService =
                 this.startServer(9090,
-                        "{\"multiplication\": { \"leftElement\": \"68.0\", \"rightElement\": \"0.5556\", \"product\": \"37.808\" }}");
+                        "{\"multiplication\": { \"leftElement\": \"68.0\", \"rightElement\": \"0.5556\", \"product\": \"37.808\" }}", p -> p.withHeader("pepe", new EqualToPattern("pepa")));
         subtractionService =
                 this.startServer(9191,
-                        "{\"subtraction\": { \"leftElement\": \"100\", \"rightElement\": \"32\", \"difference\": \"68.0\" }}");
+                        "{\"subtraction\": { \"leftElement\": \"100\", \"rightElement\": \"32\", \"difference\": \"68.0\" }}", p -> p);
         return Collections.emptyMap();
     }
 
@@ -52,10 +55,10 @@ public class OperationsMockService implements QuarkusTestResourceLifecycleManage
         }
     }
 
-    private WireMockServer startServer(final int port, final String response) {
+    private WireMockServer startServer(final int port, final String response, UnaryOperator<MappingBuilder> function) {
         final WireMockServer server = new WireMockServer(port);
         server.start();
-        server.stubFor(post(urlEqualTo("/"))
+        server.stubFor(function.apply(post(urlEqualTo("/")))
                 .willReturn(aResponse()
                         .withHeader("Content-Type", "application/json")
                         .withBody(response)));


### PR DESCRIPTION
This adds support for query and header parameter. 
And fixed an issue that ocurrs when the argument string contains a constant and JQ was considering it to be a valid expression (false positive). It turns out that we need to evaluate againts an empty context for the jq parser to realize the string literal is not a valid function. 