### PR TITLE
KOGITO-6929 spring-boot to 2.6.6

### DIFF
--- a/kogito-build/kogito-build-no-bom-parent/pom.xml
+++ b/kogito-build/kogito-build-no-bom-parent/pom.xml
@@ -48,7 +48,7 @@
 
     <!-- container images for testing -->
     <container.image.infinispan>infinispan/server:${version.org.infinispan}</container.image.infinispan>
-    <container.image.keycloak>jboss/keycloak:${version.org.keycloak}</container.image.keycloak>
+    <container.image.keycloak>quay.io/keycloak/keycloak:${version.org.keycloak}-legacy</container.image.keycloak>
     <container.image.kafka>vectorized/redpanda:v21.11.8</container.image.kafka>
     <container.image.wurstmeister.kafka>wurstmeister/kafka:${version.wurstmeister.kafka}</container.image.wurstmeister.kafka>
     <container.image.mongodb>mongo:${version.org.mongo-image}</container.image.mongodb>

--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -78,7 +78,7 @@
     <version.wurstmeister.kafka>2.12-2.2.1</version.wurstmeister.kafka>
     <version.org.mongo>4.3.4</version.org.mongo>
     <version.org.mongo-image>4.4.10</version.org.mongo-image> <!-- Version 4.3.0 is not existing ... -->
-    <version.org.mongo.springboot>4.1.0</version.org.mongo.springboot> <!-- https://issues.redhat.com/browse/KOGITO-5031 -->
+    <version.org.mongo.springboot>4.4.2</version.org.mongo.springboot> <!-- https://issues.redhat.com/browse/KOGITO-5031 -->
     <version.org.mozilla.rhino>1.7.13</version.org.mozilla.rhino>
 
     <version.org.assertj>3.21.0</version.org.assertj>

--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -73,7 +73,7 @@
     <!-- consider migrating to 3.x JDK 9: https://jakarta.ee/specifications/restful-ws/ -->
     <version.jakarta.ws.rs>2.1.6</version.jakarta.ws.rs>
     <version.org.jboss.resteasy>4.7.5.Final</version.org.jboss.resteasy>
-    <version.org.keycloak>14.0.0</version.org.keycloak>
+    <version.org.keycloak>17.0.1</version.org.keycloak>
     <!-- It seems that the confluent kafka cannot replace wurstmeister/kafka so easily. See FAI-729 -->
     <version.wurstmeister.kafka>2.12-2.2.1</version.wurstmeister.kafka>
     <version.org.mongo>4.3.4</version.org.mongo>

--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -18,7 +18,7 @@
     <!-- this version property is used in plugins but also in dependencies too -->
     <version.io.quarkus>2.7.3.Final</version.io.quarkus>
     <version.io.quarkus.quarkus-test-maven>2.7.3.Final</version.io.quarkus.quarkus-test-maven>
-    <version.org.springframework.boot>2.4.9</version.org.springframework.boot>
+    <version.org.springframework.boot>2.6.6</version.org.springframework.boot>
 
     <!-- dependencies versions -->
     <version.com.fasterxml.jackson>2.13.1</version.com.fasterxml.jackson>

--- a/kogito-test-utils/src/main/java/org/kie/kogito/testcontainers/KogitoKeycloakContainer.java
+++ b/kogito-test-utils/src/main/java/org/kie/kogito/testcontainers/KogitoKeycloakContainer.java
@@ -15,8 +15,6 @@
  */
 package org.kie.kogito.testcontainers;
 
-import java.time.Duration;
-
 import org.kie.kogito.test.resources.TestResource;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -43,7 +41,7 @@ public class KogitoKeycloakContainer extends KogitoGenericContainer<KogitoKeyclo
         withEnv("KEYCLOAK_PASSWORD", PASSWORD);
         withEnv("KEYCLOAK_IMPORT", REALM_FILE);
         withClasspathResourceMapping("testcontainers/keycloak/kogito-realm.json", REALM_FILE, BindMode.READ_ONLY);
-        waitingFor(Wait.forHttp("/auth").withStartupTimeout(Duration.ofMinutes(5)));
+        waitingFor(Wait.forHttp("/auth"));
     }
 
     @Override

--- a/springboot/bom/pom.xml
+++ b/springboot/bom/pom.xml
@@ -22,10 +22,9 @@
     <version.org.codehaus.groovy>2.4.16</version.org.codehaus.groovy>
     <version.org.spockframework>1.3-groovy-2.4</version.org.spockframework>
     <!-- Spring Boot Cloud aligned with Spring Boot Framework version. See: https://spring.io/projects/spring-cloud -->
-    <version.org.springframework.cloud.kubernetes>1.1.10.RELEASE</version.org.springframework.cloud.kubernetes>
-    <version.org.springframework.cloud.kubernetes.fabric8>2.0.3</version.org.springframework.cloud.kubernetes.fabric8>
-    <!-- Fabric8 aligned with Spring Cloud. See: https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-kubernetes-core/1.1.10.RELEASE -->
-    <version.io.fabric8>4.13.2</version.io.fabric8>
+    <version.org.springframework.cloud.kubernetes.fabric8>2.1.1</version.org.springframework.cloud.kubernetes.fabric8>
+    <!-- Fabric8 aligned with Spring Cloud. See: https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-kubernetes-fabric8-autoconfig/2.1.1 -->
+    <version.io.fabric8>5.9.0</version.io.fabric8>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-6929

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run all builds</b>  
  Please add comment: <b>Jenkins retest this</b>

* <b>Run (or rerun) specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Run (or rerun) LTS specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Run (or rerun) native specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
