### PR TITLE
[KOGITO-6931] Fixing svg resource loading and windows path

### DIFF
--- a/addons/common/process-svg/src/main/java/org/kie/kogito/svg/AbstractProcessSvgService.java
+++ b/addons/common/process-svg/src/main/java/org/kie/kogito/svg/AbstractProcessSvgService.java
@@ -41,7 +41,7 @@ public abstract class AbstractProcessSvgService implements ProcessSvgService {
     public static final String DEFAULT_ACTIVE_BORDER_COLOR = "#FF0000";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractProcessSvgService.class);
-    private static Path svgDir = Paths.get("META-INF", "processSVG");
+    private static String svgDir = "META-INF/processSVG";
     protected DataIndexClient dataIndexClient;
     protected Optional<String> svgResourcesPath;
     protected String completedColor;
@@ -83,8 +83,8 @@ public abstract class AbstractProcessSvgService implements ProcessSvgService {
     }
 
     protected Optional<String> readFileContentFromClassPath(String fileName) {
-        Path svgFile = svgDir.resolve(fileName);
-        try (InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream(svgFile.toString())) {
+        String svgFile = svgDir + '/' + fileName;
+        try (InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream(svgFile)) {
             if (is == null) {
                 return Optional.empty();
             }


### PR DESCRIPTION
There were two issues:
1) In processcodegen, it only worked if using files, changed to work with any resource
2) In addon, for windows, we were using path to access a classpath resource, which generate the wrong separator. 