### PR TITLE
[KOGITO-6773] Add support to dataInputSchema on generated OpenAPI files

### DIFF
--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/Metadata.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/Metadata.java
@@ -69,6 +69,7 @@ public class Metadata {
     public static final String ASYNC_WAITING = "ASYNC_WAITING";
     public static final String DATA_ONLY = "DataOnly";
     public static final String TAGS = "Tags";
+    public static final String DATA_INPUT_SCHEME = "dataInputScheme";
 
     private Metadata() {
     }

--- a/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/java/org/kie/kogito/codegen/process/ProcessGenerationIT.java
+++ b/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/java/org/kie/kogito/codegen/process/ProcessGenerationIT.java
@@ -71,6 +71,7 @@ import org.kie.kogito.codegen.AbstractCodegenIT;
 import org.kie.kogito.codegen.api.io.CollectedResource;
 import org.kie.kogito.process.Processes;
 import org.kie.kogito.process.impl.AbstractProcess;
+import org.kie.kogito.serverless.workflow.SWFConstants;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.jbpm.ruleflow.core.Metadata.ACTION;
@@ -107,7 +108,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 public class ProcessGenerationIT extends AbstractCodegenIT {
 
-    private static final Collection<String> IGNORED_PROCESS_META = Arrays.asList("Definitions", "BPMN.Connections", "BPMN.Associations", "ItemDefinitions");
+    private static final Collection<String> IGNORED_PROCESS_META = Arrays.asList("Definitions", "BPMN.Connections", "BPMN.Associations", "ItemDefinitions", Metadata.DATA_INPUT_SCHEME);
     private static final Path BASE_PATH = Paths.get("src/test/resources");
 
     static Stream<String> processesProvider() throws IOException {

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/InputModelClassGenerator.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/InputModelClassGenerator.java
@@ -16,8 +16,10 @@
 package org.kie.kogito.codegen.process;
 
 import org.drools.core.util.StringUtils;
+import org.eclipse.microprofile.openapi.models.media.Schema;
 import org.jbpm.compiler.canonical.ModelMetaData;
 import org.jbpm.compiler.canonical.ProcessToExecModelGenerator;
+import org.jbpm.ruleflow.core.Metadata;
 import org.kie.api.definition.process.WorkflowProcess;
 import org.kie.kogito.codegen.api.context.KogitoBuildContext;
 
@@ -44,6 +46,7 @@ public class InputModelClassGenerator {
         modelMetaData = ProcessToExecModelGenerator.INSTANCE.generateInputModel(workFlowProcess);
         modelMetaData.setSupportsValidation(context.isValidationSupported());
         modelMetaData.setSupportsOpenApiGeneration(context.isOpenApiSpecSupported());
+        modelMetaData.setModelSchema((Schema) workFlowProcess.getMetaData().get(Metadata.DATA_INPUT_SCHEME));
 
         modelFileName = modelMetaData.getModelClassName().replace('.', '/') + ".java";
         return modelMetaData;

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/ProcessCodegen.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/ProcessCodegen.java
@@ -393,11 +393,14 @@ public class ProcessCodegen extends AbstractGenerator {
                     mmd.generate());
         }
 
-        for (ModelClassGenerator modelClassGenerator : processIdToModelGenerator.values()) {
-            ModelMetaData mmd = modelClassGenerator.generate();
-            storeFile(MODEL_TYPE, modelClassGenerator.generatedFilePath(),
-                    mmd.generate());
-        }
+        /*
+         * duplicated?
+         * for (ModelClassGenerator modelClassGenerator : processIdToModelGenerator.values()) {
+         * ModelMetaData mmd = modelClassGenerator.generate();
+         * storeFile(MODEL_TYPE, modelClassGenerator.generatedFilePath(),
+         * mmd.generate());
+         * }
+         */
 
         for (InputModelClassGenerator modelClassGenerator : processIdToInputModelGenerator.values()) {
             ModelMetaData mmd = modelClassGenerator.generate();

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/SchemaUtils.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/SchemaUtils.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.serverless.workflow.parser;
+
+import java.net.URI;
+import java.util.Collections;
+
+import org.eclipse.microprofile.openapi.OASFactory;
+import org.eclipse.microprofile.openapi.models.media.Schema;
+
+import static org.kie.kogito.serverless.workflow.SWFConstants.DEFAULT_WORKFLOW_VAR;
+
+public final class SchemaUtils {
+
+    private SchemaUtils() {
+    }
+
+    public static Schema getDefaultWorkflowDataInputSchema(final URI reference) {
+        final Schema inputSchema = OASFactory.createObject(Schema.class)
+                .description("Data input schema for the workflow definition")
+                .type(Schema.SchemaType.OBJECT)
+                .properties(Collections.singletonMap(DEFAULT_WORKFLOW_VAR, OASFactory.createObject(Schema.class).type(Schema.SchemaType.OBJECT)))
+                .required(Collections.singletonList(DEFAULT_WORKFLOW_VAR));
+        if (reference != null) {
+            inputSchema.getProperties().get(DEFAULT_WORKFLOW_VAR).ref(reference.toString());
+        }
+        return inputSchema;
+    }
+
+    public static Schema getDefaultWorkflowDataInputSchema() {
+        return getDefaultWorkflowDataInputSchema(null);
+    }
+
+}


### PR DESCRIPTION
See: https://issues.redhat.com/browse/KOGITO-6773

Also, see the README in this PR to have more understanding about this change.

Related PR:

- https://github.com/kiegroup/kogito-examples/pull/1225

Signed-off-by: Ricardo Zanini <zanini@redhat.com>

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run all builds</b>  
  Please add comment: <b>Jenkins retest this</b>

* <b>Run (or rerun) specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Run (or rerun) LTS specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Run (or rerun) native specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
