### PR TITLE
[1.13.x] KOGITO-6936 - Drop Xstream from process modules

### DIFF
--- a/jbpm/jbpm-bpmn2/pom.xml
+++ b/jbpm/jbpm-bpmn2/pom.xml
@@ -91,11 +91,6 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.thoughtworks.xstream</groupId>
-      <artifactId>xstream</artifactId>
-      <scope>test</scope>
-    </dependency>
      <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>

--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/objects/Person.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/objects/Person.java
@@ -19,7 +19,7 @@ import java.io.Serializable;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
-@XmlRootElement
+@XmlRootElement(name = "person")
 public class Person implements Serializable {
 
     private static final long serialVersionUID = 5L;

--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/structureref/StructureRefTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/structureref/StructureRefTest.java
@@ -15,17 +15,20 @@
  */
 package org.jbpm.bpmn2.structureref;
 
+import java.io.StringReader;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+
 import org.jbpm.bpmn2.JbpmBpmn2TestCase;
+import org.jbpm.bpmn2.objects.Person;
 import org.jbpm.bpmn2.objects.TestWorkItemHandler;
 import org.jbpm.process.core.context.variable.VariableScope;
 import org.jbpm.process.core.datatype.impl.coverter.TypeConverterRegistry;
 import org.junit.jupiter.api.Test;
 import org.kie.kogito.internal.process.runtime.KogitoProcessInstance;
-
-import com.thoughtworks.xstream.XStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -107,9 +110,15 @@ public class StructureRefTest extends JbpmBpmn2TestCase {
 
     @Test
     public void testObjectStructureRef() throws Exception {
-
-        String personAsXml = "<org.jbpm.bpmn2.objects.Person><id>1</id><name>john</name></org.jbpm.bpmn2.objects.Person>";
-        TypeConverterRegistry.get().register("org.jbpm.bpmn2.objects.Person", (s) -> new XStream().fromXML(personAsXml));
+        JAXBContext context = JAXBContext.newInstance(Person.class);
+        String personAsXml = "<person><id>1</id><name>john</name></person>";
+        TypeConverterRegistry.get().register("org.jbpm.bpmn2.objects.Person", (s) -> {
+            try {
+                return context.createUnmarshaller().unmarshal(new StringReader(s));
+            } catch (JAXBException e) {
+                throw new RuntimeException(e);
+            }
+        });
         kruntime = createKogitoProcessRuntime("BPMN2-ObjectStructureRef.bpmn2");
 
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();

--- a/jbpm/jbpm-flow-builder/pom.xml
+++ b/jbpm/jbpm-flow-builder/pom.xml
@@ -78,11 +78,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.thoughtworks.xstream</groupId>
-      <artifactId>xstream</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>

--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -39,7 +39,7 @@
     <version.com.sun.xml.bind.core>2.3.0.1</version.com.sun.xml.bind.core>
     <version.com.sun.xml.bind.impl>2.3.5</version.com.sun.xml.bind.impl>
     <version.com.sun.activation>1.2.0</version.com.sun.activation>
-    <version.com.thoughtworks.xstream>1.4.17</version.com.thoughtworks.xstream>
+    <version.com.thoughtworks.xstream>1.4.19</version.com.thoughtworks.xstream>
     <version.javax.annotation>1.3.2</version.javax.annotation>
     <version.javax.annotation-api>1.3.2</version.javax.annotation-api>
     <version.javax.inject>1</version.javax.inject>


### PR DESCRIPTION
Cherry-pick https://github.com/kiegroup/kogito-runtimes/pull/2126
Removing only the process use of Xstream and upgrading to latest available as drools-core make use of it.