### PR TITLE
[KOGITO-6989] Error dumping files to disk should not break build

### DIFF
--- a/grafana-api/README.md
+++ b/grafana-api/README.md
@@ -16,3 +16,5 @@ This repository contains the library to create and customize grafana dashboards.
     ```
 
 - For full customization it is possible to use the class `JGrafana`, that contains all the properties to fully customize a dashboard.
+
+- Kogito might generate json files to populate grafana. If you need these files on production enviromment, please remember to include ```kogito.quarkus.codegen.dumpFiles=true``` either on your application.properties or maven pom file

--- a/integration-tests/integration-tests-quarkus-processes/src/test/java/org/kie/kogito/integrationtests/quarkus/TaskIT.java
+++ b/integration-tests/integration-tests-quarkus-processes/src/test/java/org/kie/kogito/integrationtests/quarkus/TaskIT.java
@@ -116,12 +116,14 @@ class TaskIT {
         long expectedJsonSchemas = 28;
         Path jsonDir = Paths.get("target", "classes").resolve(JsonSchemaUtil.getJsonDir());
         try (Stream<Path> paths = Files.walk(jsonDir)) {
+
             long generatedJsonSchemas = paths
                     .filter(p -> p.toString().endsWith("json"))
                     .count();
             assertThat(generatedJsonSchemas).isEqualTo(expectedJsonSchemas);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
+        } finally {
         }
     }
 

--- a/integration-tests/integration-tests-quarkus-processes/src/test/java/org/kie/kogito/integrationtests/quarkus/TaskIT.java
+++ b/integration-tests/integration-tests-quarkus-processes/src/test/java/org/kie/kogito/integrationtests/quarkus/TaskIT.java
@@ -17,21 +17,15 @@ package org.kie.kogito.integrationtests.quarkus;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import javax.ws.rs.core.UriBuilder;
 
 import org.acme.travels.Traveller;
-import org.jbpm.util.JsonSchemaUtil;
 import org.junit.jupiter.api.Test;
 import org.kie.kogito.process.workitem.AttachmentInfo;
 import org.kie.kogito.task.management.service.TaskInfo;
@@ -108,22 +102,6 @@ class TaskIT {
                     .then()
                     .statusCode(200)
                     .body(matchesJsonSchema(jsonSchema));
-        }
-    }
-
-    @Test
-    void testJsonSchemaFiles() {
-        long expectedJsonSchemas = 28;
-        Path jsonDir = Paths.get("target", "classes").resolve(JsonSchemaUtil.getJsonDir());
-        try (Stream<Path> paths = Files.walk(jsonDir)) {
-
-            long generatedJsonSchemas = paths
-                    .filter(p -> p.toString().endsWith("json"))
-                    .count();
-            assertThat(generatedJsonSchemas).isEqualTo(expectedJsonSchemas);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        } finally {
         }
     }
 

--- a/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoQuarkusResourceUtils.java
+++ b/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoQuarkusResourceUtils.java
@@ -23,6 +23,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -31,6 +32,7 @@ import org.drools.codegen.common.AppPaths;
 import org.drools.codegen.common.GeneratedFile;
 import org.drools.codegen.common.GeneratedFileType;
 import org.drools.util.PortablePath;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.jandex.CompositeIndex;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
@@ -47,9 +49,8 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.runtime.LaunchMode;
 import io.quarkus.vertx.http.deployment.spi.AdditionalStaticResourceBuildItem;
-
-import static java.util.stream.Collectors.toList;
 
 /**
  * Utility class to aggregate and share resource handling in Kogito extensions
@@ -60,6 +61,13 @@ public class KogitoQuarkusResourceUtils {
     static final String HOT_RELOAD_SUPPORT_CLASS = "HotReloadSupportClass";
     static final String HOT_RELOAD_SUPPORT_FQN = HOT_RELOAD_SUPPORT_PACKAGE + "." + HOT_RELOAD_SUPPORT_CLASS;
     static final String HOT_RELOAD_SUPPORT_PATH = HOT_RELOAD_SUPPORT_FQN.replace('.', '/');
+
+    private static boolean shouldDumpFiles = shouldDumpFiles();
+
+    private static boolean shouldDumpFiles() {
+        Optional<Boolean> prop = ConfigProvider.getConfig().getOptionalValue("kogito.quarkus.codegen.dumpFiles", Boolean.class);
+        return prop.orElse(LaunchMode.current().isDevOrTest());
+    }
 
     private KogitoQuarkusResourceUtils() {
         // utility class
@@ -139,9 +147,11 @@ public class KogitoQuarkusResourceUtils {
     }
 
     public static void dumpFilesToDisk(AppPaths appPaths, Collection<GeneratedFile> generatedFiles) {
-        generatedFileWriterBuilder
-                .build(appPaths.getFirstProjectPath())
-                .writeAll(generatedFiles);
+        if (shouldDumpFiles) {
+            generatedFileWriterBuilder
+                    .build(appPaths.getFirstProjectPath())
+                    .writeAll(generatedFiles);
+        }
     }
 
     public static void registerResources(Collection<GeneratedFile> generatedFiles,
@@ -150,7 +160,7 @@ public class KogitoQuarkusResourceUtils {
             BuildProducer<GeneratedResourceBuildItem> genResBI) {
         for (GeneratedFile f : generatedFiles) {
             if (f.category() == GeneratedFileType.Category.INTERNAL_RESOURCE || f.category() == GeneratedFileType.Category.STATIC_HTTP_RESOURCE) {
-                genResBI.produce(new GeneratedResourceBuildItem(f.relativePath(), f.contents(), true));
+                genResBI.produce(new GeneratedResourceBuildItem(f.relativePath(), f.contents(), shouldDumpFiles));
                 resource.produce(new NativeImageResourceBuildItem(f.relativePath()));
             }
             if (f.category() == GeneratedFileType.Category.STATIC_HTTP_RESOURCE) {


### PR DESCRIPTION
Dumping kogito generated files to disk (target/classes) is not really required for quarkus image to work. 
So, in production enviroment dumping kogito generated files to disk has been disabled.
This way we achieve the goal of kogito not requiring (by itself) an underlying file system with write permission (implicitly it will still write through quarkus, but we are delegating that issue to Quarkus and removing from kogito)
We also allow reading a file from file system at build time and adding it to the runtime classpath without writing it back to the file system (the scenario that trigger the issue) 
Dumping can be enable by setting  property `kogito.quarkus.codegen.dumpFiles` to true. 
This should be done only in corner cases (like the grafana unit test in metrics example) where the files needs to be copied from target/classes to the docker image (see example PR)
In development and testing, where it will be useful to check the generated files content, dumping is enabled unless stated otherwise by setting the same property to false. 
Merge with https://github.com/kiegroup/kogito-examples/pull/1230 
