### PR TITLE
[DROOLS-6914] remove possibility of using serialized packages as kie resources

### DIFF
--- a/jbpm/jbpm-flow-builder/pom.xml
+++ b/jbpm/jbpm-flow-builder/pom.xml
@@ -85,6 +85,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-core</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>

--- a/kogito-build/kogito-kie-bom/pom.xml
+++ b/kogito-build/kogito-kie-bom/pom.xml
@@ -86,7 +86,13 @@
             <dependency>
                 <groupId>org.drools</groupId>
                 <artifactId>drools-commands</artifactId>
-                <version>${version.org.kie}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.drools</groupId>
+                <artifactId>drools-core</artifactId>
+                <type>test-jar</type>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.drools</groupId>

--- a/kogito-build/kogito-kie-bom/pom.xml
+++ b/kogito-build/kogito-kie-bom/pom.xml
@@ -87,7 +87,6 @@
                 <groupId>org.drools</groupId>
                 <artifactId>drools-commands</artifactId>
                 <version>${version.org.kie}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.drools</groupId>

--- a/kogito-build/kogito-kie-bom/pom.xml
+++ b/kogito-build/kogito-kie-bom/pom.xml
@@ -86,11 +86,13 @@
             <dependency>
                 <groupId>org.drools</groupId>
                 <artifactId>drools-commands</artifactId>
+                <version>${version.org.kie}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.drools</groupId>
                 <artifactId>drools-core</artifactId>
+                <version>${version.org.kie}</version>
                 <type>test-jar</type>
                 <scope>test</scope>
             </dependency>


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/DROOLS-6914

Related PRs:
https://github.com/kiegroup/drools/pull/4329
https://github.com/kiegroup/kogito-runtimes/pull/2161