### PR TITLE
[1.21.x] Bump Quarkus version to 2.8.2.Final (#2156)

### DIFF
--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -16,13 +16,13 @@
 
   <properties>
     <!-- this version property is used in plugins but also in dependencies too -->
-    <version.io.quarkus>2.8.0.Final</version.io.quarkus>
-    <version.io.quarkus.quarkus-test-maven>2.8.0.Final</version.io.quarkus.quarkus-test-maven>
+    <version.io.quarkus>2.8.2.Final</version.io.quarkus>
+    <version.io.quarkus.quarkus-test-maven>2.8.2.Final</version.io.quarkus.quarkus-test-maven>
     <version.org.springframework.boot>2.6.6</version.org.springframework.boot>
 
     <!-- dependencies versions -->
     <version.com.fasterxml.jackson>2.13.2</version.com.fasterxml.jackson>
-    <version.com.fasterxml.jackson.databind>2.13.2.1</version.com.fasterxml.jackson.databind>
+    <version.com.fasterxml.jackson.databind>2.13.2.2</version.com.fasterxml.jackson.databind>
     <version.com.jayway.jsonpath>2.6.0</version.com.jayway.jsonpath>
     <version.net.thisptr.jackson-jq>1.0.0-preview.20210928</version.net.thisptr.jackson-jq>
     <version.io.quarkiverse.jackson-jq>1.0.1</version.io.quarkiverse.jackson-jq>
@@ -30,7 +30,7 @@
     <version.com.github.haifengl.smile>1.5.2</version.com.github.haifengl.smile>
     <version.com.github.javaparser>3.23.1</version.com.github.javaparser>
     <version.com.github.java-json-tools>2.2.14</version.com.github.java-json-tools>
-    <version.com.fasterxml.jackson.datatype>2.13.1</version.com.fasterxml.jackson.datatype>
+    <version.com.fasterxml.jackson.datatype>2.13.2</version.com.fasterxml.jackson.datatype>
     <version.com.github.erosb>1.14.1</version.com.github.erosb>
     <version.com.github.victools>4.18.0</version.com.github.victools>
     <version.com.github.tomakehurst.wiremock>2.27.2</version.com.github.tomakehurst.wiremock>
@@ -54,12 +54,12 @@
 
     <version.io.cloudevents>2.3.0</version.io.cloudevents>
     <version.io.fabric8.kubernetes-client>5.8.0</version.io.fabric8.kubernetes-client>
-    <version.io.micrometer>1.8.4</version.io.micrometer>
+    <version.io.micrometer>1.8.5</version.io.micrometer>
     <version.io.serverlessworkflow>4.0.2.Final</version.io.serverlessworkflow>
     <version.io.smallrye-open-api-core>2.1.22</version.io.smallrye-open-api-core>
-    <version.io.smallrye.reactive.mutiny-vertx-web-client>2.19.0</version.io.smallrye.reactive.mutiny-vertx-web-client>
+    <version.io.smallrye.reactive.mutiny-vertx-web-client>2.21.0</version.io.smallrye.reactive.mutiny-vertx-web-client>
 
-    <version.io.vertx>4.2.5</version.io.vertx>
+    <version.io.vertx>4.2.7</version.io.vertx>
 
     <version.io.swagger.parser.v3>2.0.24</version.io.swagger.parser.v3>
 


### PR DESCRIPTION
cherry-pick: https://github.com/kiegroup/kogito-runtimes/pull/2156

Related PRs:
- https://github.com/kiegroup/drools/pull/4342
- https://github.com/kiegroup/optaplanner/pull/1958
- https://github.com/kiegroup/optaplanner-quickstarts/pull/327
- https://github.com/kiegroup/kogito-runtimes/pull/2174
- https://github.com/kiegroup/kogito-apps/pull/1315
- https://github.com/kiegroup/kogito-examples/pull/1238