### PR TITLE
[KOGITO-7046] Integrating with Open API Quarkus extension

### DIFF
--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -26,7 +26,7 @@
     <version.com.jayway.jsonpath>2.6.0</version.com.jayway.jsonpath>
     <version.net.thisptr.jackson-jq>1.0.0-preview.20210928</version.net.thisptr.jackson-jq>
     <version.io.quarkiverse.jackson-jq>1.0.1</version.io.quarkiverse.jackson-jq>
-    <version.io.quarkiverse.openapi.generator>0.5.0</version.io.quarkiverse.openapi.generator> 
+    <version.io.quarkiverse.openapi.generator>0.4.1</version.io.quarkiverse.openapi.generator> 
     <version.io.quarkiverse.reactivemessaging.http>1.0.3</version.io.quarkiverse.reactivemessaging.http>
     <version.com.github.haifengl.smile>1.5.2</version.com.github.haifengl.smile>
     <version.com.github.javaparser>3.23.1</version.com.github.javaparser>

--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -26,7 +26,7 @@
     <version.com.jayway.jsonpath>2.6.0</version.com.jayway.jsonpath>
     <version.net.thisptr.jackson-jq>1.0.0-preview.20210928</version.net.thisptr.jackson-jq>
     <version.io.quarkiverse.jackson-jq>1.0.1</version.io.quarkiverse.jackson-jq>
-    <version.io.quarkiverse.openapi.generator>0.4.1</version.io.quarkiverse.openapi.generator> 
+    <version.io.quarkiverse.openapi.generator>0.5.0</version.io.quarkiverse.openapi.generator> 
     <version.io.quarkiverse.reactivemessaging.http>1.0.3</version.io.quarkiverse.reactivemessaging.http>
     <version.com.github.haifengl.smile>1.5.2</version.com.github.haifengl.smile>
     <version.com.github.javaparser>3.23.1</version.com.github.javaparser>
@@ -56,7 +56,7 @@
     <version.io.cloudevents>2.3.0</version.io.cloudevents>
     <version.io.fabric8.kubernetes-client>5.8.0</version.io.fabric8.kubernetes-client>
     <version.io.micrometer>1.8.5</version.io.micrometer>
-    <version.io.serverlessworkflow>4.0.2.Final</version.io.serverlessworkflow>
+    <version.io.serverlessworkflow>4.0.3.Final</version.io.serverlessworkflow>
     <version.io.smallrye-open-api-core>2.1.22</version.io.smallrye-open-api-core>
     <version.io.smallrye.reactive.mutiny-vertx-web-client>2.21.0</version.io.smallrye.reactive.mutiny-vertx-web-client>
 

--- a/kogito-codegen-modules/kogito-codegen-api/src/main/java/org/kie/kogito/codegen/api/context/KogitoBuildContext.java
+++ b/kogito-codegen-modules/kogito-codegen-api/src/main/java/org/kie/kogito/codegen/api/context/KogitoBuildContext.java
@@ -160,6 +160,7 @@ public interface KogitoBuildContext extends DroolsModelBuildContext {
                 .collect(Collectors.toUnmodifiableMap(key -> key,
                         key -> getApplicationProperty(key).get()));
     }
+    
 
     interface Builder {
 

--- a/kogito-codegen-modules/kogito-codegen-api/src/main/java/org/kie/kogito/codegen/api/context/KogitoBuildContext.java
+++ b/kogito-codegen-modules/kogito-codegen-api/src/main/java/org/kie/kogito/codegen/api/context/KogitoBuildContext.java
@@ -16,6 +16,8 @@
 package org.kie.kogito.codegen.api.context;
 
 import java.io.File;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
@@ -160,7 +162,13 @@ public interface KogitoBuildContext extends DroolsModelBuildContext {
                 .collect(Collectors.toUnmodifiableMap(key -> key,
                         key -> getApplicationProperty(key).get()));
     }
-    
+
+    default Collection<String> getGeneratedHandlers() {
+        return Collections.emptySet();
+    }
+
+    default void addGeneratedHandler(String workName) {
+    }
 
     interface Builder {
 

--- a/kogito-codegen-modules/kogito-codegen-api/src/main/java/org/kie/kogito/codegen/api/context/impl/AbstractKogitoBuildContext.java
+++ b/kogito-codegen-modules/kogito-codegen-api/src/main/java/org/kie/kogito/codegen/api/context/impl/AbstractKogitoBuildContext.java
@@ -63,6 +63,7 @@ public abstract class AbstractKogitoBuildContext implements KogitoBuildContext {
     protected final KogitoGAV gav;
     protected final SourceFileCodegenBindNotifier sourceFileCodegenBindNotifier;
     protected Set<ApplicationSection> applicationSections;
+    protected Collection<String> appHandlers;
 
     protected DependencyInjectionAnnotator dependencyInjectionAnnotator;
     protected RestAnnotator restAnnotator;
@@ -84,6 +85,7 @@ public abstract class AbstractKogitoBuildContext implements KogitoBuildContext {
         this.contextName = contextName;
         this.contextAttributes = new HashMap<>();
         this.applicationSections = new HashSet<>();
+        this.appHandlers = new HashSet<>();
         this.sourceFileCodegenBindNotifier = builder.sourceFileCodegenBindNotifier;
     }
 
@@ -184,6 +186,17 @@ public abstract class AbstractKogitoBuildContext implements KogitoBuildContext {
     @Override
     public Map<String, Object> getContextAttributes() {
         return Collections.unmodifiableMap(contextAttributes);
+    }
+
+    @Override
+    public Collection<String> getGeneratedHandlers() {
+        return Collections.unmodifiableCollection(appHandlers);
+
+    }
+
+    @Override
+    public void addGeneratedHandler(String workName) {
+        appHandlers.add(workName);
     }
 
     @Override

--- a/kogito-codegen-modules/kogito-codegen-api/src/main/java/org/kie/kogito/codegen/api/context/impl/AbstractKogitoBuildContext.java
+++ b/kogito-codegen-modules/kogito-codegen-api/src/main/java/org/kie/kogito/codegen/api/context/impl/AbstractKogitoBuildContext.java
@@ -191,7 +191,6 @@ public abstract class AbstractKogitoBuildContext implements KogitoBuildContext {
     @Override
     public Collection<String> getGeneratedHandlers() {
         return Collections.unmodifiableCollection(appHandlers);
-
     }
 
     @Override

--- a/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/resources/serverless/multiple-operations.sw.json
+++ b/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/resources/serverless/multiple-operations.sw.json
@@ -5,21 +5,18 @@
   "functions": [
     {
       "name": "helloOne",
-      "metadata": {
-        "type": "script"
-      }
+      "type": "custom",
+      "operation" : "script"
     },
     {
       "name": "helloTwo",
-      "metadata": {
-        "type": "script"
-      }
+      "type": "custom",
+      "operation" : "script"
     },
     {
       "name": "helloThree",
-      "metadata": {
-        "type": "script"
-      }
+      "type": "custom",
+      "operation" : "script"
     }
   ],
   "states":[

--- a/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/resources/serverless/multiple-operations.sw.yml
+++ b/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/resources/serverless/multiple-operations.sw.yml
@@ -4,14 +4,14 @@ name: test-wf
 start: HelloWorld
 functions:
   - name: helloOne
-    metadata:
-      type: script
+    type: custom
+    operation: script
   - name: helloTwo
-    metadata:
-      type: script
+    type: custom
+    operation: script
   - name: helloThree
-    metadata:
-      type: script
+    type: custom
+    operation: script
 states:
   - name: HelloWorld
     type: operation

--- a/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/resources/serverless/single-operation-many-functions.sw.json
+++ b/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/resources/serverless/single-operation-many-functions.sw.json
@@ -5,15 +5,13 @@
   "functions": [
     {
       "name": "helloWorld",
-      "metadata": {
-        "type": "script"
-      }
+      "type": "custom",
+      "operation" : "script"
     },
     {
       "name": "goodbyeWorld",
-      "metadata": {
-        "type": "script"
-      }
+      "type": "custom",
+      "operation" : "script"
     }
   ],
   "states":[

--- a/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/resources/serverless/single-operation-many-functions.sw.yml
+++ b/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/resources/serverless/single-operation-many-functions.sw.yml
@@ -4,11 +4,11 @@ name: test-wf
 start: HelloWorld
 functions:
   - name: helloWorld
-    metadata:
-      type: script
+    type: custom
+    operation: script
   - name: goodbyeWorld
-    metadata:
-      type: script
+    type: custom
+    operation: script
 states:
   - name: HelloWorld
     type: operation

--- a/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/resources/serverless/single-operation-with-delay.sw.json
+++ b/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/resources/serverless/single-operation-with-delay.sw.json
@@ -6,9 +6,8 @@
   "functions": [
     {
       "name": "helloWorld",
-      "metadata": {
-        "type": "script"
-      }
+      "type": "custom",
+      "operation" : "script"
     }
   ],
   "states":[

--- a/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/resources/serverless/single-operation-with-delay.sw.yml
+++ b/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/resources/serverless/single-operation-with-delay.sw.yml
@@ -5,8 +5,8 @@ version: '1.0'
 start: HelloWorld
 functions:
   - name: helloWorld
-    metadata:
-      type: script
+    type: custom
+    operation: script
 states:
   - name: HelloWorld
     type: operation

--- a/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/resources/serverless/single-operation.sw.json
+++ b/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/resources/serverless/single-operation.sw.json
@@ -6,9 +6,8 @@
   "functions": [
     {
       "name": "helloWorld",
-      "metadata": {
-        "type": "script"
-      }
+      "type": "custom",
+      "operation" : "script"
     }
   ],
   "states":[

--- a/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/resources/serverless/single-operation.sw.yml
+++ b/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/resources/serverless/single-operation.sw.yml
@@ -5,8 +5,8 @@ version: '1.0'
 start: HelloWorld
 functions:
   - name: helloWorld
-    metadata:
-      type: script
+    type: custom
+    operation: script
 states:
   - name: HelloWorld
     type: operation

--- a/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/resources/serverless/single-service-operation.sw.json
+++ b/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/resources/serverless/single-service-operation.sw.json
@@ -6,11 +6,8 @@
   "functions": [
     {
       "name": "helloWorld",
-      "metadata": {
-        "interface": "org.kie.kogito.codegen.data.HelloService",
-        "operation": "jsonHello",
-        "type": "service"
-      }
+      "type": "custom",
+      "operation" : "service:org.kie.kogito.codegen.data.HelloService::jsonHello"
     }
   ],
   "states":[

--- a/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/resources/serverless/single-service-operation.sw.yml
+++ b/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/resources/serverless/single-service-operation.sw.yml
@@ -5,10 +5,8 @@ version: '1.0'
 start: HelloWorld
 functions:
   - name: helloWorld
-    metadata:
-      interface: org.kie.kogito.codegen.data.HelloService
-      operation: jsonHello
-      type: service
+    type: custom
+    operation: service:org.kie.kogito.codegen.data.HelloService::jsonHello
 states:
   - name: HelloWorld
     type: operation

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/ServerlessWorkflowParser.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/ServerlessWorkflowParser.java
@@ -20,26 +20,14 @@ import java.io.Reader;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.eclipse.microprofile.openapi.OASFactory;
 import org.eclipse.microprofile.openapi.models.tags.Tag;
-import org.jbpm.process.core.context.variable.VariableScope;
 import org.jbpm.process.core.datatype.impl.type.ObjectDataType;
 import org.jbpm.ruleflow.core.Metadata;
-import org.jbpm.ruleflow.core.RuleFlowNodeContainerFactory;
 import org.jbpm.ruleflow.core.RuleFlowProcessFactory;
-import org.jbpm.ruleflow.core.factory.JoinFactory;
-import org.jbpm.ruleflow.core.factory.NodeFactory;
-import org.jbpm.ruleflow.core.factory.SplitFactory;
-import org.jbpm.ruleflow.core.factory.SubProcessNodeFactory;
-import org.jbpm.ruleflow.core.factory.TimerNodeFactory;
-import org.jbpm.workflow.core.impl.DataAssociation;
-import org.jbpm.workflow.core.impl.DataDefinition;
-import org.jbpm.workflow.core.node.Join;
-import org.jbpm.workflow.core.node.Split;
 import org.kie.kogito.codegen.api.GeneratedInfo;
 import org.kie.kogito.codegen.api.context.KogitoBuildContext;
 import org.kie.kogito.internal.process.runtime.KogitoWorkflowProcess;
@@ -55,11 +43,8 @@ import org.kie.kogito.serverless.workflow.utils.ServerlessWorkflowUtils;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import io.serverlessworkflow.api.Workflow;
-import io.serverlessworkflow.api.events.EventDefinition;
 import io.serverlessworkflow.api.workflow.Constants;
 
-import static org.jbpm.process.core.timer.Timer.TIME_DURATION;
-import static org.jbpm.ruleflow.core.Metadata.UNIQUE_ID;
 import static org.kie.kogito.serverless.workflow.utils.ServerlessWorkflowUtils.processResourceFile;
 
 public class ServerlessWorkflowParser {
@@ -154,86 +139,6 @@ public class ServerlessWorkflowParser {
             processInfo = parseProcess();
         }
         return processInfo;
-    }
-
-    public static <T extends RuleFlowNodeContainerFactory<T, ?>> SubProcessNodeFactory<T> subprocessNode(SubProcessNodeFactory<T> nodeFactory, String inputVar, String outputVar) {
-        Map<String, String> types = Collections.singletonMap(DEFAULT_WORKFLOW_VAR, JSON_NODE);
-        DataAssociation inputDa = new DataAssociation(
-                new DataDefinition(inputVar, inputVar, JSON_NODE),
-                new DataDefinition(DEFAULT_WORKFLOW_VAR, DEFAULT_WORKFLOW_VAR, JSON_NODE), null, null);
-        DataAssociation outputDa = new DataAssociation(
-                new DataDefinition(DEFAULT_WORKFLOW_VAR, DEFAULT_WORKFLOW_VAR, JSON_NODE),
-                new DataDefinition(outputVar, outputVar, JSON_NODE), null, null);
-
-        VariableScope variableScope = new VariableScope();
-        return nodeFactory
-                .independent(true)
-                .metaData("BPMN.InputTypes", types)
-                .metaData("BPMN.OutputTypes", types)
-                .mapDataInputAssociation(inputDa)
-                .mapDataOutputAssociation(outputDa)
-                .context(variableScope)
-                .defaultContext(variableScope);
-    }
-
-    public static <T extends NodeFactory<T, P>, P extends RuleFlowNodeContainerFactory<P, ?>> T sendEventNode(NodeFactory<T, P> actionNode,
-            EventDefinition eventDefinition, String inputVar) {
-        return actionNode
-                .name(eventDefinition.getName())
-                .metaData(Metadata.EVENT_TYPE, "message")
-                .metaData(Metadata.MAPPING_VARIABLE, inputVar)
-                .metaData(Metadata.TRIGGER_REF, eventDefinition.getType())
-                .metaData(Metadata.MESSAGE_TYPE, JSON_NODE)
-                .metaData(Metadata.TRIGGER_TYPE, "ProduceMessage");
-    }
-
-    public static <T extends NodeFactory<T, P>, P extends RuleFlowNodeContainerFactory<P, ?>> T messageNode(T nodeFactory, EventDefinition eventDefinition, String inputVar) {
-        return nodeFactory
-                .name(eventDefinition.getName())
-                .metaData(Metadata.EVENT_TYPE, "message")
-                .metaData(Metadata.TRIGGER_MAPPING, inputVar)
-                .metaData(Metadata.TRIGGER_REF, eventDefinition.getType())
-                .metaData(Metadata.MESSAGE_TYPE, JSON_NODE)
-                .metaData(Metadata.TRIGGER_TYPE, "ConsumeMessage")
-                .metaData(Metadata.DATA_ONLY, isDataOnly(eventDefinition));
-    }
-
-    // TODO remove when SDK is updated to include dataOnly in EventDefinition, see https://github.com/serverlessworkflow/sdk-java/issues/183
-    private static Boolean isDataOnly(EventDefinition eventDefinition) {
-        Boolean result = Boolean.TRUE;
-        Map<String, String> metadata = eventDefinition.getMetadata();
-        final String dataOnlyKey = "dataOnly";
-        if (metadata != null && metadata.containsKey(dataOnlyKey)) {
-            result = Boolean.parseBoolean(metadata.get(dataOnlyKey));
-        }
-        return result;
-    }
-
-    public static <T extends RuleFlowNodeContainerFactory<T, ?>> SplitFactory<T> eventBasedExclusiveSplitNode(SplitFactory<T> nodeFactory) {
-        return nodeFactory.name("ExclusiveSplit_" + nodeFactory.getNode().getId())
-                .type(Split.TYPE_XAND)
-                .metaData(UNIQUE_ID, Long.toString(nodeFactory.getNode().getId()))
-                .metaData("EventBased", "true");
-    }
-
-    public static <T extends RuleFlowNodeContainerFactory<T, ?>> SplitFactory<T> exclusiveSplitNode(SplitFactory<T> nodeFactory) {
-        return nodeFactory.name("ExclusiveSplit_" + nodeFactory.getNode().getId())
-                .type(Split.TYPE_XOR)
-                .metaData(UNIQUE_ID, Long.toString(nodeFactory.getNode().getId()));
-    }
-
-    public static <T extends RuleFlowNodeContainerFactory<T, ?>> JoinFactory<T> joinExclusiveNode(JoinFactory<T> nodeFactory) {
-        return nodeFactory.name("ExclusiveJoin_" + nodeFactory.getNode().getId())
-                .type(Join.TYPE_XOR)
-                .metaData(UNIQUE_ID, Long.toString(nodeFactory.getNode().getId()));
-    }
-
-    public static <T extends RuleFlowNodeContainerFactory<T, ?>> TimerNodeFactory<T> timerNode(TimerNodeFactory<T> nodeFactory, String duration) {
-        return nodeFactory.name("TimerNode_" + nodeFactory.getNode().getId())
-                .type(TIME_DURATION)
-                .delay(duration)
-                .metaData(UNIQUE_ID, Long.toString(nodeFactory.getNode().getId()))
-                .metaData("EventType", "Timer");
     }
 
     private static void loadConstants(Workflow workflow, ParserContext parserContext) {

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/ActionType.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/ActionType.java
@@ -15,11 +15,7 @@
  */
 package org.kie.kogito.serverless.workflow.parser.handlers;
 
-import java.util.Map;
-
 import io.serverlessworkflow.api.functions.FunctionDefinition;
-
-import static org.kie.kogito.serverless.workflow.utils.ServerlessWorkflowUtils.isOpenApiOperation;
 
 enum ActionType {
     REST("rest"),
@@ -54,7 +50,7 @@ enum ActionType {
     public static ActionType from(FunctionDefinition actionFunction) {
         switch (actionFunction.getType()) {
             case REST:
-                return isOpenApiOperation(actionFunction) ? ActionType.OPENAPI : fromMetadata(actionFunction.getMetadata());
+                return ActionType.OPENAPI;
             case EXPRESSION:
                 return ActionType.EXPRESSION;
             case CUSTOM:
@@ -75,15 +71,4 @@ enum ActionType {
         throw new UnsupportedOperationException("Unable to recognize custom format " + operation + ", supported custom formats are " + values());
     }
 
-    private static ActionType fromMetadata(Map<String, String> metadata) {
-        String type = metadata != null ? metadata.get("type") : null;
-        if (type != null) {
-            try {
-                return ActionType.valueOf(type.toUpperCase());
-            } catch (IllegalArgumentException ex) {
-                // see return 
-            }
-        }
-        return ActionType.EMPTY;
-    }
 }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/CallbackHandler.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/CallbackHandler.java
@@ -26,9 +26,9 @@ import org.kie.kogito.serverless.workflow.parser.ParserContext;
 import io.serverlessworkflow.api.Workflow;
 import io.serverlessworkflow.api.states.CallbackState;
 
-import static org.kie.kogito.serverless.workflow.parser.ServerlessWorkflowParser.eventBasedExclusiveSplitNode;
-import static org.kie.kogito.serverless.workflow.parser.ServerlessWorkflowParser.joinExclusiveNode;
-import static org.kie.kogito.serverless.workflow.parser.ServerlessWorkflowParser.timerNode;
+import static org.kie.kogito.serverless.workflow.parser.handlers.NodeFactoryUtils.eventBasedExclusiveSplitNode;
+import static org.kie.kogito.serverless.workflow.parser.handlers.NodeFactoryUtils.joinExclusiveNode;
+import static org.kie.kogito.serverless.workflow.parser.handlers.NodeFactoryUtils.timerNode;
 import static org.kie.kogito.serverless.workflow.utils.TimeoutsConfigResolver.resolveEventTimeout;
 
 public class CallbackHandler extends CompositeContextNodeHandler<CallbackState> {

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/CompositeContextNodeHandler.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/CompositeContextNodeHandler.java
@@ -15,17 +15,12 @@
  */
 package org.kie.kogito.serverless.workflow.parser.handlers;
 
-import java.io.IOException;
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
-import java.util.function.Supplier;
 
 import org.drools.mvel.java.JavaDialect;
 import org.jbpm.compiler.canonical.descriptors.TaskDescriptor;
@@ -35,7 +30,6 @@ import org.jbpm.ruleflow.core.factory.AbstractCompositeNodeFactory;
 import org.jbpm.ruleflow.core.factory.CompositeContextNodeFactory;
 import org.jbpm.ruleflow.core.factory.NodeFactory;
 import org.jbpm.ruleflow.core.factory.WorkItemNodeFactory;
-import org.kie.kogito.internal.utils.ConversionUtils;
 import org.kie.kogito.jackson.utils.JsonNodeVisitor;
 import org.kie.kogito.jackson.utils.JsonObjectUtils;
 import org.kie.kogito.process.expr.ExpressionHandlerFactory;
@@ -43,36 +37,17 @@ import org.kie.kogito.serverless.workflow.SWFConstants;
 import org.kie.kogito.serverless.workflow.parser.ParserContext;
 import org.kie.kogito.serverless.workflow.parser.ServerlessWorkflowParser;
 import org.kie.kogito.serverless.workflow.parser.SourceFileServerlessWorkflowBindEvent;
-import org.kie.kogito.serverless.workflow.parser.handlers.openapi.OpenAPIDescriptor;
-import org.kie.kogito.serverless.workflow.parser.handlers.openapi.OpenAPIDescriptorFactory;
-import org.kie.kogito.serverless.workflow.suppliers.ApiKeyAuthDecoratorSupplier;
-import org.kie.kogito.serverless.workflow.suppliers.BasicAuthDecoratorSupplier;
-import org.kie.kogito.serverless.workflow.suppliers.BearerTokenAuthDecoratorSupplier;
-import org.kie.kogito.serverless.workflow.suppliers.ClientOAuth2AuthDecoratorSupplier;
-import org.kie.kogito.serverless.workflow.suppliers.CollectionParamsDecoratorSupplier;
-import org.kie.kogito.serverless.workflow.suppliers.ConfigSuppliedWorkItemSupplier;
 import org.kie.kogito.serverless.workflow.suppliers.ExpressionActionSupplier;
 import org.kie.kogito.serverless.workflow.suppliers.ObjectResolverSupplier;
 import org.kie.kogito.serverless.workflow.suppliers.ParamsRestBodyBuilderSupplier;
-import org.kie.kogito.serverless.workflow.suppliers.PasswordOAuth2AuthDecoratorSupplier;
 import org.kie.kogito.serverless.workflow.suppliers.SysoutActionSupplier;
 import org.kie.kogito.serverless.workflow.utils.ExpressionHandlerUtils;
+import org.kie.kogito.serverless.workflow.utils.OpenAPIOperationId;
 import org.kogito.workitem.rest.RestWorkItemHandler;
 import org.kogito.workitem.rest.auth.ApiKeyAuthDecorator;
-import org.kogito.workitem.rest.auth.ApiKeyAuthDecorator.Location;
 import org.kogito.workitem.rest.auth.BearerTokenAuthDecorator;
-import org.kogito.workitem.rest.auth.ClientOAuth2AuthDecorator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.github.javaparser.ast.body.Parameter;
-import com.github.javaparser.ast.expr.Expression;
-import com.github.javaparser.ast.expr.LambdaExpr;
-import com.github.javaparser.ast.expr.MethodCallExpr;
-import com.github.javaparser.ast.expr.NameExpr;
-import com.github.javaparser.ast.expr.StringLiteralExpr;
-import com.github.javaparser.ast.type.UnknownType;
 
 import io.serverlessworkflow.api.Workflow;
 import io.serverlessworkflow.api.actions.Action;
@@ -82,24 +57,18 @@ import io.serverlessworkflow.api.functions.FunctionDefinition;
 import io.serverlessworkflow.api.functions.FunctionRef;
 import io.serverlessworkflow.api.functions.SubFlowRef;
 import io.serverlessworkflow.api.interfaces.State;
-import io.swagger.parser.OpenAPIParser;
-import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.security.SecurityScheme;
-import io.swagger.v3.oas.models.security.SecurityScheme.In;
-import io.swagger.v3.parser.core.models.SwaggerParseResult;
 
-import static org.kie.kogito.internal.utils.ConversionUtils.concatPaths;
-import static org.kie.kogito.serverless.workflow.io.URIContentLoaderFactory.buildLoader;
-import static org.kie.kogito.serverless.workflow.io.URIContentLoaderFactory.readAllBytes;
-import static org.kie.kogito.serverless.workflow.utils.ServerlessWorkflowUtils.OPENAPI_OPERATION_SEPARATOR;
-import static org.kie.kogito.serverless.workflow.utils.ServerlessWorkflowUtils.getServiceName;
+import static org.kie.kogito.serverless.workflow.parser.handlers.NodeFactoryUtils.fillRest;
+import static org.kie.kogito.serverless.workflow.parser.handlers.NodeFactoryUtils.subprocessNode;
+import static org.kie.kogito.serverless.workflow.utils.ServerlessWorkflowUtils.ACCESS_TOKEN;
+import static org.kie.kogito.serverless.workflow.utils.ServerlessWorkflowUtils.API_KEY;
+import static org.kie.kogito.serverless.workflow.utils.ServerlessWorkflowUtils.API_KEY_PREFIX;
+import static org.kie.kogito.serverless.workflow.utils.ServerlessWorkflowUtils.PASSWORD_PROP;
+import static org.kie.kogito.serverless.workflow.utils.ServerlessWorkflowUtils.USER_PROP;
 import static org.kie.kogito.serverless.workflow.utils.ServerlessWorkflowUtils.resolveFunctionMetadata;
-import static org.kie.kogito.serverless.workflow.utils.ServerlessWorkflowUtils.runtimeOpenApi;
 import static org.kie.kogito.serverless.workflow.utils.ServerlessWorkflowUtils.runtimeRestApi;
 
 public abstract class CompositeContextNodeHandler<S extends State> extends StateHandler<S> {
-
-    private static Logger logger = LoggerFactory.getLogger(CompositeContextNodeHandler.class);
 
     private static final String SCRIPT_TYPE_PARAM = "script";
     private static final String SYSOUT_TYPE_PARAM = "message";
@@ -116,11 +85,6 @@ public abstract class CompositeContextNodeHandler<S extends State> extends State
     private static final String LANG_SEPARATOR = ":";
     private static final String METHOD_SEPARATOR = ":";
     private static final String INTFC_SEPARATOR = "::";
-    private static final String USER_PROP = "username";
-    private static final String PASSWORD_PROP = "password";
-    private static final String API_KEY_PREFIX = "api_key_prefix";
-    private static final String API_KEY = "api_key";
-    private static final String ACCESS_TOKEN = "access_token";
 
     protected CompositeContextNodeHandler(S state, Workflow workflow, ParserContext parserContext) {
         super(state, workflow, parserContext);
@@ -184,7 +148,7 @@ public abstract class CompositeContextNodeHandler<S extends State> extends State
             SubFlowRef subFlowRef,
             String inputVar,
             String outputVar) {
-        return ServerlessWorkflowParser.subprocessNode(
+        return subprocessNode(
                 factory.subProcessNode(parserContext.newId()).name(subFlowRef.getWorkflowId()).processId(subFlowRef.getWorkflowId()).waitForCompletion(true),
                 inputVar,
                 outputVar);
@@ -234,26 +198,30 @@ public abstract class CompositeContextNodeHandler<S extends State> extends State
                         .inMapping(inputVar, WORKITEM_PARAM)
                         .outMapping(WORKITEM_PARAM, outputVar), actionFunction, operation, functionRef.getArguments());
             case REST:
-                return addFunctionArgs(addRestParameters(buildRestWorkItem(embeddedSubProcess, actionFunction, inputVar, outputVar), actionFunction, operation), functionRef);
+                return addFunctionArgs(addRestParameters(buildWorkItem(embeddedSubProcess, actionFunction, inputVar, outputVar), actionFunction, operation), functionRef);
             case OPENAPI:
-                return addFunctionArgs(addOpenApiParameters(buildRestWorkItem(embeddedSubProcess, actionFunction, inputVar, outputVar), actionFunction, operation), functionRef);
+                OpenAPIOperationId operationId = OpenAPIOperationId.fromOperation(operation);
+                notifySourceFileCodegenBindListeners(operationId.getUri().toString());
+                return addFunctionArgs(RestOperationHandlerFactory.get(parserContext, operationId).fillWorkItemHandler(buildWorkItem(embeddedSubProcess, actionFunction, inputVar, outputVar), workflow,
+                        actionFunction), functionRef);
             default:
                 return emptyNode(embeddedSubProcess, actionName);
         }
     }
 
-    private WorkItemNodeFactory<?> buildRestWorkItem(RuleFlowNodeContainerFactory<?, ?> embeddedSubProcess,
+    private WorkItemNodeFactory<?> buildWorkItem(RuleFlowNodeContainerFactory<?, ?> embeddedSubProcess,
             FunctionDefinition actionFunction,
             String inputVar,
             String outputVar) {
-        return embeddedSubProcess
-                .workItemNode(parserContext.newId())
-                .name(actionFunction.getName())
-                .metaData(TaskDescriptor.KEY_WORKITEM_TYPE, RestWorkItemHandler.REST_TASK_TYPE)
-                .workName(RestWorkItemHandler.REST_TASK_TYPE)
+        return embeddedSubProcess.workItemNode(parserContext.newId())
                 .inMapping(inputVar, SWFConstants.MODEL_WORKFLOW_VAR)
-                .outMapping(RestWorkItemHandler.RESULT, outputVar)
-                .workParameter(RestWorkItemHandler.BODY_BUILDER, new ParamsRestBodyBuilderSupplier());
+                .outMapping(RestWorkItemHandler.RESULT, outputVar).name(actionFunction.getName());
+    }
+
+    private void notifySourceFileCodegenBindListeners(String uri) {
+        parserContext.getContext()
+                .getSourceFileCodegenBindNotifier()
+                .ifPresent(notifier -> notifier.notify(new SourceFileServerlessWorkflowBindEvent(workflow.getId(), uri)));
     }
 
     private <T extends RuleFlowNodeContainerFactory<T, ?>> WorkItemNodeFactory<T> addFunctionArgs(WorkItemNodeFactory<T> node, FunctionRef functionRef) {
@@ -331,7 +299,7 @@ public abstract class CompositeContextNodeHandler<S extends State> extends State
             method = resolveFunctionMetadata(actionFunction, "method", parserContext.getContext());
         }
 
-        return node.workParameter(RestWorkItemHandler.URL, url)
+        return fillRest(node.workParameter(RestWorkItemHandler.URL, url)
                 .workParameter(RestWorkItemHandler.METHOD, method)
                 .workParameter(RestWorkItemHandler.USER, runtimeRestApi(actionFunction, USER_PROP, parserContext.getContext()))
                 .workParameter(RestWorkItemHandler.PASSWORD, runtimeRestApi(actionFunction, PASSWORD_PROP, parserContext.getContext()))
@@ -340,106 +308,7 @@ public abstract class CompositeContextNodeHandler<S extends State> extends State
                 .workParameter(RestWorkItemHandler.BODY_BUILDER, new ParamsRestBodyBuilderSupplier())
                 .workParameter(BearerTokenAuthDecorator.BEARER_TOKEN, runtimeRestApi(actionFunction, ACCESS_TOKEN, parserContext.getContext()))
                 .workParameter(ApiKeyAuthDecorator.KEY_PREFIX, runtimeRestApi(actionFunction, API_KEY_PREFIX, parserContext.getContext()))
-                .workParameter(ApiKeyAuthDecorator.KEY, runtimeRestApi(actionFunction, API_KEY, parserContext.getContext()));
-    }
-
-    private <T extends RuleFlowNodeContainerFactory<T, ?>> WorkItemNodeFactory<T> addOpenApiParameters(WorkItemNodeFactory<T> node,
-            FunctionDefinition function,
-            String operation) {
-        int indexOf = function.getOperation().indexOf(OPENAPI_OPERATION_SEPARATOR);
-        String uri = operation.substring(0, indexOf);
-        String serviceName = getServiceName(uri);
-        String operationId = operation.substring(indexOf + OPENAPI_OPERATION_SEPARATOR.length());
-        try {
-            // although OpenAPIParser has built in support to load uri, it messes up when using contextclassloader, so using our retrieval apis to get the content
-            SwaggerParseResult result =
-                    new OpenAPIParser().readContents(new String(readAllBytes(buildLoader(URI.create(uri), parserContext.getContext().getClassLoader(), workflow, function.getAuthRef()))), null, null);
-            OpenAPI openAPI = result.getOpenAPI();
-            if (openAPI == null) {
-                throw new IllegalArgumentException("Problem parsing uri " + uri);
-            }
-            logger.debug("OpenAPI parser messages {}", result.getMessages());
-            OpenAPIDescriptor openAPIDescriptor = OpenAPIDescriptorFactory.of(openAPI, operationId);
-            addSecurity(node, openAPIDescriptor, serviceName);
-
-            WorkItemNodeFactory<T> workItemNodeFactory = node.workParameter(RestWorkItemHandler.URL,
-                    runtimeOpenApi(serviceName, "base_path", String.class, OpenAPIDescriptorFactory.getDefaultURL(openAPI, "http://localhost:8080"),
-                            (key, clazz, defaultValue) -> new ConfigSuppliedWorkItemSupplier<String>(key, clazz, defaultValue, calculatedKey -> concatPaths(calculatedKey, openAPIDescriptor.getPath()),
-                                    new LambdaExpr(new Parameter(new UnknownType(), "calculatedKey"),
-                                            new MethodCallExpr(ConversionUtils.class.getCanonicalName() + ".concatPaths")
-                                                    .addArgument(new NameExpr("calculatedKey")).addArgument(new StringLiteralExpr(openAPIDescriptor.getPath()))))))
-                    .workParameter(RestWorkItemHandler.METHOD, openAPIDescriptor.getMethod())
-                    .workParameter(RestWorkItemHandler.PARAMS_DECORATOR, new CollectionParamsDecoratorSupplier(openAPIDescriptor.getHeaderParams(), openAPIDescriptor.getQueryParams()));
-
-            notifySourceFileCodegenBindListeners(uri);
-
-            return workItemNodeFactory;
-        } catch (IOException e) {
-            throw new IllegalArgumentException("Problem retrieving uri " + uri);
-        }
-    }
-
-    private void notifySourceFileCodegenBindListeners(String uri) {
-        parserContext.getContext()
-                .getSourceFileCodegenBindNotifier()
-                .ifPresent(notifier -> notifier.notify(new SourceFileServerlessWorkflowBindEvent(workflow.getId(), uri)));
-    }
-
-    private ApiKeyAuthDecorator.Location from(In in) {
-        switch (in) {
-            case COOKIE:
-                return Location.COOKIE;
-            case HEADER:
-                return Location.HEADER;
-            case QUERY:
-            default:
-                return Location.QUERY;
-        }
-    }
-
-    private void addSecurity(WorkItemNodeFactory<?> node, OpenAPIDescriptor openAPI, String serviceName) {
-        Collection<Supplier<Expression>> authDecorators = new ArrayList<>();
-        for (SecurityScheme scheme : openAPI.getSchemes()) {
-            switch (scheme.getType()) {
-                case APIKEY:
-                    authDecorators.add(new ApiKeyAuthDecoratorSupplier(scheme.getName(), from(scheme.getIn())));
-                    node.workParameter(ApiKeyAuthDecorator.KEY_PREFIX, runtimeOpenApi(serviceName, API_KEY_PREFIX, parserContext.getContext()))
-                            .workParameter(ApiKeyAuthDecorator.KEY, runtimeOpenApi(serviceName, API_KEY, parserContext.getContext()));
-                    break;
-                case HTTP:
-                    if (scheme.getScheme().equals("bearer")) {
-                        authDecorators.add(new BearerTokenAuthDecoratorSupplier());
-                        node.workParameter(RestWorkItemHandler.AUTH_METHOD, new BearerTokenAuthDecorator()).workParameter(BearerTokenAuthDecorator.BEARER_TOKEN,
-                                runtimeOpenApi(serviceName, ACCESS_TOKEN, parserContext.getContext()));
-                    } else if (scheme.getScheme().equals("basic")) {
-                        authDecorators.add(new BasicAuthDecoratorSupplier());
-                        node.workParameter(RestWorkItemHandler.USER, runtimeOpenApi(serviceName, USER_PROP, parserContext.getContext()))
-                                .workParameter(RestWorkItemHandler.PASSWORD, runtimeOpenApi(serviceName, PASSWORD_PROP, parserContext.getContext()));
-                    }
-                    break;
-                case OAUTH2:
-                    // only support client and password credentials
-                    if (scheme.getFlows().getClientCredentials() != null) {
-                        authDecorators.add(new ClientOAuth2AuthDecoratorSupplier(scheme.getFlows().getClientCredentials().getTokenUrl(), scheme.getFlows().getClientCredentials().getRefreshUrl()));
-                        node.workParameter(ClientOAuth2AuthDecorator.CLIENT_ID, runtimeOpenApi(serviceName, "client_id", parserContext.getContext()))
-                                .workParameter(ClientOAuth2AuthDecorator.CLIENT_SECRET, runtimeOpenApi(serviceName, "client_secret", parserContext.getContext()));
-                    } else if (scheme.getFlows().getPassword() != null) {
-                        authDecorators.add(new PasswordOAuth2AuthDecoratorSupplier(scheme.getFlows().getPassword().getTokenUrl(), scheme.getFlows().getPassword().getRefreshUrl()));
-                        node.workParameter(RestWorkItemHandler.USER, runtimeOpenApi(serviceName, USER_PROP, parserContext.getContext()))
-                                .workParameter(RestWorkItemHandler.PASSWORD, runtimeOpenApi(serviceName, PASSWORD_PROP, parserContext.getContext()));
-                    } else if (scheme.getFlows().getAuthorizationCode() != null) {
-                        logger.warn("Unsupported scheme type {} for authorization code flow {}", scheme.getType(), scheme.getFlows().getAuthorizationCode());
-                    } else if (scheme.getFlows().getImplicit() != null) {
-                        logger.warn("Unsupported scheme type {} for implicit flow {}", scheme.getType(), scheme.getFlows().getImplicit());
-                    }
-                    break;
-                default:
-                    logger.warn("Unsupported scheme type {}", scheme.getType());
-            }
-        }
-        if (!authDecorators.isEmpty()) {
-            node.workParameter(RestWorkItemHandler.AUTH_METHOD, authDecorators);
-        }
+                .workParameter(ApiKeyAuthDecorator.KEY, runtimeRestApi(actionFunction, API_KEY, parserContext.getContext())));
     }
 
     private Map<String, Object> functionsToMap(JsonNode jsonNode) {

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/CompositeContextNodeHandler.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/CompositeContextNodeHandler.java
@@ -37,6 +37,7 @@ import org.kie.kogito.serverless.workflow.SWFConstants;
 import org.kie.kogito.serverless.workflow.parser.ParserContext;
 import org.kie.kogito.serverless.workflow.parser.ServerlessWorkflowParser;
 import org.kie.kogito.serverless.workflow.parser.SourceFileServerlessWorkflowBindEvent;
+import org.kie.kogito.serverless.workflow.parser.rest.RestOperationHandlerFactory;
 import org.kie.kogito.serverless.workflow.suppliers.ExpressionActionSupplier;
 import org.kie.kogito.serverless.workflow.suppliers.ObjectResolverSupplier;
 import org.kie.kogito.serverless.workflow.suppliers.ParamsRestBodyBuilderSupplier;

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/DescriptorRestOperationHandler.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/DescriptorRestOperationHandler.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.serverless.workflow.parser.handlers;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.function.Supplier;
+
+import org.jbpm.ruleflow.core.RuleFlowNodeContainerFactory;
+import org.jbpm.ruleflow.core.factory.WorkItemNodeFactory;
+import org.kie.kogito.internal.utils.ConversionUtils;
+import org.kie.kogito.serverless.workflow.parser.ParserContext;
+import org.kie.kogito.serverless.workflow.parser.handlers.openapi.OpenAPIDescriptor;
+import org.kie.kogito.serverless.workflow.parser.handlers.openapi.OpenAPIDescriptorFactory;
+import org.kie.kogito.serverless.workflow.suppliers.ApiKeyAuthDecoratorSupplier;
+import org.kie.kogito.serverless.workflow.suppliers.BasicAuthDecoratorSupplier;
+import org.kie.kogito.serverless.workflow.suppliers.BearerTokenAuthDecoratorSupplier;
+import org.kie.kogito.serverless.workflow.suppliers.ClientOAuth2AuthDecoratorSupplier;
+import org.kie.kogito.serverless.workflow.suppliers.CollectionParamsDecoratorSupplier;
+import org.kie.kogito.serverless.workflow.suppliers.ConfigSuppliedWorkItemSupplier;
+import org.kie.kogito.serverless.workflow.suppliers.PasswordOAuth2AuthDecoratorSupplier;
+import org.kie.kogito.serverless.workflow.utils.OpenAPIOperationId;
+import org.kogito.workitem.rest.RestWorkItemHandler;
+import org.kogito.workitem.rest.auth.ApiKeyAuthDecorator;
+import org.kogito.workitem.rest.auth.ApiKeyAuthDecorator.Location;
+import org.kogito.workitem.rest.auth.BearerTokenAuthDecorator;
+import org.kogito.workitem.rest.auth.ClientOAuth2AuthDecorator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.github.javaparser.ast.body.Parameter;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.LambdaExpr;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.expr.StringLiteralExpr;
+import com.github.javaparser.ast.type.UnknownType;
+
+import io.serverlessworkflow.api.Workflow;
+import io.serverlessworkflow.api.functions.FunctionDefinition;
+import io.swagger.parser.OpenAPIParser;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.security.SecurityScheme.In;
+import io.swagger.v3.parser.core.models.SwaggerParseResult;
+
+import static org.kie.kogito.internal.utils.ConversionUtils.concatPaths;
+import static org.kie.kogito.serverless.workflow.io.URIContentLoaderFactory.buildLoader;
+import static org.kie.kogito.serverless.workflow.io.URIContentLoaderFactory.readAllBytes;
+import static org.kie.kogito.serverless.workflow.parser.handlers.NodeFactoryUtils.fillRest;
+import static org.kie.kogito.serverless.workflow.utils.ServerlessWorkflowUtils.ACCESS_TOKEN;
+import static org.kie.kogito.serverless.workflow.utils.ServerlessWorkflowUtils.API_KEY;
+import static org.kie.kogito.serverless.workflow.utils.ServerlessWorkflowUtils.API_KEY_PREFIX;
+import static org.kie.kogito.serverless.workflow.utils.ServerlessWorkflowUtils.PASSWORD_PROP;
+import static org.kie.kogito.serverless.workflow.utils.ServerlessWorkflowUtils.USER_PROP;
+import static org.kie.kogito.serverless.workflow.utils.ServerlessWorkflowUtils.runtimeOpenApi;
+
+public class DescriptorRestOperationHandler implements RestOperationHandler {
+
+    private final static Logger logger = LoggerFactory.getLogger(DescriptorRestOperationHandler.class);
+
+    private final ParserContext parserContext;
+    private final OpenAPIOperationId operationId;
+
+    public DescriptorRestOperationHandler(ParserContext parserContext, OpenAPIOperationId operationId) {
+        this.parserContext = parserContext;
+        this.operationId = operationId;
+    }
+
+    @Override
+    public <T extends RuleFlowNodeContainerFactory<T, ?>> WorkItemNodeFactory<T> fillWorkItemHandler(WorkItemNodeFactory<T> node,
+            Workflow workflow,
+            FunctionDefinition actionFunction) {
+        return fillRest(addOpenApiParameters(node, workflow, actionFunction));
+    }
+
+    private <T extends RuleFlowNodeContainerFactory<T, ?>> WorkItemNodeFactory<T> addOpenApiParameters(WorkItemNodeFactory<T> node,
+            Workflow workflow,
+            FunctionDefinition function) {
+        URI uri = operationId.getUri();
+        String serviceName = operationId.getServiceName();
+        try {
+            // although OpenAPIParser has built in support to load uri, it messes up when using contextclassloader, so using our retrieval apis to get the content
+            SwaggerParseResult result =
+                    new OpenAPIParser().readContents(new String(readAllBytes(buildLoader(uri, parserContext.getContext().getClassLoader(), workflow, function.getAuthRef()))), null, null);
+            OpenAPI openAPI = result.getOpenAPI();
+            if (openAPI == null) {
+                throw new IllegalArgumentException("Problem parsing uri " + uri);
+            }
+            logger.debug("OpenAPI parser messages {}", result.getMessages());
+            OpenAPIDescriptor openAPIDescriptor = OpenAPIDescriptorFactory.of(openAPI, operationId.getOperationId());
+            addSecurity(node, openAPIDescriptor, serviceName);
+            return node.workParameter(RestWorkItemHandler.URL,
+                    runtimeOpenApi(serviceName, "base_path", String.class, OpenAPIDescriptorFactory.getDefaultURL(openAPI, "http://localhost:8080"),
+                            (key, clazz, defaultValue) -> new ConfigSuppliedWorkItemSupplier<String>(key, clazz, defaultValue, calculatedKey -> concatPaths(calculatedKey, openAPIDescriptor.getPath()),
+                                    new LambdaExpr(new Parameter(new UnknownType(), "calculatedKey"),
+                                            new MethodCallExpr(ConversionUtils.class.getCanonicalName() + ".concatPaths")
+                                                    .addArgument(new NameExpr("calculatedKey")).addArgument(new StringLiteralExpr(openAPIDescriptor.getPath()))))))
+                    .workParameter(RestWorkItemHandler.METHOD, openAPIDescriptor.getMethod())
+                    .workParameter(RestWorkItemHandler.PARAMS_DECORATOR, new CollectionParamsDecoratorSupplier(openAPIDescriptor.getHeaderParams(), openAPIDescriptor.getQueryParams()));
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Problem retrieving uri " + uri);
+        }
+    }
+
+    private void addSecurity(WorkItemNodeFactory<?> node, OpenAPIDescriptor openAPI, String serviceName) {
+        Collection<Supplier<Expression>> authDecorators = new ArrayList<>();
+        for (SecurityScheme scheme : openAPI.getSchemes()) {
+            switch (scheme.getType()) {
+                case APIKEY:
+                    authDecorators.add(new ApiKeyAuthDecoratorSupplier(scheme.getName(), from(scheme.getIn())));
+                    node.workParameter(ApiKeyAuthDecorator.KEY_PREFIX, runtimeOpenApi(serviceName, API_KEY_PREFIX, parserContext.getContext()))
+                            .workParameter(ApiKeyAuthDecorator.KEY, runtimeOpenApi(serviceName, API_KEY, parserContext.getContext()));
+                    break;
+                case HTTP:
+                    if (scheme.getScheme().equals("bearer")) {
+                        authDecorators.add(new BearerTokenAuthDecoratorSupplier());
+                        node.workParameter(RestWorkItemHandler.AUTH_METHOD, new BearerTokenAuthDecorator()).workParameter(BearerTokenAuthDecorator.BEARER_TOKEN,
+                                runtimeOpenApi(serviceName, ACCESS_TOKEN, parserContext.getContext()));
+                    } else if (scheme.getScheme().equals("basic")) {
+                        authDecorators.add(new BasicAuthDecoratorSupplier());
+                        node.workParameter(RestWorkItemHandler.USER, runtimeOpenApi(serviceName, USER_PROP, parserContext.getContext()))
+                                .workParameter(RestWorkItemHandler.PASSWORD, runtimeOpenApi(serviceName, PASSWORD_PROP, parserContext.getContext()));
+                    }
+                    break;
+                case OAUTH2:
+                    // only support client and password credentials
+                    if (scheme.getFlows().getClientCredentials() != null) {
+                        authDecorators.add(new ClientOAuth2AuthDecoratorSupplier(scheme.getFlows().getClientCredentials().getTokenUrl(), scheme.getFlows().getClientCredentials().getRefreshUrl()));
+                        node.workParameter(ClientOAuth2AuthDecorator.CLIENT_ID, runtimeOpenApi(serviceName, "client_id", parserContext.getContext()))
+                                .workParameter(ClientOAuth2AuthDecorator.CLIENT_SECRET, runtimeOpenApi(serviceName, "client_secret", parserContext.getContext()));
+                    } else if (scheme.getFlows().getPassword() != null) {
+                        authDecorators.add(new PasswordOAuth2AuthDecoratorSupplier(scheme.getFlows().getPassword().getTokenUrl(), scheme.getFlows().getPassword().getRefreshUrl()));
+                        node.workParameter(RestWorkItemHandler.USER, runtimeOpenApi(serviceName, USER_PROP, parserContext.getContext()))
+                                .workParameter(RestWorkItemHandler.PASSWORD, runtimeOpenApi(serviceName, PASSWORD_PROP, parserContext.getContext()));
+                    } else if (scheme.getFlows().getAuthorizationCode() != null) {
+                        logger.warn("Unsupported scheme type {} for authorization code flow {}", scheme.getType(), scheme.getFlows().getAuthorizationCode());
+                    } else if (scheme.getFlows().getImplicit() != null) {
+                        logger.warn("Unsupported scheme type {} for implicit flow {}", scheme.getType(), scheme.getFlows().getImplicit());
+                    }
+                    break;
+                default:
+                    logger.warn("Unsupported scheme type {}", scheme.getType());
+            }
+        }
+        if (!authDecorators.isEmpty()) {
+            node.workParameter(RestWorkItemHandler.AUTH_METHOD, authDecorators);
+        }
+    }
+
+    private static ApiKeyAuthDecorator.Location from(In in) {
+        switch (in) {
+            case COOKIE:
+                return Location.COOKIE;
+            case HEADER:
+                return Location.HEADER;
+            case QUERY:
+            default:
+                return Location.QUERY;
+        }
+    }
+
+}

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/EventHandler.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/EventHandler.java
@@ -31,6 +31,8 @@ import io.serverlessworkflow.api.Workflow;
 import io.serverlessworkflow.api.events.OnEvents;
 import io.serverlessworkflow.api.states.EventState;
 
+import static org.kie.kogito.serverless.workflow.parser.handlers.NodeFactoryUtils.messageNode;
+
 public class EventHandler extends CompositeContextNodeHandler<EventState> {
 
     protected EventHandler(EventState state, Workflow workflow, ParserContext parserContext) {
@@ -86,6 +88,6 @@ public class EventHandler extends CompositeContextNodeHandler<EventState> {
     }
 
     private StartNodeFactory<?> messageStartNode(RuleFlowNodeContainerFactory<?, ?> factory, String eventRef, String inputVar, String outputVar) {
-        return ServerlessWorkflowParser.messageNode(factory.startNode(parserContext.newId()), eventDefinition(eventRef), inputVar).trigger(ServerlessWorkflowParser.JSON_NODE, outputVar);
+        return messageNode(factory.startNode(parserContext.newId()), eventDefinition(eventRef), inputVar).trigger(ServerlessWorkflowParser.JSON_NODE, outputVar);
     }
 }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/NodeFactoryUtils.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/NodeFactoryUtils.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.serverless.workflow.parser.handlers;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.jbpm.compiler.canonical.descriptors.TaskDescriptor;
+import org.jbpm.process.core.context.variable.VariableScope;
+import org.jbpm.ruleflow.core.Metadata;
+import org.jbpm.ruleflow.core.RuleFlowNodeContainerFactory;
+import org.jbpm.ruleflow.core.factory.JoinFactory;
+import org.jbpm.ruleflow.core.factory.NodeFactory;
+import org.jbpm.ruleflow.core.factory.SplitFactory;
+import org.jbpm.ruleflow.core.factory.SubProcessNodeFactory;
+import org.jbpm.ruleflow.core.factory.TimerNodeFactory;
+import org.jbpm.ruleflow.core.factory.WorkItemNodeFactory;
+import org.jbpm.workflow.core.impl.DataAssociation;
+import org.jbpm.workflow.core.impl.DataDefinition;
+import org.jbpm.workflow.core.node.Join;
+import org.jbpm.workflow.core.node.Split;
+import org.kie.kogito.serverless.workflow.suppliers.ParamsRestBodyBuilderSupplier;
+import org.kogito.workitem.rest.RestWorkItemHandler;
+
+import io.serverlessworkflow.api.events.EventDefinition;
+
+import static org.jbpm.process.core.timer.Timer.TIME_DURATION;
+import static org.jbpm.ruleflow.core.Metadata.UNIQUE_ID;
+import static org.kie.kogito.serverless.workflow.parser.ServerlessWorkflowParser.DEFAULT_WORKFLOW_VAR;
+import static org.kie.kogito.serverless.workflow.parser.ServerlessWorkflowParser.JSON_NODE;
+
+public class NodeFactoryUtils {
+
+    public static <T extends RuleFlowNodeContainerFactory<T, ?>> SubProcessNodeFactory<T> subprocessNode(SubProcessNodeFactory<T> nodeFactory, String inputVar, String outputVar) {
+        Map<String, String> types = Collections.singletonMap(DEFAULT_WORKFLOW_VAR, JSON_NODE);
+        DataAssociation inputDa = new DataAssociation(
+                new DataDefinition(inputVar, inputVar, JSON_NODE),
+                new DataDefinition(DEFAULT_WORKFLOW_VAR, DEFAULT_WORKFLOW_VAR, JSON_NODE), null, null);
+        DataAssociation outputDa = new DataAssociation(
+                new DataDefinition(DEFAULT_WORKFLOW_VAR, DEFAULT_WORKFLOW_VAR, JSON_NODE),
+                new DataDefinition(outputVar, outputVar, JSON_NODE), null, null);
+
+        VariableScope variableScope = new VariableScope();
+        return nodeFactory
+                .independent(true)
+                .metaData("BPMN.InputTypes", types)
+                .metaData("BPMN.OutputTypes", types)
+                .mapDataInputAssociation(inputDa)
+                .mapDataOutputAssociation(outputDa)
+                .context(variableScope)
+                .defaultContext(variableScope);
+    }
+
+    public static <T extends NodeFactory<T, P>, P extends RuleFlowNodeContainerFactory<P, ?>> T sendEventNode(NodeFactory<T, P> actionNode,
+            EventDefinition eventDefinition, String inputVar) {
+        return actionNode
+                .name(eventDefinition.getName())
+                .metaData(Metadata.EVENT_TYPE, "message")
+                .metaData(Metadata.MAPPING_VARIABLE, inputVar)
+                .metaData(Metadata.TRIGGER_REF, eventDefinition.getType())
+                .metaData(Metadata.MESSAGE_TYPE, JSON_NODE)
+                .metaData(Metadata.TRIGGER_TYPE, "ProduceMessage");
+    }
+
+    public static <T extends NodeFactory<T, P>, P extends RuleFlowNodeContainerFactory<P, ?>> T messageNode(T nodeFactory, EventDefinition eventDefinition, String inputVar) {
+        return nodeFactory
+                .name(eventDefinition.getName())
+                .metaData(Metadata.EVENT_TYPE, "message")
+                .metaData(Metadata.TRIGGER_MAPPING, inputVar)
+                .metaData(Metadata.TRIGGER_REF, eventDefinition.getType())
+                .metaData(Metadata.MESSAGE_TYPE, JSON_NODE)
+                .metaData(Metadata.TRIGGER_TYPE, "ConsumeMessage")
+                .metaData(Metadata.DATA_ONLY, isDataOnly(eventDefinition));
+    }
+
+    public static <T extends RuleFlowNodeContainerFactory<T, ?>> SplitFactory<T> eventBasedExclusiveSplitNode(SplitFactory<T> nodeFactory) {
+        return nodeFactory.name("ExclusiveSplit_" + nodeFactory.getNode().getId())
+                .type(Split.TYPE_XAND)
+                .metaData(UNIQUE_ID, Long.toString(nodeFactory.getNode().getId()))
+                .metaData("EventBased", "true");
+    }
+
+    public static <T extends RuleFlowNodeContainerFactory<T, ?>> SplitFactory<T> exclusiveSplitNode(SplitFactory<T> nodeFactory) {
+        return nodeFactory.name("ExclusiveSplit_" + nodeFactory.getNode().getId())
+                .type(Split.TYPE_XOR)
+                .metaData(UNIQUE_ID, Long.toString(nodeFactory.getNode().getId()));
+    }
+
+    public static <T extends RuleFlowNodeContainerFactory<T, ?>> JoinFactory<T> joinExclusiveNode(JoinFactory<T> nodeFactory) {
+        return nodeFactory.name("ExclusiveJoin_" + nodeFactory.getNode().getId())
+                .type(Join.TYPE_XOR)
+                .metaData(UNIQUE_ID, Long.toString(nodeFactory.getNode().getId()));
+    }
+
+    public static <T extends RuleFlowNodeContainerFactory<T, ?>> TimerNodeFactory<T> timerNode(TimerNodeFactory<T> nodeFactory, String duration) {
+        return nodeFactory.name("TimerNode_" + nodeFactory.getNode().getId())
+                .type(TIME_DURATION)
+                .delay(duration)
+                .metaData(UNIQUE_ID, Long.toString(nodeFactory.getNode().getId()))
+                .metaData("EventType", "Timer");
+    }
+
+    // TODO remove when SDK is updated to include dataOnly in EventDefinition, see https://github.com/serverlessworkflow/sdk-java/issues/183
+    private static Boolean isDataOnly(EventDefinition eventDefinition) {
+        Boolean result = Boolean.TRUE;
+        Map<String, String> metadata = eventDefinition.getMetadata();
+        final String dataOnlyKey = "dataOnly";
+        if (metadata != null && metadata.containsKey(dataOnlyKey)) {
+            result = Boolean.parseBoolean(metadata.get(dataOnlyKey));
+        }
+        return result;
+    }
+
+    public static <T extends RuleFlowNodeContainerFactory<T, ?>> WorkItemNodeFactory<T> fillRest(WorkItemNodeFactory<T> workItemNode) {
+        return workItemNode
+                .metaData(TaskDescriptor.KEY_WORKITEM_TYPE, RestWorkItemHandler.REST_TASK_TYPE)
+                .workParameter(RestWorkItemHandler.BODY_BUILDER, new ParamsRestBodyBuilderSupplier())
+                .workName(RestWorkItemHandler.REST_TASK_TYPE);
+    }
+
+}

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/NodeFactoryUtils.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/NodeFactoryUtils.java
@@ -83,7 +83,7 @@ public class NodeFactoryUtils {
                 .metaData(Metadata.TRIGGER_REF, eventDefinition.getType())
                 .metaData(Metadata.MESSAGE_TYPE, JSON_NODE)
                 .metaData(Metadata.TRIGGER_TYPE, "ConsumeMessage")
-                .metaData(Metadata.DATA_ONLY, isDataOnly(eventDefinition));
+                .metaData(Metadata.DATA_ONLY, eventDefinition.isDataOnly());
     }
 
     public static <T extends RuleFlowNodeContainerFactory<T, ?>> SplitFactory<T> eventBasedExclusiveSplitNode(SplitFactory<T> nodeFactory) {
@@ -113,22 +113,14 @@ public class NodeFactoryUtils {
                 .metaData("EventType", "Timer");
     }
 
-    // TODO remove when SDK is updated to include dataOnly in EventDefinition, see https://github.com/serverlessworkflow/sdk-java/issues/183
-    private static Boolean isDataOnly(EventDefinition eventDefinition) {
-        Boolean result = Boolean.TRUE;
-        Map<String, String> metadata = eventDefinition.getMetadata();
-        final String dataOnlyKey = "dataOnly";
-        if (metadata != null && metadata.containsKey(dataOnlyKey)) {
-            result = Boolean.parseBoolean(metadata.get(dataOnlyKey));
-        }
-        return result;
-    }
-
     public static <T extends RuleFlowNodeContainerFactory<T, ?>> WorkItemNodeFactory<T> fillRest(WorkItemNodeFactory<T> workItemNode) {
         return workItemNode
                 .metaData(TaskDescriptor.KEY_WORKITEM_TYPE, RestWorkItemHandler.REST_TASK_TYPE)
                 .workParameter(RestWorkItemHandler.BODY_BUILDER, new ParamsRestBodyBuilderSupplier())
                 .workName(RestWorkItemHandler.REST_TASK_TYPE);
+    }
+
+    private NodeFactoryUtils() {
     }
 
 }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/RestOperationHandler.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/RestOperationHandler.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.serverless.workflow.parser.handlers;
+
+import org.jbpm.ruleflow.core.RuleFlowNodeContainerFactory;
+import org.jbpm.ruleflow.core.factory.WorkItemNodeFactory;
+
+import io.serverlessworkflow.api.Workflow;
+import io.serverlessworkflow.api.functions.FunctionDefinition;
+
+public interface RestOperationHandler {
+    <T extends RuleFlowNodeContainerFactory<T, ?>> WorkItemNodeFactory<T> fillWorkItemHandler(WorkItemNodeFactory<T> node,
+            Workflow workflow,
+            FunctionDefinition actionFunction);
+}

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/RestOperationHandlerFactory.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/RestOperationHandlerFactory.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.serverless.workflow.parser.handlers;
+
+import org.kie.kogito.serverless.workflow.parser.ParserContext;
+import org.kie.kogito.serverless.workflow.utils.OpenAPIOperationId;
+
+public class RestOperationHandlerFactory {
+
+    private RestOperationHandlerFactory() {
+    }
+
+    public static RestOperationHandler get(ParserContext parserContext, OpenAPIOperationId id) {
+        return new DescriptorRestOperationHandler(parserContext, id);
+    }
+
+}

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/StateHandler.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/StateHandler.java
@@ -61,6 +61,7 @@ import io.serverlessworkflow.api.produce.ProduceEvent;
 import io.serverlessworkflow.api.transitions.Transition;
 
 import static org.kie.kogito.serverless.workflow.parser.ServerlessWorkflowParser.DEFAULT_WORKFLOW_VAR;
+import static org.kie.kogito.serverless.workflow.parser.handlers.NodeFactoryUtils.messageNode;
 import static org.kie.kogito.serverless.workflow.utils.ServerlessWorkflowUtils.processResourceFile;
 
 public abstract class StateHandler<S extends State> {
@@ -123,7 +124,7 @@ public abstract class StateHandler<S extends State> {
             EventDefinition eventDefinition,
             String data,
             String defaultWorkflowVar) {
-        return ServerlessWorkflowParser.sendEventNode(
+        return NodeFactoryUtils.sendEventNode(
                 actionNode.action(new ProduceEventActionSupplier(workflow, data)),
                 eventDefinition,
                 defaultWorkflowVar);
@@ -438,7 +439,7 @@ public abstract class StateHandler<S extends State> {
 
     protected final NodeFactory<?, ?> consumeEventNode(RuleFlowNodeContainerFactory<?, ?> factory, String eventRef, String inputVar, String outputVar) {
         EventDefinition eventDefinition = eventDefinition(eventRef);
-        return ServerlessWorkflowParser.messageNode(factory.eventNode(parserContext.newId()), eventDefinition, inputVar)
+        return messageNode(factory.eventNode(parserContext.newId()), eventDefinition, inputVar)
                 .inputVariableName(inputVar)
                 .variableName(outputVar)
                 .outMapping(inputVar, outputVar)

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/SwitchHandler.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/SwitchHandler.java
@@ -37,9 +37,9 @@ import io.serverlessworkflow.api.switchconditions.EventCondition;
 import io.serverlessworkflow.api.transitions.Transition;
 
 import static org.kie.kogito.serverless.workflow.parser.ServerlessWorkflowParser.DEFAULT_WORKFLOW_VAR;
-import static org.kie.kogito.serverless.workflow.parser.ServerlessWorkflowParser.eventBasedExclusiveSplitNode;
-import static org.kie.kogito.serverless.workflow.parser.ServerlessWorkflowParser.exclusiveSplitNode;
-import static org.kie.kogito.serverless.workflow.parser.ServerlessWorkflowParser.timerNode;
+import static org.kie.kogito.serverless.workflow.parser.handlers.NodeFactoryUtils.eventBasedExclusiveSplitNode;
+import static org.kie.kogito.serverless.workflow.parser.handlers.NodeFactoryUtils.exclusiveSplitNode;
+import static org.kie.kogito.serverless.workflow.parser.handlers.NodeFactoryUtils.timerNode;
 import static org.kie.kogito.serverless.workflow.parser.handlers.validation.SwitchValidator.validateConditions;
 import static org.kie.kogito.serverless.workflow.parser.handlers.validation.SwitchValidator.validateDefaultCondition;
 import static org.kie.kogito.serverless.workflow.utils.TimeoutsConfigResolver.resolveEventTimeout;

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/rest/DescriptorRestOperationHandler.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/rest/DescriptorRestOperationHandler.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.kie.kogito.serverless.workflow.parser.handlers;
+package org.kie.kogito.serverless.workflow.parser.rest;
 
 import java.io.IOException;
 import java.net.URI;

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/rest/DescriptorRestOperationHandler.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/rest/DescriptorRestOperationHandler.java
@@ -72,7 +72,7 @@ import static org.kie.kogito.serverless.workflow.utils.ServerlessWorkflowUtils.r
 
 public class DescriptorRestOperationHandler implements RestOperationHandler {
 
-    private final static Logger logger = LoggerFactory.getLogger(DescriptorRestOperationHandler.class);
+    private static final Logger logger = LoggerFactory.getLogger(DescriptorRestOperationHandler.class);
 
     private final ParserContext parserContext;
     private final OpenAPIOperationId operationId;
@@ -107,7 +107,7 @@ public class DescriptorRestOperationHandler implements RestOperationHandler {
             addSecurity(node, openAPIDescriptor, serviceName);
             return node.workParameter(RestWorkItemHandler.URL,
                     runtimeOpenApi(serviceName, "base_path", String.class, OpenAPIDescriptorFactory.getDefaultURL(openAPI, "http://localhost:8080"),
-                            (key, clazz, defaultValue) -> new ConfigSuppliedWorkItemSupplier<String>(key, clazz, defaultValue, calculatedKey -> concatPaths(calculatedKey, openAPIDescriptor.getPath()),
+                            (key, clazz, defaultValue) -> new ConfigSuppliedWorkItemSupplier<>(key, clazz, defaultValue, calculatedKey -> concatPaths(calculatedKey, openAPIDescriptor.getPath()),
                                     new LambdaExpr(new Parameter(new UnknownType(), "calculatedKey"),
                                             new MethodCallExpr(ConversionUtils.class.getCanonicalName() + ".concatPaths")
                                                     .addArgument(new NameExpr("calculatedKey")).addArgument(new StringLiteralExpr(openAPIDescriptor.getPath()))))))

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/rest/GeneratedRestOperationHandler.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/rest/GeneratedRestOperationHandler.java
@@ -24,7 +24,7 @@ import io.serverlessworkflow.api.functions.FunctionDefinition;
 
 public class GeneratedRestOperationHandler implements RestOperationHandler {
 
-    private OpenAPIOperationId id;
+    private final OpenAPIOperationId id;
 
     public GeneratedRestOperationHandler(OpenAPIOperationId id) {
         this.id = id;

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/rest/GeneratedRestOperationHandler.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/rest/GeneratedRestOperationHandler.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.serverless.workflow.parser.rest;
+
+import org.jbpm.ruleflow.core.RuleFlowNodeContainerFactory;
+import org.jbpm.ruleflow.core.factory.WorkItemNodeFactory;
+import org.kie.kogito.serverless.workflow.utils.OpenAPIOperationId;
+
+import io.serverlessworkflow.api.Workflow;
+import io.serverlessworkflow.api.functions.FunctionDefinition;
+
+public class GeneratedRestOperationHandler implements RestOperationHandler {
+
+    private OpenAPIOperationId id;
+
+    public GeneratedRestOperationHandler(OpenAPIOperationId id) {
+        this.id = id;
+    }
+
+    @Override
+    public <T extends RuleFlowNodeContainerFactory<T, ?>> WorkItemNodeFactory<T> fillWorkItemHandler(WorkItemNodeFactory<T> node,
+            Workflow workflow,
+            FunctionDefinition actionFunction) {
+        return node.workName(id.geClassName());
+    }
+
+}

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/rest/RestOperationHandler.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/rest/RestOperationHandler.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.kie.kogito.serverless.workflow.parser.handlers;
+package org.kie.kogito.serverless.workflow.parser.rest;
 
 import org.jbpm.ruleflow.core.RuleFlowNodeContainerFactory;
 import org.jbpm.ruleflow.core.factory.WorkItemNodeFactory;

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/rest/RestOperationHandlerFactory.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/rest/RestOperationHandlerFactory.java
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.kie.kogito.serverless.workflow.parser.handlers;
+package org.kie.kogito.serverless.workflow.parser.rest;
 
+import org.kie.kogito.codegen.api.context.KogitoBuildContext;
 import org.kie.kogito.serverless.workflow.parser.ParserContext;
 import org.kie.kogito.serverless.workflow.utils.OpenAPIOperationId;
 
@@ -24,7 +25,14 @@ public class RestOperationHandlerFactory {
     }
 
     public static RestOperationHandler get(ParserContext parserContext, OpenAPIOperationId id) {
-        return new DescriptorRestOperationHandler(parserContext, id);
+
+        KogitoBuildContext context = parserContext.getContext();
+
+        if (context.getGeneratedHandlers().contains(id.geClassName())) {
+            return new GeneratedRestOperationHandler(id);
+        } else {
+            return new DescriptorRestOperationHandler(parserContext, id);
+        }
     }
 
 }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/rest/RestOperationHandlerFactory.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/rest/RestOperationHandlerFactory.java
@@ -25,14 +25,8 @@ public class RestOperationHandlerFactory {
     }
 
     public static RestOperationHandler get(ParserContext parserContext, OpenAPIOperationId id) {
-
         KogitoBuildContext context = parserContext.getContext();
-
-        if (context.getGeneratedHandlers().contains(id.geClassName())) {
-            return new GeneratedRestOperationHandler(id);
-        } else {
-            return new DescriptorRestOperationHandler(parserContext, id);
-        }
+        return context.getGeneratedHandlers().contains(id.geClassName()) ? new GeneratedRestOperationHandler(id) : new DescriptorRestOperationHandler(parserContext, id);
     }
 
 }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/utils/OpenAPIOperationId.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/utils/OpenAPIOperationId.java
@@ -18,6 +18,8 @@ package org.kie.kogito.serverless.workflow.utils;
 import java.net.URI;
 import java.nio.file.Path;
 
+import org.drools.util.StringUtils;
+
 public class OpenAPIOperationId {
 
     static final String OPENAPI_OPERATION_SEPARATOR = "#";
@@ -32,11 +34,16 @@ public class OpenAPIOperationId {
     private final URI uri;
     private final String operationId;
     private final String fileName;
+    private final String className;
+    private final String serviceName;
 
     private OpenAPIOperationId(String uri, String operationId) {
         this.uri = URI.create(uri);
         this.operationId = operationId;
-        this.fileName = Path.of(uri).getFileName().toString().toLowerCase();
+        String fileName = Path.of(uri).getFileName().toString().toLowerCase();
+        this.className = getClassName(fileName, operationId);
+        this.serviceName = sanitizeName(removeExt(fileName));
+        this.fileName = fileName;
     }
 
     public URI getUri() {
@@ -53,11 +60,19 @@ public class OpenAPIOperationId {
     }
 
     public String getServiceName() {
-        return sanitizeName(removeExt(fileName));
+        return serviceName;
     }
 
     public String getFileName() {
-        return sanitizeName(fileName);
+        return fileName;
+    }
+
+    public String geClassName() {
+        return className;
+    }
+
+    public static String getClassName(String fileName, String operationId) {
+        return StringUtils.ucFirst(sanitizeName(removeExt(fileName)) + "_" + sanitizeName(operationId));
     }
 
     private static String removeExt(String fileName) {

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/utils/OpenAPIOperationId.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/utils/OpenAPIOperationId.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.serverless.workflow.utils;
+
+import java.net.URI;
+import java.nio.file.Path;
+
+public class OpenAPIOperationId {
+
+    static final String OPENAPI_OPERATION_SEPARATOR = "#";
+    private static final String REGEX_NO_EXT = "[.][^.]+$";
+    private static final String ONLY_CHARS = "[^a-z]";
+
+    public static OpenAPIOperationId fromOperation(String operation) {
+        int indexOf = operation.indexOf(OPENAPI_OPERATION_SEPARATOR);
+        return new OpenAPIOperationId(operation.substring(0, indexOf), operation.substring(indexOf + OPENAPI_OPERATION_SEPARATOR.length()));
+    }
+
+    private final URI uri;
+    private final String operationId;
+    private final String fileName;
+
+    private OpenAPIOperationId(String uri, String operationId) {
+        this.uri = URI.create(uri);
+        this.operationId = operationId;
+        this.fileName = Path.of(uri).getFileName().toString().toLowerCase();
+    }
+
+    public URI getUri() {
+        return uri;
+    }
+
+    public String getOperationId() {
+        return operationId;
+    }
+
+    @Override
+    public String toString() {
+        return "OpenApiOperationId [uri=" + uri + ", operationId=" + operationId + "]";
+    }
+
+    public String getServiceName() {
+        return sanitizeName(removeExt(fileName));
+    }
+
+    public String getFileName() {
+        return sanitizeName(fileName);
+    }
+
+    private static String removeExt(String fileName) {
+        return fileName.replaceFirst(REGEX_NO_EXT, "");
+    }
+
+    private static String sanitizeName(String name) {
+        return name.replaceAll(ONLY_CHARS, "");
+    }
+
+}

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/utils/ServerlessWorkflowUtils.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/utils/ServerlessWorkflowUtils.java
@@ -18,7 +18,6 @@ package org.kie.kogito.serverless.workflow.utils;
 import java.io.IOException;
 import java.io.Reader;
 import java.net.URI;
-import java.nio.file.Path;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -44,6 +43,12 @@ public class ServerlessWorkflowUtils {
 
     private static final Logger logger = LoggerFactory.getLogger(ServerlessWorkflowUtils.class);
 
+    public static final String API_KEY_PREFIX = "api_key_prefix";
+    public static final String API_KEY = "api_key";
+    public static final String ACCESS_TOKEN = "access_token";
+    public static final String USER_PROP = "username";
+    public static final String PASSWORD_PROP = "password";
+
     public static final String DEFAULT_WORKFLOW_FORMAT = "json";
     public static final String ALTERNATE_WORKFLOW_FORMAT = "yml";
     private static final String APP_PROPERTIES_BASE = "kogito.sw.";
@@ -51,10 +56,6 @@ public class ServerlessWorkflowUtils {
 
     private static final String APP_PROPERTIES_FUNCTIONS_BASE = APP_PROPERTIES_BASE + "functions.";
     private static final String APP_PROPERTIES_STATES_BASE = "states.";
-    public static final String OPENAPI_OPERATION_SEPARATOR = "#";
-
-    private static final String REGEX_NO_EXT = "[.][^.]+$";
-    private static final String ONLY_CHARS = "[^a-z]";
 
     private ServerlessWorkflowUtils() {
     }
@@ -126,35 +127,6 @@ public class ServerlessWorkflowUtils {
         Supplier<Expression> create(String key, Class<T> clazz, T defaultValue);
     }
 
-    public static String getForEachVarName(KogitoBuildContext context) {
-        return context.getApplicationProperty(APP_PROPERTIES_BASE + APP_PROPERTIES_STATES_BASE + "foreach.outputVarName").orElse("_swf_eval_temp");
-    }
-
-    /**
-     * @see <a href="https://github.com/serverlessworkflow/specification/blob/main/specification.md#Using-Functions-For-RESTful-Service-Invocations">Using Functions For RESTful Service
-     *      Invocations</a>
-     * @param function to extract the OpenApi URI
-     * @return the OpenApi URI if found, or an empty string if not
-     */
-    public static String getOpenApiURI(FunctionDefinition function) {
-        return isOpenApiOperation(function) ? function.getOperation().substring(0, function.getOperation().indexOf(OPENAPI_OPERATION_SEPARATOR)) : "";
-    }
-
-    public static String getOpenApiFileName(URI uri) {
-        return sanitizeName(fileName(uri.getPath()));
-    }
-
-    /**
-     * @see <a href="https://github.com/serverlessworkflow/specification/blob/main/specification.md#Using-Functions-For-RESTful-Service-Invocations">Using Functions For RESTful Service
-     *      Invocations</a>
-     * @param function to extract the OpenApi operationId
-     * @return the OpenApi operationId if found, otherwise an empty string
-     */
-    public static String getOpenApiOperationId(FunctionDefinition function) {
-        final String uri = getOpenApiURI(function);
-        return uri.isEmpty() ? uri : function.getOperation().substring(uri.length() + 1);
-    }
-
     /**
      * Checks whether or not the Function definition is an OpenApi operation
      *
@@ -162,23 +134,11 @@ public class ServerlessWorkflowUtils {
      * @return true if the given function refers to an OpenApi operation
      */
     public static boolean isOpenApiOperation(FunctionDefinition function) {
-        return function.getType() == Type.REST && function.getOperation() != null && function.getOperation().contains(OPENAPI_OPERATION_SEPARATOR);
+        return function.getType() == Type.REST && function.getOperation() != null && function.getOperation().contains(OpenAPIOperationId.OPENAPI_OPERATION_SEPARATOR);
     }
 
-    public static String getServiceName(String uri) {
-        return sanitizeName(removeExt(fileName(uri)));
-    }
-
-    public static String removeExt(String fileName) {
-        return fileName.replaceFirst(REGEX_NO_EXT, "");
-    }
-
-    private static String fileName(String uri) {
-        return Path.of(uri).getFileName().toString().toLowerCase();
-    }
-
-    private static String sanitizeName(String name) {
-        return name.replaceAll(ONLY_CHARS, "");
+    public static String getForEachVarName(KogitoBuildContext context) {
+        return context.getApplicationProperty(APP_PROPERTIES_BASE + APP_PROPERTIES_STATES_BASE + "foreach.outputVarName").orElse("_swf_eval_temp");
     }
 
     public static Optional<byte[]> processResourceFile(Workflow workflow, ParserContext parserContext, String uriStr) {

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/java/org/kie/kogito/serverless/workflow/utils/OpenAPIOperationIdTest.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/java/org/kie/kogito/serverless/workflow/utils/OpenAPIOperationIdTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.serverless.workflow.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class OpenAPIOperationIdTest {
+
+    @Test
+    void testOperationId() {
+        OpenAPIOperationId id = OpenAPIOperationId.fromOperation("http://myserver.com/spec/PePE1.yaml#doSomething");
+        assertEquals("doSomething", id.getOperationId());
+        assertEquals("PePE1.yaml", id.getFileName());
+        assertEquals("Pepe1_doSomething", id.geClassName());
+        assertEquals("pepe", id.getServiceName());
+        assertEquals("http://myserver.com/spec/PePE1.yaml", id.getUri().toString());
+        assertEquals(id.geClassName(), OpenAPIOperationId.getClassName(id.getFileName(), id.getOperationId()));
+    }
+}

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/java/org/kie/kogito/serverless/workflow/utils/WorkflowUtilsTest.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/java/org/kie/kogito/serverless/workflow/utils/WorkflowUtilsTest.java
@@ -31,7 +31,6 @@ import io.serverlessworkflow.api.mapper.YamlObjectMapper;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.kie.kogito.serverless.workflow.utils.ServerlessWorkflowUtils.getOpenApiProperty;
-import static org.kie.kogito.serverless.workflow.utils.ServerlessWorkflowUtils.getServiceName;
 import static org.kie.kogito.serverless.workflow.utils.ServerlessWorkflowUtils.resolveFunctionMetadata;
 
 public class WorkflowUtilsTest {
@@ -71,10 +70,4 @@ public class WorkflowUtilsTest {
         assertThat(getOpenApiProperty("testfunction", "base_path", context, String.class, "http://localhost:8080")).isEqualTo("http://localhost:8282");
         assertThat(getOpenApiProperty("testfunction1", "base_path2", context, Integer.class, 0)).isZero();
     }
-
-    @Test
-    public void testGetServiceName() {
-        assertThat(getServiceName("testMethod_1")).isEqualTo("testmethod");
-    }
-
 }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/callback.sw.json
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/callback.sw.json
@@ -15,23 +15,18 @@
   "functions": [
     {
       "name": "publishMove",
-      "metadata": {
-        "interface": "org.kie.kogito.examples.PublishService",
-        "operation": "publishMove",
-        "type": "service"
-      }
+      "type": "custom",
+      "operation": "service:org.kie.kogito.examples.PublishService::publishMove"
     },
     {
       "name": "printMessage",
-      "metadata": {
-        "type": "sysout"
-      }
+      "type": "custom",
+      "operation": "sysout"
     },
     {
       "name": "injectPI",
-      "metadata": {
-        "type": "script"
-      }
+      "type": "custom",
+      "operation": "script"
     }
   ],
   "states": [

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/error.sw.json
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/error.sw.json
@@ -12,17 +12,13 @@
   "functions": [
     {
       "name": "isEven",
-      "metadata": {
-        "interface": "org.kie.kogito.examples.EvenService",
-        "operation": "isEven",
-        "type": "service"
-      }
+      "type": "custom",
+      "operation": "service:org.kie.kogito.examples.EvenService::isEven"
     },
     {
       "name": "printMessage",
-      "metadata": {
-        "type": "sysout"
-      }
+      "type": "custom",
+      "operation": "sysout"
     }
   ],
   "states": [

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/expression.sw.json
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/expression.sw.json
@@ -12,9 +12,8 @@
     },
     {
       "name": "printMessage",
-      "metadata": {
-        "type": "sysout"
-      }
+      "type": "custom",
+      "operation": "sysout"
     }
   ],
   "states": [

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/foreach.sw.json
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/foreach.sw.json
@@ -7,9 +7,8 @@
   "functions": [
     {
       "name": "printMessage",
-      "metadata": {
-        "type": "sysout"
-      }
+      "type" : "custom",
+      "operation": "sysout"
     },
     {
       "name": "increase",

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/multiple-operations.sw.json
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/multiple-operations.sw.json
@@ -6,21 +6,18 @@
   "functions": [
     {
       "name": "helloOne",
-      "metadata": {
-        "type": "script"
-      }
+      "type": "custom",
+      "operation": "script"
     },
     {
       "name": "helloTwo",
-      "metadata": {
-        "type": "script"
-      }
+      "type": "custom",
+      "operation": "script"
     },
     {
       "name": "helloThree",
-      "metadata": {
-        "type": "script"
-      }
+      "type": "custom",
+      "operation": "script"
     }
   ],
   "states": [

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/multiple-operations.sw.yml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/multiple-operations.sw.yml
@@ -3,14 +3,14 @@ name: test-wf
 start: HelloWorld
 functions:
   - name: helloOne
-    metadata:
-      type: script
+    type: custom
+    operation: script
   - name: helloTwo
-    metadata:
-      type: script
+    type: custom
+    operation: script
   - name: helloThree
-    metadata:
-      type: script
+    type: custom
+    operation: script
 states:
   - name: HelloWorld
     type: operation

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/prchecker.sw.json
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/prchecker.sw.json
@@ -7,27 +7,18 @@
   "functions": [
     {
       "name": "AddLabels",
-      "metadata": {
-        "interface": "org.kogito.examples.sw.github.workflow.GithubService",
-        "operation": "addLabels",
-        "type": "service"
-      }
+      "type": "custom",
+      "operation": "service:org.kogito.examples.sw.github.workflow.GithubService::addLabels"      
     },
     {
       "name": "AddReviewers",
-      "metadata": {
-        "interface": "org.kogito.examples.sw.github.workflow.GithubService",
-        "operation": "addReviewers",
-        "type": "service"
-      }
+      "type": "custom",
+      "operation": "service:org.kogito.examples.sw.github.workflow.GithubService::addReviewers"
     },
     {
       "name": "FetchPRFiles",
-      "metadata": {
-        "interface": "org.kogito.examples.sw.github.workflow.GithubService",
-        "operation": "fetchPRFiles",
-        "type": "service"
-      }
+      "type": "custom",
+      "operation": "service:org.kogito.examples.sw.github.workflow.GithubService::fetchPRFiles"
     }
   ],
   "events": [

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/prchecker.sw.yml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/prchecker.sw.yml
@@ -4,20 +4,14 @@ version: '1.0'
 start: HandleOpenPR
 functions:
   - name: AddLabels
-    metadata:
-      interface: org.kogito.examples.sw.github.workflow.GithubService
-      operation: addLabels
-      type: service
+    type: custom
+    operation: service:org.kogito.examples.sw.github.workflow.GithubService::addLabels
   - name: AddReviewers
-    metadata:
-      interface: org.kogito.examples.sw.github.workflow.GithubService
-      operation: addReviewers
-      type: service
+    type: custom
+    operation: service:org.kogito.examples.sw.github.workflow.GithubService::addReviewers
   - name: FetchPRFiles
-    metadata:
-      interface: org.kogito.examples.sw.github.workflow.GithubService
-      operation: fetchPRFiles
-      type: service
+    type: custom
+    operation: service:org.kogito.examples.sw.github.workflow.GithubService::fetchPRFiles
 events:
   - name: PROpened
     source: github

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/single-eventstate-multi-eventrefs.sw.json
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/single-eventstate-multi-eventrefs.sw.json
@@ -17,11 +17,10 @@
     }
   ],
   "functions": [
-    {
+     {
       "name": "greetFunction",
-      "metadata": {
-        "type": "script"
-      }
+      "type": "custom",
+      "operation": "script"
     }
   ],
   "states": [

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/single-eventstate-multi-eventrefs.sw.yml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/single-eventstate-multi-eventrefs.sw.yml
@@ -11,8 +11,8 @@ events:
     type: kafka
 functions:
   - name: greetFunction
-    metadata:
-      type: script
+    type: custom
+    operation: script
 states:
   - name: WaitForGreeting
     type: event

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/single-eventstate.sw.json
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/single-eventstate.sw.json
@@ -14,9 +14,8 @@
   "functions": [
     {
       "name": "greetFunction",
-      "metadata": {
-        "type": "script"
-      }
+      "type": "custom",
+      "operation": "script"
     }
   ],
   "states": [

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/single-eventstate.sw.yml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/single-eventstate.sw.yml
@@ -8,8 +8,8 @@ events:
     type: kafka
 functions:
   - name: greetFunction
-    metadata:
-      type: script
+    type: custom
+    operation: script
 states:
   - name: WaitForGreeting
     type: event

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/single-operation-many-functions.sw.json
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/single-operation-many-functions.sw.json
@@ -6,15 +6,13 @@
   "functions": [
     {
       "name": "helloWorld",
-      "metadata": {
-        "type": "script"
-      }
+      "operation": "script",
+      "type": "custom"
     },
     {
       "name": "goodbyeWorld",
-      "metadata": {
-        "type": "script"
-      }
+      "operation": "script",
+      "type": "custom"
     }
   ],
   "states": [

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/single-operation-many-functions.sw.yml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/single-operation-many-functions.sw.yml
@@ -3,11 +3,11 @@ name: test-wf
 start: HelloWorld
 functions:
   - name: helloWorld
-    metadata:
-      type: script
+    type: custom
+    operation: script
   - name: goodbyeWorld
-    metadata:
-      type: script
+    type: custom
+    operation: script
 states:
   - name: HelloWorld
     type: operation

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/single-operation-with-delay.sw.json
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/single-operation-with-delay.sw.json
@@ -7,9 +7,8 @@
   "functions": [
     {
       "name": "helloWorld",
-      "metadata": {
-        "type": "script"
-      }
+      "operation": "script",
+      "type": "custom"
     }
   ],
   "states": [

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/single-operation-with-delay.sw.yml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/single-operation-with-delay.sw.yml
@@ -4,8 +4,8 @@ version: '1.0'
 start: HelloWorld
 functions:
   - name: helloWorld
-    metadata:
-      type: script
+    type: custom
+    operation: script
 states:
   - name: HelloWorld
     type: operation

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/single-operation.sw.json
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/single-operation.sw.json
@@ -7,9 +7,8 @@
   "functions": [
     {
       "name": "helloWorld",
-      "metadata": {
-        "type": "script"
-      }
+      "operation": "script",
+      "type": "custom"
     }
   ],
   "states": [

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/single-operation.sw.yml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/single-operation.sw.yml
@@ -4,8 +4,8 @@ version: '1.0'
 start: HelloWorld
 functions:
   - name: helloWorld
-    metadata:
-      type: script
+    type: custom
+    operation: script
 states:
   - name: HelloWorld
     type: operation

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/single-service-operation.sw.json
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/single-service-operation.sw.json
@@ -7,11 +7,8 @@
   "functions": [
     {
       "name": "helloWorld",
-      "metadata": {
-        "interface": "org.something.other.TestService",
-        "operation": "get",
-        "type": "service"
-      }
+      "type": "custom",
+      "operation": "service:org.something.other.TestService::get"
     }
   ],
   "states": [

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/single-service-operation.sw.yml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/single-service-operation.sw.yml
@@ -4,10 +4,8 @@ version: '1.0'
 start: HelloWorld
 functions:
   - name: helloWorld
-    metadata:
-      interface: org.something.other.TestService
-      operation: get
-      type: service
+    type: custom
+    operation: service:org.something.other.TestService::get
 states:
   - name: HelloWorld
     type: operation

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/transition-produce-event.sw.json
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/transition-produce-event.sw.json
@@ -13,15 +13,13 @@
   "functions": [
     {
       "name": "helloOne",
-      "metadata": {
-        "type": "script"
-      }
+      "operation": "script",
+      "type": "custom"
     },
     {
       "name": "helloTwo",
-      "metadata": {
-        "type": "script"
-      }
+     "operation": "script",
+      "type": "custom"
     }
   ],
   "states": [

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/transition-produce-event.sw.yml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/transition-produce-event.sw.yml
@@ -7,11 +7,11 @@ events:
     type: kafka
 functions:
   - name: helloOne
-    metadata:
-      type: script
+    type: custom
+    operation: script
   - name: helloTwo
-    metadata:
-      type: script
+    type: custom
+    operation: script
 states:
   - name: HelloWorld
     type: operation

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/transition-produce-multi-events.sw.json
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/transition-produce-multi-events.sw.json
@@ -28,15 +28,13 @@
   "functions": [
     {
       "name": "helloOne",
-      "metadata": {
-        "type": "script"
-      }
+      "operation": "script",
+      "type": "custom"
     },
     {
       "name": "helloTwo",
-      "metadata": {
-        "type": "script"
-      }
+      "operation": "script",
+      "type": "custom"
     }
   ],
   "states": [

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/transition-produce-multi-events.sw.yml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/resources/exec/transition-produce-multi-events.sw.yml
@@ -16,11 +16,11 @@ events:
     type: kafka
 functions:
   - name: helloOne
-    metadata:
-      type: script
+    type: custom
+    operation: script
   - name: helloTwo
-    metadata:
-      type: script
+    type: custom
+    operation: script
 states:
   - name: HelloWorld
     type: operation

--- a/quarkus/addons/messaging/deployment/src/main/java/org/kie/kogito/addon/cloudevents/quarkus/deployment/KogitoAddOnMessagingProcessor.java
+++ b/quarkus/addons/messaging/deployment/src/main/java/org/kie/kogito/addon/cloudevents/quarkus/deployment/KogitoAddOnMessagingProcessor.java
@@ -32,7 +32,7 @@ import org.jbpm.compiler.canonical.ProcessMetaData;
 import org.kie.kogito.codegen.api.context.KogitoBuildContext;
 import org.kie.kogito.codegen.process.ProcessGenerator;
 import org.kie.kogito.quarkus.addons.common.deployment.AnyEngineKogitoAddOnProcessor;
-import org.kie.kogito.quarkus.common.deployment.KogitoAddonsGeneratedSourcesBuildItem;
+import org.kie.kogito.quarkus.common.deployment.KogitoAddonsPostGeneratedSourcesBuildItem;
 import org.kie.kogito.quarkus.common.deployment.KogitoBuildContextBuildItem;
 import org.kie.kogito.quarkus.extensions.spi.deployment.KogitoProcessContainerGeneratorBuildItem;
 
@@ -56,7 +56,7 @@ public class KogitoAddOnMessagingProcessor extends AnyEngineKogitoAddOnProcessor
     }
 
     @BuildStep
-    KogitoAddonsGeneratedSourcesBuildItem generate(Optional<KogitoProcessContainerGeneratorBuildItem> processBuildItem, BuildProducer<KogitoMessagingMetadataBuildItem> metadataProducer,
+    KogitoAddonsPostGeneratedSourcesBuildItem generate(Optional<KogitoProcessContainerGeneratorBuildItem> processBuildItem, BuildProducer<KogitoMessagingMetadataBuildItem> metadataProducer,
             KogitoBuildContextBuildItem kogitoContext) {
 
         Collection<ChannelInfo> channelsInfo = ChannelMappingStrategy.getChannelMapping();
@@ -78,7 +78,7 @@ public class KogitoAddOnMessagingProcessor extends AnyEngineKogitoAddOnProcessor
             }
         }
 
-        return new KogitoAddonsGeneratedSourcesBuildItem(generatedFiles);
+        return new KogitoAddonsPostGeneratedSourcesBuildItem(generatedFiles);
     }
 
     private Set<EventGenerator> getGenerators(Map<DotName, EventGenerator> generators,

--- a/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoAddonsPostGeneratedSourcesBuildItem.java
+++ b/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoAddonsPostGeneratedSourcesBuildItem.java
@@ -19,25 +19,10 @@ import java.util.Collection;
 
 import org.drools.codegen.common.GeneratedFile;
 
-import io.quarkus.builder.item.MultiBuildItem;
+public final class KogitoAddonsPostGeneratedSourcesBuildItem extends KogitoAddonsGeneratedSourcesBuildItem {
 
-public abstract class KogitoAddonsGeneratedSourcesBuildItem extends MultiBuildItem implements Comparable<KogitoAddonsGeneratedSourcesBuildItem> {
-
-    private static int counter;
-    private final Collection<GeneratedFile> generatedFiles;
-    private final int order;
-
-    protected KogitoAddonsGeneratedSourcesBuildItem(Collection<GeneratedFile> generatedFiles) {
-        this.generatedFiles = generatedFiles;
-        this.order = counter++;
+    public KogitoAddonsPostGeneratedSourcesBuildItem(Collection<GeneratedFile> generatedFiles) {
+        super(generatedFiles);
     }
 
-    public Collection<GeneratedFile> getGeneratedFiles() {
-        return generatedFiles;
-    }
-
-    @Override
-    public int compareTo(KogitoAddonsGeneratedSourcesBuildItem o) {
-        return order - o.order;
-    }
 }

--- a/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoAddonsPreGeneratedSourcesBuildItem.java
+++ b/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoAddonsPreGeneratedSourcesBuildItem.java
@@ -19,25 +19,10 @@ import java.util.Collection;
 
 import org.drools.codegen.common.GeneratedFile;
 
-import io.quarkus.builder.item.MultiBuildItem;
+public final class KogitoAddonsPreGeneratedSourcesBuildItem extends KogitoAddonsGeneratedSourcesBuildItem {
 
-public abstract class KogitoAddonsGeneratedSourcesBuildItem extends MultiBuildItem implements Comparable<KogitoAddonsGeneratedSourcesBuildItem> {
-
-    private static int counter;
-    private final Collection<GeneratedFile> generatedFiles;
-    private final int order;
-
-    protected KogitoAddonsGeneratedSourcesBuildItem(Collection<GeneratedFile> generatedFiles) {
-        this.generatedFiles = generatedFiles;
-        this.order = counter++;
+    public KogitoAddonsPreGeneratedSourcesBuildItem(Collection<GeneratedFile> generatedFiles) {
+        super(generatedFiles);
     }
 
-    public Collection<GeneratedFile> getGeneratedFiles() {
-        return generatedFiles;
-    }
-
-    @Override
-    public int compareTo(KogitoAddonsGeneratedSourcesBuildItem o) {
-        return order - o.order;
-    }
 }

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/src/main/java/org/kie/kogito/quarkus/serverless/openapi/WorkflowOpenApiHandlerGenerator.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/src/main/java/org/kie/kogito/quarkus/serverless/openapi/WorkflowOpenApiHandlerGenerator.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.quarkus.serverless.openapi;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.drools.codegen.common.GeneratedFile;
+import org.drools.codegen.common.GeneratedFileType;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.Type;
+import org.jboss.jandex.Type.Kind;
+import org.kie.kogito.codegen.api.context.KogitoBuildContext;
+import org.kie.kogito.process.impl.CachedWorkItemHandlerConfig;
+import org.kie.kogito.serverless.workflow.openapi.OpenApiWorkItemHandler;
+import org.kie.kogito.serverless.workflow.utils.OpenAPIOperationId;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Modifier.Keyword;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.CastExpr;
+import com.github.javaparser.ast.expr.ClassExpr;
+import com.github.javaparser.ast.expr.FieldAccessExpr;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.expr.NullLiteralExpr;
+import com.github.javaparser.ast.expr.StringLiteralExpr;
+import com.github.javaparser.ast.expr.SuperExpr;
+import com.github.javaparser.ast.expr.ThisExpr;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.ReturnStmt;
+
+import io.quarkiverse.openapi.generator.annotations.GeneratedClass;
+import io.quarkiverse.openapi.generator.annotations.GeneratedMethod;
+import io.quarkiverse.openapi.generator.annotations.GeneratedParam;
+
+import static com.github.javaparser.StaticJavaParser.parseClassOrInterfaceType;
+
+public class WorkflowOpenApiHandlerGenerator implements Runnable {
+
+    private static final DotName generatedClass = DotName.createSimple(GeneratedClass.class.getCanonicalName());
+    private static final DotName generatedMethod = DotName.createSimple(GeneratedMethod.class.getCanonicalName());
+    private static final DotName generatedParam = DotName.createSimple(GeneratedParam.class.getCanonicalName());
+
+    private static final String WORK_ITEM_PARAMETERS = "parameters";
+    private static final String OPEN_API_REF = "openApiRef";
+
+    private final IndexView index;
+    private final KogitoBuildContext context;
+    private final Collection<GeneratedFile> files = new ArrayList<>();
+
+    private WorkflowOpenApiHandlerGenerator(KogitoBuildContext context, IndexView index) {
+        this.index = index;
+        this.context = context;
+    }
+
+    @Override
+    public void run() {
+        index.getAnnotations(generatedClass).forEach(this::generateHandler);
+        if (!context.getGeneratedHandlers().isEmpty()) {
+            generateWorkItemHandlerConfig();
+        }
+    }
+
+    private void generateWorkItemHandlerConfig() {
+        CompilationUnit unit = new CompilationUnit(context.getPackageName());
+        final String className = "OpenApiWorkItemHandlerConfig";
+        ClassOrInterfaceDeclaration clazz = unit.addClass(className);
+        clazz.addExtendedType(CachedWorkItemHandlerConfig.class);
+        clazz.addAnnotation(ApplicationScoped.class);
+        BlockStmt body = clazz.addMethod("init").addAnnotation(PostConstruct.class).createBody();
+        for (String refHandler : context.getGeneratedHandlers()) {
+            final String fieldName = refHandler.toLowerCase();
+            clazz.addField(context.getPackageName() + "." + refHandler, fieldName).addAnnotation(Inject.class);
+            body.addStatement(new MethodCallExpr(new SuperExpr(), "register").addArgument(new StringLiteralExpr(refHandler))
+                    .addArgument(new NameExpr(fieldName)));
+        }
+        files.add(fromCompilationUnit(unit, className));
+    }
+
+    public static Collection<GeneratedFile> generateHandlerClasses(KogitoBuildContext context, IndexView index) {
+        WorkflowOpenApiHandlerGenerator runnable = new WorkflowOpenApiHandlerGenerator(context, index);
+        runnable.run();
+        return runnable.files;
+    }
+
+    private void generateHandler(AnnotationInstance a) {
+        final String fileName = a.value().asString();
+        final ClassInfo classInfo = a.target().asClass();
+        classInfo.methods().stream().filter(m -> m.hasAnnotation(generatedMethod)).map(m -> generateHandler(classInfo, fileName, m)).forEach(files::add);
+    }
+
+    private GeneratedFile generateHandler(ClassInfo classInfo, String fileName, MethodInfo m) {
+        final String packageName = context.getPackageName();
+        final String methodName = m.annotation(generatedMethod).value().asString();
+        final String className = OpenAPIOperationId.getClassName(fileName, methodName);
+        CompilationUnit unit = new CompilationUnit(packageName);
+        ClassOrInterfaceDeclaration clazz = unit.addClass(className);
+        clazz.addExtendedType(OpenApiWorkItemHandler.class);
+        clazz.addAnnotation(ApplicationScoped.class);
+        clazz.addField(classInfo.name().toString(), OPEN_API_REF).addAnnotation(RestClient.class).addAnnotation(Inject.class);
+        MethodDeclaration executeMethod = clazz.addMethod("internalExecute", Keyword.PROTECTED).addParameter(parseClassOrInterfaceType(Map.class.getCanonicalName()).setTypeArguments(
+                parseClassOrInterfaceType(String.class.getCanonicalName()), parseClassOrInterfaceType(Object.class.getCanonicalName())), WORK_ITEM_PARAMETERS).setType(Object.class);
+        BlockStmt body = executeMethod.createBody();
+        MethodCallExpr methodCallExpr = new MethodCallExpr(new FieldAccessExpr(new ThisExpr(), OPEN_API_REF), m.name());
+        final NameExpr parameters = new NameExpr(WORK_ITEM_PARAMETERS);
+        if (m.returnType().kind() == Kind.VOID) {
+            body.addStatement(methodCallExpr).addStatement(new ReturnStmt(new NullLiteralExpr()));
+        } else {
+            body.addStatement(new ReturnStmt(methodCallExpr));
+        }
+        for (Type param : m.parameters()) {
+            if (param.hasAnnotation(generatedParam)) {
+                methodCallExpr.addArgument(new CastExpr(fromClass(param), new MethodCallExpr(parameters, "remove").addArgument(param.annotation(generatedParam).value().asString())));
+            } else {
+                methodCallExpr.addArgument(new MethodCallExpr(new SuperExpr(), "buildPojo").addArgument(parameters).addArgument(new ClassExpr(fromClass(param))));
+            }
+        }
+        context.addGeneratedHandler(className);
+        return fromCompilationUnit(unit, className);
+    }
+
+    private GeneratedFile fromCompilationUnit(CompilationUnit unit, String className) {
+        return new GeneratedFile(GeneratedFileType.SOURCE, Path.of("", context.getPackageName().split("\\.")).resolve(className + ".java"),
+                unit.toString());
+    }
+
+    private com.github.javaparser.ast.type.Type fromClass(Type param) {
+        switch (param.kind()) {
+            case CLASS:
+                return parseClassOrInterfaceType(param.asClassType().name().toString());
+            case PRIMITIVE:
+                return StaticJavaParser.parseType(param.asPrimitiveType().name().toString());
+            default:
+                throw new UnsupportedOperationException("Kind " + param.kind() + " is not supported");
+        }
+
+    }
+}

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/src/main/java/org/kie/kogito/quarkus/serverless/openapi/WorkflowOpenApiSpecInputProvider.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/src/main/java/org/kie/kogito/quarkus/serverless/openapi/WorkflowOpenApiSpecInputProvider.java
@@ -27,6 +27,7 @@ import java.util.stream.Stream;
 
 import org.kie.kogito.codegen.process.ProcessCodegen;
 import org.kie.kogito.serverless.workflow.io.URIContentLoaderFactory;
+import org.kie.kogito.serverless.workflow.utils.OpenAPIOperationId;
 import org.kie.kogito.serverless.workflow.utils.ServerlessWorkflowUtils;
 
 import io.quarkiverse.openapi.generator.deployment.codegen.OpenApiSpecInputProvider;
@@ -76,8 +77,9 @@ public class WorkflowOpenApiSpecInputProvider implements OpenApiSpecInputProvide
 
     private SpecInputModel getSpecInput(FunctionDefinition function, Workflow workflow) {
         try {
-            URI uri = URI.create(ServerlessWorkflowUtils.getOpenApiURI(function));
-            return new SpecInputModel(ServerlessWorkflowUtils.getOpenApiFileName(uri),
+            OpenAPIOperationId operationId = OpenAPIOperationId.fromOperation(function.getOperation());
+            URI uri = operationId.getUri();
+            return new SpecInputModel(operationId.getFileName(),
                     URIContentLoaderFactory.buildLoader(uri, Thread.currentThread().getContextClassLoader(), workflow, function.getAuthRef()).getInputStream());
         } catch (IOException io) {
             throw new IllegalStateException(io);

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/src/main/java/org/kie/kogito/quarkus/serverless/workflow/deployment/ServerlessWorkflowAssetsProcessor.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/src/main/java/org/kie/kogito/quarkus/serverless/workflow/deployment/ServerlessWorkflowAssetsProcessor.java
@@ -16,9 +16,13 @@
 package org.kie.kogito.quarkus.serverless.workflow.deployment;
 
 import org.kie.kogito.process.expr.ExpressionHandler;
+import org.kie.kogito.quarkus.common.deployment.KogitoAddonsGeneratedSourcesBuildItem;
+import org.kie.kogito.quarkus.common.deployment.KogitoBuildContextBuildItem;
+import org.kie.kogito.quarkus.serverless.openapi.WorkflowOpenApiHandlerGenerator;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ServiceProviderBuildItem;
 import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
@@ -36,6 +40,11 @@ public class ServerlessWorkflowAssetsProcessor {
     @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
     void addExpressionHandlers(BuildProducer<ServiceProviderBuildItem> serviceProvider) {
         serviceProvider.produce(ServiceProviderBuildItem.allProvidersFromClassPath(ExpressionHandler.class.getCanonicalName()));
+    }
+
+    @BuildStep
+    void addOpenAPIWorkItemHandler(KogitoBuildContextBuildItem contextBI, CombinedIndexBuildItem indexBuildItem, BuildProducer<KogitoAddonsGeneratedSourcesBuildItem> sources) {
+        sources.produce(new KogitoAddonsGeneratedSourcesBuildItem(WorkflowOpenApiHandlerGenerator.generateHandlerClasses(contextBI.getKogitoBuildContext(), indexBuildItem.getIndex())));
     }
 
 }

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/src/main/java/org/kie/kogito/quarkus/serverless/workflow/deployment/ServerlessWorkflowAssetsProcessor.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/src/main/java/org/kie/kogito/quarkus/serverless/workflow/deployment/ServerlessWorkflowAssetsProcessor.java
@@ -16,7 +16,7 @@
 package org.kie.kogito.quarkus.serverless.workflow.deployment;
 
 import org.kie.kogito.process.expr.ExpressionHandler;
-import org.kie.kogito.quarkus.common.deployment.KogitoAddonsGeneratedSourcesBuildItem;
+import org.kie.kogito.quarkus.common.deployment.KogitoAddonsPreGeneratedSourcesBuildItem;
 import org.kie.kogito.quarkus.common.deployment.KogitoBuildContextBuildItem;
 import org.kie.kogito.quarkus.serverless.openapi.WorkflowOpenApiHandlerGenerator;
 
@@ -43,8 +43,8 @@ public class ServerlessWorkflowAssetsProcessor {
     }
 
     @BuildStep
-    void addOpenAPIWorkItemHandler(KogitoBuildContextBuildItem contextBI, CombinedIndexBuildItem indexBuildItem, BuildProducer<KogitoAddonsGeneratedSourcesBuildItem> sources) {
-        sources.produce(new KogitoAddonsGeneratedSourcesBuildItem(WorkflowOpenApiHandlerGenerator.generateHandlerClasses(contextBI.getKogitoBuildContext(), indexBuildItem.getIndex())));
+    void addOpenAPIWorkItemHandler(KogitoBuildContextBuildItem contextBI, CombinedIndexBuildItem indexBuildItem, BuildProducer<KogitoAddonsPreGeneratedSourcesBuildItem> sources) {
+        sources.produce(new KogitoAddonsPreGeneratedSourcesBuildItem(WorkflowOpenApiHandlerGenerator.generateHandlerClasses(contextBI.getKogitoBuildContext(), indexBuildItem.getIndex())));
     }
 
 }

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/event.sw.json
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/event.sw.json
@@ -15,9 +15,8 @@
   "functions": [
     {
       "name": "printMessage",
-      "metadata": {
-        "type": "sysout"
-      }
+      "type": "custom",
+      "operation": "sysout"
     }
   ],
   "states": [

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/eventMultiple.sw.json
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/eventMultiple.sw.json
@@ -21,9 +21,8 @@
   "functions": [
     {
       "name": "printMessage",
-      "metadata": {
-        "type": "sysout"
-      }
+      "type": "custom",
+      "operation": "sysout"
     }
   ],
   "states": [

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/pojoService.sw.json
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/pojoService.sw.json
@@ -7,17 +7,13 @@
   "functions": [
     {
       "name": "getPerson",
-      "metadata": {
-        "interface": "org.kie.kogito.workflows.services.PersonService",
-        "operation": "from",
-        "type": "service"
-      }
+      "operation": "service:org.kie.kogito.workflows.services.PersonService::from",
+      "type": "custom"
     },
     {
       "name": "printMessage",
-      "metadata": {
-        "type": "sysout"
-      }
+      "type": "custom",
+      "operation": "sysout"
     }
   ],
   "states": [

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/pojoServiceFilter.sw.json
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/pojoServiceFilter.sw.json
@@ -7,17 +7,13 @@
   "functions": [
     {
       "name": "getPerson",
-      "metadata": {
-        "interface": "org.kie.kogito.workflows.services.AgePersonService",
-        "operation": "from",
-        "type": "service"
-      }
+      "operation": "service:org.kie.kogito.workflows.services.AgePersonService::from",
+      "type": "custom"
     },
     {
       "name": "printMessage",
-      "metadata": {
-        "type": "sysout"
-      }
+      "operation" : "sysout",
+      "type" : "custom"
     }
   ],
   "states": [

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/src/main/java/org/kie/kogito/serverless/workflow/openapi/OpenApiWorkItemHandler.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/src/main/java/org/kie/kogito/serverless/workflow/openapi/OpenApiWorkItemHandler.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.serverless.workflow.openapi;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.kie.kogito.internal.process.runtime.KogitoWorkItem;
+import org.kie.kogito.internal.process.runtime.KogitoWorkItemHandler;
+import org.kie.kogito.internal.process.runtime.KogitoWorkItemManager;
+import org.kie.kogito.jackson.utils.JsonObjectUtils;
+import org.kie.kogito.jackson.utils.ObjectMapperFactory;
+
+public abstract class OpenApiWorkItemHandler implements KogitoWorkItemHandler {
+
+    @Override
+    public void executeWorkItem(KogitoWorkItem workItem, KogitoWorkItemManager manager) {
+        manager.completeWorkItem(workItem.getStringId(), Collections.singletonMap("Result",
+                JsonObjectUtils.fromValue(internalExecute(workItem.getParameters()))));
+    }
+
+    @Override
+    public void abortWorkItem(KogitoWorkItem workItem, KogitoWorkItemManager manager) {
+    }
+
+    protected final <T> T buildPojo(Map<String, Object> params, Class<T> clazz) {
+        return ObjectMapperFactory.get().convertValue(params, clazz);
+    }
+
+    protected abstract Object internalExecute(Map<String, Object> parameters);
+}


### PR DESCRIPTION
The quarkus extension will generate a handler to invoke the generated open api file 

```
package org.kie.kogito.app;

import org.kie.kogito.serverless.workflow.openapi.OpenApiWorkItemHandler;
import javax.enterprise.context.ApplicationScoped;
import org.eclipse.microprofile.rest.client.inject.RestClient;
import javax.inject.Inject;

@ApplicationScoped()
public class Queryservice_sendQuery extends OpenApiWorkItemHandler {

    @RestClient()
    @Inject()
    org.openapi.quarkus.api.DefaultApi openApiRef;

    protected Object internalExecute(java.util.Map<java.lang.String, java.lang.Object> parameters) {
        this.openApiRef.sendQuery(super.buildPojo(parameters, org.openapi.quarkus.model.QueryRequest.class));
        return null;
    }
}
```

The parser, if there is a generated handler for the open api URI being processed (this is the change in KogitoBuildContext), will use that handler name. 
If not, it will use RESTWorkItemHandler (parsing the OpenAPI uri) to do the call (so runner will be working without additional properties)

Since this JIRA  is a breaking compatibility change because of changes in open api properties (we are starting to using quarkus ones and dropping the ones we use to have), Ill take the license to remove support for medatata to select the type of operation (a really legacy stuff the implies updating a lot of test, so we did not do that till now) and to refactor static utility method to build nodes in a class different than the main parser. 

Examples changes required by property dropping are here https://github.com/kiegroup/kogito-examples/pull/1241

