### PR TITLE
KOGITO-7087 increase unit test coverage in kogito-jsonpath-expression

### DIFF
--- a/kogito-serverless-workflow/kogito-jsonpath-expression/src/test/java/org/kie/kogito/expr/jsonpath/JsonPathExpressionHandlerTest.java
+++ b/kogito-serverless-workflow/kogito-jsonpath-expression/src/test/java/org/kie/kogito/expr/jsonpath/JsonPathExpressionHandlerTest.java
@@ -26,9 +26,13 @@ import org.kie.kogito.process.expr.ExpressionHandlerFactory;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.jayway.jsonpath.PathNotFoundException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class JsonPathExpressionHandlerTest {
@@ -68,5 +72,128 @@ class JsonPathExpressionHandlerTest {
         ObjectMapper objectMapper = new ObjectMapper();
         JsonNode node = objectMapper.createObjectNode().set("foo", objectMapper.createArrayNode().add("pepe").add(false).add(3).add(objectMapper.createArrayNode().add(1.1).add(1.2).add(1.3)));
         assertEquals(Arrays.asList("pepe", false, 3, Arrays.asList(1.1, 1.2, 1.3)), parsedExpression.eval(node, Collection.class, context));
+    }
+
+    @Test
+    void testCollectFromArrayJsonNode() {
+        Expression parsedExpression = ExpressionHandlerFactory.get("jsonpath", "$.foo[*].bar");
+        assertTrue(parsedExpression.isValid(Optional.ofNullable(context)));
+        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectNode objectNode = objectMapper.createObjectNode();
+        ArrayNode node = objectNode.putArray("foo");
+        node.add(objectMapper.createObjectNode().put("bar", "value1"));
+        node.add(objectMapper.createObjectNode().put("bar", "value2"));
+        node.add(objectMapper.createObjectNode().put("bar", "value3"));
+        JsonNode eval = parsedExpression.eval(objectNode, JsonNode.class, context);
+        assertTrue(eval.isArray(), "Expected array as a result.");
+        assertEquals(3, eval.size(), "Unexpected size of the array.");
+        assertEquals("value1", eval.get(0).asText(), "Unexpected value in array at index 0.");
+        assertEquals("value2", eval.get(1).asText(), "Unexpected value in array at index 0.");
+        assertEquals("value3", eval.get(2).asText(), "Unexpected value in array at index 0.");
+    }
+
+    @Test
+    void testCollectFromArrayCollection() {
+        Expression parsedExpression = ExpressionHandlerFactory.get("jsonpath", "$.foo[*].bar");
+        assertTrue(parsedExpression.isValid(Optional.ofNullable(context)));
+        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectNode objectNode = objectMapper.createObjectNode();
+        ArrayNode node = objectNode.putArray("foo");
+        node.add(objectMapper.createObjectNode().put("bar", "value1"));
+        node.add(objectMapper.createObjectNode().put("bar", "value2"));
+        node.add(objectMapper.createObjectNode().put("bar", "value3"));
+        assertEquals(Arrays.asList("value1", "value2", "value3"), parsedExpression.eval(objectNode, Collection.class, context), "Unexpected contents of the collected values.");
+
+    }
+
+    @Test
+    void testNonValidExpression() {
+        Expression parsedExpression = ExpressionHandlerFactory.get("jsonpath", "$-");
+        assertEquals(false, parsedExpression.isValid(Optional.ofNullable(context)), "Exception was not thrown for invalid expression.");
+    }
+
+    @Test
+    void testNonMatchingExpression() {
+        Expression parsedExpression = ExpressionHandlerFactory.get("jsonpath", "$.foo.bar");
+        assertTrue(parsedExpression.isValid(Optional.ofNullable(context)));
+        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectNode objectNode = objectMapper.createObjectNode();
+        objectNode.putArray("foo").add(objectMapper.createArrayNode().add(objectMapper.createObjectNode().put("bar", "1")).add(objectMapper.createObjectNode().put("bar", "2")));
+        assertThrows(PathNotFoundException.class, () -> parsedExpression.eval(objectNode, String.class, context), "Exception expected for non-matched expression.");
+    }
+
+    @Test
+    void testAssignSimpleObjectUnderGivenProperty() {
+        Expression parsedExpression = ExpressionHandlerFactory.get("jsonpath", "$.bar2");
+        assertTrue(parsedExpression.isValid(Optional.ofNullable(context)));
+        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectNode toBeInserted = objectMapper.createObjectNode();
+        toBeInserted.put("bar", "value1");
+        ObjectNode targetNode = objectMapper.createObjectNode();
+        targetNode.put("bar2", "value2");
+        parsedExpression.assign(targetNode, toBeInserted, context);
+        assertFalse(targetNode.has("bar"), "Property 'bar' should not be in root.");
+        assertTrue(targetNode.has("bar2"), "Property 'bar2' is missing in root.");
+        assertTrue(targetNode.get("bar2").has("bar"), "Property 'bar2' should contain 'bar'.");
+        assertEquals("value1", targetNode.get("bar2").get("bar").asText(), "Unexpected value under 'bar2'->'bar' property.");
+    }
+
+    @Test
+    void testAssignArrayUnderGivenProperty() {
+        Expression parsedExpression = ExpressionHandlerFactory.get("jsonpath", "$.bar2");
+        assertTrue(parsedExpression.isValid(Optional.ofNullable(context)));
+        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectNode toBeInserted = objectMapper.createObjectNode();
+        toBeInserted.putArray("bar").add("value1").add("value2");
+        ObjectNode targetNode = objectMapper.createObjectNode();
+        targetNode.put("bar2", "value2");
+        parsedExpression.assign(targetNode, toBeInserted, context);
+        assertFalse(targetNode.has("bar"), "Property 'bar' should not be in root.");
+        assertTrue(targetNode.has("bar2"), "Property 'bar2' was removed.");
+        assertTrue(targetNode.get("bar2").has("bar"), "Property 'bar' is not under 'bar2'.");
+        assertTrue(targetNode.get("bar2").get("bar").isArray(), "Property 'bar' is not an array.");
+        assertEquals(2, targetNode.get("bar2").get("bar").size(), "'bar' array has unexpected size");
+        assertEquals("value1", targetNode.get("bar2").get("bar").get(0).asText(), "Unexpected value in 'bar' array at index 0.");
+        assertEquals("value2", targetNode.get("bar2").get("bar").get(1).asText(), "Unexpected value in 'bar' array at index 1.");
+    }
+
+    @Test
+    void testAssignCollectedFromArrayUnderRootAsFallback() {
+        Expression parsedExpression = ExpressionHandlerFactory.get("jsonpath", "$.foo[*].bar");
+        assertTrue(parsedExpression.isValid(Optional.ofNullable(context)));
+        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectNode targetNode = objectMapper.createObjectNode();
+        ArrayNode node = targetNode.putArray("foo");
+        node.add(objectMapper.createObjectNode().set("bar", objectMapper.createObjectNode().put("property", 1)));
+        node.add(objectMapper.createObjectNode().set("bar", objectMapper.createObjectNode().put("property", 2)));
+        node.add(objectMapper.createObjectNode().set("bar", objectMapper.createObjectNode().put("property", 3)));
+        ObjectNode toBeInserted = objectMapper.createObjectNode().put("property", 4);
+
+        parsedExpression.assign(targetNode, toBeInserted, context);
+
+        assertTrue(targetNode.has("bar"), "A new property 'bar' should have been added at root as a fallback.");
+        assertTrue(targetNode.get("bar").isArray(), "Property 'bar' should contain array");
+        assertEquals(4, targetNode.get("bar").size(), "'bar' array length mismatch.");
+        assertEquals(1, targetNode.get("bar").get(0).get("property").asInt(), "Unexpected value in 'bar' array at index 0.");
+        assertEquals(2, targetNode.get("bar").get(1).get("property").asInt(), "Unexpected value in 'bar' array at index 1.");
+        assertEquals(3, targetNode.get("bar").get(2).get("property").asInt(), "Unexpected value in 'bar' array at index 2.");
+        assertEquals(4, targetNode.get("bar").get(3).get("property").asInt(), "Unexpected value in 'bar' array at index 3.");
+    }
+
+    @Test
+    void testAssignWithNonExistentNodePathExpression() {
+        Expression parsedExpression = ExpressionHandlerFactory.get("jsonpath", "$.bar3");
+        assertTrue(parsedExpression.isValid(Optional.ofNullable(context)));
+        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectNode toBeInserted = objectMapper.createObjectNode();
+        toBeInserted.put("bar", "value1");
+        ObjectNode targetNode = objectMapper.createObjectNode();
+        targetNode.put("bar2", "value2");
+        parsedExpression.assign(targetNode, toBeInserted, context);
+        assertFalse(targetNode.has("bar"), "Property 'bar' should not be in root.");
+        assertTrue(targetNode.has("bar2"), "Property 'bar2' is missing in root.");
+        assertTrue(targetNode.has("bar3"), "Property 'bar2' is missing in root.");
+        assertTrue(targetNode.get("bar3").has("bar"), "Property 'bar3' should contain 'bar'.");
+        assertEquals("value1", targetNode.get("bar3").get("bar").asText(), "Unexpected value under 'bar3'->'bar' property.");
     }
 }


### PR DESCRIPTION
Jira: [KOGITO-7087](https://issues.redhat.com/browse/KOGITO-7087)

Increasing test coverage for kogito-jsonpath-expression module.

Resulting coverage report (compiled locally):
![Screenshot from 2022-05-04 13-06-20](https://user-images.githubusercontent.com/11939909/166670329-2ea0fad0-4be5-4429-90cb-58fd39a06a2c.png)


<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Run all builds</b>  
  Please add comment: <b>Jenkins retest this</b>

* <b>Run (or rerun) specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Run (or rerun) LTS specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

* <b>Run (or rerun) native specific test(s)</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

* <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
