### PR TITLE
[DROOLS-6937] remove naming convention to infer rule unit name from drl file

### DIFF
--- a/kogito-codegen-modules/kogito-codegen-rules/src/test/resources/org/kie/kogito/codegen/rules/myunit/MyUnit.drl
+++ b/kogito-codegen-modules/kogito-codegen-rules/src/test/resources/org/kie/kogito/codegen/rules/myunit/MyUnit.drl
@@ -15,5 +15,7 @@
  */
 package org.kie.kogito.codegen.rules.myunit
 
+unit MyUnit
+
 rule IAmAInAUnitAMA when
 then  end


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/DROOLS-6937

Related PRs:
https://github.com/kiegroup/drools/pull/4353
https://github.com/kiegroup/kogito-runtimes/pull/2183