### PR TITLE
KOGITO-7177 Setup Quarkus LTS nightly/pr checks

### DIFF
--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -54,6 +54,7 @@ setupDeployJob(Folder.NIGHTLY)
 setupNativeJob()
 setupQuarkusJob(Folder.NIGHTLY_QUARKUS_MAIN)
 setupQuarkusJob(Folder.NIGHTLY_QUARKUS_BRANCH)
+setupQuarkusJob(Folder.NIGHTLY_QUARKUS_LTS)
 setupMandrelJob()
 
 // Release jobs


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-7177

This PR will add the nightly check against Quarkus LTS version
as well as the optional PR check which can be started with `jenkins run quarkus-lts`

Related PRs:
- https://github.com/kiegroup/kogito-pipelines/pull/434
- https://github.com/kiegroup/kogito-runtimes/pull/2210