### PR TITLE
[KOGITO-7174] Default values should be cloned per process instance

### DIFF
--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/context/variable/Variable.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/context/variable/Variable.java
@@ -105,10 +105,12 @@ public class Variable implements TypeObject, ValueObject, Serializable {
         this.id = id;
     }
 
+    @Override
     public DataType getType() {
         return this.type;
     }
 
+    @Override
     public void setType(final DataType type) {
         if (type == null) {
             throw new IllegalArgumentException("type is null");
@@ -116,10 +118,12 @@ public class Variable implements TypeObject, ValueObject, Serializable {
         this.type = type;
     }
 
+    @Override
     public Object getValue() {
         return this.value;
     }
 
+    @Override
     public void setValue(final Object value) {
         if (this.type.verifyDataType(value)) {
             this.value = value;
@@ -149,6 +153,7 @@ public class Variable implements TypeObject, ValueObject, Serializable {
         return this.metaData;
     }
 
+    @Override
     public String toString() {
         return this.name;
     }
@@ -159,6 +164,10 @@ public class Variable implements TypeObject, ValueObject, Serializable {
 
         }
         return tags;
+    }
+
+    public Object cloneValue() {
+        return type.clone(getValue());
     }
 
     public boolean hasTag(String tagName) {

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/DataType.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/DataType.java
@@ -43,4 +43,8 @@ public interface DataType extends Externalizable {
     default boolean isAssignableFrom(DataType dataType) {
         return DataTypeUtils.isAssignableFrom(this, dataType);
     }
+
+    default Object clone(Object value) {
+        return value;
+    }
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/coverter/CloneHelper.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/coverter/CloneHelper.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.process.core.datatype.impl.coverter;
+
+import java.lang.reflect.Constructor;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CloneHelper {
+
+    private static final Logger logger = LoggerFactory.getLogger(CloneHelper.class);
+
+    private CloneHelper() {
+    }
+
+    public static <T> T clone(T o) {
+        Class<?> type = o.getClass();
+
+        // handling cloneable
+        if (Cloneable.class.isAssignableFrom(type)) {
+            try {
+                return (T) type.getMethod("clone").invoke(o);
+            } catch (NoSuchMethodException ex) {
+                throw new IllegalStateException(type + " implements cloneable but clone method cannot be found", ex);
+            } catch (ReflectiveOperationException ex) {
+                throw new IllegalStateException(type + " implements cloneable but invocation to clone method failed", ex);
+            }
+        }
+
+        // search copy constructor
+        Optional<Constructor<?>> copyConstructor = findCopyConstructor(type);
+        if (copyConstructor.isPresent()) {
+            try {
+                return (T) copyConstructor.get().newInstance(o);
+            } catch (ReflectiveOperationException e) {
+                throw new IllegalStateException(
+                        "cannot clone object " + o + " of type " + type + " using copy constructor. There was a failure when invoking it. Please review copy constructor implementation", e);
+            }
+        }
+
+        logger.warn("Object cannot be cloned. Please either register a cloner, implements cloneable or provide copy constructor. Returning same instance");
+        return o;
+    }
+
+    private static Optional<Constructor<?>> findCopyConstructor(Class<?> type) {
+
+        try {
+            return Optional.of(type.getConstructor(type));
+        } catch (ReflectiveOperationException ex) {
+            for (Constructor<?> constructor : type.getConstructors()) {
+                if (constructor.getParameterCount() == 1 && constructor.getParameterTypes()[0].isAssignableFrom(type)) {
+                    return Optional.of(constructor);
+                }
+            }
+        }
+        logger.debug("Cannot find copy constructor for type {}", type);
+        return Optional.empty();
+    }
+
+}

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/coverter/TypeConverterRegistry.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/coverter/TypeConverterRegistry.java
@@ -18,6 +18,7 @@ package org.jbpm.process.core.datatype.impl.coverter;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import org.kie.kogito.jackson.utils.JsonNodeConverter;
 import org.kie.kogito.jackson.utils.StringConverter;
@@ -30,6 +31,7 @@ public class TypeConverterRegistry {
 
     private Map<String, Function<String, ? extends Object>> converters = new HashMap<>();
     private Map<String, Function<? extends Object, String>> unconverters = new HashMap<>();
+    private Map<String, UnaryOperator<Object>> cloners = new HashMap<>();
 
     private Function<String, String> defaultConverter = new NoOpTypeConverter();
 
@@ -37,6 +39,7 @@ public class TypeConverterRegistry {
         converters.put("java.util.Date", new DateTypeConverter());
         converters.put(JsonNode.class.getName(), new JsonNodeConverter());
         unconverters.put(JsonNode.class.getName(), new StringConverter());
+        cloners.put(JsonNode.class.getName(), o -> ((JsonNode) o).deepCopy());
     }
 
     public boolean isRegistered(String type) {
@@ -55,6 +58,10 @@ public class TypeConverterRegistry {
             clazz = clazz.getSuperclass();
         } while (clazz != null && result == null);
         return result == null ? Object::toString : result;
+    }
+
+    public UnaryOperator<Object> forTypeCloner(String type) {
+        return cloners.getOrDefault(type, o -> o);
     }
 
     public void register(String type, Function<String, ? extends Object> converter) {

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/coverter/TypeConverterRegistry.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/coverter/TypeConverterRegistry.java
@@ -17,6 +17,7 @@ package org.jbpm.process.core.datatype.impl.coverter;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
@@ -61,16 +62,21 @@ public class TypeConverterRegistry {
     }
 
     public UnaryOperator<Object> forTypeCloner(String type) {
-        return cloners.getOrDefault(type, o -> o);
+        return cloners.getOrDefault(type, CloneHelper::clone);
     }
 
     public void register(String type, Function<String, ? extends Object> converter) {
-        register(type, converter, Object::toString);
+        register(type, converter, Optional.empty(), Optional.empty());
     }
 
     public <T> void register(String type, Function<String, T> converter, Function<T, String> unconverter) {
+        register(type, converter, Optional.of(unconverter), Optional.empty());
+    }
+
+    public <T> void register(String type, Function<String, T> converter, Optional<Function<T, String>> unconverter, Optional<UnaryOperator<Object>> cloner) {
         this.converters.put(type, converter);
-        this.unconverters.put(type, unconverter);
+        unconverter.ifPresent(u -> this.unconverters.put(type, u));
+        cloner.ifPresent(c -> this.cloners.put(type, c));
     }
 
     public static TypeConverterRegistry get() {

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/type/ObjectDataType.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/type/ObjectDataType.java
@@ -98,6 +98,11 @@ public class ObjectDataType implements DataType {
     }
 
     @Override
+    public Object clone(Object value) {
+        return TypeConverterRegistry.get().forTypeCloner(getStringType()).apply(value);
+    }
+
+    @Override
     public String writeValue(Object value) {
         return value.toString();
     }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/context/variable/VariableScopeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/context/variable/VariableScopeInstance.java
@@ -136,7 +136,7 @@ public class VariableScopeInstance extends AbstractContextInstance {
         super.setContextInstanceContainer(contextInstanceContainer);
         for (Variable variable : getVariableScope().getVariables()) {
             if (variable.getValue() != null) {
-                setVariable(variable.getName(), variable.getType().clone(variable.getValue()));
+                setVariable(variable.getName(), variable.cloneValue());
             }
         }
         if (contextInstanceContainer instanceof CompositeContextNodeInstance) {

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/context/variable/VariableScopeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/context/variable/VariableScopeInstance.java
@@ -136,7 +136,7 @@ public class VariableScopeInstance extends AbstractContextInstance {
         super.setContextInstanceContainer(contextInstanceContainer);
         for (Variable variable : getVariableScope().getVariables()) {
             if (variable.getValue() != null) {
-                setVariable(variable.getName(), variable.getValue());
+                setVariable(variable.getName(), variable.getType().clone(variable.getValue()));
             }
         }
         if (contextInstanceContainer instanceof CompositeContextNodeInstance) {

--- a/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcessInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcessInstance.java
@@ -99,7 +99,7 @@ public abstract class AbstractProcessInstance<T extends Model> implements Proces
         setCorrelationKey(businessKey);
 
         Map<String, Object> map = bind(variables);
-        String processId = process.process().getId();
+        String processId = process.get().getId();
         syncProcessInstance((WorkflowProcessInstance) ((CorrelationAwareProcessRuntime) rt).createProcessInstance(processId, correlationKey, map));
         processInstance.setMetaData(KOGITO_PROCESS_INSTANCE, this);
     }

--- a/jbpm/jbpm-flow/src/test/java/org/jbpm/process/core/datatype/impl/coverter/CloneHelperTest.java
+++ b/jbpm/jbpm-flow/src/test/java/org/jbpm/process/core/datatype/impl/coverter/CloneHelperTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.process.core.datatype.impl.coverter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class CloneHelperTest {
+
+    public static class CollectionHolder<T> {
+
+        private final Collection<T> collection;
+
+        public Collection<T> getCollection() {
+            return collection;
+        }
+
+        public CollectionHolder(Collection<T> collection) {
+            this.collection = collection;
+        }
+    }
+
+    public static class CloneableCollectionHolder<T> extends CollectionHolder<T> implements Cloneable {
+        public CloneableCollectionHolder(Collection<T> collection) {
+            super(collection);
+        }
+
+        @Override
+        public Object clone() {
+            return new CloneableCollectionHolder<>(new ArrayList<>(super.getCollection()));
+        }
+    }
+
+    public static class DumbCloneableCollectionHolder<T> extends CollectionHolder<T> implements Cloneable {
+        public DumbCloneableCollectionHolder(Collection<T> collection) {
+            super(collection);
+        }
+
+        @Override
+        public Object clone() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    public static class DumbCopyCollectionHolder<T> extends CollectionHolder<T> {
+        public DumbCopyCollectionHolder(Collection<T> collection) {
+            super(collection);
+        }
+
+        public DumbCopyCollectionHolder(CollectionHolder<T> collection) {
+            super(new ArrayList<>(collection.getCollection()));
+            throw new RuntimeException();
+        }
+    }
+
+    public static class CopyCollectionHolder<T> extends CollectionHolder<T> {
+        public CopyCollectionHolder(Collection<T> collection) {
+            super(collection);
+        }
+
+        public CopyCollectionHolder(CopyCollectionHolder<T> collection) {
+            super(new ArrayList<>(collection.getCollection()));
+        }
+    }
+
+    @Test
+    void testCloneable() {
+        CollectionHolder<Integer> toClone = new CloneableCollectionHolder<>(Arrays.asList(1, 2, 3, 4));
+        CollectionHolder<Integer> cloned = CloneHelper.clone(toClone);
+        assertNotSame(toClone.getCollection(), cloned.getCollection());
+        assertEquals(toClone.getCollection(), cloned.getCollection());
+    }
+
+    @Test
+    void testCopyConstructor() {
+        CollectionHolder<Integer> toClone = new CopyCollectionHolder<>(Arrays.asList(1, 2, 3, 4));
+        CollectionHolder<Integer> cloned = CloneHelper.clone(toClone);
+        assertNotSame(toClone.getCollection(), cloned.getCollection());
+        assertEquals(toClone.getCollection(), cloned.getCollection());
+    }
+
+    @Test
+    void testDefault() {
+        CollectionHolder<Integer> toClone = new CollectionHolder<>(Arrays.asList(1, 2, 3, 4));
+        CollectionHolder<Integer> cloned = CloneHelper.clone(toClone);
+        assertSame(toClone.getCollection(), cloned.getCollection());
+    }
+
+    @Test
+    void testCloneableError() {
+        CollectionHolder<Integer> toClone = new DumbCloneableCollectionHolder<>(Arrays.asList(1, 2, 3, 4));
+        assertThrows(IllegalStateException.class, () -> CloneHelper.clone(toClone));
+    }
+
+    @Test
+    void testCopyError() {
+        CollectionHolder<Integer> toClone = new DumbCopyCollectionHolder<>(Arrays.asList(1, 2, 3, 4));
+        assertThrows(IllegalStateException.class, () -> CloneHelper.clone(toClone));
+    }
+}

--- a/jbpm/jbpm-flow/src/test/java/org/kie/kogito/process/impl/AbstractProcessInstanceTest.java
+++ b/jbpm/jbpm-flow/src/test/java/org/kie/kogito/process/impl/AbstractProcessInstanceTest.java
@@ -65,7 +65,9 @@ public class AbstractProcessInstanceTest {
         MockitoAnnotations.initMocks(this);
 
         AbstractProcess<TestModel> process = mock(AbstractProcess.class);
-        when(process.process()).thenReturn(mock(Process.class));
+        Process piProcess = mock(Process.class);
+        when(process.process()).thenReturn(piProcess);
+        when(process.get()).thenReturn(piProcess);
         InternalProcessRuntime pr = mock(InternalProcessRuntime.class);
         when(pr.createProcessInstance(any(), any(), any())).thenReturn(wpi);
         when(pr.getProcessInstanceManager()).thenReturn(pim);

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/helloworld.sw.json
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/helloworld.sw.json
@@ -4,13 +4,25 @@
 "name": "Hello World Workflow",
 "description": "Inject Hello World",
 "start": "Hello State",
+"functions": [
+    {
+      "name": "concat",
+      "type": "expression",
+      "operation": ".result|=.+\"Hello World!\""
+    }
+  ],
 "states":[  
   {  
      "name":"Hello State",
-     "type":"inject",
-     "data": {
-        "result": "Hello World!"
-     },
+     "type":"operation",
+     "actions": [
+        {
+          "name": "concat",
+          "functionRef": {
+            "refName": "concat"
+            }
+        }
+     ],
      "end": true
   }
 ]

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/HelloWorldIT.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/HelloWorldIT.java
@@ -37,13 +37,17 @@ class HelloWorldIT {
 
     @Test
     void testHelloWorld() {
-        given()
-                .contentType(ContentType.JSON)
-                .when()
-                .body(Collections.emptyMap())
-                .post("/helloworld")
-                .then()
-                .statusCode(201)
-                .body("workflowdata.result", is("Hello World!"));
+
+        byte counter = 2;
+        do {
+            given()
+                    .contentType(ContentType.JSON)
+                    .when()
+                    .body(Collections.emptyMap())
+                    .post("/helloworld")
+                    .then()
+                    .statusCode(201)
+                    .body("workflowdata.result", is("Hello World!"));
+        } while (counter-- > 0);
     }
 }


### PR DESCRIPTION
When the default value of a process variable is not constant, it should be cloned per process instance, or different process instances will see changes performed by other process instances. 
This adds an specific cloner for JsonNode and a default generic one for POJOS implementing cloneable or providing a copy constructor 