### PR TITLE
[1.13.x] KOGITO-7201 - Filter starters and addons based on profile

### DIFF
--- a/springboot/archetype/pom.xml
+++ b/springboot/archetype/pom.xml
@@ -12,6 +12,10 @@
   <name>Kogito :: Spring Boot :: Maven Archetype</name>
   <description>Kogito based on Spring Boot runtime Archetype</description>
 
+  <properties>
+    <artefacts.all>false</artefacts.all>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -84,6 +88,9 @@
           <name>!productized</name>
         </property>
       </activation>
+      <properties>
+        <artefacts.all>true</artefacts.all>
+      </properties>
       <dependencies>
         <dependency>
           <groupId>org.kie.kogito</groupId>


### PR DESCRIPTION
Creating a project without including a starter will generate the following error:

`[ERROR] Failed to execute goal org.apache.maven.plugins:maven-archetype-plugin:3.2.1:generate (default-cli) on project standalone-pom: Invalid Kogito starter, please use one of the following: rules, decisions, predictions -> [Help 1]`