### PR TITLE
KOGITO-7235: Add endpoint to get source definition file content

### DIFF
--- a/addons/common/source-files/pom.xml
+++ b/addons/common/source-files/pom.xml
@@ -13,7 +13,10 @@
     <name>Kogito :: Add-Ons :: Source Files :: Common</name>
 
     <dependencies>
-
+        <dependency>
+            <groupId>org.kie.kogito</groupId>
+            <artifactId>kogito-codegen-processes</artifactId>
+        </dependency>
         <!-- Test -->
 
         <dependency>

--- a/addons/common/source-files/src/main/java/org/kie/kogito/addon/source/files/SourceFilesException.java
+++ b/addons/common/source-files/src/main/java/org/kie/kogito/addon/source/files/SourceFilesException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.addon.source.files;
+
+public class SourceFilesException extends RuntimeException {
+
+    public SourceFilesException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/addons/common/source-files/src/main/java/org/kie/kogito/addon/source/files/SourceFilesProvider.java
+++ b/addons/common/source-files/src/main/java/org/kie/kogito/addon/source/files/SourceFilesProvider.java
@@ -16,14 +16,23 @@
 package org.kie.kogito.addon.source.files;
 
 import java.util.Collection;
+import java.util.Optional;
 
 public interface SourceFilesProvider {
 
     /**
-     * Returns the source files for the given ID.
+     * Returns the source files for the given processId.
      * 
-     * @param id the source file ID
+     * @param processId the process identifier
      * @return the source files collection. The collection may be empty but not null.
      */
-    Collection<SourceFile> getSourceFiles(String id);
+    Collection<SourceFile> getProcessSourceFiles(String processId);
+
+    /**
+     * Returns the source file for the given processId.
+     *
+     * @param processId the process identifier
+     * @return the source file content.
+     */
+    Optional<String> getProcessSourceFile(String processId);
 }

--- a/addons/common/source-files/src/test/java/org/kie/kogito/addon/source/files/SourceFilesProviderImplTest.java
+++ b/addons/common/source-files/src/test/java/org/kie/kogito/addon/source/files/SourceFilesProviderImplTest.java
@@ -15,36 +15,58 @@
  */
 package org.kie.kogito.addon.source.files;
 
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class SourceFilesProviderImplTest {
 
+    private SourceFilesProviderImpl sourceFilesProvider;
+
+    private static String readFileContent(String file) throws URISyntaxException, IOException {
+        Path path = Paths.get(Thread.currentThread().getContextClassLoader().getResource(file).toURI());
+        return Files.readString(path);
+    }
+
+    private String getTestFileContentByFilename(String fileName) throws Exception {
+        return readFileContent("META-INF/resources/sources/" + fileName);
+    }
+
+    @BeforeEach
+    public void setup() {
+        sourceFilesProvider = new SourceFilesProviderImpl();
+    }
+
     @Test
     void addSourceFile() {
-        SourceFilesProviderImpl sourceFilesProvider = new SourceFilesProviderImpl();
         sourceFilesProvider.addSourceFile("a_process", new SourceFile("myworkflow.sw.json"));
 
-        assertThat(sourceFilesProvider.getSourceFiles("a_process"))
+        assertThat(sourceFilesProvider.getProcessSourceFiles("a_process"))
                 .contains(new SourceFile("myworkflow.sw.json"));
     }
 
     @Test
     void getSourceFilesByProcessId() {
-        SourceFilesProviderImpl sourceFilesProvider = new SourceFilesProviderImpl();
         sourceFilesProvider.addSourceFile("a_process", new SourceFile("myworkflow.sw.json"));
         sourceFilesProvider.addSourceFile("a_process", new SourceFile("myworkflow.sw.yaml"));
 
         sourceFilesProvider.addSourceFile("another_process", new SourceFile("myanotherworkflow.sw.json"));
         sourceFilesProvider.addSourceFile("another_process", new SourceFile("myanotherworkflow.sw.yaml"));
 
-        assertThat(sourceFilesProvider.getSourceFiles("a_process"))
+        assertThat(sourceFilesProvider.getProcessSourceFiles("a_process"))
                 .containsExactlyInAnyOrder(
                         new SourceFile("myworkflow.sw.json"),
                         new SourceFile("myworkflow.sw.yaml"));
 
-        assertThat(sourceFilesProvider.getSourceFiles("another_process"))
+        assertThat(sourceFilesProvider.getProcessSourceFiles("another_process"))
                 .containsExactlyInAnyOrder(
                         new SourceFile("myanotherworkflow.sw.json"),
                         new SourceFile("myanotherworkflow.sw.yaml"));
@@ -52,9 +74,34 @@ class SourceFilesProviderImplTest {
 
     @Test
     void getSourceFilesByProcessIdShouldNotReturnNull() {
-        SourceFilesProviderImpl sourceFilesProvider = new SourceFilesProviderImpl();
-
-        assertThat(sourceFilesProvider.getSourceFiles("a_process"))
+        assertThat(sourceFilesProvider.getProcessSourceFiles("a_process"))
                 .isEmpty();
+    }
+
+    @Test
+    void getValidSourceFileDefinitionByProcessIdTest() throws Exception {
+        sourceFilesProvider.addSourceFile("petstore_json_process", new SourceFile("petstore.json"));
+        sourceFilesProvider.addSourceFile("petstore_sw_json_process", new SourceFile("petstore.sw.json"));
+        sourceFilesProvider.addSourceFile("ymlgreet.sw_process", new SourceFile("ymlgreet.sw.yml"));
+        sourceFilesProvider.addSourceFile("bpmn_process", new SourceFile("hiring.bpmn"));
+
+        assertThat(sourceFilesProvider.getProcessSourceFile("petstore_sw_json_process")).contains(getTestFileContentByFilename("petstore.sw.json"));
+        assertThat(sourceFilesProvider.getProcessSourceFile("ymlgreet.sw_process")).contains(getTestFileContentByFilename("ymlgreet.sw.yml"));
+        assertThat(sourceFilesProvider.getProcessSourceFile("bpmn_process")).contains(getTestFileContentByFilename("hiring.bpmn"));
+    }
+
+    @Test
+    void getInvalidSourceFileDefinitionByProcessIdTest() {
+        sourceFilesProvider.addSourceFile("petstore_json_process", new SourceFile("petstore.json"));
+
+        //invalid extension
+        assertThat(sourceFilesProvider.getProcessSourceFile("petstore_json_process")).isEmpty();
+        //invalid process
+        assertThat(sourceFilesProvider.getProcessSourceFile("invalidProcess")).isEmpty();
+        // Unable to find referenced file with valid extension
+        sourceFilesProvider.addSourceFile("unexistingFile_sw_json_process", new SourceFile("unexistingFile.sw.json"));
+        assertThatThrownBy(() -> sourceFilesProvider.getProcessSourceFile("unexistingFile_sw_json_process"))
+                .isInstanceOf(SourceFilesException.class)
+                .hasMessage("Exception trying to read definition source file with relative URI:/sources/unexistingFile.sw.json");
     }
 }

--- a/addons/common/source-files/src/test/resources/META-INF/resources/sources/hiring.bpmn
+++ b/addons/common/source-files/src/test/resources/META-INF/resources/sources/hiring.bpmn
@@ -1,0 +1,257 @@
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_DEbcYMK_EDmVtvGs7DWZtQ" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
+  <bpmn2:itemDefinition id="_candidateItem" structureRef="org.kie.kogito.hr.Candidate"/>
+  <bpmn2:itemDefinition id="_hr_approvalItem" structureRef="Boolean"/>
+  <bpmn2:itemDefinition id="_it_approvalItem" structureRef="Boolean"/>
+  <bpmn2:itemDefinition id="__B8C4F63C-81AD-4291-9C1B-84967277EEF6_SkippableInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__B8C4F63C-81AD-4291-9C1B-84967277EEF6_PriorityInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__B8C4F63C-81AD-4291-9C1B-84967277EEF6_CommentInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__B8C4F63C-81AD-4291-9C1B-84967277EEF6_DescriptionInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__B8C4F63C-81AD-4291-9C1B-84967277EEF6_CreatedByInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__B8C4F63C-81AD-4291-9C1B-84967277EEF6_TaskNameInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__B8C4F63C-81AD-4291-9C1B-84967277EEF6_GroupIdInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__B8C4F63C-81AD-4291-9C1B-84967277EEF6_ContentInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__B8C4F63C-81AD-4291-9C1B-84967277EEF6_NotStartedReassignInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__B8C4F63C-81AD-4291-9C1B-84967277EEF6_NotCompletedReassignInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__B8C4F63C-81AD-4291-9C1B-84967277EEF6_NotStartedNotifyInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__B8C4F63C-81AD-4291-9C1B-84967277EEF6_NotCompletedNotifyInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__B8C4F63C-81AD-4291-9C1B-84967277EEF6_candidateInputXItem" structureRef="org.kie.kogito.hr.Candidate"/>
+  <bpmn2:itemDefinition id="__B8C4F63C-81AD-4291-9C1B-84967277EEF6_approveOutputXItem" structureRef="Boolean"/>
+  <bpmn2:itemDefinition id="__8962C15F-55EC-46F7-B926-5D5A1FD8D35E_SkippableInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__8962C15F-55EC-46F7-B926-5D5A1FD8D35E_PriorityInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__8962C15F-55EC-46F7-B926-5D5A1FD8D35E_CommentInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__8962C15F-55EC-46F7-B926-5D5A1FD8D35E_DescriptionInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__8962C15F-55EC-46F7-B926-5D5A1FD8D35E_CreatedByInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__8962C15F-55EC-46F7-B926-5D5A1FD8D35E_TaskNameInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__8962C15F-55EC-46F7-B926-5D5A1FD8D35E_GroupIdInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__8962C15F-55EC-46F7-B926-5D5A1FD8D35E_ContentInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__8962C15F-55EC-46F7-B926-5D5A1FD8D35E_NotStartedReassignInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__8962C15F-55EC-46F7-B926-5D5A1FD8D35E_NotCompletedReassignInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__8962C15F-55EC-46F7-B926-5D5A1FD8D35E_NotStartedNotifyInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__8962C15F-55EC-46F7-B926-5D5A1FD8D35E_NotCompletedNotifyInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__8962C15F-55EC-46F7-B926-5D5A1FD8D35E_candidateInputXItem" structureRef="org.kie.kogito.hr.Candidate"/>
+  <bpmn2:itemDefinition id="__8962C15F-55EC-46F7-B926-5D5A1FD8D35E_approveOutputXItem" structureRef="Boolean"/>
+  <bpmn2:process id="hiring" drools:packageName="org.kie.kogito.hr" drools:version="1.0" drools:adHoc="false" name="hiring" isExecutable="true" processType="Public">
+    <bpmn2:property id="candidate" itemSubjectRef="_candidateItem" name="candidate"/>
+    <bpmn2:property id="hr_approval" itemSubjectRef="_hr_approvalItem" name="hr_approval"/>
+    <bpmn2:property id="it_approval" itemSubjectRef="_it_approvalItem" name="it_approval"/>
+    <bpmn2:sequenceFlow id="_D762FECA-89D1-40DE-97EC-F69FA9A3E4B3" sourceRef="_8962C15F-55EC-46F7-B926-5D5A1FD8D35E" targetRef="_CCB6F569-A925-4F03-93BA-BD9CAA1843C5">
+      <bpmn2:extensionElements>
+        <drools:metaData name="isAutoConnection.source">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+        <drools:metaData name="isAutoConnection.target">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+    </bpmn2:sequenceFlow>
+    <bpmn2:sequenceFlow id="_27F81353-7101-4BDF-BB04-2FD45983C17F" sourceRef="_B8C4F63C-81AD-4291-9C1B-84967277EEF6" targetRef="_8962C15F-55EC-46F7-B926-5D5A1FD8D35E">
+      <bpmn2:extensionElements>
+        <drools:metaData name="isAutoConnection.target">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+    </bpmn2:sequenceFlow>
+    <bpmn2:sequenceFlow id="_2E69C0D9-AA97-4100-80F3-852553D7622D" sourceRef="_1639F738-45F3-4CD6-A80E-CCEBAA605D56" targetRef="_B8C4F63C-81AD-4291-9C1B-84967277EEF6">
+      <bpmn2:extensionElements>
+        <drools:metaData name="isAutoConnection.source">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+        <drools:metaData name="isAutoConnection.target">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+    </bpmn2:sequenceFlow>
+    <bpmn2:userTask id="_8962C15F-55EC-46F7-B926-5D5A1FD8D35E" name="IT Interview">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[IT Interview]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_27F81353-7101-4BDF-BB04-2FD45983C17F</bpmn2:incoming>
+      <bpmn2:outgoing>_D762FECA-89D1-40DE-97EC-F69FA9A3E4B3</bpmn2:outgoing>
+      <bpmn2:ioSpecification>
+        <bpmn2:dataInput id="_8962C15F-55EC-46F7-B926-5D5A1FD8D35E_TaskNameInputX" drools:dtype="Object" itemSubjectRef="__8962C15F-55EC-46F7-B926-5D5A1FD8D35E_TaskNameInputXItem" name="TaskName"/>
+        <bpmn2:dataInput id="_8962C15F-55EC-46F7-B926-5D5A1FD8D35E_candidateInputX" drools:dtype="org.kie.kogito.hr.Candidate" itemSubjectRef="__8962C15F-55EC-46F7-B926-5D5A1FD8D35E_candidateInputXItem" name="candidate"/>
+        <bpmn2:dataInput id="_8962C15F-55EC-46F7-B926-5D5A1FD8D35E_SkippableInputX" drools:dtype="Object" itemSubjectRef="__8962C15F-55EC-46F7-B926-5D5A1FD8D35E_SkippableInputXItem" name="Skippable"/>
+        <bpmn2:dataOutput id="_8962C15F-55EC-46F7-B926-5D5A1FD8D35E_approveOutputX" drools:dtype="Boolean" itemSubjectRef="__8962C15F-55EC-46F7-B926-5D5A1FD8D35E_approveOutputXItem" name="approve"/>
+        <bpmn2:inputSet>
+          <bpmn2:dataInputRefs>_8962C15F-55EC-46F7-B926-5D5A1FD8D35E_TaskNameInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_8962C15F-55EC-46F7-B926-5D5A1FD8D35E_candidateInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_8962C15F-55EC-46F7-B926-5D5A1FD8D35E_SkippableInputX</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet>
+          <bpmn2:dataOutputRefs>_8962C15F-55EC-46F7-B926-5D5A1FD8D35E_approveOutputX</bpmn2:dataOutputRefs>
+        </bpmn2:outputSet>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation>
+        <bpmn2:targetRef>_8962C15F-55EC-46F7-B926-5D5A1FD8D35E_TaskNameInputX</bpmn2:targetRef>
+        <bpmn2:assignment>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA[ITInterview]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_8962C15F-55EC-46F7-B926-5D5A1FD8D35E_TaskNameInputX]]></bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation>
+        <bpmn2:sourceRef>candidate</bpmn2:sourceRef>
+        <bpmn2:targetRef>_8962C15F-55EC-46F7-B926-5D5A1FD8D35E_candidateInputX</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation>
+        <bpmn2:targetRef>_8962C15F-55EC-46F7-B926-5D5A1FD8D35E_SkippableInputX</bpmn2:targetRef>
+        <bpmn2:assignment>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA[false]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_8962C15F-55EC-46F7-B926-5D5A1FD8D35E_SkippableInputX]]></bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataOutputAssociation>
+        <bpmn2:sourceRef>_8962C15F-55EC-46F7-B926-5D5A1FD8D35E_approveOutputX</bpmn2:sourceRef>
+        <bpmn2:targetRef>it_approval</bpmn2:targetRef>
+      </bpmn2:dataOutputAssociation>
+      <bpmn2:potentialOwner id="_DEg78MK_EDmVtvGs7DWZtQ">
+        <bpmn2:resourceAssignmentExpression id="_DEg78cK_EDmVtvGs7DWZtQ">
+          <bpmn2:formalExpression>jdoe</bpmn2:formalExpression>
+        </bpmn2:resourceAssignmentExpression>
+      </bpmn2:potentialOwner>
+    </bpmn2:userTask>
+    <bpmn2:endEvent id="_CCB6F569-A925-4F03-93BA-BD9CAA1843C5">
+      <bpmn2:incoming>_D762FECA-89D1-40DE-97EC-F69FA9A3E4B3</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:userTask id="_B8C4F63C-81AD-4291-9C1B-84967277EEF6" name="HR Interview">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[HR Interview]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_2E69C0D9-AA97-4100-80F3-852553D7622D</bpmn2:incoming>
+      <bpmn2:outgoing>_27F81353-7101-4BDF-BB04-2FD45983C17F</bpmn2:outgoing>
+      <bpmn2:ioSpecification>
+        <bpmn2:dataInput id="_B8C4F63C-81AD-4291-9C1B-84967277EEF6_TaskNameInputX" drools:dtype="Object" itemSubjectRef="__B8C4F63C-81AD-4291-9C1B-84967277EEF6_TaskNameInputXItem" name="TaskName"/>
+        <bpmn2:dataInput id="_B8C4F63C-81AD-4291-9C1B-84967277EEF6_candidateInputX" drools:dtype="org.kie.kogito.hr.Candidate" itemSubjectRef="__B8C4F63C-81AD-4291-9C1B-84967277EEF6_candidateInputXItem" name="candidate"/>
+        <bpmn2:dataInput id="_B8C4F63C-81AD-4291-9C1B-84967277EEF6_SkippableInputX" drools:dtype="Object" itemSubjectRef="__B8C4F63C-81AD-4291-9C1B-84967277EEF6_SkippableInputXItem" name="Skippable"/>
+        <bpmn2:dataOutput id="_B8C4F63C-81AD-4291-9C1B-84967277EEF6_approveOutputX" drools:dtype="Boolean" itemSubjectRef="__B8C4F63C-81AD-4291-9C1B-84967277EEF6_approveOutputXItem" name="approve"/>
+        <bpmn2:inputSet>
+          <bpmn2:dataInputRefs>_B8C4F63C-81AD-4291-9C1B-84967277EEF6_TaskNameInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_B8C4F63C-81AD-4291-9C1B-84967277EEF6_candidateInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_B8C4F63C-81AD-4291-9C1B-84967277EEF6_SkippableInputX</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet>
+          <bpmn2:dataOutputRefs>_B8C4F63C-81AD-4291-9C1B-84967277EEF6_approveOutputX</bpmn2:dataOutputRefs>
+        </bpmn2:outputSet>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation>
+        <bpmn2:targetRef>_B8C4F63C-81AD-4291-9C1B-84967277EEF6_TaskNameInputX</bpmn2:targetRef>
+        <bpmn2:assignment>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA[HRInterview]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_B8C4F63C-81AD-4291-9C1B-84967277EEF6_TaskNameInputX]]></bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation>
+        <bpmn2:sourceRef>candidate</bpmn2:sourceRef>
+        <bpmn2:targetRef>_B8C4F63C-81AD-4291-9C1B-84967277EEF6_candidateInputX</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation>
+        <bpmn2:targetRef>_B8C4F63C-81AD-4291-9C1B-84967277EEF6_SkippableInputX</bpmn2:targetRef>
+        <bpmn2:assignment>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA[false]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_B8C4F63C-81AD-4291-9C1B-84967277EEF6_SkippableInputX]]></bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataOutputAssociation>
+        <bpmn2:sourceRef>_B8C4F63C-81AD-4291-9C1B-84967277EEF6_approveOutputX</bpmn2:sourceRef>
+        <bpmn2:targetRef>hr_approval</bpmn2:targetRef>
+      </bpmn2:dataOutputAssociation>
+      <bpmn2:potentialOwner id="_DEiKEMK_EDmVtvGs7DWZtQ">
+        <bpmn2:resourceAssignmentExpression id="_DEiKEcK_EDmVtvGs7DWZtQ">
+          <bpmn2:formalExpression>jdoe</bpmn2:formalExpression>
+        </bpmn2:resourceAssignmentExpression>
+      </bpmn2:potentialOwner>
+    </bpmn2:userTask>
+    <bpmn2:startEvent id="_1639F738-45F3-4CD6-A80E-CCEBAA605D56">
+      <bpmn2:outgoing>_2E69C0D9-AA97-4100-80F3-852553D7622D</bpmn2:outgoing>
+    </bpmn2:startEvent>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram>
+    <bpmndi:BPMNPlane bpmnElement="hiring">
+      <bpmndi:BPMNShape id="shape__1639F738-45F3-4CD6-A80E-CCEBAA605D56" bpmnElement="_1639F738-45F3-4CD6-A80E-CCEBAA605D56">
+        <dc:Bounds height="56" width="56" x="107" y="114"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__B8C4F63C-81AD-4291-9C1B-84967277EEF6" bpmnElement="_B8C4F63C-81AD-4291-9C1B-84967277EEF6">
+        <dc:Bounds height="102" width="154" x="243" y="91"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__CCB6F569-A925-4F03-93BA-BD9CAA1843C5" bpmnElement="_CCB6F569-A925-4F03-93BA-BD9CAA1843C5">
+        <dc:Bounds height="56" width="56" x="719" y="114"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__8962C15F-55EC-46F7-B926-5D5A1FD8D35E" bpmnElement="_8962C15F-55EC-46F7-B926-5D5A1FD8D35E">
+        <dc:Bounds height="102" width="154" x="485" y="91"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="edge_shape__1639F738-45F3-4CD6-A80E-CCEBAA605D56_to_shape__B8C4F63C-81AD-4291-9C1B-84967277EEF6" bpmnElement="_2E69C0D9-AA97-4100-80F3-852553D7622D">
+        <di:waypoint x="163" y="142"/>
+        <di:waypoint x="243" y="142"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_shape__B8C4F63C-81AD-4291-9C1B-84967277EEF6_to_shape__8962C15F-55EC-46F7-B926-5D5A1FD8D35E" bpmnElement="_27F81353-7101-4BDF-BB04-2FD45983C17F">
+        <di:waypoint x="320" y="142"/>
+        <di:waypoint x="562" y="91"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_shape__8962C15F-55EC-46F7-B926-5D5A1FD8D35E_to_shape__CCB6F569-A925-4F03-93BA-BD9CAA1843C5" bpmnElement="_D762FECA-89D1-40DE-97EC-F69FA9A3E4B3">
+        <di:waypoint x="639" y="142"/>
+        <di:waypoint x="719" y="142"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters/>
+          <bpsim:ElementParameters elementRef="_1639F738-45F3-4CD6-A80E-CCEBAA605D56">
+            <bpsim:TimeParameters>
+              <bpsim:ProcessingTime>
+                <bpsim:NormalDistribution mean="0" standardDeviation="0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters elementRef="_B8C4F63C-81AD-4291-9C1B-84967277EEF6">
+            <bpsim:TimeParameters>
+              <bpsim:ProcessingTime>
+                <bpsim:NormalDistribution mean="0" standardDeviation="0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters>
+              <bpsim:Availability>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:Availability>
+              <bpsim:Quantity>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters>
+              <bpsim:UnitCost>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters elementRef="_8962C15F-55EC-46F7-B926-5D5A1FD8D35E">
+            <bpsim:TimeParameters>
+              <bpsim:ProcessingTime>
+                <bpsim:NormalDistribution mean="0" standardDeviation="0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters>
+              <bpsim:Availability>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:Availability>
+              <bpsim:Quantity>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters>
+              <bpsim:UnitCost>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_DEbcYMK_EDmVtvGs7DWZtQ</bpmn2:source>
+    <bpmn2:target>_DEbcYMK_EDmVtvGs7DWZtQ</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>

--- a/addons/common/source-files/src/test/resources/META-INF/resources/sources/petstore.json
+++ b/addons/common/source-files/src/test/resources/META-INF/resources/sources/petstore.json
@@ -1,0 +1,222 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "description": "A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "name": "Swagger API Team"
+    },
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/api",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "description": "Returns all pets from the system that the user has access to",
+        "operationId": "findPets",
+        "produces": [
+          "application/json",
+          "application/xml",
+          "text/xml",
+          "text/html"
+        ],
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "tags to filter by",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "csv"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "maximum number of results to return",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Pet"
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Creates a new pet in the store.  Duplicates are allowed",
+        "operationId": "addPet",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "pet",
+            "in": "body",
+            "description": "Pet to add to the store",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NewPet"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      }
+    },
+    "/pets/{id}": {
+      "get": {
+        "description": "Returns a user based on a single ID, if the user does not have access to the pet",
+        "operationId": "findPetById",
+        "produces": [
+          "application/json",
+          "application/xml",
+          "text/xml",
+          "text/html"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of pet to fetch",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "deletes a single pet based on the ID supplied",
+        "operationId": "deletePet",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of pet to delete",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "pet deleted"
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/NewPet"
+        },
+        {
+          "required": [
+            "id"
+          ],
+          "properties": {
+            "id": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        }
+      ]
+    },
+    "NewPet": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "ErrorModel": {
+      "type": "object",
+      "required": [
+        "code",
+        "message"
+      ],
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/addons/common/source-files/src/test/resources/META-INF/resources/sources/petstore.sw.json
+++ b/addons/common/source-files/src/test/resources/META-INF/resources/sources/petstore.sw.json
@@ -1,0 +1,31 @@
+{
+  "id": "petstore",
+  "version": "1.0",
+  "name": "Send CloudEvent after creating Pluto",
+  "start": "AddPluto",
+  "functions": [
+    {
+      "name": "addPet",
+      "operation": "petstore.json#addPet"
+    }
+  ],
+  "states": [
+    {
+      "name": "AddPluto",
+      "type": "operation",
+      "actions": [
+        {
+          "functionRef": {
+            "refName": "addPet",
+            "parameters": {
+              "body": {
+                "name": "Pluto"
+              }
+            }
+          }
+        }
+      ],
+      "end": true
+    }
+  ]
+}

--- a/addons/common/source-files/src/test/resources/META-INF/resources/sources/ymlgreet.sw.yml
+++ b/addons/common/source-files/src/test/resources/META-INF/resources/sources/ymlgreet.sw.yml
@@ -1,0 +1,40 @@
+id: ymlgreet
+version: '1.0'
+name: Greeting workflow
+description: YAML based greeting workflow
+expressionLang: jsonpath
+start: ChooseOnLanguage
+functions:
+  - name: greetFunction
+    type: custom
+    operation: sysout
+states:
+  - name: ChooseOnLanguage
+    type: switch
+    dataConditions:
+      - condition: "{{ $.[?(@.language  == 'English')] }}"
+        transition: GreetInEnglish
+      - condition: "{{ $.[?(@.language  == 'Spanish')] }}"
+        transition: GreetInSpanish
+    defaultCondition:
+      transition: GreetInEnglish
+  - name: GreetInEnglish
+    type: inject
+    data:
+      greeting: 'Hello from YAML Workflow, '
+    transition: GreetPerson
+  - name: GreetInSpanish
+    type: inject
+    data:
+      greeting: 'Saludos desde YAML Workflow, '
+    transition: GreetPerson
+  - name: GreetPerson
+    type: operation
+    actions:
+      - name: greetAction
+        functionRef:
+          refName: greetFunction
+          arguments:
+            message: "$.greeting $.name"
+    end:
+      terminate: true

--- a/integration-tests/integration-tests-quarkus-source-files/pom.xml
+++ b/integration-tests/integration-tests-quarkus-source-files/pom.xml
@@ -66,11 +66,6 @@
       <artifactId>rest-assured</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
-      <scope>test</scope>
-    </dependency>
 
     <!-- this is used implicitly by quarkus tests so let's make Maven aware of it -->
     <dependency>

--- a/integration-tests/integration-tests-quarkus-source-files/src/main/resources/application.properties
+++ b/integration-tests/integration-tests-quarkus-source-files/src/main/resources/application.properties
@@ -5,3 +5,7 @@ quarkus.security.users.embedded.roles.scott=source-files-client
 
 quarkus.security.users.embedded.users.helber=k0g1t0
 quarkus.security.users.embedded.roles.helber=any-role
+
+quarkus.http.auth.policy.source-files-addon-policy.roles-allowed=source-files-client
+quarkus.http.auth.permission.source-files-addon.paths=/sources/*,/management/processes/*
+quarkus.http.auth.permission.source-files-addon.policy=source-files-addon-policy

--- a/integration-tests/integration-tests-quarkus-source-files/src/test/resources/ymlgreet-expected.sw.yml
+++ b/integration-tests/integration-tests-quarkus-source-files/src/test/resources/ymlgreet-expected.sw.yml
@@ -1,0 +1,40 @@
+id: ymlgreet
+version: '1.0'
+name: Greeting workflow
+description: YAML based greeting workflow
+expressionLang: jsonpath
+start: ChooseOnLanguage
+functions:
+  - name: greetFunction
+    type: custom
+    operation: sysout
+states:
+  - name: ChooseOnLanguage
+    type: switch
+    dataConditions:
+      - condition: "{{ $.[?(@.language  == 'English')] }}"
+        transition: GreetInEnglish
+      - condition: "{{ $.[?(@.language  == 'Spanish')] }}"
+        transition: GreetInSpanish
+    defaultCondition:
+      transition: GreetInEnglish
+  - name: GreetInEnglish
+    type: inject
+    data:
+      greeting: 'Hello from YAML Workflow, '
+    transition: GreetPerson
+  - name: GreetInSpanish
+    type: inject
+    data:
+      greeting: 'Saludos desde YAML Workflow, '
+    transition: GreetPerson
+  - name: GreetPerson
+    type: operation
+    actions:
+      - name: greetAction
+        functionRef:
+          refName: greetFunction
+          arguments:
+            message: "$.greeting $.name"
+    end:
+      terminate: true

--- a/quarkus/addons/source-files/runtime/pom.xml
+++ b/quarkus/addons/source-files/runtime/pom.xml
@@ -73,6 +73,11 @@
             <artifactId>quarkus-test-security</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/quarkus/addons/source-files/runtime/src/main/java/org/kie/kogito/addon/source/files/SourceFilesResource.java
+++ b/quarkus/addons/source-files/runtime/src/main/java/org/kie/kogito/addon/source/files/SourceFilesResource.java
@@ -16,8 +16,8 @@
 package org.kie.kogito.addon.source.files;
 
 import java.util.Collection;
+import java.util.Optional;
 
-import javax.annotation.security.RolesAllowed;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -25,19 +25,35 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 @ApplicationScoped
-@Path("/management/process/")
-@RolesAllowed("source-files-client")
+@Path("/management/processes/")
 public final class SourceFilesResource {
 
-    @Inject
     SourceFilesProvider sourceFilesProvider;
 
     @GET
-    @Path("{id}/sources")
+    @Path("{processId}/sources")
     @Produces(MediaType.APPLICATION_JSON)
-    public Collection<SourceFile> getSourceFiles(@PathParam("id") String processId) {
-        return sourceFilesProvider.getSourceFiles(processId);
+    public Collection<SourceFile> getSourceFilesByProcessId(@PathParam("processId") String processId) {
+        return sourceFilesProvider.getProcessSourceFiles(processId);
+    }
+
+    @GET
+    @Path("{processId}/source")
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response getSourceFileByProcessId(@PathParam("processId") String processId) {
+        Optional<String> processSourceFileContent = sourceFilesProvider.getProcessSourceFile(processId);
+        if (processSourceFileContent.isPresent()) {
+            return Response.ok(processSourceFileContent.get()).build();
+        } else {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+    }
+
+    @Inject
+    void setSourceFilesProvider(SourceFilesProvider sourceFilesProvider) {
+        this.sourceFilesProvider = sourceFilesProvider;
     }
 }

--- a/quarkus/addons/source-files/runtime/src/test/resources/application.properties
+++ b/quarkus/addons/source-files/runtime/src/test/resources/application.properties
@@ -1,4 +1,0 @@
-quarkus.security.users.embedded.enabled=true
-quarkus.security.users.embedded.plain-text=true
-quarkus.security.users.embedded.users.scott=jb0ss
-quarkus.security.users.embedded.roles.scott=source-files-client


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/KOGITO-7235

Renamed getSourcesFiles endpoint path to "/sources/processes/{processId}"
Removed hard-coded @rolesAllowed, leaving the control to quarkus security framework on /sources/ path like it was done before:
   quarkus.http.auth.policy.source-files-addon-policy.roles-allowed=source-files-client
   quarkus.http.auth.permission.source-files-addon.paths=/sources/*
   quarkus.http.auth.permission.source-files-addon.policy=source-files-addon-policy
Added new endpoint with path "/sources/processes/{processId}/definition" to get the process definition file content.


<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>

- <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
