### PR TITLE
[KOGITO-7318] Improving jsonpath handling of secret, workflow, constant

### DIFF
--- a/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/expr/ExpressionHandler.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/expr/ExpressionHandler.java
@@ -15,15 +15,9 @@
  */
 package org.kie.kogito.process.expr;
 
-import java.util.function.Function;
-
 public interface ExpressionHandler {
 
     Expression get(String expr);
 
     String lang();
-
-    default Function<Object, String> getValueInjector() {
-        return Object::toString;
-    }
 }

--- a/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/expr/ExpressionHandlerFactory.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/expr/ExpressionHandlerFactory.java
@@ -17,7 +17,6 @@ package org.kie.kogito.process.expr;
 
 import java.util.Optional;
 import java.util.ServiceLoader;
-import java.util.function.Function;
 
 public class ExpressionHandlerFactory {
 
@@ -33,10 +32,6 @@ public class ExpressionHandlerFactory {
 
     public static boolean isSupported(String lang) {
         return serviceLoader.stream().anyMatch(p -> p.get().lang().equals(lang));
-    }
-
-    public static Function<Object, String> getValueInjector(String lang) {
-        return getExpressionHandler(lang).map(p -> p.getValueInjector()).orElse(Object::toString);
     }
 
     private static Optional<ExpressionHandler> getExpressionHandler(String lang) {

--- a/kogito-serverless-workflow/kogito-jq-expression/src/main/java/org/kie/kogito/expr/jq/JqExpressionHandler.java
+++ b/kogito-serverless-workflow/kogito-jq-expression/src/main/java/org/kie/kogito/expr/jq/JqExpressionHandler.java
@@ -15,7 +15,6 @@
  */
 package org.kie.kogito.expr.jq;
 
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.kie.kogito.process.expr.Expression;
@@ -58,14 +57,5 @@ public class JqExpressionHandler extends CachedExpressionHandler {
     @Override
     public String lang() {
         return "jq";
-    }
-
-    @Override
-    public Function<Object, String> getValueInjector() {
-        return JqExpressionHandler::inject;
-    }
-
-    static String inject(Object value) {
-        return value instanceof String ? "\"" + value + "\"" : value.toString();
     }
 }

--- a/kogito-serverless-workflow/kogito-jsonpath-expression/src/main/java/org/kie/kogito/expr/jsonpath/JsonPathExpression.java
+++ b/kogito-serverless-workflow/kogito-jsonpath-expression/src/main/java/org/kie/kogito/expr/jsonpath/JsonPathExpression.java
@@ -43,7 +43,8 @@ public class JsonPathExpression implements Expression {
     }
 
     private static final String replaceMagic(String expr, String magic) {
-        return expr.replace("$" + magic, "@." + magic);
+        magic = "$" + magic;
+        return expr.replace(magic, "@." + magic);
     }
 
     private Configuration getConfiguration(KogitoProcessContext context) {

--- a/kogito-serverless-workflow/kogito-jsonpath-expression/src/main/java/org/kie/kogito/expr/jsonpath/JsonPathExpression.java
+++ b/kogito-serverless-workflow/kogito-jsonpath-expression/src/main/java/org/kie/kogito/expr/jsonpath/JsonPathExpression.java
@@ -60,7 +60,8 @@ public class JsonPathExpression implements Expression {
         DocumentContext parsedContext = JsonPath.using(jsonPathConfig).parse(context);
         if (String.class.isAssignableFrom(returnClass)) {
             StringBuilder sb = new StringBuilder();
-            for (String part : expr.split("((?=\\$\\.))")) {
+            // valid json path is $. or $[
+            for (String part : expr.split("((?=\\$\\.|\\$\\[))")) {
                 JsonNode partResult = parsedContext.read(part, JsonNode.class);
                 sb.append(partResult.isTextual() ? partResult.asText() : partResult.toPrettyString());
             }

--- a/kogito-serverless-workflow/kogito-jsonpath-expression/src/main/java/org/kie/kogito/expr/jsonpath/JsonPathExpression.java
+++ b/kogito-serverless-workflow/kogito-jsonpath-expression/src/main/java/org/kie/kogito/expr/jsonpath/JsonPathExpression.java
@@ -60,7 +60,7 @@ public class JsonPathExpression implements Expression {
         DocumentContext parsedContext = JsonPath.using(jsonPathConfig).parse(context);
         if (String.class.isAssignableFrom(returnClass)) {
             StringBuilder sb = new StringBuilder();
-            for (String part : expr.split("((?=\\$))")) {
+            for (String part : expr.split("((?=\\$\\.))")) {
                 JsonNode partResult = parsedContext.read(part, JsonNode.class);
                 sb.append(partResult.isTextual() ? partResult.asText() : partResult.toPrettyString());
             }

--- a/kogito-serverless-workflow/kogito-jsonpath-expression/src/main/java/org/kie/kogito/expr/jsonpath/JsonPathExpressionHandler.java
+++ b/kogito-serverless-workflow/kogito-jsonpath-expression/src/main/java/org/kie/kogito/expr/jsonpath/JsonPathExpressionHandler.java
@@ -15,8 +15,6 @@
  */
 package org.kie.kogito.expr.jsonpath;
 
-import java.util.function.Function;
-
 import org.kie.kogito.process.expr.Expression;
 import org.kie.kogito.serverless.workflow.utils.CachedExpressionHandler;
 
@@ -30,14 +28,5 @@ public class JsonPathExpressionHandler extends CachedExpressionHandler {
     @Override
     public String lang() {
         return "jsonpath";
-    }
-
-    @Override
-    public Function<Object, String> getValueInjector() {
-        return JsonPathExpressionHandler::inject;
-    }
-
-    static String inject(Object value) {
-        return value instanceof String ? "'" + value + "'" : value.toString();
     }
 }

--- a/kogito-serverless-workflow/kogito-jsonpath-expression/src/main/java/org/kie/kogito/expr/jsonpath/WorkflowJacksonJsonNodeJsonProvider.java
+++ b/kogito-serverless-workflow/kogito-jsonpath-expression/src/main/java/org/kie/kogito/expr/jsonpath/WorkflowJacksonJsonNodeJsonProvider.java
@@ -36,11 +36,11 @@ public class WorkflowJacksonJsonNodeJsonProvider extends JacksonJsonNodeJsonProv
             return ((Function<String, Object>) obj).apply(key);
         } else {
             switch (key) {
-                case ExpressionHandlerUtils.SECRET_MAGIC:
+                case "$" + ExpressionHandlerUtils.SECRET_MAGIC:
                     return (Function<String, Object>) ExpressionHandlerUtils::getSecret;
-                case ExpressionHandlerUtils.CONTEXT_MAGIC:
+                case "$" + ExpressionHandlerUtils.CONTEXT_MAGIC:
                     return ExpressionHandlerUtils.getContextFunction(context);
-                case ExpressionHandlerUtils.CONST_MAGIC:
+                case "$" + ExpressionHandlerUtils.CONST_MAGIC:
                     return ExpressionHandlerUtils.getConstants(context);
                 default:
                     return super.getMapValue(obj, key);

--- a/kogito-serverless-workflow/kogito-jsonpath-expression/src/test/java/org/kie/kogito/expr/jsonpath/JsonPathExpressionHandlerTest.java
+++ b/kogito-serverless-workflow/kogito-jsonpath-expression/src/test/java/org/kie/kogito/expr/jsonpath/JsonPathExpressionHandlerTest.java
@@ -24,7 +24,6 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -42,7 +41,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
-import com.jayway.jsonpath.JsonPathException;
 import com.jayway.jsonpath.PathNotFoundException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -108,11 +106,11 @@ class JsonPathExpressionHandlerTest {
     }
 
     @Test
-    @Disabled("KOGITO-7318")
     void testCollectFromArrayCollectionRecursive() {
         Expression parsedExpression = ExpressionHandlerFactory.get("jsonpath", "$..property1");
         assertTrue(parsedExpression.isValid());
-        assertEquals(Arrays.asList("value1", "p1-value1", "p1-value2", "p1-value3"), parsedExpression.eval(getObjectNode(), Collection.class, getContext()));
+        assertEquals(Arrays.asList("value1", "p1-value1", "p1-value2", "p1-value3", "accessible_value", "accessible_value", "accessible_value"),
+                parsedExpression.eval(getObjectNode(), Collection.class, getContext()));
     }
 
     @Test
@@ -219,24 +217,21 @@ class JsonPathExpressionHandlerTest {
     void testConstPropertyFromJsonAccessible() {
         Expression parsedExpression = ExpressionHandlerFactory.get("jsonpath", "$.CONST.property1");
         assertTrue(parsedExpression.isValid());
-        // it's not considering the JsonNode property 'CONST', but '$CONST' variable
-        assertThrows(JsonPathException.class, () -> parsedExpression.eval(getObjectNode(), String.class, getContext()));
+        assertEquals("accessible_value", parsedExpression.eval(getObjectNode(), String.class, getContext()));
     }
 
     @Test
     void testSecretPropertyFromJsonAccessible() {
         Expression parsedExpression = ExpressionHandlerFactory.get("jsonpath", "$.SECRET.property1");
         assertTrue(parsedExpression.isValid());
-        // it's not considering the JsonNode property 'SECRET', but '$SECRET' variable
-        assertEquals("null", parsedExpression.eval(getObjectNode(), String.class, getContext()));
+        assertEquals("accessible_value", parsedExpression.eval(getObjectNode(), String.class, getContext()));
     }
 
     @Test
     void testWorkflowPropertyFromJsonAccessible() {
         Expression parsedExpression = ExpressionHandlerFactory.get("jsonpath", "$.WORKFLOW.property1");
         assertTrue(parsedExpression.isValid());
-        // it's not considering the JsonNode property 'WORKFLOW', but '$WORKFLOW' variable
-        assertThrows(IllegalArgumentException.class, () -> parsedExpression.eval(getObjectNode(), String.class, getContext()));
+        assertEquals(parsedExpression.eval(getObjectNode(), String.class, getContext()), "accessible_value");
     }
 
     @ParameterizedTest(name = "{index} \"{0}\" is resolved to \"{1}\"")
@@ -250,9 +245,7 @@ class JsonPathExpressionHandlerTest {
     private static Stream<Arguments> provideMagicWordExpressionsToTest() {
         return Stream.of(
                 Arguments.of("$WORKFLOW.instanceId", "1111-2222-3333", getContext()),
-                Arguments.of("WORKFLOW.instanceId", "1111-2222-3333", getContext()), // a side effect of jsonpath and prior variable resolution
                 Arguments.of("$SECRET.lettersonly", "secretlettersonly", getContext()),
-                Arguments.of("SECRET.lettersonly", "secretlettersonly", getContext()), // a side effect of jsonpath and prior variable resolution
                 Arguments.of("$SECRET.none", "null", getContext()),
                 //                Arguments.of("$SECRET.dot.secret", "null", getContext()), // exception due to missing object at path .dot
                 Arguments.of("$SECRET[\"dot.secret\"]", "secretdotsecret", getContext()),

--- a/kogito-serverless-workflow/kogito-jsonpath-expression/src/test/java/org/kie/kogito/expr/jsonpath/JsonPathExpressionHandlerTest.java
+++ b/kogito-serverless-workflow/kogito-jsonpath-expression/src/test/java/org/kie/kogito/expr/jsonpath/JsonPathExpressionHandlerTest.java
@@ -231,7 +231,7 @@ class JsonPathExpressionHandlerTest {
     void testWorkflowPropertyFromJsonAccessible() {
         Expression parsedExpression = ExpressionHandlerFactory.get("jsonpath", "$.WORKFLOW.property1");
         assertTrue(parsedExpression.isValid());
-        assertEquals(parsedExpression.eval(getObjectNode(), String.class, getContext()), "accessible_value");
+        assertEquals("accessible_value", parsedExpression.eval(getObjectNode(), String.class, getContext()));
     }
 
     @ParameterizedTest(name = "{index} \"{0}\" is resolved to \"{1}\"")


### PR DESCRIPTION
It turns out we can keep the $ if prefixing by @