### PR TITLE
[DROOLS-7016] align JavaParser version with the one used in Quarkus

### DIFF
--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -29,7 +29,7 @@
     <version.io.quarkiverse.openapi.generator>0.7.0</version.io.quarkiverse.openapi.generator>
     <version.io.quarkiverse.reactivemessaging.http>1.0.3</version.io.quarkiverse.reactivemessaging.http>
     <version.com.github.haifengl.smile>1.5.2</version.com.github.haifengl.smile>
-    <version.com.github.javaparser>3.23.1</version.com.github.javaparser>
+    <version.com.github.javaparser>3.24.2</version.com.github.javaparser>
     <version.com.github.java-json-tools>2.2.14</version.com.github.java-json-tools>
     <version.com.fasterxml.jackson.datatype>2.13.3</version.com.fasterxml.jackson.datatype>
     <version.com.github.erosb>1.14.1</version.com.github.erosb>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/DROOLS-7016
