### PR TITLE
[KOGITO-7414] Avoid null pointer exception if operationid is null

### DIFF
--- a/api/kogito-api/src/main/java/org/kie/kogito/internal/utils/ConversionUtils.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/internal/utils/ConversionUtils.java
@@ -68,6 +68,9 @@ public class ConversionUtils {
      * @return
      */
     public static String toCamelCase(String text) {
+        if (text == null) {
+            return null;
+        }
         StringBuilder builder = new StringBuilder();
         boolean convertNextCharToUpper = false;
 


### PR DESCRIPTION
Once the null pointer exception is prevented, the proper error message is displayed