### PR TITLE
[KOGITO-6687] Update openapi extension version

### DIFF
--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -26,7 +26,7 @@
     <version.com.jayway.jsonpath>2.6.0</version.com.jayway.jsonpath>
     <version.net.thisptr.jackson-jq>1.0.0-preview.20210928</version.net.thisptr.jackson-jq>
     <version.io.quarkiverse.jackson-jq>1.0.1</version.io.quarkiverse.jackson-jq>
-    <version.io.quarkiverse.openapi.generator>0.7.0</version.io.quarkiverse.openapi.generator>
+    <version.io.quarkiverse.openapi.generator>0.9.0</version.io.quarkiverse.openapi.generator>
     <version.io.quarkiverse.reactivemessaging.http>1.0.3</version.io.quarkiverse.reactivemessaging.http>
     <version.com.github.haifengl.smile>1.5.2</version.com.github.haifengl.smile>
     <version.com.github.javaparser>3.24.2</version.com.github.javaparser>

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/operationid/WorkflowOperationIdFactoryProvider.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/operationid/WorkflowOperationIdFactoryProvider.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
 public class WorkflowOperationIdFactoryProvider {
 
     private static final Logger logger = LoggerFactory.getLogger(WorkflowOperationIdFactoryProvider.class);
-    public static final String PROPERTY_NAME = "quarkus.kogito.sw.operationIdStrategy";
+    public static final String PROPERTY_NAME = "kogito.sw.operationIdStrategy";
 
     private static final WorkflowOperationIdFactoryType defaultType = WorkflowOperationIdFactoryType.FILE_NAME;
 


### PR DESCRIPTION
Also removing quarkus prefix from property, which was uneeded, so final property name will be 
`kogito.sw.operationIdStrategy`
See examples at https://github.com/kiegroup/kogito-examples/pull/1314