### PR TITLE
KOGITO-7453: Add ExceptionHandlerPolicy implementation classes to extend error code evaluation

### DIFF
--- a/jbpm/jbpm-bpmn2/pom.xml
+++ b/jbpm/jbpm-bpmn2/pom.xml
@@ -113,6 +113,11 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-client</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 

--- a/jbpm/jbpm-bpmn2/pom.xml
+++ b/jbpm/jbpm-bpmn2/pom.xml
@@ -94,6 +94,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>

--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/ProcessFactoryTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/ProcessFactoryTest.java
@@ -29,6 +29,8 @@ import org.jbpm.ruleflow.core.RuleFlowProcessFactory;
 import org.jbpm.test.util.NodeLeftCountDownProcessEventListener;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.kie.api.event.process.ProcessNodeLeftEvent;
 import org.kie.api.io.Resource;
 import org.kie.api.runtime.process.ProcessInstance;
@@ -368,10 +370,10 @@ public class ProcessFactoryTest extends JbpmBpmn2TestCase {
 
     }
 
-    @Test
-    public void testBoundaryErrorEvent() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = { "java.lang.RuntimeException", "Unknown error", "Status code 400", "(.*)code 4[0-9]{2}" })
+    public void testBoundaryErrorEvent(String errorCode) throws Exception {
         final String boundaryErrorEvent = "BoundaryErrorEvent";
-        final String errorCode = "java.lang.RuntimeException";
         final String processId = "myProcess";
         final RuleFlowProcessFactory factory = RuleFlowProcessFactory.createProcess(processId);
         final String startNode = "Start";

--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/objects/ExceptionOnPurposeHandler.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/objects/ExceptionOnPurposeHandler.java
@@ -23,7 +23,7 @@ public class ExceptionOnPurposeHandler implements KogitoWorkItemHandler {
 
     @Override
     public void executeWorkItem(KogitoWorkItem workItem, KogitoWorkItemManager manager) {
-        throw new RuntimeException("Thrown on purpose");
+        throw new RuntimeException("Unknown error, status code 400");
     }
 
     @Override

--- a/jbpm/jbpm-flow/pom.xml
+++ b/jbpm/jbpm-flow/pom.xml
@@ -86,6 +86,11 @@
       <artifactId>jaxb-api</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-client</artifactId>
+      <scope>provided</scope>
+    </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/jbpm/jbpm-flow/pom.xml
+++ b/jbpm/jbpm-flow/pom.xml
@@ -104,6 +104,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/context/exception/AbstractHierarchyExceptionPolicy.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/context/exception/AbstractHierarchyExceptionPolicy.java
@@ -15,9 +15,22 @@
  */
 package org.jbpm.process.core.context.exception;
 
-public class RootCauseExceptionPolicy extends AbstractHierarchyExceptionPolicy {
+public abstract class AbstractHierarchyExceptionPolicy implements ExceptionHandlerPolicy {
     @Override
-    protected boolean verify(String errorCode, Throwable exception) {
-        return errorCode.equals(exception.getClass().getName());
+    public boolean test(String errorCode, Throwable exception) {
+        boolean found = verifyRoot(errorCode, exception);
+        Throwable rootCause = exception.getCause();
+        while (!found && rootCause != null) {
+            found = verify(errorCode, rootCause);
+            rootCause = rootCause.getCause();
+        }
+        return found;
     }
+
+    protected boolean verifyRoot(String errorCode, Throwable exception) {
+        return verify(errorCode, exception);
+    }
+
+    protected abstract boolean verify(String errorCode, Throwable exception);
+
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/context/exception/ExceptionHandlerPolicyFactory.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/context/exception/ExceptionHandlerPolicyFactory.java
@@ -29,6 +29,7 @@ public class ExceptionHandlerPolicyFactory {
         policies.add(new SubclassExceptionPolicy());
         policies.add(new RootCauseExceptionPolicy());
         policies.add(new MessageContentExceptionPolicy());
+        policies.add(new WebApplicationExceptionPolicy());
     }
 
     public static Collection<ExceptionHandlerPolicy> getHandlerPolicies() {

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/context/exception/MessageContentExceptionPolicy.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/context/exception/MessageContentExceptionPolicy.java
@@ -15,24 +15,13 @@
  */
 package org.jbpm.process.core.context.exception;
 
-public class MessageContentExceptionPolicy implements ExceptionHandlerPolicy {
+public class MessageContentExceptionPolicy extends AbstractHierarchyExceptionPolicy {
     @Override
-    public boolean test(String test, Throwable exception) {
-        boolean found = verify(test, exception);
-        Throwable rootCause = exception.getCause();
-        while (!found && rootCause != null) {
-            found = verify(test, rootCause);
-            rootCause = rootCause.getCause();
-        }
-        return found;
-    }
-
-    private boolean verify(String test, Throwable exception) {
+    protected boolean verify(String errorCode, Throwable exception) {
         String msg = exception.getMessage();
         if (msg != null) {
-            return msg.toLowerCase().contains(test.toLowerCase()) || msg.matches(test);
+            return msg.toLowerCase().contains(errorCode.toLowerCase()) || msg.matches(errorCode);
         }
         return false;
     }
-
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/context/exception/MessageContentExceptionPolicy.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/context/exception/MessageContentExceptionPolicy.java
@@ -15,23 +15,24 @@
  */
 package org.jbpm.process.core.context.exception;
 
-import java.util.ArrayList;
-import java.util.Collection;
-
-public class ExceptionHandlerPolicyFactory {
-
-    private ExceptionHandlerPolicyFactory() {
+public class MessageContentExceptionPolicy implements ExceptionHandlerPolicy {
+    @Override
+    public boolean test(String test, Throwable exception) {
+        boolean found = verify(test, exception);
+        Throwable rootCause = exception.getCause();
+        while (!found && rootCause != null) {
+            found = verify(test, rootCause);
+            rootCause = rootCause.getCause();
+        }
+        return found;
     }
 
-    private static Collection<ExceptionHandlerPolicy> policies = new ArrayList<>();
-
-    static {
-        policies.add(new SubclassExceptionPolicy());
-        policies.add(new RootCauseExceptionPolicy());
-        policies.add(new MessageContentExceptionPolicy());
+    private boolean verify(String test, Throwable exception) {
+        String msg = exception.getMessage();
+        if (msg != null) {
+            return msg.toLowerCase().contains(test.toLowerCase()) || msg.matches(test);
+        }
+        return false;
     }
 
-    public static Collection<ExceptionHandlerPolicy> getHandlerPolicies() {
-        return policies;
-    }
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/context/exception/RootCauseExceptionPolicy.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/context/exception/RootCauseExceptionPolicy.java
@@ -16,6 +16,12 @@
 package org.jbpm.process.core.context.exception;
 
 public class RootCauseExceptionPolicy extends AbstractHierarchyExceptionPolicy {
+
+    @Override
+    protected boolean verifyRoot(String errorCode, Throwable exception) {
+        return false;
+    }
+
     @Override
     protected boolean verify(String errorCode, Throwable exception) {
         return errorCode.equals(exception.getClass().getName());

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/context/exception/WebApplicationExceptionPolicy.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/context/exception/WebApplicationExceptionPolicy.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.process.core.context.exception;
+
+import javax.ws.rs.WebApplicationException;
+
+public class WebApplicationExceptionPolicy implements ExceptionHandlerPolicy {
+
+    @Override
+    public boolean test(String errorCode, Throwable exception) {
+        boolean found = false;
+        if (exception instanceof WebApplicationException) {
+            int statusCode = ((WebApplicationException) exception).getResponse().getStatus();
+            String error[] = errorCode.split(":");
+            if (error.length == 1) {
+                // test if errorCode contains the http code, eg. "500"
+                found = Integer.parseInt(error[0]) == statusCode;
+            } else if (error.length == 2) {
+                // test if errorCode contains the http code, eg. "HTTP:500"
+                found = Integer.parseInt(error[1]) == statusCode;
+            }
+        }
+        return found;
+    }
+
+}

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/context/exception/WebApplicationExceptionPolicy.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/context/exception/WebApplicationExceptionPolicy.java
@@ -22,16 +22,20 @@ public class WebApplicationExceptionPolicy implements ExceptionHandlerPolicy {
     @Override
     public boolean test(String errorCode, Throwable exception) {
         boolean found = false;
-        if (exception instanceof WebApplicationException) {
-            int statusCode = ((WebApplicationException) exception).getResponse().getStatus();
-            String error[] = errorCode.split(":");
-            if (error.length == 1) {
-                // test if errorCode contains the http code, eg. "500"
-                found = Integer.parseInt(error[0]) == statusCode;
-            } else if (error.length == 2) {
-                // test if errorCode contains the http code, eg. "HTTP:500"
-                found = Integer.parseInt(error[1]) == statusCode;
+        try {
+            if (exception instanceof WebApplicationException) {
+                int statusCode = ((WebApplicationException) exception).getResponse().getStatus();
+                String error[] = errorCode.split(":");
+                if (error.length == 1) {
+                    // test if errorCode contains the http code, eg. "500"
+                    found = Integer.parseInt(error[0]) == statusCode;
+                } else if (error.length == 2) {
+                    // test if errorCode contains the http code, eg. "HTTP:500"
+                    found = Integer.parseInt(error[1]) == statusCode;
+                }
             }
+        } catch (NoClassDefFoundError error) {
+            // ignore CL error
         }
         return found;
     }

--- a/jbpm/jbpm-flow/src/test/java/org/jbpm/process/core/context/exception/ExceptionHandlerPolicyTest.java
+++ b/jbpm/jbpm-flow/src/test/java/org/jbpm/process/core/context/exception/ExceptionHandlerPolicyTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ExceptionHandlerPolicyTest {
@@ -54,6 +55,13 @@ class ExceptionHandlerPolicyTest {
     void testWebExceptionHandlerPolicyFactory(String errorString) {
         Throwable exception = new javax.ws.rs.WebApplicationException(Response.status(500).entity("Unknown error").build());
         assertTrue(test(policies, errorString, exception));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "HTTP:xyz", "xyz" })
+    void testWebExceptionHandlerPolicyFactoryIncorrectFormat(String errorString) {
+        Throwable exception = new javax.ws.rs.WebApplicationException(Response.status(500).entity("Unknown error").build());
+        assertFalse(test(policies, errorString, exception));
     }
 
     private boolean test(Collection<ExceptionHandlerPolicy> policies, String className, Throwable exception) {

--- a/jbpm/jbpm-flow/src/test/java/org/jbpm/process/core/context/exception/ExceptionHandlerPolicyTest.java
+++ b/jbpm/jbpm-flow/src/test/java/org/jbpm/process/core/context/exception/ExceptionHandlerPolicyTest.java
@@ -16,10 +16,12 @@
 package org.jbpm.process.core.context.exception;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Iterator;
-import java.util.Map;
 
+import javax.ws.rs.core.Response;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -28,15 +30,29 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ExceptionHandlerPolicyTest {
 
-    protected Map<String, ExceptionHandler> exceptionHandlers = new HashMap<String, ExceptionHandler>();
+    static private Collection<ExceptionHandlerPolicy> policies;
+
+    @BeforeAll
+    static void setup() {
+        policies = ExceptionHandlerPolicyFactory.getHandlerPolicies();
+    }
+
+    @Test
+    void testExceptionHandlerPolicies() {
+        assertEquals(4, policies.size());
+    }
 
     @ParameterizedTest
     @ValueSource(strings = { "java.lang.RuntimeException", "Unknown error", "Status code 400", "(.*)code 4[0-9]{2}" })
     void testExceptionHandlerPolicyFactory(String errorString) {
         Throwable exception = new IllegalStateException("Unknown error, status code 400");
-        Collection<ExceptionHandlerPolicy> policies = ExceptionHandlerPolicyFactory.getHandlerPolicies();
-        assertEquals(3, policies.size());
+        assertTrue(test(policies, errorString, exception));
+    }
 
+    @ParameterizedTest
+    @ValueSource(strings = { "HTTP:500", "500" })
+    void testWebExceptionHandlerPolicyFactory(String errorString) {
+        Throwable exception = new javax.ws.rs.WebApplicationException(Response.status(500).entity("Unknown error").build());
         assertTrue(test(policies, errorString, exception));
     }
 

--- a/jbpm/jbpm-flow/src/test/java/org/jbpm/process/core/context/exception/ExceptionHandlerPolicyTest.java
+++ b/jbpm/jbpm-flow/src/test/java/org/jbpm/process/core/context/exception/ExceptionHandlerPolicyTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.process.core.context.exception;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ExceptionHandlerPolicyTest {
+
+    protected Map<String, ExceptionHandler> exceptionHandlers = new HashMap<String, ExceptionHandler>();
+
+    @ParameterizedTest
+    @ValueSource(strings = { "java.lang.RuntimeException", "Unknown error", "Status code 400", "(.*)code 4[0-9]{2}" })
+    void testExceptionHandlerPolicyFactory(String errorString) {
+        Throwable exception = new IllegalStateException("Unknown error, status code 400");
+        Collection<ExceptionHandlerPolicy> policies = ExceptionHandlerPolicyFactory.getHandlerPolicies();
+        assertEquals(3, policies.size());
+
+        assertTrue(test(policies, errorString, exception));
+    }
+
+    private boolean test(Collection<ExceptionHandlerPolicy> policies, String className, Throwable exception) {
+        if (className == null)
+            return false;
+        Iterator<ExceptionHandlerPolicy> iter = policies.iterator();
+        boolean found = false;
+        while (!found && iter.hasNext()) {
+            found = iter.next().test(className, exception);
+        }
+        return found;
+    }
+}


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/KOGITO-7453

This PR extends the current logic to map error codes in a workflow definition to exceptions handled by the engine at runtime. In addition to use the FQCN of an exception in the error code, it allows to map errors using a (partial) match of the error message, or in case of a WebApplicationException, using the http status code.
 
The PR adds two new ExceptionHandlerPolicy implementation classes:
- `MessageContentExceptionPolicy`: Compares the defined error code against the error message caught by the engine. Uses lowercase/partial comparison and supports usage of regex
- `WebApplicationExceptionPolicy`: For exceptions of type `javax.ws.rs.WebApplicationException`, this policy evaluates the defined error code against the HTTP code from the underlying response object. The error code can be defined either as the HTTP code itself ("500"), or as colon separated string where the error code is in the second part ("HTTP:404").

Examples:
|Error code definition|Applicable ExceptionHandlerPolicy implementation|
|----------|----------|
|`"code": "java.lang.RuntimeException"`|`SubclassExceptionPolicy` (existing)|
|`"code": "Unknown error"`|`MessageContentExceptionPolicy` (new)|
|`"code": "(.*)status code 4[0-9]\{2\}"`|`MessageContentExceptionPolicy` (new)|
|`"code": "500"`|`MessageContentExceptionPolicy`, `WebApplicationExceptionPolicy` (new)|
|`"code": "HTTP:404"`|`WebApplicationExceptionPolicy` (new)|
