### PR TITLE
KOGITO-7461 - Add event dispatcher listener to make for the possibility of throttling the message consumer

### DIFF
--- a/api/kogito-services/src/main/java/org/kie/kogito/services/event/EventDispatcherListener.java
+++ b/api/kogito-services/src/main/java/org/kie/kogito/services/event/EventDispatcherListener.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.services.event;
+
+import org.kie.kogito.process.ProcessInstance;
+
+public interface EventDispatcherListener {
+
+    void onItem(Object payload);
+
+    void onComplete(ProcessInstance<?> processInstance, Throwable ex);
+}
+


### PR DESCRIPTION
This functionality allowed us to register listeners of the event handler execution, which allows us to have metrics of worker thread loading during execution and thereby be able to control the intensity of the event flow. In simple words, this functionality allows us to implement throttling of the event flow. As a result, we were able to solve the 'thread blocked' problem.