### PR TITLE
KOGITO-7557: RestWorkItemHandler does not propagate exceptions/errors from invoked service

### DIFF
--- a/kogito-workitems/kogito-rest-workitem/pom.xml
+++ b/kogito-workitems/kogito-rest-workitem/pom.xml
@@ -61,6 +61,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-jackson-utils</artifactId>
     </dependency>

--- a/kogito-workitems/kogito-rest-workitem/pom.xml
+++ b/kogito-workitems/kogito-rest-workitem/pom.xml
@@ -26,6 +26,11 @@
        <artifactId>smallrye-mutiny-vertx-auth-oauth2</artifactId>
     </dependency>
     <dependency>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>

--- a/kogito-workitems/kogito-rest-workitem/src/main/java/org/kogito/workitem/rest/RestWorkItemHandler.java
+++ b/kogito-workitems/kogito-rest-workitem/src/main/java/org/kogito/workitem/rest/RestWorkItemHandler.java
@@ -28,6 +28,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import javax.ws.rs.WebApplicationException;
+
 import org.jbpm.process.core.Process;
 import org.jbpm.process.core.context.variable.Variable;
 import org.jbpm.process.core.context.variable.VariableScope;
@@ -139,6 +141,9 @@ public class RestWorkItemHandler implements KogitoWorkItemHandler {
         authDecorators.forEach(d -> d.decorate(workItem, parameters, request));
         paramsDecorator.decorate(workItem, parameters, request);
         HttpResponse<Buffer> response = method.equals(HttpMethod.POST) || method.equals(HttpMethod.PUT) ? request.sendJsonAndAwait(bodyBuilder.apply(parameters)) : request.sendAndAwait();
+        if (response.statusCode() >= 300) {
+            throw new WebApplicationException(response.statusMessage(), response.statusCode());
+        }
         manager.completeWorkItem(workItem.getStringId(), Collections.singletonMap(RESULT, resultHandler.apply(response, targetInfo)));
     }
 

--- a/kogito-workitems/kogito-rest-workitem/src/test/java/org/kogito/workitem/rest/RestWorkItemHandlerTest.java
+++ b/kogito-workitems/kogito-rest-workitem/src/test/java/org/kogito/workitem/rest/RestWorkItemHandlerTest.java
@@ -19,6 +19,8 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 
+import javax.ws.rs.WebApplicationException;
+
 import org.jbpm.process.core.Process;
 import org.jbpm.process.core.context.variable.Variable;
 import org.jbpm.process.core.context.variable.VariableScope;
@@ -28,6 +30,7 @@ import org.jbpm.process.instance.context.variable.VariableScopeInstance;
 import org.jbpm.workflow.core.impl.IOSpecification;
 import org.jbpm.workflow.core.node.WorkItemNode;
 import org.jbpm.workflow.instance.node.WorkItemNodeInstance;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -172,6 +175,21 @@ public class RestWorkItemHandlerTest {
         handler.executeWorkItem(workItem, manager);
 
         assertResult(manager, argCaptor);
+    }
+
+    @Test
+    public void testFailingCall() {
+        parameters.put(RestWorkItemHandler.URL, "http://localhost:8080/error");
+        parameters.put(RestWorkItemHandler.METHOD, "GET");
+        parameters.put(RestWorkItemHandler.CONTENT_DATA, workflowData);
+        when(response.statusCode()).thenReturn(400);
+
+        WebApplicationException thrown = Assertions.assertThrows(WebApplicationException.class, () -> {
+            handler.executeWorkItem(workItem, manager);
+        }, "WebApplicationException was expected");
+
+        Assertions.assertEquals(400, thrown.getResponse().getStatus());
+
     }
 
     @Test


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/KOGITO-7557

The idea of this PR is to throw a WebApplicationException if the called service returns an error (http status code >= 300), in order to allow the exception handling logic within the workflow to be executed.