### PR TITLE
KOGITO-7612 - Implement gRPC streaming scenarios

### DIFF
--- a/kogito-serverless-workflow/kogito-serverless-workflow-runtime/src/main/java/org/kie/kogito/serverless/workflow/rpc/ProtobufUtilRPCConverter.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-runtime/src/main/java/org/kie/kogito/serverless/workflow/rpc/ProtobufUtilRPCConverter.java
@@ -17,7 +17,6 @@ package org.kie.kogito.serverless.workflow.rpc;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.Map;
 
 import org.kie.kogito.jackson.utils.ObjectMapperFactory;
 
@@ -28,9 +27,9 @@ import com.google.protobuf.util.JsonFormat;
 
 class ProtobufUtilRPCConverter implements RPCConverter {
     @Override
-    public Builder buildMessage(Map<String, Object> parameters, Builder builder) {
+    public Builder buildMessage(Object object, Builder builder) {
         try {
-            JsonFormat.parser().merge(ObjectMapperFactory.get().writeValueAsString(parameters), builder);
+            JsonFormat.parser().merge(ObjectMapperFactory.get().writeValueAsString(object), builder);
             return builder;
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/kogito-serverless-workflow/kogito-serverless-workflow-runtime/src/main/java/org/kie/kogito/serverless/workflow/rpc/RPCConverter.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-runtime/src/main/java/org/kie/kogito/serverless/workflow/rpc/RPCConverter.java
@@ -15,14 +15,12 @@
  */
 package org.kie.kogito.serverless.workflow.rpc;
 
-import java.util.Map;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.protobuf.Message;
 
 public interface RPCConverter {
 
-    Message.Builder buildMessage(Map<String, Object> parameters, Message.Builder builder);
+    Message.Builder buildMessage(Object object, Message.Builder builder);
 
     JsonNode getJsonNode(Message message);
 }


### PR DESCRIPTION
JIRA: [KOGITO-7612](https://issues.redhat.com/browse/KOGITO-7612)

PR set:
* https://github.com/kiegroup/kogito-runtimes/pull/2342
* https://github.com/kiegroup/kogito-examples/pull/1332

Info:
1. Method type is now properly set (Unary, Client/Server streaming, Bidirectional).
1. Unary scenario remains unchanged.
1. Server streaming (one message sent, multiple messages received from the server) is similar to the unary scenario, just more messages are received. They are merged as an array to the workflow data under the `response` tag by default. This behaviour was in place from the beginning unless a specific `actionDataFilter` is used.
1. In fact, when I looked at the implementation of unary and server streaming calls, they are async internally but they wait until the response comes from the server.
1. Remaining scenarios involve client streaming, which means they must be done in an async way - client is streaming data but server can already be sending them, hence async. In this case there has to be a response observer created which stores received messages in a collection. Client streams all the data and completes the sending after which it waits until the server has finished which is signaled either using onComplete or onError events, both of which free the countDownLatch which wakes up the main thread to process the responses/error. 
1. Inputs for the client streaming are taken from the hard-coded `elements` parameter, which contains an array of objects, each object represents an individual message to send to the server. If you have a better idea, just tell, but I wouldn't complicate it too much.
1. In case the onError event is received from the server, either during the sending (periodically checked) or after the workflow engine finished sending, an exception is thrown. If the server doesn't respond in 20 seconds (it doesn't complete the sending or doesn't throw an error), the workflow engine throws an exception as well.
1. In case the error happens on the client side during the sending, the workflow now just ends - it throws an exception, maybe it would be good to catch the exception and inform server of an error and rethrow, but for this we would need to have a special exception type so we can distinguish between error coming from server (no further calls allowed, immediately stop an execution and throw an exception - already implemented) and coming from the client (send onError event to the server and only then throw an exception).
1. We can discuss the error handling as to which exception should be thrown etc. RuntimeException is just an example, maybe we could throw some kind of WorkItem exception?

In general it works OK, see the examples I added. If needed, I can add integration tests also here, but that would be just a duplication probably.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>

- <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
