### PR TITLE
[KOGITO-7617] Changing error handling to print list of exceptions

### DIFF
--- a/kogito-serverless-workflow/kogito-serverless-workflow-runtime/src/main/java/org/kie/kogito/serverless/workflow/actions/DataInputSchemaAction.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-runtime/src/main/java/org/kie/kogito/serverless/workflow/actions/DataInputSchemaAction.java
@@ -49,9 +49,12 @@ public class DataInputSchemaAction implements Action {
             SchemaLoader.load(mapper.readValue(readAllBytes(runtimeLoader(schema)), JSONObject.class))
                     .validate(mapper.convertValue(getWorkflowData(context), JSONObject.class));
         } catch (ValidationException ex) {
-            logger.warn("There are validation errors {}", ex.getCausingExceptions());
+            String validationError = String.format("Error validating input schema %s", ex.getCausingExceptions().isEmpty()
+                    ? ex
+                    : ex.getCausingExceptions());
+            logger.warn(validationError, ex);
             if (failOnValidationErrors) {
-                throw new IllegalArgumentException("Error validating input schema", ex);
+                throw new IllegalArgumentException(validationError);
             }
         }
 


### PR DESCRIPTION
This will include the list of exceptions, if more than one, in the exception being thrown when validation is active. 
This message will be later used to build the error object returned by the rest call. 
This also align the message being logged with the exception being launched, which in some cases were not the same
