### PR TITLE
KOGITO-7716 - Remove quarkus-test-kafka-companion dependency

### DIFF
--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -82,7 +82,7 @@
     <version.org.assertj>3.22.0</version.org.assertj>
     <version.org.json-unit-assertj>2.9.0</version.org.json-unit-assertj>
     <version.org.hamcrest>1.3</version.org.hamcrest> <!-- else old version coming from Mockito wins and breaks tests -->
-    <version.org.junit.minor>8.0</version.org.junit.minor> <!-- so that org.junit.platform and org.junit can share the same minor version -->
+    <version.org.junit.minor>8.2</version.org.junit.minor> <!-- so that org.junit.platform and org.junit can share the same minor version -->
     <version.org.junit>5.${version.org.junit.minor}</version.org.junit>
     <version.org.junit.jupiter>5.8.2</version.org.junit.jupiter>
     <version.org.junit.vintage>5.8.2</version.org.junit.vintage>

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/pom.xml
@@ -60,6 +60,11 @@
 
     <!-- Testing dependencies -->
     <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-quarkus-test-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-devtools-testing</artifactId>
       <scope>test</scope>
@@ -67,16 +72,6 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-internal</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-test-kafka-companion</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -92,6 +87,11 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -125,18 +125,6 @@
   </dependencies>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>io.quarkus</groupId>
-          <artifactId>quarkus-maven-plugin</artifactId>
-          <configuration>
-            <noDeps>true</noDeps>
-            <skip>${skipTests}</skip>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>
@@ -168,12 +156,17 @@
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
+        <version>${version.io.quarkus}</version>
+        <extensions>true</extensions>
+        <configuration>
+          <skip>${skipTests}</skip>
+        </configuration>
         <executions>
           <execution>
             <goals>
+              <goal>build</goal>
               <goal>generate-code</goal>
               <goal>generate-code-tests</goal>
-              <goal>build</goal>
             </goals>
           </execution>
         </executions>
@@ -252,27 +245,6 @@
       <properties>
         <quarkus.package.type>native</quarkus.package.type>
       </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-failsafe-plugin</artifactId>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>integration-test</goal>
-                  <goal>verify</goal>
-                </goals>
-                <configuration>
-                  <systemPropertyVariables>
-                    <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                  </systemPropertyVariables>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
     </profile>
   </profiles>
 

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/application.properties
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/application.properties
@@ -1,5 +1,15 @@
+quarkus.kogito.logger.always-include=true
+
+kogito.persistence.type=jdbc
+kogito.persistence.proto.marshaller=false
+kogito.persistence.auto.ddl=true
+quarkus.datasource.db-kind=postgresql
+
+quarkus.http.test-port=0
 quarkus.log.level=INFO
 #quarkus.log.category."org.kie.kogito".level=DEBUG
+
+quarkus.kafka.devservices.enabled=false
 
 # OpenApi client properties, see OperationsMockService, which is mocking these two services
 quarkus.rest-client.multiplication.url=${multiplication-service-mock.url}
@@ -21,8 +31,6 @@ mp.messaging.incoming.never.connector=quarkus-http
 mp.messaging.incoming.never.path=/never
 
 my_name=javierito
-
-kafka.bootstrap.servers=localhost:9092
 
 # Kafka configuration for the sw tests that produce events
 mp.messaging.outgoing.kogito_outgoing_stream.connector=smallrye-kafka
@@ -52,7 +60,6 @@ mp.messaging.incoming.visa_denied_in.connector=smallrye-kafka
 mp.messaging.incoming.visa_denied_in.topic=visa_denied_topic
 mp.messaging.incoming.visa_denied_in.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
 
-
 # kafka configurations for the CorrelationIT test.
 mp.messaging.incoming.correlation_start_event_type.connector=smallrye-kafka
 mp.messaging.incoming.correlation_start_event_type.topic=correlation_start_event_type
@@ -60,19 +67,13 @@ mp.messaging.incoming.correlation_start_event_type.value.deserializer=org.apache
 mp.messaging.incoming.correlation_start_event_type.group.id=kogito-sw-it
 mp.messaging.incoming.correlation_start_event_type.auto.offset.reset=earliest
 
-
 mp.messaging.incoming.correlation_event_type.connector=smallrye-kafka
 mp.messaging.incoming.correlation_event_type.topic=correlation_event_type
 mp.messaging.incoming.correlation_event_type.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
 mp.messaging.incoming.correlation_event_type.group.id=kogito-sw-it
 mp.messaging.incoming.correlation_event_type.auto.offset.reset=earliest
 
-kogito.persistence.proto.marshaller=false
-
 quarkus.grpc.clients.Greeter.host=localhost
-quarkus.grpc.clients.Greeter.port=${kogito.grpc.server.port}
-
-quarkus.grpc.server.port=${kogito.grpc.server.port}
 
 # Token propagation support test properties, relates to the TokenPropagationIT and the token-propagation.sw.json
 # 1) Configure the desired packages for the code generation, this information is basically source
@@ -81,14 +82,12 @@ quarkus.openapi-generator.codegen.spec.token_propagation_external_service2_yaml.
 quarkus.openapi-generator.codegen.spec.token_propagation_external_service3_yaml.base-package=org.acme.externalservice3
 quarkus.openapi-generator.codegen.spec.token_propagation_external_service4_yaml.base-package=org.acme.externalservice4
 quarkus.openapi-generator.codegen.spec.token_propagation_external_service5_yaml.base-package=org.acme.externalservice5
-
 # 2) Configure the access url for the four services.
 quarkus.rest-client.token_propagation_external_service1_yaml.url=${propagation-external-service-mock.url}
 quarkus.rest-client.token_propagation_external_service2_yaml.url=${propagation-external-service-mock.url}
 quarkus.rest-client.token_propagation_external_service3_yaml.url=${propagation-external-service-mock.url}
 quarkus.rest-client.token_propagation_external_service4_yaml.url=${propagation-external-service-mock.url}
 quarkus.rest-client.token_propagation_external_service5_yaml.url=${propagation-external-service-mock.url}
-
 
 # 3) Configure the different propagation alternatives.
 # default propagation for token_propagation_external_service1 invocation
@@ -129,4 +128,3 @@ quarkus.oidc-client.service5_oauth2.client-id=kogito-app
 quarkus.oidc-client.service5_oauth2.grant.type=client
 quarkus.oidc-client.service5_oauth2.credentials.client-secret.method=basic
 quarkus.oidc-client.service5_oauth2.credentials.client-secret.value=secret
-

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/AbstractCallbackStateIT.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/AbstractCallbackStateIT.java
@@ -20,9 +20,11 @@ import java.net.URI;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 
-import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.kie.kogito.test.quarkus.QuarkusTestProperty;
+import org.kie.kogito.test.quarkus.kafka.KafkaTestClient;
+import org.kie.kogito.testcontainers.quarkus.KafkaQuarkusTestResource;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -30,11 +32,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.cloudevents.core.builder.CloudEventBuilder;
 import io.cloudevents.jackson.JsonCloudEventData;
 import io.cloudevents.jackson.JsonFormat;
-import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.kafka.InjectKafkaCompanion;
-import io.quarkus.test.kafka.KafkaCompanionResource;
 import io.restassured.path.json.JsonPath;
-import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.kogito.quarkus.workflows.ExternalServiceMock.GENERATE_ERROR_QUERY;
@@ -45,18 +43,18 @@ import static org.kie.kogito.quarkus.workflows.WorkflowTestUtils.assertProcessIn
 import static org.kie.kogito.quarkus.workflows.WorkflowTestUtils.newProcessInstance;
 import static org.kie.kogito.quarkus.workflows.WorkflowTestUtils.newProcessInstanceAndGetId;
 
-@QuarkusTestResource(KafkaCompanionResource.class)
 abstract class AbstractCallbackStateIT {
 
     static final String ANSWER = "ANSWER";
 
+    @QuarkusTestProperty(name = KafkaQuarkusTestResource.KOGITO_KAFKA_PROPERTY)
+    String kafkaBootstrapServers;
     ObjectMapper objectMapper;
-
-    @InjectKafkaCompanion
-    KafkaCompanion kafkaCompanion;
+    KafkaTestClient kafkaClient;
 
     @BeforeEach
     void setup() {
+        kafkaClient = new KafkaTestClient(kafkaBootstrapServers);
         objectMapper = new ObjectMapper()
                 .registerModule(new JavaTimeModule())
                 .registerModule(JsonFormat.getCloudEventJacksonModule())
@@ -85,7 +83,7 @@ abstract class AbstractCallbackStateIT {
                         "kogitoprocrefid", processInstanceId)
                 .withData(JsonCloudEventData.wrap(objectMapper.createObjectNode().put("answer", answer)))
                 .build());
-        kafkaCompanion.produceStrings().usingGenerator(i -> new ProducerRecord<>(callbackEventTopic, response));
+        kafkaClient.produce(response, callbackEventTopic);
 
         // give some time for the event to be processed and the process to finish.
         assertProcessInstanceHasFinished(callbackProcessGetByIdUrl, processInstanceId, 1, 180);
@@ -105,7 +103,7 @@ abstract class AbstractCallbackStateIT {
 
     @AfterEach
     void cleanUp() {
-        kafkaCompanion.close();
+        kafkaClient.shutdown();
     }
 
     protected static String buildProcessInput(String query) {

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/CallbackStateIT.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/CallbackStateIT.java
@@ -17,12 +17,14 @@
 package org.kie.kogito.quarkus.workflows;
 
 import org.junit.jupiter.api.Test;
+import org.kie.kogito.testcontainers.quarkus.KafkaQuarkusTestResource;
 
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@QuarkusTestResource(ExternalServiceMock.class)
 @QuarkusIntegrationTest
+@QuarkusTestResource(ExternalServiceMock.class)
+@QuarkusTestResource(KafkaQuarkusTestResource.class)
 class CallbackStateIT extends AbstractCallbackStateIT {
 
     private static final String CALLBACK_STATE_SERVICE_URL = "/callback_state";

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/CallbackStateTimeoutsIT.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/CallbackStateTimeoutsIT.java
@@ -17,6 +17,7 @@
 package org.kie.kogito.quarkus.workflows;
 
 import org.junit.jupiter.api.Test;
+import org.kie.kogito.testcontainers.quarkus.KafkaQuarkusTestResource;
 
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
@@ -26,8 +27,9 @@ import static org.kie.kogito.quarkus.workflows.WorkflowTestUtils.assertProcessIn
 import static org.kie.kogito.quarkus.workflows.WorkflowTestUtils.assertProcessInstanceHasFinished;
 import static org.kie.kogito.quarkus.workflows.WorkflowTestUtils.newProcessInstanceAndGetId;
 
-@QuarkusTestResource(ExternalServiceMock.class)
 @QuarkusIntegrationTest
+@QuarkusTestResource(ExternalServiceMock.class)
+@QuarkusTestResource(KafkaQuarkusTestResource.class)
 class CallbackStateTimeoutsIT extends AbstractCallbackStateIT {
 
     private static final String CALLBACK_STATE_TIMEOUTS_SERVICE_URL = "/callback_state_timeouts";

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/CorrelationIT.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/CorrelationIT.java
@@ -21,9 +21,11 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.kie.kogito.test.quarkus.QuarkusTestProperty;
+import org.kie.kogito.test.quarkus.kafka.KafkaTestClient;
+import org.kie.kogito.testcontainers.quarkus.KafkaQuarkusTestResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,9 +37,6 @@ import io.cloudevents.jackson.JsonCloudEventData;
 import io.cloudevents.jackson.JsonFormat;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
-import io.quarkus.test.kafka.InjectKafkaCompanion;
-import io.quarkus.test.kafka.KafkaCompanionResource;
-import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
 
 import static org.awaitility.Awaitility.await;
 import static org.kie.kogito.quarkus.workflows.WorkflowTestUtils.assertProcessInstanceExists;
@@ -45,7 +44,7 @@ import static org.kie.kogito.quarkus.workflows.WorkflowTestUtils.assertProcessIn
 import static org.kie.kogito.quarkus.workflows.WorkflowTestUtils.getProcessInstance;
 
 @QuarkusIntegrationTest
-@QuarkusTestResource(KafkaCompanionResource.class)
+@QuarkusTestResource(KafkaQuarkusTestResource.class)
 public class CorrelationIT {
 
     public static final String USER_ID = "userid";
@@ -57,15 +56,16 @@ public class CorrelationIT {
     public static final String START_EVENT_TOPIC = START_EVENT_TYPE;
     private static final Logger LOGGER = LoggerFactory.getLogger(CorrelationIT.class);
 
-    @InjectKafkaCompanion
-    KafkaCompanion kafkaCompanion;
+    private KafkaTestClient kafkaClient;
 
+    @QuarkusTestProperty(name = KafkaQuarkusTestResource.KOGITO_KAFKA_PROPERTY)
     private String kafkaBootstrapServers;
 
     private ObjectMapper objectMapper;
 
     @BeforeEach
     void setup() {
+        kafkaClient = new KafkaTestClient(kafkaBootstrapServers);
         objectMapper = new ObjectMapper()
                 .registerModule(new JavaTimeModule())
                 .registerModule(JsonFormat.getCloudEventJacksonModule())
@@ -86,7 +86,7 @@ public class CorrelationIT {
                 .withExtension(USER_ID, userId)
                 .withData(JsonCloudEventData.wrap(objectMapper.createObjectNode().put("message", "Starting workflow using correlation")))
                 .build());
-        kafkaCompanion.produce(String.class).fromRecords(new ProducerRecord<>(START_EVENT_TYPE, request)).awaitCompletion();
+        kafkaClient.produce(request, START_EVENT_TOPIC);
 
         // double check that the process instance is there.
         AtomicReference<String> processInstanceId = new AtomicReference<>();
@@ -109,7 +109,7 @@ public class CorrelationIT {
                 .withExtension(USER_ID, userId)
                 .withData(JsonCloudEventData.wrap(objectMapper.createObjectNode().put("message", "Hello using correlation")))
                 .build());
-        kafkaCompanion.produce(String.class).fromRecords(new ProducerRecord<>(CORRELATION_EVENT_TOPIC, response)).awaitCompletion();
+        kafkaClient.produce(response, CORRELATION_EVENT_TOPIC);
         // give some time for the event to be processed and the process to finish.
         assertProcessInstanceHasFinished(PROCESS_GET_BY_ID_URL, processInstanceId.get(), 1, 180);
         LOGGER.debug("Workflow {} completed", processInstanceId.get());

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/GrpcServerPortResource.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/GrpcServerPortResource.java
@@ -15,9 +15,9 @@
  */
 package org.kie.kogito.quarkus.workflows;
 
-import java.util.Collections;
 import java.util.Map;
 
+import org.apache.groovy.util.Maps;
 import org.kie.kogito.quarkus.utils.SocketUtils;
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
@@ -26,8 +26,10 @@ public class GrpcServerPortResource implements QuarkusTestResourceLifecycleManag
 
     @Override
     public Map<String, String> start() {
-        int port = SocketUtils.findAvailablePort();
-        return Collections.singletonMap("kogito.grpc.server.port", Integer.toString(port));
+        String port = Integer.toString(SocketUtils.findAvailablePort());
+        return Maps.of("quarkus.grpc.clients.Greeter.port", port,
+                "quarkus.grpc.server.port", port,
+                "quarkus.grpc.server.test-port", port);
     }
 
     @Override

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/RPCGreetIT.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/RPCGreetIT.java
@@ -38,7 +38,7 @@ class RPCGreetIT {
                 .post("/rpcgreet")
                 .then()
                 .statusCode(201)
-                .body("workflowdata.message", containsString("Hello"))
+                .body("workflowdata.message", is("Hello from gRPC service John"))
                 .body("workflowdata.state", is("SUCCESS"))
                 .body("workflowdata.innerMessage.number", is(23));
 
@@ -53,7 +53,7 @@ class RPCGreetIT {
                 .post("/rpcgreet")
                 .then()
                 .statusCode(201)
-                .body("workflowdata.message", containsString("Saludos"))
+                .body("workflowdata.message", is("Saludos desde gRPC service Javierito"))
                 .body("workflowdata.state", nullValue());
     }
 


### PR DESCRIPTION

Fixes failing tests on main.

@fjtirado Moved the newly added gPRC test to use `QuarkusTest` temporarily as it seems to be an issue with DevServices to restart the app when using a TestProfile. More details https://quarkusio.zulipchat.com/#narrow/stream/187030-users/topic/DevServices.20properties.20on.20profile.20restart