### PR TITLE
quarkus-devtools-testing to version.io.quarkus.quarkus-test-maven

### DIFF
--- a/.ci/jenkins/Jenkinsfile.quarkus
+++ b/.ci/jenkins/Jenkinsfile.quarkus
@@ -228,7 +228,7 @@ MavenCommand getMavenCommand(String directory, boolean addQuarkusVersion=true) {
     def mvnCmd = getBasicMavenCommand(directory)
     if (addQuarkusVersion) {
         mvnCmd.withProperty('version.io.quarkus', '999-SNAPSHOT')
-        mvnCmd.withProperty('version.io.quarkus.quarkus-test-maven', '999-SNAPSHOT')
+        mvnCmd.withProperty('version.io.quarkus.quarkus-test', '999-SNAPSHOT')
         mvnCmd.withProperty('quarkus-plugin.version', '999-SNAPSHOT')
         mvnCmd.withProperty('quarkus.platform.version', '999-SNAPSHOT')
     }

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -65,7 +65,7 @@ setupPromoteJob(Folder.RELEASE)
 KogitoJobUtils.createQuarkusUpdateToolsJob(this, 'kogito-runtimes', [
   modules: [ 'kogito-dependencies-bom', 'kogito-build-parent', 'kogito-quarkus-bom', 'kogito-build-no-bom-parent' ],
   compare_deps_remote_poms: [ 'io.quarkus:quarkus-bom' ],
-  properties: [ 'version.io.quarkus', 'version.io.quarkus.quarkus-test-maven' ],
+  properties: [ 'version.io.quarkus', 'version.io.quarkus.quarkus-test' ],
 ])
 
 /////////////////////////////////////////////////////////////////

--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -17,7 +17,7 @@
   <properties>
     <!-- this version property is used in plugins but also in dependencies too -->
     <version.io.quarkus>2.11.2.Final</version.io.quarkus>
-    <version.io.quarkus.quarkus-test-maven>2.11.2.Final</version.io.quarkus.quarkus-test-maven>
+    <version.io.quarkus.quarkus-test>2.11.2.Final</version.io.quarkus.quarkus-test>
     <version.org.springframework.boot>2.6.6</version.org.springframework.boot>
 
     <!-- dependencies versions -->

--- a/quarkus/bom/pom.xml
+++ b/quarkus/bom/pom.xml
@@ -28,7 +28,7 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devtools-testing</artifactId>
-        <version>${version.io.quarkus}</version>
+        <version>${version.io.quarkus.quarkus-test-maven}</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/quarkus/bom/pom.xml
+++ b/quarkus/bom/pom.xml
@@ -28,7 +28,7 @@
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devtools-testing</artifactId>
-        <version>${version.io.quarkus.quarkus-test-maven}</version>
+        <version>${version.io.quarkus.quarkus-test}</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-integration-test-maven-devmode/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-integration-test-maven-devmode/pom.xml
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-test-maven</artifactId>
-      <version>${version.io.quarkus.quarkus-test-maven}</version>
+      <version>${version.io.quarkus.quarkus-test}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
The kogito-runtimes prod nightly build is failing due to `io.quarkus:quarkus-devtools-testing` is not productized by throwing
```
[ERROR] Failed to execute goal on project kogito-quarkus-serverless-workflow-integration-test: Could not resolve dependencies for project org.kie.kogito:kogito-quarkus-serverless-workflow-integration-test:jar:2.0.0.redhat-2022080923: Failure to find io.quarkus:quarkus-devtools-testing:jar:2.7.5.Final-redhat-00011 in REPO_URL was cached in the local repository, resolution will not be reattempted until the update interval of qe-repository has elapsed or updates are forced -> [Help 1]
```
I suggest to use `version.io.quarkus.quarkus-test-maven` property for `io.quarkus:quarkus-devtools-testing` dependency, this way community libraries for this particular dependency will be taken.

Related to:

* https://github.com/kiegroup/kogito-runtimes/pull/2389
* https://github.com/kiegroup/kogito-pipelines/pull/583
* https://gitlab.cee.redhat.com/middleware/build-configurations/-/merge_requests/887

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>

- <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
