### PR TITLE
[KOGITO-7752] Merge arrays should replace by default

### DIFF
--- a/kogito-workitems/kogito-jackson-utils/src/main/java/org/kie/kogito/jackson/utils/MergeUtils.java
+++ b/kogito-workitems/kogito-jackson-utils/src/main/java/org/kie/kogito/jackson/utils/MergeUtils.java
@@ -36,29 +36,29 @@ public class MergeUtils {
         return merge(src, target, false);
     }
 
-    public static JsonNode merge(JsonNode src, JsonNode target, boolean skipDuplicates) {
+    public static JsonNode merge(JsonNode src, JsonNode target, boolean mergeArray) {
         if (target == null || target.isNull()) {
             return src;
         } else if (target.isArray()) {
-            return mergeArray(src, (ArrayNode) target, skipDuplicates);
+            return mergeArray(src, (ArrayNode) target, mergeArray);
         } else if (target.isObject()) {
-            return mergeObject(src, (ObjectNode) target, skipDuplicates);
+            return mergeObject(src, (ObjectNode) target, mergeArray);
         } else {
             if (src.isArray()) {
                 ArrayNode srcArray = (ArrayNode) src;
-                insert(srcArray, target, getExistingNodes(srcArray, skipDuplicates));
+                insert(srcArray, target, getExistingNodes(srcArray));
             }
             return src;
         }
     }
 
-    private static ObjectNode mergeObject(JsonNode src, ObjectNode target, boolean skipDuplicates) {
+    private static ObjectNode mergeObject(JsonNode src, ObjectNode target, boolean mergeArray) {
         if (src.isObject()) {
             Iterator<Map.Entry<String, JsonNode>> mergedIterator = src.fields();
             while (mergedIterator.hasNext()) {
                 Map.Entry<String, JsonNode> entry = mergedIterator.next();
                 JsonNode found = target.get(entry.getKey());
-                target.set(entry.getKey(), found != null ? merge(entry.getValue(), found, skipDuplicates) : entry.getValue());
+                target.set(entry.getKey(), found != null ? merge(entry.getValue(), found, mergeArray) : entry.getValue());
             }
         } else if (!src.isNull()) {
             target.set("response", src);
@@ -66,13 +66,16 @@ public class MergeUtils {
         return target;
     }
 
-    private static JsonNode mergeArray(JsonNode src, ArrayNode target, boolean skipDuplicates) {
+    private static JsonNode mergeArray(JsonNode src, ArrayNode target, boolean mergeArray) {
         if (src != target) {
-            Set<JsonNode> existingNodes = getExistingNodes(target, skipDuplicates);
             if (src.isArray()) {
-                ((ArrayNode) src).forEach(node -> add(target, node, existingNodes));
+                if (mergeArray) {
+                    ((ArrayNode) src).forEach(node -> add(target, node, getExistingNodes(target)));
+                } else {
+                    return src;
+                }
             } else {
-                add(target, src, existingNodes);
+                add(target, src, Collections.emptySet());
             }
         }
         return target;
@@ -90,12 +93,9 @@ public class MergeUtils {
         }
     }
 
-    private static Set<JsonNode> getExistingNodes(ArrayNode arrayNode, boolean skipDuplicates) {
-        Set<JsonNode> existingNodes = Collections.emptySet();
-        if (skipDuplicates) {
-            existingNodes = new HashSet<>();
-            arrayNode.forEach(existingNodes::add);
-        }
+    private static Set<JsonNode> getExistingNodes(ArrayNode arrayNode) {
+        Set<JsonNode> existingNodes = new HashSet<>();
+        arrayNode.forEach(existingNodes::add);
         return existingNodes;
     }
 

--- a/kogito-workitems/kogito-jackson-utils/src/main/java/org/kie/kogito/jackson/utils/MergeUtils.java
+++ b/kogito-workitems/kogito-jackson-utils/src/main/java/org/kie/kogito/jackson/utils/MergeUtils.java
@@ -15,7 +15,6 @@
  */
 package org.kie.kogito.jackson.utils;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
@@ -75,7 +74,7 @@ public class MergeUtils {
                     return src;
                 }
             } else {
-                add(target, src, Collections.emptySet());
+                add(target, src, getExistingNodes(target));
             }
         }
         return target;

--- a/kogito-workitems/kogito-jackson-utils/src/test/java/org/kie/kogito/jackson/utils/MergeUtilsTest.java
+++ b/kogito-workitems/kogito-jackson-utils/src/test/java/org/kie/kogito/jackson/utils/MergeUtilsTest.java
@@ -32,7 +32,8 @@ public class MergeUtilsTest {
     @Test
     void testSrcTargetArray() {
         assertEquals(Arrays.asList(1, 2, 3, 4, 5, 6),
-                JsonObjectUtils.toJavaValue(MergeUtils.merge(ObjectMapperFactory.get().createArrayNode().add(4).add(5).add(6), ObjectMapperFactory.get().createArrayNode().add(1).add(2).add(3))));
+                JsonObjectUtils
+                        .toJavaValue(MergeUtils.merge(ObjectMapperFactory.get().createArrayNode().add(4).add(5).add(6), ObjectMapperFactory.get().createArrayNode().add(1).add(2).add(3), true)));
     }
 
     @Test
@@ -72,14 +73,14 @@ public class MergeUtilsTest {
         ObjectNode vipCustomer = getCustomer("Messi", 69, 1221312.2, true, "Parla", Arrays.asList("Isla paradisiaca anonima", "Palacio presidencial S/N"));
         JsonNode expectedMerged =
                 getCustomer("Fulanito", 23, 999.9, false, "Parla", Arrays.asList("Isla paradisiaca anonima", "Palacio presidencial S/N", "percebe 13", "casa de mis padres en Mostoles"));
-        assertEquals(expectedMerged, MergeUtils.merge(dummyCustomer, vipCustomer));
+        assertEquals(expectedMerged, MergeUtils.merge(dummyCustomer, vipCustomer, true));
     }
 
     @Test
     void testObjectArrayMerge() {
         ObjectNode dummyCustomer = getCustomer("Fulanito", 23, 999.9, false, "Parla", Arrays.asList("percebe 13", "casa de mis padres en Mostoles"));
         ObjectNode vipCustomer = getCustomer("Messi", 69, 1221312.2, true, "Islas Virgenes", Arrays.asList("Isla paradisiaca anonima", "Palacio presidencial S/N"));
-        ArrayNode merged = (ArrayNode) MergeUtils.merge(ObjectMapperFactory.get().createArrayNode().add(dummyCustomer), ObjectMapperFactory.get().createArrayNode().add(vipCustomer));
+        ArrayNode merged = (ArrayNode) MergeUtils.merge(ObjectMapperFactory.get().createArrayNode().add(dummyCustomer), ObjectMapperFactory.get().createArrayNode().add(vipCustomer), true);
         assertEquals(2, merged.size());
         assertEquals(vipCustomer, merged.get(0));
         assertEquals(dummyCustomer, merged.get(1));

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/rpcgreet.sw.json
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/rpcgreet.sw.json
@@ -19,6 +19,11 @@
       "name": "doNothing",
       "type": "rpc",
       "operation": "greeting.proto#Greeter#DoNothing"
+    }, 
+    {
+       "name" : "expression",
+       "type" : "expression",
+       "operation" : ".minority[0].message = \"marquitos\""
     }
   ],
   "states": [
@@ -63,6 +68,9 @@
            "results" : ".replies",
            "toStateData" : ".minority"
           }
+        },
+        {
+          "functionRef" : "expression"
         }
       ],
       "end": {

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/EmitEnumRPCGreetIT.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/EmitEnumRPCGreetIT.java
@@ -31,7 +31,7 @@ import static org.hamcrest.CoreMatchers.is;
 class EmitEnumRPCGreetIT {
 
     @Test
-    void testSpanish() {
+    void testStateIsUnknown() {
         given()
                 .contentType(ContentType.JSON)
                 .accept(ContentType.JSON)

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/RPCGreetIT.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/RPCGreetIT.java
@@ -25,6 +25,7 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.hasSize;
 
 @QuarkusTestResource(GrpcServerPortResource.class)
 @QuarkusIntegrationTest
@@ -40,7 +41,10 @@ class RPCGreetIT {
                 .statusCode(201)
                 .body("workflowdata.message", is("Hello from gRPC service John"))
                 .body("workflowdata.state", is("SUCCESS"))
-                .body("workflowdata.innerMessage.number", is(23));
+                .body("workflowdata.innerMessage.number", is(23))
+                .body("workflowdata.minority", hasSize(2))
+                .body("workflowdata.minority[0].message", is("marquitos"))
+                .body("workflowdata.minority[1].message", is("Boungiorno Marco"));
 
     }
 


### PR DESCRIPTION
Before this JIRA, the code always try to merge the two arrays (an union), and the boolean just indicates if duplicates should be skipped. Now the boolean indicates whether the array should be merged (true) or replaced (false). Therefore true is equivalent to previous behaviour when skipDuplicate was true (this is the expected behaviour for JsonSchema generation), And by default (false), the array will be replaced, which is the desired behaviour for Serverless Workflow action

Why should be the default for Serveless Workflow?
Considers this case, where we have an array called minority in our workflow model with following content
```
[ {
  "message" : "Marc",
  "innerMessage" : {
    "number" : 23,
    "state" : "UNKNOWN"
  },
  "state" : "UNKNOWN"
}, {
  "message" : "Boungiorno Marco",
  "innerMessage" : {
    "number" : 23,
    "state" : "UNKNOWN"
  },
  "state" : "UNKNOWN"
} ]
```
And an expression in our workflow 
```

 {
       "name" : "expression",
       "type" : "expression",
       "operation" : ".minority[0].message = \"marquitos\""
    }
```
We want the result model to be 

```
[ {
  "message" : "marquitos",
  "innerMessage" : {
    "number" : 23,
    "state" : "UNKNOWN"
  },
  "state" : "UNKNOWN"
}, {
  "message" : "Boungiorno Marco",
  "innerMessage" : {
    "number" : 23,
    "state" : "UNKNOWN"
  },
  "state" : "UNKNOWN"
} ]
```

but if merge array is active (with skip duplicated) the result will be

```
[
{
  "message" : "marquitos",
  "innerMessage" : {
    "number" : 23,
    "state" : "UNKNOWN"
  },
  "state" : "UNKNOWN"
},
 {
  "message" : "Marc",
  "innerMessage" : {
    "number" : 23,
    "state" : "UNKNOWN"
  },
  "state" : "UNKNOWN"
}, {
  "message" : "Boungiorno Marco",
  "innerMessage" : {
    "number" : 23,
    "state" : "UNKNOWN"
  },
  "state" : "UNKNOWN"
} ]
```







