### PR TITLE
[KOGITO-7557]  Supporting multiple workitemhandlers

### DIFF
--- a/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcessConfig.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcessConfig.java
@@ -57,7 +57,7 @@ public abstract class AbstractProcessConfig implements ProcessConfig {
             Iterable<UnitOfWorkEventListener> unitOfWorkListeners,
             Iterable<ProcessVersionResolver> versionResolver) {
 
-        this.workItemHandlerConfig = orDefault(workItemHandlerConfig, DefaultWorkItemHandlerConfig::new);
+        this.workItemHandlerConfig = mergeWorkItemHandler(workItemHandlerConfig, DefaultWorkItemHandlerConfig::new);
         this.processEventListenerConfig = merge(processEventListenerConfigs, processEventListeners);
         this.unitOfWorkManager = orDefault(unitOfWorkManager,
                 () -> new DefaultUnitOfWorkManager(
@@ -68,6 +68,33 @@ public abstract class AbstractProcessConfig implements ProcessConfig {
         eventPublishers.forEach(publisher -> unitOfWorkManager().eventManager().addPublisher(publisher));
         unitOfWorkListeners.forEach(listener -> unitOfWorkManager().register(listener));
         unitOfWorkManager().eventManager().setService(kogitoService);
+    }
+
+    private static WorkItemHandlerConfig mergeWorkItemHandler(Iterable<WorkItemHandlerConfig> workItemHandlerConfigs,
+            Supplier<WorkItemHandlerConfig> supplier) {
+        Iterator<WorkItemHandlerConfig> iterator = workItemHandlerConfigs.iterator();
+        if (iterator.hasNext()) {
+            WorkItemHandlerConfig config = iterator.next();
+            if (iterator.hasNext()) {
+                CachedWorkItemHandlerConfig multiConfig = new CachedWorkItemHandlerConfig();
+                mergeWorkItemHandler(multiConfig, config);
+                do {
+                    config = iterator.next();
+                    mergeWorkItemHandler(multiConfig, config);
+                } while (iterator.hasNext());
+                return multiConfig;
+            } else {
+                return config;
+            }
+        } else {
+            return supplier.get();
+        }
+    }
+
+    private static void mergeWorkItemHandler(CachedWorkItemHandlerConfig multiConfig, WorkItemHandlerConfig config) {
+        for (String name : config.names()) {
+            multiConfig.register(name, config.forName(name));
+        }
     }
 
     @Override

--- a/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcessConfig.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcessConfig.java
@@ -75,25 +75,9 @@ public abstract class AbstractProcessConfig implements ProcessConfig {
         Iterator<WorkItemHandlerConfig> iterator = workItemHandlerConfigs.iterator();
         if (iterator.hasNext()) {
             WorkItemHandlerConfig config = iterator.next();
-            if (iterator.hasNext()) {
-                CachedWorkItemHandlerConfig multiConfig = new CachedWorkItemHandlerConfig();
-                mergeWorkItemHandler(multiConfig, config);
-                do {
-                    config = iterator.next();
-                    mergeWorkItemHandler(multiConfig, config);
-                } while (iterator.hasNext());
-                return multiConfig;
-            } else {
-                return config;
-            }
+            return iterator.hasNext() ? new MultiWorkItemHandlerConfig(workItemHandlerConfigs) : config;
         } else {
             return supplier.get();
-        }
-    }
-
-    private static void mergeWorkItemHandler(CachedWorkItemHandlerConfig multiConfig, WorkItemHandlerConfig config) {
-        for (String name : config.names()) {
-            multiConfig.register(name, config.forName(name));
         }
     }
 

--- a/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/MultiWorkItemHandlerConfig.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/MultiWorkItemHandlerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/MultiWorkItemHandlerConfig.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/MultiWorkItemHandlerConfig.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.process.impl;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.NoSuchElementException;
+
+import org.kie.kogito.internal.process.runtime.KogitoWorkItemHandler;
+import org.kie.kogito.process.WorkItemHandlerConfig;
+
+public class MultiWorkItemHandlerConfig implements WorkItemHandlerConfig {
+
+    private final Iterable<WorkItemHandlerConfig> workItemHandlerConfigs;
+
+    public MultiWorkItemHandlerConfig(Iterable<WorkItemHandlerConfig> workItemHandlerConfigs) {
+        this.workItemHandlerConfigs = workItemHandlerConfigs;
+    }
+
+    @Override
+    public KogitoWorkItemHandler forName(String name) {
+        RuntimeException trackException = null;
+        for (WorkItemHandlerConfig workItemHandlerConfig : workItemHandlerConfigs) {
+            try {
+                return workItemHandlerConfig.forName(name);
+            } catch (RuntimeException ex) {
+                trackException = ex;
+            }
+        }
+        throw trackException != null ? trackException : new NoSuchElementException("Cannot find work item for name " + name);
+    }
+
+    @Override
+    public Collection<String> names() {
+        Collection<String> names = new HashSet<>();
+        workItemHandlerConfigs.forEach(w -> names.addAll(w.names()));
+        return names;
+    }
+}

--- a/jbpm/jbpm-flow/src/test/java/org/kie/kogito/process/impl/AbstractProcessConfigTest.java
+++ b/jbpm/jbpm-flow/src/test/java/org/kie/kogito/process/impl/AbstractProcessConfigTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.process.impl;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.kie.kogito.internal.process.runtime.KogitoWorkItemHandler;
+import org.kie.kogito.process.ProcessConfig;
+import org.kie.kogito.process.WorkItemHandlerConfig;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+
+public class AbstractProcessConfigTest {
+
+    private static class MockProcessConfig extends AbstractProcessConfig {
+        protected MockProcessConfig(Iterable<WorkItemHandlerConfig> workItemHandlerConfig) {
+            super(workItemHandlerConfig, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
+                    Collections.emptyList(), null, Collections.emptyList(), Collections.emptyList());
+        }
+    }
+
+    @Test
+    void testOneWorkItemHandlerConfig() {
+        CachedWorkItemHandlerConfig workItemConfig = new CachedWorkItemHandlerConfig();
+        ProcessConfig config = new MockProcessConfig(List.of(workItemConfig));
+        assertSame(workItemConfig, config.workItemHandlers());
+    }
+
+    @Test
+    void testMultipleWorkItemHandlerConfig() {
+        CachedWorkItemHandlerConfig workItemConfig1 = new CachedWorkItemHandlerConfig();
+        CachedWorkItemHandlerConfig workItemConfig2 = new CachedWorkItemHandlerConfig();
+        final String name1 = "Javierito1";
+        final String name2 = "Javierito2";
+        final KogitoWorkItemHandler workItem1 = mock(KogitoWorkItemHandler.class);
+        final KogitoWorkItemHandler workItem2 = mock(KogitoWorkItemHandler.class);
+        workItemConfig1.register(name1, workItem1);
+        workItemConfig2.register(name2, workItem2);
+        ProcessConfig config = new MockProcessConfig(List.of(workItemConfig1, workItemConfig2));
+        assertEquals(Set.of(name1, name2), config.workItemHandlers().names());
+        assertSame(workItem1, config.workItemHandlers().forName(name1));
+        assertSame(workItem2, config.workItemHandlers().forName(name2));
+        final String name3 = "Javierito3";
+        final KogitoWorkItemHandler workItem3 = mock(KogitoWorkItemHandler.class);
+        workItemConfig2.register(name3, workItem3);
+        assertEquals(Set.of(name1, name2, name3), config.workItemHandlers().names());
+        assertSame(workItem3, config.workItemHandlers().forName(name3));
+    }
+
+}


### PR DESCRIPTION
There were two options to support this, either change the interface from single instance to iterable or consolidate the iterable information into one instance. The second is less intrusive, in my opinion, because existing code is already using forName directly over the object returned by ProcessConfig in a couple of places and we will need an utility method that does that in order to avoid duplication. 
This second approach can be implemented using two different approaches,either the consolidated instance is just a wrapper (new class)  that invoke the different underlying implementation (similar that the utility method that would have been added if we took he discarded approach) or we can use existing CachedWorkItemHandler class and register all instance into it. I chose the second one because I prioritize runtime performance and because it seems simple. 