### PR TITLE
[KOGITO-7777] Signal action takes variableName if inputName is null

### DIFF
--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/ErrorEventTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/ErrorEventTest.java
@@ -44,6 +44,7 @@ import org.kie.kogito.process.workitem.WorkItemExecutionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ErrorEventTest extends JbpmBpmn2TestCase {
 
@@ -447,6 +448,15 @@ public class ErrorEventTest extends JbpmBpmn2TestCase {
         assertEquals(processInstance.getState(), KogitoProcessInstance.STATE_ABORTED);
     }
 
+    @Test
+    public void testErrorVariable() throws Exception {
+        kruntime = createKogitoProcessRuntime("error/ErrorVariable.bpmn2");
+        kruntime.getKogitoWorkItemManager().registerWorkItemHandler("Service Task", new WorkItemExecutionErrorWorkItemHandler("MY_ERROR"));
+        KogitoProcessInstance processInstance = kruntime.startProcess("ErrorVariable");
+        Object theException = processInstance.getVariables().get("theException");
+        assertTrue(theException instanceof WorkItemExecutionException);
+    }
+
     class ExceptionWorkItemHandler implements KogitoWorkItemHandler {
 
         @Override
@@ -462,9 +472,19 @@ public class ErrorEventTest extends JbpmBpmn2TestCase {
 
     class WorkItemExecutionErrorWorkItemHandler implements KogitoWorkItemHandler {
 
+        private final String errorCode;
+
+        public WorkItemExecutionErrorWorkItemHandler() {
+            this("500");
+        }
+
+        public WorkItemExecutionErrorWorkItemHandler(String errorCode) {
+            this.errorCode = errorCode;
+        }
+
         @Override
         public void executeWorkItem(KogitoWorkItem workItem, KogitoWorkItemManager manager) {
-            throw new WorkItemExecutionException("500");
+            throw new WorkItemExecutionException(errorCode);
         }
 
         @Override

--- a/jbpm/jbpm-bpmn2/src/test/resources/error/ErrorVariable.bpmn2
+++ b/jbpm/jbpm-bpmn2/src/test/resources/error/ErrorVariable.bpmn2
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" xmlns:xsi="xsi" id="_EH_30P-VEDqi9NLL5J8UtQ" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
+  <bpmn2:itemDefinition id="_theExceptionItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__66C19E01-4C23-45AA-95A1-A94DBEBA0B67_ErrorOutputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__E5B0E78B-0112-42F4-89FF-0DCC4FCB6BCD_exInputXItem" structureRef="Object"/>
+  <bpmn2:error id="MY_ERROR" errorCode="MY_ERROR"/>
+  <bpmn2:interface id="_8DA0CD88-0714-43C1-B492-A70FADE42361_ServiceInterface" name="org.jbpm.bpmn2.services.AlwaysThrowingComponent" implementationRef="org.jbpm.bpmn2.services.AlwaysThrowingComponent">
+    <bpmn2:operation id="_8DA0CD88-0714-43C1-B492-A70FADE42361_ServiceOperation" name="throwException" implementationRef="throwException"/>
+  </bpmn2:interface>
+  <bpmn2:interface id="_E5B0E78B-0112-42F4-89FF-0DCC4FCB6BCD_ServiceInterface" name="org.jbpm.services.LoggingComponent" implementationRef="org.jbpm.bpmn2.services.LoggingComponent">
+    <bpmn2:operation id="_E5B0E78B-0112-42F4-89FF-0DCC4FCB6BCD_ServiceOperation" name="logException" implementationRef="logException"/>
+  </bpmn2:interface>
+  <bpmn2:process id="ErrorVariable" drools:packageName="com.example" drools:version="1.0" drools:adHoc="false" name="ErrorVariable" isExecutable="true" processType="Public">
+    <bpmn2:property id="theException" itemSubjectRef="_theExceptionItem" name="theException"/>
+    <bpmn2:sequenceFlow id="_52EEDF72-07C7-46FE-BB5C-9513565AB210" sourceRef="_E5B0E78B-0112-42F4-89FF-0DCC4FCB6BCD" targetRef="_62803D2E-7500-4772-99F8-12CF68FB029A"/>
+    <bpmn2:sequenceFlow id="_96D31184-08C6-4DC9-B405-4FC97B477DCC" sourceRef="_62803D2E-7500-4772-99F8-12CF68FB029A" targetRef="_D318B115-D923-4448-AA4E-CACCCDEB9DD5"/>
+    <bpmn2:sequenceFlow id="_3254F9E3-A671-4CC6-A96E-F642D8095B4E" sourceRef="_8DA0CD88-0714-43C1-B492-A70FADE42361" targetRef="_62803D2E-7500-4772-99F8-12CF68FB029A">
+      <bpmn2:extensionElements>
+        <drools:metaData name="isAutoConnection.target">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+    </bpmn2:sequenceFlow>
+    <bpmn2:sequenceFlow id="_CCE428E6-F550-4944-BDE7-13FC4ECABC4D" sourceRef="_3DFFE8BD-F6F8-48DE-93FB-9A929B92485D" targetRef="_8DA0CD88-0714-43C1-B492-A70FADE42361"/>
+    <bpmn2:sequenceFlow id="_B77C7C61-40AF-4F07-95CF-DEB00A8FCFBF" sourceRef="_66C19E01-4C23-45AA-95A1-A94DBEBA0B67" targetRef="_E5B0E78B-0112-42F4-89FF-0DCC4FCB6BCD"/>
+    <bpmn2:exclusiveGateway id="_62803D2E-7500-4772-99F8-12CF68FB029A" gatewayDirection="Converging">
+      <bpmn2:incoming>_3254F9E3-A671-4CC6-A96E-F642D8095B4E</bpmn2:incoming>
+      <bpmn2:incoming>_52EEDF72-07C7-46FE-BB5C-9513565AB210</bpmn2:incoming>
+      <bpmn2:outgoing>_96D31184-08C6-4DC9-B405-4FC97B477DCC</bpmn2:outgoing>
+    </bpmn2:exclusiveGateway>
+    <bpmn2:serviceTask id="_E5B0E78B-0112-42F4-89FF-0DCC4FCB6BCD" drools:serviceimplementation="Java" drools:serviceinterface="org.jbpm.bpmn2.servicesLoggingComponent" drools:serviceoperation="logException" name="Error Handling" implementation="Java" operationRef="_E5B0E78B-0112-42F4-89FF-0DCC4FCB6BCD_ServiceOperation">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Error Handling]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_B77C7C61-40AF-4F07-95CF-DEB00A8FCFBF</bpmn2:incoming>
+      <bpmn2:outgoing>_52EEDF72-07C7-46FE-BB5C-9513565AB210</bpmn2:outgoing>
+      <bpmn2:ioSpecification>
+        <bpmn2:dataInput id="_E5B0E78B-0112-42F4-89FF-0DCC4FCB6BCD_exInputX" drools:dtype="Object" itemSubjectRef="__E5B0E78B-0112-42F4-89FF-0DCC4FCB6BCD_exInputXItem" name="ex"/>
+        <bpmn2:inputSet>
+          <bpmn2:dataInputRefs>_E5B0E78B-0112-42F4-89FF-0DCC4FCB6BCD_exInputX</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation>
+        <bpmn2:sourceRef>theException</bpmn2:sourceRef>
+        <bpmn2:targetRef>_E5B0E78B-0112-42F4-89FF-0DCC4FCB6BCD_exInputX</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+    </bpmn2:serviceTask>
+    <bpmn2:endEvent id="_D318B115-D923-4448-AA4E-CACCCDEB9DD5">
+      <bpmn2:incoming>_96D31184-08C6-4DC9-B405-4FC97B477DCC</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:serviceTask id="_8DA0CD88-0714-43C1-B492-A70FADE42361" drools:serviceimplementation="Java" drools:serviceinterface="org.jbpm.bpmn2.services.AlwaysThrowingComponent" drools:serviceoperation="throwException" name="Always Throwing" implementation="Java" operationRef="_8DA0CD88-0714-43C1-B492-A70FADE42361_ServiceOperation">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Always Throwing]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_CCE428E6-F550-4944-BDE7-13FC4ECABC4D</bpmn2:incoming>
+      <bpmn2:outgoing>_3254F9E3-A671-4CC6-A96E-F642D8095B4E</bpmn2:outgoing>
+    </bpmn2:serviceTask>
+    <bpmn2:startEvent id="_3DFFE8BD-F6F8-48DE-93FB-9A929B92485D">
+      <bpmn2:outgoing>_CCE428E6-F550-4944-BDE7-13FC4ECABC4D</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:boundaryEvent id="_66C19E01-4C23-45AA-95A1-A94DBEBA0B67" drools:dockerinfo="46.11320754716981^74|" drools:boundaryca="true" attachedToRef="_8DA0CD88-0714-43C1-B492-A70FADE42361">
+      <bpmn2:outgoing>_B77C7C61-40AF-4F07-95CF-DEB00A8FCFBF</bpmn2:outgoing>
+      <bpmn2:dataOutput id="_66C19E01-4C23-45AA-95A1-A94DBEBA0B67_ErrorOutputX" drools:dtype="Object" itemSubjectRef="__66C19E01-4C23-45AA-95A1-A94DBEBA0B67_ErrorOutputXItem" name="Error"/>
+      <bpmn2:dataOutputAssociation>
+        <bpmn2:sourceRef>_66C19E01-4C23-45AA-95A1-A94DBEBA0B67_ErrorOutputX</bpmn2:sourceRef>
+        <bpmn2:targetRef>theException</bpmn2:targetRef>
+      </bpmn2:dataOutputAssociation>
+      <bpmn2:outputSet>
+        <bpmn2:dataOutputRefs>_66C19E01-4C23-45AA-95A1-A94DBEBA0B67_ErrorOutputX</bpmn2:dataOutputRefs>
+      </bpmn2:outputSet>
+      <bpmn2:errorEventDefinition drools:erefname="MY_ERROR" errorRef="MY_ERROR"/>
+    </bpmn2:boundaryEvent>
+  </bpmn2:process>
+</bpmn2:definitions>

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/actions/SignalProcessInstanceAction.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/actions/SignalProcessInstanceAction.java
@@ -80,14 +80,17 @@ public class SignalProcessInstanceAction implements Action, Serializable {
         Object signal = null;
         if (inputVariable != null) {
             signal = context.getContextData().get(inputVariable);
-        } else {
+        }
+        if (signal == null) {
             if (variableName != null) {
                 signal = context.getVariable(variableName);
             } else {
                 signal = eventDataSupplier.apply(context);
             }
         }
-        signal = signal != null ? signal : variableName;
+        if (signal == null) {
+            signal = variableName;
+        }
         // compute inputs for throwing
         Map<String, Object> inputSet = new HashMap<>();
         inputSet.put("Data", signal);


### PR DESCRIPTION
If inputName variable is null, rather than taking variable name, take variable value.

This partially fixes issue reported in the JIRA https://github.com/comlinegmbh/kogito-error-boundary-poc
Partially because there is still two variable change event rather than one, but at least the "theException" has the expected value. 

@elguardian Maybe there is a better solution, please take a look. 
