### PR TITLE
[1.27.x] KOGITO-7878 - Override workitemhandler.getName method with work item …

### DIFF
--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/src/main/java/org/kie/kogito/quarkus/serverless/workflow/openapi/WorkflowOpenApiHandlerGenerator.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/src/main/java/org/kie/kogito/quarkus/serverless/workflow/openapi/WorkflowOpenApiHandlerGenerator.java
@@ -112,6 +112,8 @@ public class WorkflowOpenApiHandlerGenerator extends ClassAnnotatedWorkflowHandl
         }
         clazz.addMethod("getRestClass", Keyword.PROTECTED).setType(parseClassOrInterfaceType(Class.class.getCanonicalName()).setTypeArguments(classNameType))
                 .setBody(new BlockStmt().addStatement(new ReturnStmt(new ClassExpr(classNameType))));
+        clazz.addMethod("getName", Keyword.PUBLIC).setType(parseClassOrInterfaceType(String.class.getCanonicalName()))
+                .setBody(new BlockStmt().addStatement(new ReturnStmt(new StringLiteralExpr(className))));
         return WorkflowCodeGenUtils.fromCompilationUnit(context, unit, className);
     }
 

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/src/main/java/org/kie/kogito/quarkus/serverless/workflow/rpc/WorkflowRPCHandlerGenerator.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/src/main/java/org/kie/kogito/quarkus/serverless/workflow/rpc/WorkflowRPCHandlerGenerator.java
@@ -71,6 +71,8 @@ public class WorkflowRPCHandlerGenerator implements WorkflowHandlerGenerator {
         addAnnotation(constructor, boolean.class, "enumDefault", RPCWorkItemHandler.GRPC_ENUM_DEFAULT_PROPERTY, Boolean.toString(RPCWorkItemHandler.GRPC_ENUM_DEFAULT_VALUE));
         addAnnotation(constructor, int.class, "streamTimeout", RPCWorkItemHandler.GRPC_STREAM_TIMEOUT_PROPERTY, Integer.toString(RPCWorkItemHandler.GRPC_STREAM_TIMEOUT_VALUE));
         constructor.setBody(new BlockStmt().addStatement(new MethodCallExpr(null, "super").addArgument("enumDefault").addArgument("streamTimeout")));
+        clazz.addMethod("getName", Keyword.PUBLIC).setType(parseClassOrInterfaceType(String.class.getCanonicalName()))
+                .setBody(new BlockStmt().addStatement(new ReturnStmt(new StringLiteralExpr(className))));
         return WorkflowCodeGenUtils.fromCompilationUnit(context, unit, className);
     }
 


### PR DESCRIPTION
…handler name, using fixed name instead of class name. (#2425)

Cherry-pick from main