### PR TITLE
Replace EmptyBuildItem with ArtifactResultBuildItem

### DIFF
--- a/quarkus/addons/common/deployment/src/main/java/org/kie/kogito/quarkus/addons/common/deployment/AnyEngineKogitoAddOnProcessor.java
+++ b/quarkus/addons/common/deployment/src/main/java/org/kie/kogito/quarkus/addons/common/deployment/AnyEngineKogitoAddOnProcessor.java
@@ -15,10 +15,10 @@
  */
 package org.kie.kogito.quarkus.addons.common.deployment;
 
-import io.quarkus.builder.item.EmptyBuildItem;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Produce;
+import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
 
 /**
  * You don't need to point to a particular engine if your add-on fits any set of it.
@@ -36,7 +36,7 @@ public abstract class AnyEngineKogitoAddOnProcessor {
      * @param capabilities
      */
     @BuildStep
-    @Produce(EmptyBuildItem.class)
+    @Produce(ArtifactResultBuildItem.class)
     void verifyCapabilities(final Capabilities capabilities) {
         if (KogitoCapability.ENGINES.stream().noneMatch(kc -> capabilities.isPresent(kc.getCapability()))) {
             throw this.exceptionForEngineNotPresent();

--- a/quarkus/addons/common/deployment/src/main/java/org/kie/kogito/quarkus/addons/common/deployment/RequireCapabilityKogitoAddOnProcessor.java
+++ b/quarkus/addons/common/deployment/src/main/java/org/kie/kogito/quarkus/addons/common/deployment/RequireCapabilityKogitoAddOnProcessor.java
@@ -18,10 +18,10 @@ package org.kie.kogito.quarkus.addons.common.deployment;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import io.quarkus.builder.item.EmptyBuildItem;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Produce;
+import io.quarkus.deployment.pkg.builditem.ArtifactResultBuildItem;
 
 import static java.util.Arrays.asList;
 
@@ -65,7 +65,7 @@ public abstract class RequireCapabilityKogitoAddOnProcessor {
      *
      */
     @BuildStep
-    @Produce(EmptyBuildItem.class)
+    @Produce(ArtifactResultBuildItem.class)
     void verifyCapabilities(final Capabilities capabilities) {
         final List<KogitoCapability> missing = requiredCapabilities.stream()
                 .filter(kc -> capabilities.isMissing(kc.getCapability()))

--- a/quarkus/addons/messaging/deployment/src/main/java/org/kie/kogito/addon/cloudevents/quarkus/deployment/KogitoProcessMessagingProcessor.java
+++ b/quarkus/addons/messaging/deployment/src/main/java/org/kie/kogito/addon/cloudevents/quarkus/deployment/KogitoProcessMessagingProcessor.java
@@ -26,19 +26,13 @@ import org.jboss.jandex.FieldInfo;
 import org.jboss.jandex.Type;
 import org.kie.kogito.event.EventEmitter;
 import org.kie.kogito.event.EventReceiver;
-import org.kie.kogito.quarkus.addons.common.deployment.KogitoCapability;
-import org.kie.kogito.quarkus.addons.common.deployment.RequireCapabilityKogitoAddOnProcessor;
 
 import io.quarkus.arc.deployment.AnnotationsTransformerBuildItem;
 import io.quarkus.arc.processor.AnnotationsTransformer;
 import io.quarkus.arc.processor.DotNames;
 import io.quarkus.deployment.annotations.BuildStep;
 
-public class KogitoProcessMessagingProcessor extends RequireCapabilityKogitoAddOnProcessor {
-
-    public KogitoProcessMessagingProcessor() {
-        super(KogitoCapability.PROCESSES);
-    }
+public class KogitoProcessMessagingProcessor {
 
     private static class MessagingAnnotationTransfomer implements AnnotationsTransformer {
         private Map<DotName, DotName> fieldMapping;

--- a/quarkus/addons/process-svg/deployment/src/main/java/org/kie/kogito/svg/deployment/KogitoAddOnProcessSVGProcessor.java
+++ b/quarkus/addons/process-svg/deployment/src/main/java/org/kie/kogito/svg/deployment/KogitoAddOnProcessSVGProcessor.java
@@ -15,9 +15,6 @@
  */
 package org.kie.kogito.svg.deployment;
 
-import org.kie.kogito.quarkus.addons.common.deployment.KogitoCapability;
-import org.kie.kogito.quarkus.addons.common.deployment.RequireCapabilityKogitoAddOnProcessor;
-
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
@@ -27,13 +24,9 @@ import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
 
 import static org.kie.kogito.svg.AbstractProcessSvgService.SVG_RELATIVE_PATH;
 
-class KogitoAddOnProcessSVGProcessor extends RequireCapabilityKogitoAddOnProcessor {
+class KogitoAddOnProcessSVGProcessor {
 
     private static final String FEATURE = "kogito-addon-process-svg-extension";
-
-    KogitoAddOnProcessSVGProcessor() {
-        super(KogitoCapability.PROCESSES);
-    }
 
     @BuildStep
     FeatureBuildItem feature() {


### PR DESCRIPTION
In next versions of Quarkus, it won't allow using `@Produce(EmptyBuildItem.class)` (an exception will be thrown). 
More information about this change can be found here: https://github.com/quarkusio/quarkus/pull/27427
Moreover, for the use case you were using `@Produce(EmptyBuildItem.class)`, validations, we should use `ValidationErrorBuildItem`. I didn't do it because it would require adding the dependency `quarkus-arc-deployment`, so I replaced it with `@Produce(ArtifactResultBuildItem.class)` which is guaranteed that the build step will be executed.

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [ ] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>

- <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
