### PR TITLE
KOGITO-7911 - Allow to override Data Index image version

### DIFF
--- a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-deployment/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-deployment/pom.xml
@@ -13,7 +13,7 @@
   <name>Kogito :: Quarkus Processes Extension :: Deployment</name>
 
   <properties>
-    <data-index-ephemeral.image>quay.io/kiegroup/kogito-data-index-ephemeral</data-index-ephemeral.image>
+    <data-index-ephemeral.image>quay.io/kiegroup/kogito-data-index-ephemeral:{placeholder}</data-index-ephemeral.image>
   </properties>
 
   <dependencies>
@@ -102,7 +102,7 @@
         </property>
       </activation>
       <properties>
-        <data-index-ephemeral.image>registry.redhat.io/openshift-serverless-1-tech-preview/logic-data-index-ephemeral-rhel8</data-index-ephemeral.image>
+        <data-index-ephemeral.image>registry.redhat.io/openshift-serverless-1-tech-preview/logic-data-index-ephemeral-rhel8:1.25</data-index-ephemeral.image>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
Unless `placeholder` string is used, DevServices will now use the full string that is defined in the pom.xml, including the version part of it.