### PR TITLE
[KOGITO-7792]-Project fails to build if no SW file is defined and Knative Eventing and Kubernetes add-on is presented in classpath

### DIFF
--- a/quarkus/addons/knative/eventing/deployment/src/main/java/org/kie/kogito/addons/quarkus/knative/eventing/deployment/KogitoProcessKnativeEventingProcessor.java
+++ b/quarkus/addons/knative/eventing/deployment/src/main/java/org/kie/kogito/addons/quarkus/knative/eventing/deployment/KogitoProcessKnativeEventingProcessor.java
@@ -63,18 +63,20 @@ public class KogitoProcessKnativeEventingProcessor {
             List<KubernetesDeploymentTargetBuildItem> allDeploymentTargets,
             List<KubernetesResourceMetadataBuildItem> kubernetesMetaBuildItems,
             BuildProducer<KogitoKnativeResourcesMetadataBuildItem> metadataProducer) {
-        final Set<CloudEventMeta> cloudEvents = new HashSet<>(this.getCloudEventMetaBuilder().build(processContainerBuildItem.getProcessContainerGenerators()));
-        final Set<CloudEventMeta> extendedCloudEvents = extendedCloudEventsBuildItems.stream()
-                .flatMap(cloudEventsBuildItem -> cloudEventsBuildItem.getCloudEvents().stream())
-                .collect(Collectors.toSet());
-        cloudEvents.addAll(extendedCloudEvents);
-        if (!cloudEvents.isEmpty()) {
-            Optional<KogitoServiceDeploymentTarget> target = this.selectDeploymentTarget(allDeploymentTargets, kubernetesMetaBuildItems);
+        if(processContainerBuildItem != null) {
+            final Set<CloudEventMeta> cloudEvents = new HashSet<>(this.getCloudEventMetaBuilder().build(processContainerBuildItem.getProcessContainerGenerators()));
+            final Set<CloudEventMeta> extendedCloudEvents = extendedCloudEventsBuildItems.stream()
+                    .flatMap(cloudEventsBuildItem -> cloudEventsBuildItem.getCloudEvents().stream())
+                    .collect(Collectors.toSet());
+            cloudEvents.addAll(extendedCloudEvents);
+            if (!cloudEvents.isEmpty()) {
+                Optional<KogitoServiceDeploymentTarget> target = this.selectDeploymentTarget(allDeploymentTargets, kubernetesMetaBuildItems);
 
-            if (target.isEmpty()) {
-                LOGGER.warn("Impossible to get the Kubernetes deployment target for this Kogito service. Skipping generation.");
-            } else {
-                metadataProducer.produce(new KogitoKnativeResourcesMetadataBuildItem(cloudEvents, target.get()));
+                if (target.isEmpty()) {
+                    LOGGER.warn("Impossible to get the Kubernetes deployment target for this Kogito service. Skipping generation.");
+                } else {
+                    metadataProducer.produce(new KogitoKnativeResourcesMetadataBuildItem(cloudEvents, target.get()));
+                }
             }
         }
     }

--- a/quarkus/addons/knative/eventing/deployment/src/main/java/org/kie/kogito/addons/quarkus/knative/eventing/deployment/KogitoProcessKnativeEventingProcessor.java
+++ b/quarkus/addons/knative/eventing/deployment/src/main/java/org/kie/kogito/addons/quarkus/knative/eventing/deployment/KogitoProcessKnativeEventingProcessor.java
@@ -63,7 +63,7 @@ public class KogitoProcessKnativeEventingProcessor {
             List<KubernetesDeploymentTargetBuildItem> allDeploymentTargets,
             List<KubernetesResourceMetadataBuildItem> kubernetesMetaBuildItems,
             BuildProducer<KogitoKnativeResourcesMetadataBuildItem> metadataProducer) {
-        if(processContainerBuildItem != null) {
+        if (processContainerBuildItem != null) {
             final Set<CloudEventMeta> cloudEvents = new HashSet<>(this.getCloudEventMetaBuilder().build(processContainerBuildItem.getProcessContainerGenerators()));
             final Set<CloudEventMeta> extendedCloudEvents = extendedCloudEventsBuildItems.stream()
                     .flatMap(cloudEventsBuildItem -> cloudEventsBuildItem.getCloudEvents().stream())


### PR DESCRIPTION
Jira- https://issues.redhat.com/browse/KOGITO-7792

When there is no SW file in the resources folder KogitoProcessContainerGeneratorBuildItem shouldn't be called.  Added a guard check to return if processContainerBuildItem is null , in order to avoid  KogitoProcessContainerGeneratorBuildItem getting executed.