### PR TITLE
[KOGITO-7933] Avoiding NPE for error definition

### DIFF
--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/StateHandler.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/StateHandler.java
@@ -15,14 +15,14 @@
  */
 package org.kie.kogito.serverless.workflow.parser.handlers;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.NoSuchElementException;
 import java.util.Optional;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import org.jbpm.process.core.context.exception.CompensationScope;
 import org.jbpm.process.core.context.variable.Variable;
@@ -60,6 +60,7 @@ import io.serverlessworkflow.api.filters.StateDataFilter;
 import io.serverlessworkflow.api.interfaces.State;
 import io.serverlessworkflow.api.produce.ProduceEvent;
 import io.serverlessworkflow.api.transitions.Transition;
+import io.serverlessworkflow.api.workflow.Errors;
 
 import static org.kie.kogito.serverless.workflow.parser.ServerlessWorkflowParser.DEFAULT_WORKFLOW_VAR;
 import static org.kie.kogito.serverless.workflow.parser.handlers.NodeFactoryUtils.messageNode;
@@ -221,25 +222,45 @@ public abstract class StateHandler<S extends State> {
         }
     }
 
-    protected final Iterable<ErrorDefinition> getErrorDefinitions(Error error) {
-        Predicate<? super ErrorDefinition> pred;
-        if (error.getErrorRef() != null) {
-            pred = e -> error.getErrorRef().equals(e.getName());
-        } else if (error.getErrorRefs() != null) {
-            pred = e -> error.getErrorRefs().contains(e.getName());
-        } else {
-            throw new IllegalStateException("errorRef or errorRefs should be defined in list of error definitions");
+    private boolean hasCode(ErrorDefinition errorDef) {
+        if (errorDef.getCode() == null) {
+            logger.error("Kogito requires code error to be set. Ignoring {}", errorDef.getName());
+            return false;
         }
-        return workflow.getErrors().getErrorDefs().stream().filter(pred).collect(Collectors.toList());
+        return true;
+    }
+
+    protected final Collection<ErrorDefinition> getErrorDefinitions(Error error) {
+        Errors errors = workflow.getErrors();
+        if (errors == null) {
+            throw new IllegalArgumentException("workflow should contain errors property");
+        }
+        List<ErrorDefinition> errorDefs = errors.getErrorDefs();
+        if (errorDefs == null) {
+            throw new IllegalArgumentException("workflow errors property must contain errorDefs property");
+        }
+
+        if (error.getErrorRef() != null) {
+            return getErrorsDefinitions(errorDefs, Arrays.asList(error.getErrorRef()));
+        } else if (error.getErrorRefs() != null) {
+            return getErrorsDefinitions(errorDefs, error.getErrorRefs());
+        } else {
+            throw new IllegalArgumentException("state errors should contain either errorRef or errorRefs property");
+        }
+    }
+
+    private Collection<ErrorDefinition> getErrorsDefinitions(List<ErrorDefinition> errorDefs, List<String> errorRefs) {
+        Collection<ErrorDefinition> result = new ArrayList<>();
+        for (String errorRef : errorRefs) {
+            result.add(errorDefs.stream().filter(errorDef -> errorDef.getName().equals(errorRef) && hasCode(errorDef)).findAny()
+                    .orElseThrow(() -> new IllegalArgumentException("Cannot find any error definition for errorRef" + errorRef)));
+        }
+        return result;
     }
 
     protected final void handleErrors(RuleFlowNodeContainerFactory<?, ?> factory, RuleFlowNodeContainerFactory<?, ?> targetNode) {
         for (Error error : state.getOnErrors()) {
-            for (ErrorDefinition errorDef : getErrorDefinitions(error)) {
-                if (errorDef.getCode() == null) {
-                    logger.error("Kogito requires code error to be set. Ignoring {}", errorDef.getName());
-                    return;
-                }
+            getErrorDefinitions(error).forEach(errorDef -> {
                 String errorPrefix = RuleFlowProcessFactory.ERROR_TYPE_PREFIX + targetNode.getNode().getMetaData().get("UniqueId") + '-';
                 BoundaryEventNodeFactory<?> boundaryNode = factory.boundaryEventNode(parserContext.newId()).attachedTo(targetNode.getNode().getId())
                         .metaData(Metadata.EVENT_TYPE, Metadata.EVENT_TYPE_ERROR).metaData("HasErrorEvent", true).metaData(Metadata.ERROR_EVENT, errorDef.getCode())
@@ -251,7 +272,7 @@ public abstract class StateHandler<S extends State> {
                 } else {
                     handleTransitions(factory, error.getTransition(), boundaryNode.getNode().getId());
                 }
-            }
+            });
         }
     }
 


### PR DESCRIPTION
Rather than throwing NPE when user has provided an error reference but there is not any error definition is present, a clear message stating that should be printed

The building will continue failing, as expected

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](CONTRIBUTING.md)
- [ ] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>

- <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
