### PR TITLE
[KOGITO-7852] Remove workflowdata from POST start request

### DIFF
--- a/api/kogito-api/src/main/java/org/kie/kogito/Models.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/Models.java
@@ -20,8 +20,6 @@ import java.beans.IntrospectionException;
 import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -58,16 +56,12 @@ public class Models {
                     continue;
                 }
                 k = unprefixVar(k);
-                map.put(k, getValue(e.getValue(), m));
+                map.put(k, e.getValue().getReadMethod().invoke(m));
             }
             return map;
         } catch (IntrospectionException | ReflectiveOperationException e) {
             throw new ReflectiveModelAccessException(e);
         }
-    }
-
-    private static Object getValue(PropertyDescriptor pd, Object target) throws ReflectiveOperationException {
-        return pd.getReadMethod() == null ? pd.getValue(pd.getName()) : pd.getReadMethod().invoke(target);
     }
 
     public static <T> T fromMap(T m, String id, Map<String, Object> map) {
@@ -84,7 +78,7 @@ public class Models {
                 String k = e.getKey();
                 k = unprefixVar(k);
                 if (map.containsKey(k)) {
-                    updateValue(e.getValue(), m, map.get(k));
+                    e.getValue().getWriteMethod().invoke(m, map.get(k));
                 }
             }
             return m;
@@ -107,23 +101,12 @@ public class Models {
         }
     }
 
-    private static void updateValue(PropertyDescriptor pd, Object target, Object value) throws ReflectiveOperationException {
-        Method writeMethod = pd.getWriteMethod();
-        if (writeMethod != null) {
-            writeMethod.invoke(target, value);
-        } else {
-            Field f = target.getClass().getDeclaredField(pd.getName());
-            f.setAccessible(true);
-            f.set(target, value);
-        }
-    }
-
     public static void setId(Object m, String id) {
         try {
             BeanInfo beanInfo = Introspector.getBeanInfo(m.getClass());
             for (PropertyDescriptor pd : beanInfo.getPropertyDescriptors()) {
                 if (isIdentifier(pd.getName())) {
-                    updateValue(pd, m, id);
+                    pd.getWriteMethod().invoke(m, id);
                     return;
                 }
             }

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/LambdaSubProcessNodeVisitor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/LambdaSubProcessNodeVisitor.java
@@ -93,7 +93,7 @@ public class LambdaSubProcessNodeVisitor extends AbstractNodeVisitor<SubProcessN
                 VariableDeclarations.ofRawInfo(inputTypes),
                 false);
 
-        retValue.ifPresent(retValueExpression -> {
+        retValue.ifPresentOrElse(retValueExpression -> {
             retValueExpression.findAll(ClassOrInterfaceType.class)
                     .stream()
                     .filter(t -> t.getNameAsString().equals("$Type$"))
@@ -105,13 +105,9 @@ public class LambdaSubProcessNodeVisitor extends AbstractNodeVisitor<SubProcessN
                     .ifPresent(m -> m.setBody(createInstance(node, metadata)));
             retValueExpression.findFirst(MethodDeclaration.class, m -> m.getNameAsString().equals("unbind"))
                     .ifPresent(m -> m.setBody(unbind(variableScope, node)));
-        });
+            body.addStatement(getFactoryMethod(getNodeId(node), getNodeKey(), retValueExpression));
+        }, () -> body.addStatement(getFactoryMethod(getNodeId(node), getNodeKey())));
 
-        if (retValue.isPresent()) {
-            body.addStatement(getFactoryMethod(getNodeId(node), getNodeKey(), retValue.get()));
-        } else {
-            body.addStatement(getFactoryMethod(getNodeId(node), getNodeKey()));
-        }
         addNodeMappings(node, body, getNodeId(node));
         visitMetaData(node.getMetaData(), body, getNodeId(node));
         body.addStatement(getDoneMethod(getNodeId(node)));

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/LambdaSubProcessNodeVisitor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/LambdaSubProcessNodeVisitor.java
@@ -84,9 +84,10 @@ public class LambdaSubProcessNodeVisitor extends AbstractNodeVisitor<SubProcessN
 
         Map<String, String> inputTypes = node.getIoSpecification().getInputTypes();
 
-        String subProcessModelClassName = ProcessToExecModelGenerator.extractModelClassName(subProcessId);
+        String subProcessModelClassName = metadata.getModelClassName() != null ? metadata.getModelClassName() : ProcessToExecModelGenerator.extractModelClassName(subProcessId);
+
         ModelMetaData subProcessModel = new ModelMetaData(subProcessId,
-                metadata.getPackageName(),
+                metadata.getModelPackageName() != null ? metadata.getModelPackageName() : metadata.getPackageName(),
                 subProcessModelClassName,
                 KogitoWorkflowProcess.PRIVATE_VISIBILITY,
                 VariableDeclarations.ofRawInfo(inputTypes),

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ProcessMetaData.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ProcessMetaData.java
@@ -53,6 +53,9 @@ public class ProcessMetaData {
     private boolean startable;
     private boolean dynamic;
 
+    private String modelPackageName;
+    private String modelClassName;
+
     private Map<String, CompilationUnit> generatedHandlers = new HashMap<>();
     private Set<CompilationUnit> generatedListeners = new HashSet<>();
 
@@ -205,6 +208,22 @@ public class ProcessMetaData {
                 ", processId=" + processId + ", extractedProcessId=" + extractedProcessId +
                 ", processName=" + processName + ", processVersion=" + processVersion +
                 ", workItems=" + workItems + "]";
+    }
+
+    public String getModelPackageName() {
+        return modelPackageName;
+    }
+
+    public void setModelPackageName(String modelPackageName) {
+        this.modelPackageName = modelPackageName;
+    }
+
+    public String getModelClassName() {
+        return modelClassName;
+    }
+
+    public void setModelClassName(String modelClassName) {
+        this.modelClassName = modelClassName;
     }
 
 }

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ProcessToExecModelGenerator.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ProcessToExecModelGenerator.java
@@ -87,6 +87,11 @@ public class ProcessToExecModelGenerator {
                 new ProcessMetaData(process.getId(), extractedProcessId, process.getName(), process.getVersion(),
                         packageName, processClazz.getNameAsString());
 
+        if (process.getType().equals(KogitoWorkflowProcess.SW_TYPE)) {
+            metadata.setModelClassName("JsonNodeModel");
+            metadata.setModelPackageName("org.kie.kogito.serverless.workflow.models");
+        }
+
         Optional<MethodDeclaration> processMethod = parsedClazzFile.findFirst(MethodDeclaration.class, sl -> sl
                 .getName()
                 .asString()

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/MessageConsumerGenerator.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/MessageConsumerGenerator.java
@@ -95,6 +95,7 @@ public class MessageConsumerGenerator {
                 .withPackageName(processPackageName)
                 .build(context, "MessageConsumer");
         this.clazz = generator.compilationUnitOrThrow("Cannot generate message consumer");
+        clazz.addImport(modelfqcn);
     }
 
     public String className() {

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/ModelClassGenerator.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/ModelClassGenerator.java
@@ -15,40 +15,31 @@
  */
 package org.kie.kogito.codegen.process;
 
-import org.drools.util.StringUtils;
 import org.jbpm.compiler.canonical.ModelMetaData;
 import org.jbpm.compiler.canonical.ProcessToExecModelGenerator;
 import org.jbpm.ruleflow.core.Metadata;
 import org.kie.api.definition.process.WorkflowProcess;
 import org.kie.kogito.codegen.api.context.KogitoBuildContext;
+import org.kie.kogito.internal.process.runtime.KogitoWorkflowProcess;
+import org.kie.kogito.serverless.workflow.utils.ServerlessWorkflowUtils;
 
 public class ModelClassGenerator {
 
-    private final KogitoBuildContext context;
-    private final WorkflowProcess workFlowProcess;
-    private String modelFileName;
-    private ModelMetaData modelMetaData;
-    private String modelClassName;
+    private final String modelFileName;
+    private final ModelMetaData modelMetaData;
+    private final String modelClassName;
 
     public ModelClassGenerator(KogitoBuildContext context, WorkflowProcess workFlowProcess) {
-        String pid = workFlowProcess.getId();
-        String name = ProcessToExecModelGenerator.extractProcessId(pid);
-        this.modelClassName = workFlowProcess.getPackageName() + "." +
-                StringUtils.ucFirst(name) + "Model";
-
-        this.context = context;
-        this.workFlowProcess = workFlowProcess;
-    }
-
-    public ModelMetaData generate() {
-        // create model class for all variables
-        modelMetaData = ProcessToExecModelGenerator.INSTANCE.generateModel(workFlowProcess);
+        modelMetaData = workFlowProcess.getType().equals(KogitoWorkflowProcess.SW_TYPE) ? ServerlessWorkflowUtils.getModelMetadata(workFlowProcess)
+                : ProcessToExecModelGenerator.INSTANCE.generateModel(workFlowProcess);
+        modelClassName = modelMetaData.getModelClassName();
         modelFileName = modelMetaData.getModelClassName().replace('.', '/') + ".java";
-
         modelMetaData.setSupportsValidation(context.isValidationSupported());
         modelMetaData.setSupportsOpenApiGeneration(context.isOpenApiSpecSupported());
         modelMetaData.setModelSchemaRef((String) workFlowProcess.getMetaData().get(Metadata.DATA_INPUT_SCHEMA_REF));
+    }
 
+    public ModelMetaData generate() {
         return modelMetaData;
     }
 

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/ProcessCodegen.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/ProcessCodegen.java
@@ -270,6 +270,10 @@ public class ProcessCodegen extends AbstractGenerator {
         return packageName + ".ProcessEventListenerConfig";
     }
 
+    private boolean skipModelGeneration(WorkflowProcess process) {
+        return process.getType().equals(KogitoWorkflowProcess.SW_TYPE);
+    }
+
     @Override
     protected Collection<GeneratedFile> internalGenerate() {
 
@@ -289,14 +293,16 @@ public class ProcessCodegen extends AbstractGenerator {
 
         // first we generate all the data classes from variable declarations
         for (WorkflowProcess workFlowProcess : processes.values()) {
-            ModelClassGenerator mcg = new ModelClassGenerator(context(), workFlowProcess);
-            processIdToModelGenerator.put(workFlowProcess.getId(), mcg);
+            if (!skipModelGeneration(workFlowProcess)) {
+                ModelClassGenerator mcg = new ModelClassGenerator(context(), workFlowProcess);
+                processIdToModelGenerator.put(workFlowProcess.getId(), mcg);
 
-            InputModelClassGenerator imcg = new InputModelClassGenerator(context(), workFlowProcess);
-            processIdToInputModelGenerator.put(workFlowProcess.getId(), imcg);
+                InputModelClassGenerator imcg = new InputModelClassGenerator(context(), workFlowProcess);
+                processIdToInputModelGenerator.put(workFlowProcess.getId(), imcg);
 
-            OutputModelClassGenerator omcg = new OutputModelClassGenerator(context(), workFlowProcess);
-            processIdToOutputModelGenerator.put(workFlowProcess.getId(), omcg);
+                OutputModelClassGenerator omcg = new OutputModelClassGenerator(context(), workFlowProcess);
+                processIdToOutputModelGenerator.put(workFlowProcess.getId(), omcg);
+            }
         }
 
         // then we generate user task inputs and outputs if any
@@ -330,7 +336,7 @@ public class ProcessCodegen extends AbstractGenerator {
             String classPrefix = StringUtils.ucFirst(execModelGen.extractedProcessId());
             KogitoWorkflowProcess workFlowProcess = execModelGen.process();
             ModelClassGenerator modelClassGenerator =
-                    processIdToModelGenerator.get(execModelGen.getProcessId());
+                    processIdToModelGenerator.getOrDefault(execModelGen.getProcessId(), new ModelClassGenerator(context(), workFlowProcess));
 
             ProcessGenerator p = new ProcessGenerator(
                     context(),

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/ProcessGenerator.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/ProcessGenerator.java
@@ -146,6 +146,7 @@ public class ProcessGenerator {
 
     public CompilationUnit compilationUnit() {
         CompilationUnit compilationUnit = new CompilationUnit(packageName);
+        compilationUnit.addImport(modelTypeName);
         compilationUnit.getTypes().add(classDeclaration());
         processExecutable.generate().getGeneratedClassModel().getImports().forEach(compilationUnit::addImport);
         return compilationUnit;
@@ -489,11 +490,13 @@ public class ProcessGenerator {
 
                 String fieldName = "process" + subProcess.getKey();
                 ClassOrInterfaceType modelType = new ClassOrInterfaceType(null, new SimpleName(org.kie.kogito.process.Process.class.getCanonicalName()),
-                        NodeList.nodeList(new ClassOrInterfaceType(null, StringUtils.ucFirst(subProcess.getKey() + "Model"))));
+                        NodeList.nodeList(
+                                new ClassOrInterfaceType(null, processMetaData.getModelPackageName() != null ? processMetaData.getModelPackageName() + "." + processMetaData.getModelClassName()
+                                        : StringUtils.ucFirst(subProcess.getKey() + "Model"))));
                 if (context.hasDI()) {
                     subprocessFieldDeclaration
                             .addVariable(new VariableDeclarator(modelType, fieldName));
-                    context.getDependencyInjectionAnnotator().withInjection(subprocessFieldDeclaration);
+                    context.getDependencyInjectionAnnotator().withNamedInjection(subprocessFieldDeclaration, subProcess.getValue());
                 } else {
                     // app.get(org.kie.kogito.process.Processes.class).processById()
                     MethodCallExpr initSubProcessField = new MethodCallExpr(

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/ProcessInstanceGenerator.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/ProcessInstanceGenerator.java
@@ -86,6 +86,7 @@ public class ProcessInstanceGenerator {
     public CompilationUnit compilationUnit() {
         CompilationUnit compilationUnit = new CompilationUnit(packageName);
         compilationUnit.getTypes().add(classDeclaration());
+        compilationUnit.addImport(model.getModelClassName());
         return compilationUnit;
     }
 

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/ProcessResourceGenerator.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/ProcessResourceGenerator.java
@@ -99,7 +99,7 @@ public class ProcessResourceGenerator {
         String classPrefix = StringUtils.ucFirst(processName);
         this.resourceClazzName = classPrefix + "Resource";
         this.relativePath = process.getPackageName().replace(".", "/") + "/" + resourceClazzName + ".java";
-        this.modelfqcn = modelfqcn + "Output";
+        this.modelfqcn = modelfqcn;
         this.dataClazzName = modelfqcn.substring(modelfqcn.lastIndexOf('.') + 1);
         this.processClazzName = processfqcn;
     }
@@ -147,7 +147,8 @@ public class ProcessResourceGenerator {
                 .compilationUnitOrThrow();
         clazz.setPackageDeclaration(process.getPackageName());
         clazz.addImport(modelfqcn);
-
+        clazz.addImport(modelfqcn + "Output");
+        clazz.addImport(modelfqcn + "Input");
         ClassOrInterfaceDeclaration template = clazz
                 .findFirst(ClassOrInterfaceDeclaration.class)
                 .orElseThrow(() -> new NoSuchElementException("Compilation unit doesn't contain a class or interface declaration!"));
@@ -170,7 +171,7 @@ public class ProcessResourceGenerator {
                             .filter(e -> Objects.nonNull(e.getKey()))
                             .forEach(entry -> {
                                 String methodName = "signal_" + index.getAndIncrement();
-                                String outputType = modelfqcn;
+                                String outputType = modelfqcn + "Output";
                                 String signalName = entry.getKey();
                                 String signalType = entry.getValue();
 

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/utils/ServerlessWorkflowUtils.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/utils/ServerlessWorkflowUtils.java
@@ -240,6 +240,7 @@ public class ServerlessWorkflowUtils {
     }
 
     private static ModelMetaData getModelMetadata(WorkflowProcess process, Class<?> modelClass) {
-        return new ModelMetaData(process.getId(), modelClass.getPackage().getName(), modelClass.getSimpleName(), KogitoWorkflowProcess.PUBLIC_VISIBILITY, VariableDeclarations.of(Collections.emptyMap()), false);
+        return new ModelMetaData(process.getId(), modelClass.getPackage().getName(), modelClass.getSimpleName(), KogitoWorkflowProcess.PUBLIC_VISIBILITY,
+                VariableDeclarations.of(Collections.emptyMap()), false);
     }
 }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/utils/ServerlessWorkflowUtils.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/utils/ServerlessWorkflowUtils.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.UncheckedIOException;
 import java.net.URI;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -26,10 +27,15 @@ import java.util.function.Supplier;
 import org.drools.codegen.common.GeneratedFile;
 import org.drools.codegen.common.GeneratedFileType;
 import org.drools.util.StringUtils;
+import org.jbpm.compiler.canonical.ModelMetaData;
+import org.jbpm.compiler.canonical.VariableDeclarations;
+import org.kie.api.definition.process.WorkflowProcess;
 import org.kie.kogito.codegen.api.context.KogitoBuildContext;
+import org.kie.kogito.internal.process.runtime.KogitoWorkflowProcess;
 import org.kie.kogito.serverless.workflow.extensions.FunctionNamespaces;
 import org.kie.kogito.serverless.workflow.extensions.URIDefinitions;
 import org.kie.kogito.serverless.workflow.io.URIContentLoaderFactory;
+import org.kie.kogito.serverless.workflow.models.JsonNodeModel;
 import org.kie.kogito.serverless.workflow.parser.ParserContext;
 import org.kie.kogito.serverless.workflow.suppliers.ConfigWorkItemSupplier;
 import org.slf4j.Logger;
@@ -227,5 +233,13 @@ public class ServerlessWorkflowUtils {
             }
         }
         return sb.toString();
+    }
+
+    public static ModelMetaData getModelMetadata(WorkflowProcess process) {
+        return getModelMetadata(process, JsonNodeModel.class);
+    }
+
+    private static ModelMetaData getModelMetadata(WorkflowProcess process, Class<?> modelClass) {
+        return new ModelMetaData(process.getId(), modelClass.getPackage().getName(), modelClass.getSimpleName(), KogitoWorkflowProcess.PUBLIC_VISIBILITY, VariableDeclarations.of(Collections.emptyMap()), false);
     }
 }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-runtime/src/main/java/org/kie/kogito/serverless/workflow/models/JsonNodeModel.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-runtime/src/main/java/org/kie/kogito/serverless/workflow/models/JsonNodeModel.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.serverless.workflow.models;
+
+import org.kie.kogito.MapInput;
+import org.kie.kogito.MapInputId;
+import org.kie.kogito.MapOutput;
+import org.kie.kogito.MappableToModel;
+import org.kie.kogito.Model;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class JsonNodeModel implements Model, MapInput, MapInputId, MapOutput, MappableToModel<JsonNodeModelOutput> {
+
+    private JsonNode workflowdata;
+    private String id;
+
+    public JsonNodeModel() {
+    }
+
+    public JsonNodeModel(JsonNode workflowdata) {
+        this.workflowdata = workflowdata;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @JsonAnyGetter
+    public JsonNode getWorkflowdata() {
+        return workflowdata;
+    }
+
+    public void setWorkflowdata(JsonNode workflowdata) {
+        this.workflowdata = workflowdata;
+    }
+
+    @Override
+    public JsonNodeModelOutput toModel() {
+        return new JsonNodeModelOutput(id, workflowdata);
+    }
+}

--- a/kogito-serverless-workflow/kogito-serverless-workflow-runtime/src/main/java/org/kie/kogito/serverless/workflow/models/JsonNodeModelInput.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-runtime/src/main/java/org/kie/kogito/serverless/workflow/models/JsonNodeModelInput.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public class JsonNodeModelInput implements Model, MapInput, MapInputId, MapOutput, MappableToModel<JsonNodeModel> {
 
-    private ObjectNode workflowdata = ObjectMapperFactory.listenerAware().createObjectNode();
+    private JsonNode workflowdata;
 
     public JsonNode getWorkflowdata() {
         return workflowdata;
@@ -36,7 +36,12 @@ public class JsonNodeModelInput implements Model, MapInput, MapInputId, MapOutpu
 
     @JsonAnySetter
     public void setData(String key, JsonNode value) {
-        workflowdata.set(key, value);
+        if (workflowdata == null) {
+            workflowdata = ObjectMapperFactory.listenerAware().createObjectNode();
+        }
+        if (workflowdata.isObject()) {
+            ((ObjectNode) workflowdata).set(key, value);
+        }
     }
 
     @Override

--- a/kogito-serverless-workflow/kogito-serverless-workflow-runtime/src/main/java/org/kie/kogito/serverless/workflow/models/JsonNodeModelInput.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-runtime/src/main/java/org/kie/kogito/serverless/workflow/models/JsonNodeModelInput.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.serverless.workflow.models;
+
+import org.kie.kogito.MapInput;
+import org.kie.kogito.MapInputId;
+import org.kie.kogito.MapOutput;
+import org.kie.kogito.MappableToModel;
+import org.kie.kogito.Model;
+import org.kie.kogito.jackson.utils.ObjectMapperFactory;
+
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+public class JsonNodeModelInput implements Model, MapInput, MapInputId, MapOutput, MappableToModel<JsonNodeModel> {
+
+    private ObjectNode workflowdata = ObjectMapperFactory.listenerAware().createObjectNode();
+
+    public JsonNode getWorkflowdata() {
+        return workflowdata;
+    }
+
+    @JsonAnySetter
+    public void setData(String key, JsonNode value) {
+        workflowdata.set(key, value);
+    }
+
+    @Override
+    public JsonNodeModel toModel() {
+        return new JsonNodeModel(workflowdata);
+    }
+}

--- a/kogito-serverless-workflow/kogito-serverless-workflow-runtime/src/main/java/org/kie/kogito/serverless/workflow/models/JsonNodeModelOutput.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-runtime/src/main/java/org/kie/kogito/serverless/workflow/models/JsonNodeModelOutput.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.serverless.workflow.models;
+
+import org.kie.kogito.MapInput;
+import org.kie.kogito.MapInputId;
+import org.kie.kogito.MapOutput;
+import org.kie.kogito.MappableToModel;
+import org.kie.kogito.Model;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class JsonNodeModelOutput implements Model, MapInput, MapInputId, MapOutput, MappableToModel<JsonNodeModel> {
+
+    private String id;
+    private JsonNode workflowdata;
+
+    public JsonNodeModelOutput() {
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public JsonNodeModelOutput(String id, JsonNode workflowdata) {
+        this.id = id;
+        this.workflowdata = workflowdata;
+    }
+
+    public JsonNode getWorkflowdata() {
+        return workflowdata;
+    }
+
+    @Override
+    public JsonNodeModel toModel() {
+        return new JsonNodeModel(workflowdata);
+    }
+}

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/RPCGreetIT.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/RPCGreetIT.java
@@ -35,7 +35,7 @@ class RPCGreetIT {
         given()
                 .contentType(ContentType.JSON)
                 .accept(ContentType.JSON)
-                .body("{\"workflowdata\" : {\"name\" : \"John\", \"language\":\"English\"}}").when()
+                .body("{\"name\" : \"John\", \"language\":\"English\"}").when()
                 .post("/rpcgreet")
                 .then()
                 .statusCode(201)


### PR DESCRIPTION
The purpose of this JIRA is to be able to start a process using REST  by passing as body 

`{"input":[2,4,6,8,10], "divisor": 2}`
rather than 
`{"workflowdata":{"input":[2,4,6,8,10], "divisor": 2}}`

Backward compatibility is maintained, process can still be started passing workflowdata

In order to do that the overall idea is to skip model generation for serverless workflow and use hardcoded models that follow the same structure than the generated ones. 
I made some improvements (from my point of view) to model class reflection handling 

@hbelmiro  is going to work on  https://issues.redhat.com/browse/KOGITO-7956 to update swagger doscs