### PR TITLE
KOGITO-7969 - Review Jandex API usage to maintain compatibility with …

### DIFF
--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -27,7 +27,7 @@
     <version.net.thisptr.jackson-jq>1.0.0-preview.20210928</version.net.thisptr.jackson-jq>
     <version.io.quarkiverse.jackson-jq>1.0.1</version.io.quarkiverse.jackson-jq>
     <version.io.quarkiverse.openapi.generator>0.11.0</version.io.quarkiverse.openapi.generator>
-    <version.io.quarkiverse.reactivemessaging.http>1.0.6</version.io.quarkiverse.reactivemessaging.http>
+    <version.io.quarkiverse.reactivemessaging.http>1.0.8</version.io.quarkiverse.reactivemessaging.http>
     <version.com.github.haifengl.smile>1.5.2</version.com.github.haifengl.smile>
     <version.com.github.javaparser>3.24.2</version.com.github.javaparser>
     <version.com.github.java-json-tools>2.2.14</version.com.github.java-json-tools>

--- a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-deployment/src/test/java/org/kie/kogito/quarkus/JandexTestUtils.java
+++ b/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-deployment/src/test/java/org/kie/kogito/quarkus/JandexTestUtils.java
@@ -80,9 +80,9 @@ public final class JandexTestUtils {
             JacksonData.class,
             ListWithoutType.class);
 
-    private static ClassInfo indexClass(Indexer indexer, Class<?> toIndex) {
+    private static void indexClass(Indexer indexer, Class<?> toIndex) {
         try {
-            return indexer.index(Objects.requireNonNull(JandexProtoGenerator.class.getClassLoader()
+            indexer.index(Objects.requireNonNull(JandexProtoGenerator.class.getClassLoader()
                     .getResourceAsStream(toPath(toIndex))));
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/src/main/java/org/kie/kogito/quarkus/serverless/workflow/openapi/WorkflowOpenApiHandlerGenerator.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/src/main/java/org/kie/kogito/quarkus/serverless/workflow/openapi/WorkflowOpenApiHandlerGenerator.java
@@ -102,7 +102,8 @@ public class WorkflowOpenApiHandlerGenerator extends ClassAnnotatedWorkflowHandl
         }
         for (int i = 0; i < annotations.length; i++) {
             AnnotationInstance annotation = annotations[i];
-            Type param = m.parameters().get(i);
+            // Using deprecated args method because it is the only way to make it work across Quarkus main and 2.7
+            Type param = m.args()[i];
             if (annotation != null) {
                 methodCallExpr.addArgument(new CastExpr(fromClass(param), new MethodCallExpr(parameters, "remove").addArgument(new StringLiteralExpr(annotation.value().asString()))));
             } else {


### PR DESCRIPTION
…versions 2.4.x and 3.x

This issue is to avoid the errors showing in the build log regarding https://github.com/quarkusio/quarkus/issues/12486
To fully avoid the issue, we still need a new release of Quarkus HTTP connector, see https://github.com/quarkiverse/quarkus-reactive-messaging-http/issues/95