### PR TITLE
[1.28.x][KOGITO-7971] Align smallrye openapi components to Quarkus 2.7 LTS

### DIFF
--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -53,7 +53,9 @@
     <version.io.fabric8.kubernetes-client>5.8.0</version.io.fabric8.kubernetes-client>
     <version.io.micrometer>1.9.3</version.io.micrometer>
     <version.io.serverlessworkflow>4.0.3.Final</version.io.serverlessworkflow>
-    <version.io.smallrye-open-api-core>2.2.1</version.io.smallrye-open-api-core>
+    <!-- Aligned with Quarkus 2.7 (LTS) - see https://issues.redhat.com/browse/KOGITO-7971 -->
+    <version.io.smallrye-open-api>2.1.22</version.io.smallrye-open-api>
+
     <version.io.smallrye.reactive.mutiny-vertx-web-client>2.25.0</version.io.smallrye.reactive.mutiny-vertx-web-client>
 
     <version.io.vertx>4.3.2</version.io.vertx>
@@ -259,8 +261,29 @@
       <dependency>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-open-api-core</artifactId>
-        <version>${version.io.smallrye-open-api-core}</version>
+        <version>${version.io.smallrye-open-api}</version>
       </dependency>
+      <dependency>
+        <groupId>io.smallrye</groupId>
+        <artifactId>smallrye-open-api-ui</artifactId>
+        <version>${version.io.smallrye-open-api}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.smallrye</groupId>
+        <artifactId>smallrye-open-api-jaxrs</artifactId>
+        <version>${version.io.smallrye-open-api}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.smallrye</groupId>
+        <artifactId>smallrye-open-api-spring</artifactId>
+        <version>${version.io.smallrye-open-api}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.smallrye</groupId>
+        <artifactId>smallrye-open-api-vertx</artifactId>
+        <version>${version.io.smallrye-open-api}</version>
+      </dependency>
+
       <dependency>
         <groupId>io.smallrye.reactive</groupId>
         <artifactId>smallrye-mutiny-vertx-web-client</artifactId>


### PR DESCRIPTION
Cherry pick for https://github.com/kiegroup/kogito-runtimes/pull/2484