### PR TITLE
KOGITO-7941 Sonarcloud - (Java) Methods should not be empty (97)

### DIFF
--- a/api/kogito-api/src/main/java/org/kie/kogito/process/flexible/Milestone.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/process/flexible/Milestone.java
@@ -37,6 +37,7 @@ public class Milestone extends ItemDescription {
         private Status status;
 
         public Builder() {
+            //intentionally blank constructor
         }
 
         public Builder withId(String id) {

--- a/api/kogito-api/src/main/java/org/kie/kogito/rules/DataObserver.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/rules/DataObserver.java
@@ -33,12 +33,12 @@ public interface DataObserver extends org.drools.ruleunits.api.DataObserver {
 
             @Override
             public void update(DataHandle handle, T object) {
-
+                //intentionally blank - must implement all methods from interface
             }
 
             @Override
             public void delete(DataHandle handle) {
-
+                //intentionally blank - must implement all methods from interface
             }
         };
     }

--- a/api/kogito-timer/src/main/java/org/kie/kogito/timer/impl/DefaultTimerJobFactoryManager.java
+++ b/api/kogito-timer/src/main/java/org/kie/kogito/timer/impl/DefaultTimerJobFactoryManager.java
@@ -48,8 +48,10 @@ public class DefaultTimerJobFactoryManager
     }
 
     public void addTimerJobInstance(TimerJobInstance instance) {
+        //intentionally blank - must implement all methods from interface
     }
 
     public void removeTimerJobInstance(TimerJobInstance instance) {
+        //intentionally blank - must implement all methods from interface
     }
 }

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/MetaDataHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/MetaDataHandler.java
@@ -112,6 +112,7 @@ public class MetaDataHandler extends BaseAbstractHandler
         }
 
         public void setType(DataType type) {
+            //intentionally blank - must implement all methods from interface
         }
     }
 

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xpath/XPATHActionBuilder.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xpath/XPATHActionBuilder.java
@@ -63,7 +63,7 @@ public class XPATHActionBuilder
     }
 
     public XPATHActionBuilder() {
-
+        //intentionally blank constructor
     }
 
     public void build(final PackageBuildContext context,

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xpath/XPATHReturnValueEvaluatorBuilder.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xpath/XPATHReturnValueEvaluatorBuilder.java
@@ -28,7 +28,7 @@ public class XPATHReturnValueEvaluatorBuilder
         ReturnValueEvaluatorBuilder {
 
     public XPATHReturnValueEvaluatorBuilder() {
-
+        //intentionally blank constructor
     }
 
     public void build(final PackageBuildContext context,

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/assembler/DRFAssemblerService.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/assembler/DRFAssemblerService.java
@@ -27,5 +27,6 @@ public class DRFAssemblerService extends AbstractProcessAssembler {
 
     @Override
     protected void configurePackageBuilder(KnowledgeBuilderImpl kb) {
+        //intentionally blank - must implement all methods from interface
     }
 }

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/AccumulateHandler.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/AccumulateHandler.java
@@ -31,6 +31,7 @@ public class AccumulateHandler extends BaseAbstractHandler
         Handler {
 
     public AccumulateHandler() {
+        //intentionally-blank constructor
     }
 
     public Object start(final String uri,

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/AccumulateHelperHandler.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/AccumulateHelperHandler.java
@@ -29,6 +29,7 @@ public class AccumulateHelperHandler extends BaseAbstractHandler
         Handler {
 
     public AccumulateHelperHandler() {
+        //intentionally-blank constructor
     }
 
     public Object start(final String uri,

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/AndHandler.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/AndHandler.java
@@ -36,6 +36,7 @@ public class AndHandler extends BaseAbstractHandler
         implements
         Handler {
     public AndHandler() {
+        //intentionally-blank constructor
     }
 
     public Object start(final String uri,

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/CollectHandler.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/CollectHandler.java
@@ -31,6 +31,7 @@ public class CollectHandler extends BaseAbstractHandler
         Handler {
 
     public CollectHandler() {
+        //intentionally-blank constructor
     }
 
     public Object start(final String uri,

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/EvalHandler.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/EvalHandler.java
@@ -33,6 +33,7 @@ public class EvalHandler extends BaseAbstractHandler
         implements
         Handler {
     public EvalHandler() {
+        //intentionally-blank constructor
     }
 
     public Object start(final String uri,

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/ExistsHandler.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/ExistsHandler.java
@@ -35,6 +35,7 @@ public class ExistsHandler extends BaseAbstractHandler
         implements
         Handler {
     public ExistsHandler() {
+        //intentionally-blank constructor
     }
 
     public Object start(final String uri,

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/ExprConstraintHandler.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/ExprConstraintHandler.java
@@ -33,6 +33,7 @@ public class ExprConstraintHandler extends BaseAbstractHandler
         implements
         Handler {
     public ExprConstraintHandler() {
+        //intentionally-blank constructor
     }
 
     public Object start(final String uri,

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/ExpressionHandler.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/ExpressionHandler.java
@@ -30,6 +30,7 @@ public class ExpressionHandler extends BaseAbstractHandler
         Handler {
 
     public ExpressionHandler() {
+        //intentionally-blank constructor
     }
 
     public Class generateNodeFor() {

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/FieldBindingHandler.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/FieldBindingHandler.java
@@ -28,6 +28,7 @@ public class FieldBindingHandler extends BaseAbstractHandler
         implements
         Handler {
     public FieldBindingHandler() {
+        //intentionally-blank constructor
     }
 
     public Object start(final String uri,

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/FieldConstraintHandler.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/FieldConstraintHandler.java
@@ -35,6 +35,7 @@ public class FieldConstraintHandler extends BaseAbstractHandler
         implements
         Handler {
     public FieldConstraintHandler() {
+        //intentionally-blank constructor
     }
 
     public Object start(final String uri,

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/ForallHandler.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/ForallHandler.java
@@ -29,7 +29,7 @@ public class ForallHandler extends BaseAbstractHandler
         Handler {
 
     public ForallHandler() {
-
+        //intentionally-blank constructor
     }
 
     /*

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/FromHandler.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/FromHandler.java
@@ -30,6 +30,7 @@ public class FromHandler extends BaseAbstractHandler
         Handler {
 
     public FromHandler() {
+        //intentionally-blank constructor
     }
 
     public Object start(final String uri,

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/FunctionHandler.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/FunctionHandler.java
@@ -35,6 +35,7 @@ public class FunctionHandler extends BaseAbstractHandler
         implements
         Handler {
     public FunctionHandler() {
+        //intentionally-blank constructor
     }
 
     public Object start(final String uri,

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/LiteralRestrictionHandler.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/LiteralRestrictionHandler.java
@@ -30,6 +30,7 @@ public class LiteralRestrictionHandler extends BaseAbstractHandler
         implements
         Handler {
     public LiteralRestrictionHandler() {
+        //intentionally-blank constructor
     }
 
     public Object start(final String uri,

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/NotHandler.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/NotHandler.java
@@ -35,6 +35,7 @@ public class NotHandler extends BaseAbstractHandler
         implements
         Handler {
     public NotHandler() {
+        //intentionally-blank constructor
     }
 
     public Object start(final String uri,

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/OrHandler.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/OrHandler.java
@@ -31,6 +31,7 @@ public class OrHandler extends BaseAbstractHandler
         implements
         Handler {
     public OrHandler() {
+        //intentionally-blank constructor
     }
 
     public Object start(final String uri,

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/PackageHandler.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/PackageHandler.java
@@ -37,6 +37,7 @@ public class PackageHandler extends BaseAbstractHandler
         implements
         Handler {
     public PackageHandler() {
+        //intentionally-blank constructor
     }
 
     public Object start(final String uri,

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/PatternHandler.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/PatternHandler.java
@@ -35,7 +35,7 @@ public class PatternHandler extends BaseAbstractHandler
         implements
         Handler {
     public PatternHandler() {
-
+        //intentionally-blank constructor
     }
 
     public Object start(final String uri,

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/PredicateHandler.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/PredicateHandler.java
@@ -35,6 +35,7 @@ public class PredicateHandler extends BaseAbstractHandler
         implements
         Handler {
     public PredicateHandler() {
+        //intentionally-blank constructor
     }
 
     public Object start(final String uri,

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/QualifiedIdentifierRestrictionHandler.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/QualifiedIdentifierRestrictionHandler.java
@@ -28,6 +28,7 @@ public class QualifiedIdentifierRestrictionHandler extends BaseAbstractHandler
         implements
         Handler {
     public QualifiedIdentifierRestrictionHandler() {
+        //intentionally-blank constructor
     }
 
     public Object start(final String uri,

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/QueryHandler.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/QueryHandler.java
@@ -35,6 +35,7 @@ public class QueryHandler extends BaseAbstractHandler
         implements
         Handler {
     public QueryHandler() {
+        //intentionally-blank constructor
     }
 
     public Object start(final String uri,

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/RestrictionConnectiveHandler.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/RestrictionConnectiveHandler.java
@@ -41,6 +41,7 @@ public class RestrictionConnectiveHandler extends BaseAbstractHandler
     public final static String OR = "or-";
 
     public RestrictionConnectiveHandler() {
+        //intentionally-blank constructor
     }
 
     public Object start(final String uri,

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/ReturnValueRestrictionHandler.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/ReturnValueRestrictionHandler.java
@@ -28,6 +28,7 @@ public class ReturnValueRestrictionHandler extends BaseAbstractHandler
         implements
         Handler {
     public ReturnValueRestrictionHandler() {
+        //intentionally-blank constructor
     }
 
     public Object start(final String uri,

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/RuleHandler.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/RuleHandler.java
@@ -32,6 +32,7 @@ public class RuleHandler extends BaseAbstractHandler
         implements
         Handler {
     public RuleHandler() {
+        //intentionally-blank constructor
     }
 
     public Object start(final String uri,

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/VariableRestrictionsHandler.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/rules/VariableRestrictionsHandler.java
@@ -28,6 +28,7 @@ public class VariableRestrictionsHandler extends BaseAbstractHandler
         implements
         Handler {
     public VariableRestrictionsHandler() {
+        //intentionally-blank constructor
     }
 
     public Object start(final String uri,

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/processes/MetaDataHandler.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/processes/MetaDataHandler.java
@@ -87,6 +87,7 @@ public class MetaDataHandler extends BaseAbstractHandler
         }
 
         public void setType(DataType type) {
+            //intentionally blank - must implement all methods from interface
         }
     }
 

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/dialect/mvel/MVELActionBuilder.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/dialect/mvel/MVELActionBuilder.java
@@ -48,7 +48,7 @@ public class MVELActionBuilder extends AbstractMVELBuilder implements ActionBuil
     }
 
     public MVELActionBuilder() {
-
+        //intentionally-blank constructor
     }
 
     public static String processMacros(String consequence) {

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/dialect/mvel/MVELReturnValueEvaluatorBuilder.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/dialect/mvel/MVELReturnValueEvaluatorBuilder.java
@@ -38,7 +38,7 @@ public class MVELReturnValueEvaluatorBuilder extends AbstractMVELBuilder
         ReturnValueEvaluatorBuilder {
 
     public MVELReturnValueEvaluatorBuilder() {
-
+        //intentionally-blank constructor
     }
 
     public void build(final PackageBuildContext context,

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/type/BooleanDataType.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/type/BooleanDataType.java
@@ -30,10 +30,12 @@ public final class BooleanDataType implements DataType {
 
     @Override
     public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        //intentionally-blank override
     }
 
     @Override
     public void writeExternal(ObjectOutput out) throws IOException {
+        //intentionally-blank override
     }
 
     @Override

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/type/FloatDataType.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/type/FloatDataType.java
@@ -30,10 +30,12 @@ public final class FloatDataType implements DataType {
 
     @Override
     public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        //intentionally-blank override
     }
 
     @Override
     public void writeExternal(ObjectOutput out) throws IOException {
+        //intentionally-blank override
     }
 
     @Override

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/type/IntegerDataType.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/type/IntegerDataType.java
@@ -30,10 +30,12 @@ public class IntegerDataType implements DataType {
 
     @Override
     public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        //intentionally-blank override
     }
 
     @Override
     public void writeExternal(ObjectOutput out) throws IOException {
+        //intentionally-blank override
     }
 
     @Override

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/type/StringDataType.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/type/StringDataType.java
@@ -30,10 +30,12 @@ public class StringDataType implements DataType {
 
     @Override
     public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        //intentionally-blank override
     }
 
     @Override
     public void writeExternal(ObjectOutput out) throws IOException {
+        //intentionally-blank override
     }
 
     @Override

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/type/UndefinedDataType.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/type/UndefinedDataType.java
@@ -38,10 +38,12 @@ public final class UndefinedDataType implements DataType {
 
     @Override
     public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        //intentionally-blank override
     }
 
     @Override
     public void writeExternal(ObjectOutput out) throws IOException {
+        //intentionally-blank override
     }
 
     @Override

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/DummyKnowledgeRuntime.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/DummyKnowledgeRuntime.java
@@ -77,12 +77,12 @@ class DummyKnowledgeRuntime implements InternalKnowledgeRuntime, KogitoProcessRu
 
     @Override
     public void setIdentifier(long id) {
-
+        //intentionally-blank override
     }
 
     @Override
     public void setEndOperationListener(EndOperationListener listener) {
-
+        //intentionally-blank override
     }
 
     @Override
@@ -122,12 +122,12 @@ class DummyKnowledgeRuntime implements InternalKnowledgeRuntime, KogitoProcessRu
 
     @Override
     public void startOperation() {
-
+        //intentionally-blank override
     }
 
     @Override
     public void endOperation() {
-
+        //intentionally-blank override
     }
 
     @Override
@@ -137,7 +137,7 @@ class DummyKnowledgeRuntime implements InternalKnowledgeRuntime, KogitoProcessRu
 
     @Override
     public void setGlobal(String identifier, Object value) {
-
+        //intentionally-blank override
     }
 
     @Override
@@ -167,12 +167,12 @@ class DummyKnowledgeRuntime implements InternalKnowledgeRuntime, KogitoProcessRu
 
     @Override
     public void registerChannel(String name, Channel channel) {
-
+        //intentionally-blank override
     }
 
     @Override
     public void unregisterChannel(String name) {
-
+        //intentionally-blank override
     }
 
     @Override
@@ -192,12 +192,12 @@ class DummyKnowledgeRuntime implements InternalKnowledgeRuntime, KogitoProcessRu
 
     @Override
     public void addEventListener(ProcessEventListener listener) {
-
+        //intentionally-blank override
     }
 
     @Override
     public void removeEventListener(ProcessEventListener listener) {
-
+        //intentionally-blank override
     }
 
     @Override
@@ -207,12 +207,12 @@ class DummyKnowledgeRuntime implements InternalKnowledgeRuntime, KogitoProcessRu
 
     @Override
     public void addEventListener(RuleRuntimeEventListener listener) {
-
+        //intentionally-blank override
     }
 
     @Override
     public void removeEventListener(RuleRuntimeEventListener listener) {
-
+        //intentionally-blank override
     }
 
     @Override
@@ -222,12 +222,12 @@ class DummyKnowledgeRuntime implements InternalKnowledgeRuntime, KogitoProcessRu
 
     @Override
     public void addEventListener(AgendaEventListener listener) {
-
+        //intentionally-blank override
     }
 
     @Override
     public void removeEventListener(AgendaEventListener listener) {
-
+        //intentionally-blank override
     }
 
     @Override
@@ -313,7 +313,7 @@ class DummyKnowledgeRuntime implements InternalKnowledgeRuntime, KogitoProcessRu
 
     @Override
     public void abortProcessInstance(String processInstanceId) {
-
+        //intentionally-blank override
     }
 
     @Override
@@ -323,7 +323,7 @@ class DummyKnowledgeRuntime implements InternalKnowledgeRuntime, KogitoProcessRu
 
     @Override
     public void halt() {
-
+        //intentionally-blank override
     }
 
     @Override
@@ -358,27 +358,27 @@ class DummyKnowledgeRuntime implements InternalKnowledgeRuntime, KogitoProcessRu
 
     @Override
     public void retract(FactHandle handle) {
-
+        //intentionally-blank override
     }
 
     @Override
     public void delete(FactHandle handle) {
-
+        //intentionally-blank override
     }
 
     @Override
     public void delete(FactHandle handle, FactHandle.State fhState) {
-
+        //intentionally-blank override
     }
 
     @Override
     public void update(FactHandle handle, Object object) {
-
+        //intentionally-blank override
     }
 
     @Override
     public void update(FactHandle handle, Object object, String... modifiedProperties) {
-
+        //intentionally-blank override
     }
 
     @Override

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/LightProcessRuntimeContext.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/LightProcessRuntimeContext.java
@@ -48,22 +48,22 @@ public class LightProcessRuntimeContext implements ProcessRuntimeContext {
 
     @Override
     public void startOperation() {
-
+        //intentionally-blank override
     }
 
     @Override
     public void endOperation() {
-
+        //intentionally-blank override
     }
 
     @Override
     public void queueWorkingMemoryAction(WorkingMemoryAction action) {
-
+        //intentionally-blank override
     }
 
     @Override
     public void addEventListener(DefaultAgendaEventListener conditional) {
-
+        //intentionally-blank override
     }
 
     @Override

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/event/listeners/TriggerRulesEventListener.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/event/listeners/TriggerRulesEventListener.java
@@ -46,36 +46,37 @@ public class TriggerRulesEventListener implements AgendaEventListener {
 
     @Override
     public void matchCreated(MatchCreatedEvent event) {
+        //intentionally-blank override
     }
 
     @Override
     public void matchCancelled(MatchCancelledEvent event) {
-
+        //intentionally-blank override
     }
 
     @Override
     public void beforeMatchFired(BeforeMatchFiredEvent event) {
-
+        //intentionally-blank override
     }
 
     @Override
     public void afterMatchFired(AfterMatchFiredEvent event) {
-
+        //intentionally-blank override
     }
 
     @Override
     public void agendaGroupPopped(AgendaGroupPoppedEvent event) {
-
+        //intentionally-blank override
     }
 
     @Override
     public void agendaGroupPushed(AgendaGroupPushedEvent event) {
-
+        //intentionally-blank override
     }
 
     @Override
     public void beforeRuleFlowGroupActivated(RuleFlowGroupActivatedEvent event) {
-
+        //intentionally-blank override
     }
 
     @Override
@@ -86,11 +87,11 @@ public class TriggerRulesEventListener implements AgendaEventListener {
 
     @Override
     public void beforeRuleFlowGroupDeactivated(RuleFlowGroupDeactivatedEvent event) {
-
+        //intentionally-blank override
     }
 
     @Override
     public void afterRuleFlowGroupDeactivated(RuleFlowGroupDeactivatedEvent event) {
-
+        //intentionally-blank override
     }
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/DefaultProcessInstanceManager.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/DefaultProcessInstanceManager.java
@@ -83,7 +83,7 @@ public class DefaultProcessInstanceManager implements ProcessInstanceManager {
     }
 
     public void clearProcessInstancesState() {
-
+        //intentionally blank - must implement all methods from interface
     }
 
     public void setLock(boolean lock) {

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/ReturnValueConstraintEvaluator.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/ReturnValueConstraintEvaluator.java
@@ -48,6 +48,7 @@ public class ReturnValueConstraintEvaluator
     private boolean isDefault = false;
 
     public ReturnValueConstraintEvaluator() {
+        //intentionally-blank constructor
     }
 
     private ReturnValueEvaluator evaluator;

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/demo/DoNothingWorkItemHandler.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/demo/DoNothingWorkItemHandler.java
@@ -26,10 +26,12 @@ public class DoNothingWorkItemHandler implements KogitoWorkItemHandler {
 
     @Override
     public void executeWorkItem(KogitoWorkItem workItem, KogitoWorkItemManager manager) {
+        //intentionally-blank override
     }
 
     @Override
     public void abortWorkItem(KogitoWorkItem workItem, KogitoWorkItemManager manager) {
+        //intentionally-blank override
     }
 
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/demo/MockDataWorkItemHandler.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/demo/MockDataWorkItemHandler.java
@@ -57,6 +57,7 @@ public class MockDataWorkItemHandler implements KogitoWorkItemHandler {
 
     @Override
     public void abortWorkItem(KogitoWorkItem workItem, KogitoWorkItemManager manager) {
+        //intentionally-blank override
     }
 
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/ruleflow/instance/RuleFlowProcessInstanceFactory.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/ruleflow/instance/RuleFlowProcessInstanceFactory.java
@@ -32,9 +32,11 @@ public class RuleFlowProcessInstanceFactory extends AbstractProcessInstanceFacto
     }
 
     public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        //intentionally blank - must implement all methods from interface
     }
 
     public void writeExternal(ObjectOutput out) throws IOException {
+        //intentionally blank - must implement all methods from interface
     }
 
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/DummyEventListener.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/DummyEventListener.java
@@ -26,6 +26,7 @@ public class DummyEventListener implements KogitoEventListener {
 
     @Override
     public void signalEvent(String type, Object event) {
+        //intentionally-blank override
     }
 
     @Override

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/EventNodeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/EventNodeInstance.java
@@ -232,7 +232,7 @@ public class EventNodeInstance extends ExtendedNodeInstanceImpl implements Kogit
 
     @Override
     public void removeEventListeners() {
-
+        //intentionally-blank override
     }
 
     public String getEventType() {

--- a/jbpm/process-workitems/src/main/java/org/kie/kogito/process/workitems/impl/KogitoDefaultWorkItemManager.java
+++ b/jbpm/process-workitems/src/main/java/org/kie/kogito/process/workitems/impl/KogitoDefaultWorkItemManager.java
@@ -211,7 +211,7 @@ public class KogitoDefaultWorkItemManager implements InternalKogitoWorkItemManag
 
     @Override
     public void internalCompleteWorkItem(InternalKogitoWorkItem workItem) {
-
+        //intentionally-blank override
     }
 
     @Override

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/events/ProcessCloudEventMetaBuilder.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/events/ProcessCloudEventMetaBuilder.java
@@ -29,6 +29,7 @@ import org.kie.kogito.codegen.process.ProcessGenerator;
 public class ProcessCloudEventMetaBuilder implements CloudEventMetaBuilder<ProcessCloudEventMeta, Collection<ProcessExecutableModelGenerator>> {
 
     public ProcessCloudEventMetaBuilder() {
+        //intentionally-blank constructor
     }
 
     public Set<ProcessCloudEventMeta> build(Set<ProcessContainerGenerator> sourceModel) {


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-7941

Goal here is to reduce the number of code smells in Kogito-runtimes.

Addressed in this PR is the code smell, "(Java) Methods should not be empty (97)"
https://sonarcloud.io/project/issues?resolved=false&rules=java%3AS1186&id=org.kie.kogito%3Akogito-runtimes

I have remedied this by adding nested comments as per sonarclouds recommendation, which explain why the method is empty.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

<b>Jenkins retest this</b>

</details>
