### PR TITLE
Kogito-7943 Sonarcloud - (Java) The diamond operator ("<>") should be used (199)

### DIFF
--- a/addons/common/monitoring/core/src/main/java/org/kie/kogito/monitoring/core/common/process/MetricsProcessEventListener.java
+++ b/addons/common/monitoring/core/src/main/java/org/kie/kogito/monitoring/core/common/process/MetricsProcessEventListener.java
@@ -42,7 +42,7 @@ import io.micrometer.core.instrument.Tag;
 public class MetricsProcessEventListener extends DefaultKogitoProcessEventListener {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MetricsProcessEventListener.class);
-    private static Map<String, AtomicInteger> gaugeMap = new HashMap<String, AtomicInteger>();
+    private static Map<String, AtomicInteger> gaugeMap = new HashMap<>();
     private final String identifier;
     private final KogitoGAV gav;
     private final MeterRegistry meterRegistry;

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/core/Interface.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/core/Interface.java
@@ -26,7 +26,7 @@ public class Interface implements Serializable {
     private String id;
     private String name;
     private String implementationRef;
-    private Map<String, Operation> operations = new HashMap<String, Operation>();
+    private Map<String, Operation> operations = new HashMap<>();
 
     public Interface(String id, String name) {
         this.id = id;

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/core/IntermediateLink.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/core/IntermediateLink.java
@@ -36,7 +36,7 @@ public class IntermediateLink implements Serializable {
     private List<String> sources;
 
     public IntermediateLink() {
-        this.sources = new ArrayList<String>();
+        this.sources = new ArrayList<>();
     }
 
     public void setUniqueId(String id) {

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/core/Lane.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/core/Lane.java
@@ -27,8 +27,8 @@ public class Lane implements Serializable {
 
     private String id;
     private String name;
-    private List<String> flowElementIds = new ArrayList<String>();
-    private Map<String, Object> metaData = new HashMap<String, Object>();
+    private List<String> flowElementIds = new ArrayList<>();
+    private Map<String, Object> metaData = new HashMap<>();
 
     public Lane(String id) {
         this.id = id;

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/core/SequenceFlow.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/core/SequenceFlow.java
@@ -32,7 +32,7 @@ public class SequenceFlow implements Serializable {
     private String language;
     private String name;
     private int priority;
-    private Map<String, Object> metaData = new HashMap<String, Object>();
+    private Map<String, Object> metaData = new HashMap<>();
 
     public SequenceFlow(String id, String sourceRef, String targetRef) {
         this.id = id;

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/handler/LoggingTaskHandlerDecorator.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/handler/LoggingTaskHandlerDecorator.java
@@ -64,10 +64,10 @@ public class LoggingTaskHandlerDecorator extends AbstractExceptionHandlingTaskHa
 
     private static final Logger logger = LoggerFactory.getLogger(LoggingTaskHandlerDecorator.class);
     private int loggedExceptionsLimit = 100;
-    private Queue<WorkItemExceptionInfo> exceptionInfoList = new ArrayDeque<WorkItemExceptionInfo>(loggedExceptionsLimit);
+    private Queue<WorkItemExceptionInfo> exceptionInfoList = new ArrayDeque<>(loggedExceptionsLimit);
 
     private String configuredMessage = "{0} thrown when work item {1} ({2}) was {3}ed in process instance {4}.";
-    private List<InputParameter> configuredInputList = new ArrayList<InputParameter>();
+    private List<InputParameter> configuredInputList = new ArrayList<>();
     private boolean printStackTrace = true;
 
     /**
@@ -180,13 +180,13 @@ public class LoggingTaskHandlerDecorator extends AbstractExceptionHandlingTaskHa
 
     private void initializeExceptionInfoList(int listSize) {
         this.loggedExceptionsLimit = listSize;
-        Queue<WorkItemExceptionInfo> newExceptionInfoList = new ArrayDeque<WorkItemExceptionInfo>(loggedExceptionsLimit + 1);
+        Queue<WorkItemExceptionInfo> newExceptionInfoList = new ArrayDeque<>(loggedExceptionsLimit + 1);
         newExceptionInfoList.addAll(exceptionInfoList);
         this.exceptionInfoList = newExceptionInfoList;
     }
 
     public synchronized List<WorkItemExceptionInfo> getWorkItemExceptionInfoList() {
-        return new ArrayList<WorkItemExceptionInfo>(exceptionInfoList);
+        return new ArrayList<>(exceptionInfoList);
     }
 
     @Override
@@ -217,7 +217,7 @@ public class LoggingTaskHandlerDecorator extends AbstractExceptionHandlingTaskHa
             cause = cause.getCause();
         }
 
-        List<String> inputList = new ArrayList<String>();
+        List<String> inputList = new ArrayList<>();
         if (configuredInputList.isEmpty()) {
 
             if (workItem.getParameter("Interface") != null) {

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/handler/SignallingTaskHandlerDecorator.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/handler/SignallingTaskHandlerDecorator.java
@@ -47,7 +47,7 @@ public class SignallingTaskHandlerDecorator extends AbstractExceptionHandlingTas
 
     private String workItemExceptionParameterName = "jbpm.workitem.exception";
 
-    final private Map<String, Integer> processInstanceExceptionMap = new HashMap<String, Integer>();
+    final private Map<String, Integer> processInstanceExceptionMap = new HashMap<>();
     private int exceptionCountLimit = 1;
 
     /**

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/handler/WorkItemHandlerRuntimeException.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/handler/WorkItemHandlerRuntimeException.java
@@ -30,7 +30,7 @@ public class WorkItemHandlerRuntimeException extends RuntimeException {
 
     public final static String WORKITEMHANDLERTYPE = "workItemHandlerType";
 
-    private HashMap<String, Object> info = new HashMap<String, Object>();
+    private HashMap<String, Object> info = new HashMap<>();
 
     public WorkItemHandlerRuntimeException(Throwable cause, String message) {
         super(message, cause);

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/AbstractNodeHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/AbstractNodeHandler.java
@@ -260,7 +260,7 @@ public abstract class AbstractNodeHandler extends BaseAbstractHandler implements
                         if (subXmlNode.getNodeName().contains(type + "-script")) {
                             List<DroolsAction> actions = node.getActions(type);
                             if (actions == null) {
-                                actions = new ArrayList<DroolsAction>();
+                                actions = new ArrayList<>();
                                 node.setActions(type, actions);
                             }
                             DroolsAction action = extractScript((Element) subXmlNode);

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/BoundaryEventHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/BoundaryEventHandler.java
@@ -146,7 +146,7 @@ public class BoundaryEventHandler extends AbstractNodeHandler {
                     if (escalation == null) {
                         throw new ProcessParsingValidationException("Could not find escalation " + escalationRef);
                     }
-                    List<EventFilter> eventFilters = new ArrayList<EventFilter>();
+                    List<EventFilter> eventFilters = new ArrayList<>();
                     EventTypeFilter eventFilter = new EventTypeFilter();
                     String type = escalation.getEscalationCode();
                     eventFilter.setType("Escalation-" + attachedTo + "-" + type);
@@ -203,7 +203,7 @@ public class BoundaryEventHandler extends AbstractNodeHandler {
                         }
                     }
 
-                    List<EventFilter> eventFilters = new ArrayList<EventFilter>();
+                    List<EventFilter> eventFilters = new ArrayList<>();
                     EventTypeFilter eventFilter = new EventTypeFilter();
                     eventFilter.setType("Error-" + attachedTo + "-" + type);
                     eventFilters.add(eventFilter);
@@ -250,14 +250,14 @@ public class BoundaryEventHandler extends AbstractNodeHandler {
                     subNode = subNode.getNextSibling();
                 }
                 if (timeDuration != null && timeDuration.trim().length() > 0) {
-                    List<EventFilter> eventFilters = new ArrayList<EventFilter>();
+                    List<EventFilter> eventFilters = new ArrayList<>();
                     EventTypeFilter eventFilter = new EventTypeFilter();
                     eventFilter.setType("Timer-" + attachedTo + "-" + timeDuration + "-" + eventNode.getId());
                     eventFilters.add(eventFilter);
                     eventNode.setEventFilters(eventFilters);
                     eventNode.setMetaData("TimeDuration", timeDuration);
                 } else if (timeCycle != null && timeCycle.trim().length() > 0) {
-                    List<EventFilter> eventFilters = new ArrayList<EventFilter>();
+                    List<EventFilter> eventFilters = new ArrayList<>();
                     EventTypeFilter eventFilter = new EventTypeFilter();
                     eventFilter.setType("Timer-" + attachedTo + "-" + timeCycle + "-" + eventNode.getId());
                     eventFilters.add(eventFilter);
@@ -265,7 +265,7 @@ public class BoundaryEventHandler extends AbstractNodeHandler {
                     eventNode.setMetaData("TimeCycle", timeCycle);
                     eventNode.setMetaData("Language", language);
                 } else if (timeDate != null && timeDate.trim().length() > 0) {
-                    List<EventFilter> eventFilters = new ArrayList<EventFilter>();
+                    List<EventFilter> eventFilters = new ArrayList<>();
                     EventTypeFilter eventFilter = new EventTypeFilter();
                     eventFilter.setType("Timer-" + attachedTo + "-" + timeDate + "-" + eventNode.getId());
                     eventFilters.add(eventFilter);
@@ -306,7 +306,7 @@ public class BoundaryEventHandler extends AbstractNodeHandler {
         // 2. Add the event filter (never fires, purely for dumping purposes)
         EventTypeFilter eventFilter = new NonAcceptingEventTypeFilter();
         eventFilter.setType("Compensation");
-        List<EventFilter> eventFilters = new ArrayList<EventFilter>();
+        List<EventFilter> eventFilters = new ArrayList<>();
         eventNode.setEventFilters(eventFilters);
         eventFilters.add(eventFilter);
 
@@ -332,7 +332,7 @@ public class BoundaryEventHandler extends AbstractNodeHandler {
 
                     type = checkSignalAndConvertToRealSignalNam(parser, type);
 
-                    List<EventFilter> eventFilters = new ArrayList<EventFilter>();
+                    List<EventFilter> eventFilters = new ArrayList<>();
                     EventTypeFilter eventFilter = new EventTypeFilter();
                     eventFilter.setType(type);
                     eventFilters.add(eventFilter);
@@ -363,7 +363,7 @@ public class BoundaryEventHandler extends AbstractNodeHandler {
                     String subnodeName = subNode.getNodeName();
                     if ("condition".equals(subnodeName)) {
                         eventNode.setMetaData("Condition", xmlNode.getTextContent());
-                        List<EventFilter> eventFilters = new ArrayList<EventFilter>();
+                        List<EventFilter> eventFilters = new ArrayList<>();
                         EventTypeFilter eventFilter = new EventTypeFilter();
                         eventFilter.setType("Condition-" + attachedTo);
                         eventFilters.add(eventFilter);
@@ -404,7 +404,7 @@ public class BoundaryEventHandler extends AbstractNodeHandler {
                 eventNode.setMetaData("MessageType", message.getType());
                 eventNode.setMetaData("TriggerType", "ConsumeMessage");
                 eventNode.setMetaData("TriggerRef", message.getName());
-                List<EventFilter> eventFilters = new ArrayList<EventFilter>();
+                List<EventFilter> eventFilters = new ArrayList<>();
                 EventTypeFilter eventFilter = new EventTypeFilter();
                 eventFilter.setCorrelationManager(((RuleFlowProcess) parser.getMetaData().get("CurrentProcessDefinition")).getCorrelationManager());
                 eventFilter.setType("Message-" + message.getName());

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/Bpmn2ImportHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/Bpmn2ImportHandler.java
@@ -64,7 +64,7 @@ public class Bpmn2ImportHandler extends BaseAbstractHandler implements Handler {
         if (type != null && location != null && namespace != null) {
             List<Bpmn2Import> typedImports = (List<Bpmn2Import>) buildData.getMetaData("Bpmn2Imports");
             if (typedImports == null) {
-                typedImports = new ArrayList<Bpmn2Import>();
+                typedImports = new ArrayList<>();
                 buildData.setMetaData("Bpmn2Imports", typedImports);
             }
             typedImports.add(new Bpmn2Import(type, location, namespace));

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/CompositeContextNodeHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/CompositeContextNodeHandler.java
@@ -78,7 +78,7 @@ public class CompositeContextNodeHandler extends AbstractCompositeNodeHandler {
 
     protected List<Node> getSubNodes(CompositeNode compositeNode) {
         List<Node> subNodes =
-                new ArrayList<Node>();
+                new ArrayList<>();
         for (org.kie.api.definition.process.Node subNode : compositeNode.getNodes()) {
             // filter out composite start and end nodes as they can be regenerated
             if ((!(subNode instanceof CompositeNode.CompositeNodeStart)) &&

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/DataStoreHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/DataStoreHandler.java
@@ -81,7 +81,7 @@ public class DataStoreHandler extends BaseAbstractHandler implements Handler {
         Definitions parent = (Definitions) parser.getParent();
         List<DataStore> dataStores = parent.getDataStores();
         if (dataStores == null) {
-            dataStores = new ArrayList<DataStore>();
+            dataStores = new ArrayList<>();
             parent.setDataStores(dataStores);
         }
         dataStores.add(store);

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/EndEventHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/EndEventHandler.java
@@ -164,7 +164,7 @@ public class EndEventHandler extends AbstractNodeHandler {
                 DroolsConsequenceAction action = createJavaAction(
                         new SignalProcessInstanceAction(signalName, variable, inputVariable, (String) endNode.getMetaData("customScope")));
 
-                List<DroolsAction> actions = new ArrayList<DroolsAction>();
+                List<DroolsAction> actions = new ArrayList<>();
                 actions.add(action);
                 endNode.setActions(EndNode.EVENT_NODE_ENTER, actions);
             }

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/ErrorHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/ErrorHandler.java
@@ -66,7 +66,7 @@ public class ErrorHandler extends BaseAbstractHandler implements Handler {
 
         List<Error> errors = definitions.getErrors();
         if (errors == null) {
-            errors = new ArrayList<Error>();
+            errors = new ArrayList<>();
             definitions.setErrors(errors);
             ((ProcessBuildData) parser.getData()).setMetaData("Errors", errors);
         }

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/EscalationHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/EscalationHandler.java
@@ -64,7 +64,7 @@ public class EscalationHandler extends BaseAbstractHandler implements Handler {
         ProcessBuildData buildData = (ProcessBuildData) parser.getData();
         Map<String, Escalation> escalations = (Map<String, Escalation>) buildData.getMetaData(ProcessHandler.ESCALATIONS);
         if (escalations == null) {
-            escalations = new HashMap<String, Escalation>();
+            escalations = new HashMap<>();
             buildData.setMetaData(ProcessHandler.ESCALATIONS, escalations);
         }
         Escalation e = new Escalation(id, escalationCode);

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/ForEachNodeHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/ForEachNodeHandler.java
@@ -81,7 +81,7 @@ public class ForEachNodeHandler extends AbstractCompositeNodeHandler {
 
     protected List<Node> getSubNodes(ForEachNode forEachNode) {
         List<Node> subNodes =
-                new ArrayList<Node>();
+                new ArrayList<>();
         for (org.kie.api.definition.process.Node subNode : forEachNode.getNodes()) {
             // filter out composite start and end nodes as they can be regenerated
             if ((!(subNode instanceof CompositeNode.CompositeNodeStart)) &&

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/GlobalHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/GlobalHandler.java
@@ -55,7 +55,7 @@ public class GlobalHandler extends BaseAbstractHandler implements Handler {
 
         Map<String, String> map = process.getGlobals();
         if (map == null) {
-            map = new HashMap<String, String>();
+            map = new HashMap<>();
             process.setGlobals(map);
         }
         map.put(identifier, type);

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/ImportHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/ImportHandler.java
@@ -56,7 +56,7 @@ public class ImportHandler extends BaseAbstractHandler implements Handler {
         if (type != null && location != null && namespace != null) {
             Map<String, String> typedImports = (Map<String, String>) process.getMetaData(type);
             if (typedImports == null) {
-                typedImports = new HashMap<String, String>();
+                typedImports = new HashMap<>();
                 process.setMetaData(type, typedImports);
             }
             typedImports.put(namespace, location);
@@ -64,7 +64,7 @@ public class ImportHandler extends BaseAbstractHandler implements Handler {
 
             java.util.Set<String> list = process.getImports();
             if (list == null) {
-                list = new HashSet<String>();
+                list = new HashSet<>();
                 process.setImports(list);
             }
             list.add(name);

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/InterfaceHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/InterfaceHandler.java
@@ -69,7 +69,7 @@ public class InterfaceHandler extends BaseAbstractHandler implements Handler {
         ProcessBuildData buildData = (ProcessBuildData) parser.getData();
         List<Interface> interfaces = (List<Interface>) buildData.getMetaData("Interfaces");
         if (interfaces == null) {
-            interfaces = new ArrayList<Interface>();
+            interfaces = new ArrayList<>();
             buildData.setMetaData("Interfaces", interfaces);
         }
         Interface i = new Interface(id, name);

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/IntermediateCatchEventHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/IntermediateCatchEventHandler.java
@@ -164,7 +164,7 @@ public class IntermediateCatchEventHandler extends AbstractNodeHandler {
             List<IntermediateLink> links = (List<IntermediateLink>) process
                     .getMetaData().get(ProcessHandler.LINKS);
             if (null == links) {
-                links = new ArrayList<IntermediateLink>();
+                links = new ArrayList<>();
             }
             links.add(aLink);
             process.setMetaData(ProcessHandler.LINKS, links);
@@ -173,7 +173,7 @@ public class IntermediateCatchEventHandler extends AbstractNodeHandler {
             List<IntermediateLink> links = (List<IntermediateLink>) subprocess
                     .getMetaData().get(ProcessHandler.LINKS);
             if (null == links) {
-                links = new ArrayList<IntermediateLink>();
+                links = new ArrayList<>();
             }
             links.add(aLink);
             subprocess.setMetaData(ProcessHandler.LINKS, links);
@@ -194,7 +194,7 @@ public class IntermediateCatchEventHandler extends AbstractNodeHandler {
 
                     type = checkSignalAndConvertToRealSignalNam(parser, type);
 
-                    List<EventFilter> eventFilters = new ArrayList<EventFilter>();
+                    List<EventFilter> eventFilters = new ArrayList<>();
                     EventTypeFilter eventFilter = new EventTypeFilter();
                     eventFilter.setType(type);
                     eventFilters.add(eventFilter);
@@ -239,7 +239,7 @@ public class IntermediateCatchEventHandler extends AbstractNodeHandler {
                 eventNode.setMetaData(MESSAGE_TYPE, message.getType());
                 eventNode.setMetaData(TRIGGER_TYPE, CONSUME_MESSAGE);
                 eventNode.setMetaData(TRIGGER_REF, message.getName());
-                List<EventFilter> eventFilters = new ArrayList<EventFilter>();
+                List<EventFilter> eventFilters = new ArrayList<>();
                 EventTypeFilter eventFilter = new EventTypeFilter();
                 eventFilter.setCorrelationManager(((RuleFlowProcess) parser.getMetaData().get("CurrentProcessDefinition")).getCorrelationManager());
                 eventFilter.setType("Message-" + message.getName());

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/IntermediateThrowEventHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/IntermediateThrowEventHandler.java
@@ -154,7 +154,7 @@ public class IntermediateThrowEventHandler extends AbstractNodeHandler {
 
                 // if there is no list, create one
                 if (null == sources) {
-                    sources = new ArrayList<String>();
+                    sources = new ArrayList<>();
                 }
 
                 // to connect nodes.
@@ -173,7 +173,7 @@ public class IntermediateThrowEventHandler extends AbstractNodeHandler {
             List<IntermediateLink> links = (List<IntermediateLink>) process
                     .getMetaData().get(ProcessHandler.LINKS);
             if (null == links) {
-                links = new ArrayList<IntermediateLink>();
+                links = new ArrayList<>();
             }
             links.add(aLink);
             process.setMetaData(ProcessHandler.LINKS, links);
@@ -182,7 +182,7 @@ public class IntermediateThrowEventHandler extends AbstractNodeHandler {
             List<IntermediateLink> links = (List<IntermediateLink>) subprocess
                     .getMetaData().get(ProcessHandler.LINKS);
             if (null == links) {
-                links = new ArrayList<IntermediateLink>();
+                links = new ArrayList<>();
             }
             links.add(aLink);
             subprocess.setMetaData(ProcessHandler.LINKS, links);

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/ItemDefinitionHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/ItemDefinitionHandler.java
@@ -64,7 +64,7 @@ public class ItemDefinitionHandler extends BaseAbstractHandler implements Handle
         ProcessBuildData buildData = (ProcessBuildData) parser.getData();
         Map<String, ItemDefinition> itemDefinitions = (Map<String, ItemDefinition>) buildData.getMetaData("ItemDefinitions");
         if (itemDefinitions == null) {
-            itemDefinitions = new HashMap<String, ItemDefinition>();
+            itemDefinitions = new HashMap<>();
             buildData.setMetaData("ItemDefinitions", itemDefinitions);
         }
         ItemDefinition itemDefinition = new ItemDefinition(id);

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/LaneHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/LaneHandler.java
@@ -69,7 +69,7 @@ public class LaneHandler extends BaseAbstractHandler implements Handler {
 
         List<Lane> lanes = (List<Lane>) ((RuleFlowProcess) process).getMetaData(LaneHandler.LANES);
         if (lanes == null) {
-            lanes = new ArrayList<Lane>();
+            lanes = new ArrayList<>();
             ((RuleFlowProcess) process).setMetaData(LaneHandler.LANES, lanes);
         }
         Lane lane = new Lane(id);

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/MessageHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/MessageHandler.java
@@ -77,7 +77,7 @@ public class MessageHandler extends BaseAbstractHandler implements Handler {
         ProcessBuildData buildData = (ProcessBuildData) parser.getData();
         Map<String, Message> messages = (Map<String, Message>) ((ProcessBuildData) parser.getData()).getMetaData("Messages");
         if (messages == null) {
-            messages = new HashMap<String, Message>();
+            messages = new HashMap<>();
             buildData.setMetaData("Messages", messages);
         }
         Message message = new Message(id);

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/ProcessHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/ProcessHandler.java
@@ -489,7 +489,7 @@ public class ProcessHandler extends BaseAbstractHandler implements Handler {
         if (cancelActivity) {
             List<DroolsAction> actions = ((EventNode) node).getActions(EndNode.EVENT_NODE_EXIT);
             if (actions == null) {
-                actions = new ArrayList<DroolsAction>();
+                actions = new ArrayList<>();
             }
             DroolsConsequenceAction cancelAction = new DroolsConsequenceAction("java", "");
             cancelAction.setMetaData("Action", new CancelNodeInstanceAction(attachedTo));
@@ -523,7 +523,7 @@ public class ProcessHandler extends BaseAbstractHandler implements Handler {
 
         List<DroolsAction> actions = ((EventNode) node).getActions(EndNode.EVENT_NODE_EXIT);
         if (actions == null) {
-            actions = new ArrayList<DroolsAction>();
+            actions = new ArrayList<>();
         }
         DroolsConsequenceAction cancelAction = new DroolsConsequenceAction("java", null);
         cancelAction.setMetaData("Action", new CancelNodeInstanceAction(attachedTo));
@@ -571,7 +571,7 @@ public class ProcessHandler extends BaseAbstractHandler implements Handler {
         if (cancelActivity) {
             List<DroolsAction> actions = ((EventNode) node).getActions(EndNode.EVENT_NODE_EXIT);
             if (actions == null) {
-                actions = new ArrayList<DroolsAction>();
+                actions = new ArrayList<>();
             }
             DroolsConsequenceAction action = createJavaAction(new CancelNodeInstanceAction(attachedTo));
             actions.add(action);
@@ -603,7 +603,7 @@ public class ProcessHandler extends BaseAbstractHandler implements Handler {
         if (cancelActivity) {
             List<DroolsAction> actions = ((EventNode) node).getActions(EndNode.EVENT_NODE_EXIT);
             if (actions == null) {
-                actions = new ArrayList<DroolsAction>();
+                actions = new ArrayList<>();
             }
             DroolsConsequenceAction action = createJavaAction(new CancelNodeInstanceAction(attachedTo));
             actions.add(action);
@@ -619,7 +619,7 @@ public class ProcessHandler extends BaseAbstractHandler implements Handler {
         if (cancelActivity) {
             List<DroolsAction> actions = ((EventNode) node).getActions(EndNode.EVENT_NODE_EXIT);
             if (actions == null) {
-                actions = new ArrayList<DroolsAction>();
+                actions = new ArrayList<>();
             }
             DroolsConsequenceAction action = createJavaAction(new CancelNodeInstanceAction(attachedTo));
             actions.add(action);
@@ -812,8 +812,8 @@ public class ProcessHandler extends BaseAbstractHandler implements Handler {
     }
 
     private void assignLanes(RuleFlowProcess process, List<Lane> lanes) {
-        List<String> laneNames = new ArrayList<String>();
-        Map<String, String> laneMapping = new HashMap<String, String>();
+        List<String> laneNames = new ArrayList<>();
+        Map<String, String> laneMapping = new HashMap<>();
         if (lanes != null) {
             for (Lane lane : lanes) {
                 String name = lane.getName();
@@ -832,7 +832,7 @@ public class ProcessHandler extends BaseAbstractHandler implements Handler {
     }
 
     private void postProcessNodes(RuleFlowProcess process, NodeContainer container) {
-        List<String> eventSubProcessHandlers = new ArrayList<String>();
+        List<String> eventSubProcessHandlers = new ArrayList<>();
         for (Node node : container.getNodes()) {
 
             if (node instanceof StateNode) {

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/SignalHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/SignalHandler.java
@@ -81,7 +81,7 @@ public class SignalHandler extends BaseAbstractHandler implements Handler {
         ProcessBuildData buildData = (ProcessBuildData) parser.getData();
         Map<String, Signal> signals = (Map<String, Signal>) buildData.getMetaData("Signals");
         if (signals == null) {
-            signals = new HashMap<String, Signal>();
+            signals = new HashMap<>();
             buildData.setMetaData("Signals", signals);
         }
 

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/UserTaskHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/UserTaskHandler.java
@@ -51,7 +51,7 @@ public class UserTaskHandler extends TaskHandler {
         setParameter(work, "Skippable", humanTaskNode.getIoSpecification().getDataInputAssociation());
         setParameter(work, "Content", humanTaskNode.getIoSpecification().getDataInputAssociation());
 
-        List<String> owners = new ArrayList<String>();
+        List<String> owners = new ArrayList<>();
         org.w3c.dom.Node xmlNode = element.getFirstChild();
         while (xmlNode != null) {
             String nodeName = xmlNode.getNodeName();

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/XmlBPMNProcessDumper.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/XmlBPMNProcessDumper.java
@@ -145,9 +145,9 @@ public class XmlBPMNProcessDumper implements XmlProcessDumper {
                         "             xmlns:tns=\"http://www.jboss.org/drools\">" + EOL + EOL);
 
         // item definitions
-        this.visitedVariables = new HashSet<String>();
+        this.visitedVariables = new HashSet<>();
         VariableScope variableScope = (VariableScope) ((org.jbpm.process.core.Process) process).getDefaultContext(VariableScope.VARIABLE_SCOPE);
-        Set<String> dumpedItemDefs = new HashSet<String>();
+        Set<String> dumpedItemDefs = new HashSet<>();
         Map<String, ItemDefinition> itemDefs = (Map<String, ItemDefinition>) process.getMetaData().get("ItemDefinitions");
 
         if (itemDefs != null) {
@@ -167,7 +167,7 @@ public class XmlBPMNProcessDumper implements XmlProcessDumper {
 
         visitInterfaces(process.getNodes(), xmlDump);
 
-        visitEscalations(process.getNodes(), xmlDump, new ArrayList<String>());
+        visitEscalations(process.getNodes(), xmlDump, new ArrayList<>());
         Definitions def = (Definitions) process.getMetaData().get("Definitions");
         visitErrors(def, xmlDump);
 
@@ -202,7 +202,7 @@ public class XmlBPMNProcessDumper implements XmlProcessDumper {
         xmlDump.append(">" + EOL + EOL);
         visitHeader(process, xmlDump, metaDataType);
 
-        List<Node> processNodes = new ArrayList<Node>();
+        List<Node> processNodes = new ArrayList<>();
         for (org.kie.api.definition.process.Node procNode : process.getNodes()) {
             processNodes.add((Node) procNode);
         }
@@ -402,7 +402,7 @@ public class XmlBPMNProcessDumper implements XmlProcessDumper {
     }
 
     public static Map<String, Object> getMetaData(Map<String, Object> input) {
-        Map<String, Object> metaData = new HashMap<String, Object>();
+        Map<String, Object> metaData = new HashMap<>();
         for (Map.Entry<String, Object> entry : input.entrySet()) {
             String name = entry.getKey();
             if (entry.getKey().startsWith("custom")
@@ -714,7 +714,7 @@ public class XmlBPMNProcessDumper implements XmlProcessDumper {
 
     private void visitConnections(org.kie.api.definition.process.Node[] nodes, StringBuilder xmlDump, int metaDataType) {
         xmlDump.append("    <!-- connections -->" + EOL);
-        List<Connection> connections = new ArrayList<Connection>();
+        List<Connection> connections = new ArrayList<>();
         for (org.kie.api.definition.process.Node node : nodes) {
             for (List<Connection> connectionList : node.getIncomingConnections().values()) {
                 connections.addAll(connectionList);
@@ -798,7 +798,7 @@ public class XmlBPMNProcessDumper implements XmlProcessDumper {
     }
 
     private void visitConnectionsDi(org.kie.api.definition.process.Node[] nodes, StringBuilder xmlDump) {
-        List<Connection> connections = new ArrayList<Connection>();
+        List<Connection> connections = new ArrayList<>();
         for (org.kie.api.definition.process.Node node : nodes) {
             for (List<Connection> connectionList : node.getIncomingConnections().values()) {
                 connections.addAll(connectionList);

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/di/BPMNPlaneHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/di/BPMNPlaneHandler.java
@@ -158,8 +158,8 @@ public class BPMNPlaneHandler extends BaseAbstractHandler implements Handler {
     public static class ProcessInfo {
 
         private String processRef;
-        private List<NodeInfo> nodeInfos = new ArrayList<NodeInfo>();
-        private List<ConnectionInfo> connectionInfos = new ArrayList<ConnectionInfo>();
+        private List<NodeInfo> nodeInfos = new ArrayList<>();
+        private List<ConnectionInfo> connectionInfos = new ArrayList<>();
 
         public ProcessInfo(String processRef) {
             this.processRef = processRef;

--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/KogitoSetProcessInstanceVariablesCommand.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/KogitoSetProcessInstanceVariablesCommand.java
@@ -36,7 +36,7 @@ public class KogitoSetProcessInstanceVariablesCommand implements ExecutableComma
 
     private String processInstanceId;
 
-    private Map<String, Object> variables = new HashMap<String, Object>();
+    private Map<String, Object> variables = new HashMap<>();
 
     public KogitoSetProcessInstanceVariablesCommand() {
     }

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/ProcessBuilderImpl.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/ProcessBuilderImpl.java
@@ -90,7 +90,7 @@ public class ProcessBuilderImpl implements org.drools.compiler.compiler.ProcessB
     private static final Logger logger = LoggerFactory.getLogger(ProcessBuilderImpl.class);
 
     private KnowledgeBuilderImpl knowledgeBuilder;
-    private final List<KnowledgeBuilderResult> errors = new ArrayList<KnowledgeBuilderResult>();
+    private final List<KnowledgeBuilderResult> errors = new ArrayList<>();
 
     public ProcessBuilderImpl(KnowledgeBuilderImpl packageBuilder) {
         this.knowledgeBuilder = packageBuilder;

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/ProcessBuildData.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/ProcessBuildData.java
@@ -35,11 +35,11 @@ public class ProcessBuildData {
 
     private static List<ProcessDataEventListenerProvider> providers = collectProviders();
 
-    private List<Process> processes = new ArrayList<Process>();
-    private Map<Long, Node> nodes = new HashMap<Long, Node>();
-    private Map<String, Object> metaData = new HashMap<String, Object>();
+    private List<Process> processes = new ArrayList<>();
+    private Map<Long, Node> nodes = new HashMap<>();
+    private Map<String, Object> metaData = new HashMap<>();
 
-    private List<ProcessDataEventListener> listeners = new ArrayList<ProcessDataEventListener>();
+    private List<ProcessDataEventListener> listeners = new ArrayList<>();
 
     public ProcessBuildData() {
         if (providers != null) {
@@ -122,7 +122,7 @@ public class ProcessBuildData {
 
     private static List<ProcessDataEventListenerProvider> collectProviders() {
         ServiceLoader<ProcessDataEventListenerProvider> availableProviders = ServiceLoader.load(ProcessDataEventListenerProvider.class);
-        List<ProcessDataEventListenerProvider> collected = new ArrayList<ProcessDataEventListenerProvider>();
+        List<ProcessDataEventListenerProvider> collected = new ArrayList<>();
         try {
             for (ProcessDataEventListenerProvider provider : availableProviders) {
                 collected.add(provider);

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/XmlWorkflowProcessDumper.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/XmlWorkflowProcessDumper.java
@@ -233,7 +233,7 @@ public class XmlWorkflowProcessDumper {
     }
 
     private void visitConnections(org.kie.api.definition.process.Node[] nodes, StringBuilder xmlDump, boolean includeMeta) {
-        List<Connection> connections = new ArrayList<Connection>();
+        List<Connection> connections = new ArrayList<>();
         for (org.kie.api.definition.process.Node node : nodes) {
             for (List<Connection> connectionList : node.getIncomingConnections().values()) {
                 connections.addAll(connectionList);

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/core/DefaultSemanticModule.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/core/DefaultSemanticModule.java
@@ -28,8 +28,8 @@ public class DefaultSemanticModule implements SemanticModule {
 
     public DefaultSemanticModule(String uri) {
         this.uri = uri;
-        this.handlers = new HashMap<String, Handler>();
-        this.handlersByClass = new HashMap<Class<?>, Handler>();
+        this.handlers = new HashMap<>();
+        this.handlersByClass = new HashMap<>();
     }
 
     public String getUri() {

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/core/SemanticModules.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/core/SemanticModules.java
@@ -24,7 +24,7 @@ public class SemanticModules {
     public Map<String, SemanticModule> modules;
 
     public SemanticModules() {
-        this.modules = new HashMap<String, SemanticModule>();
+        this.modules = new HashMap<>();
     }
 
     public void addSemanticModule(SemanticModule module) {

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/processes/AbstractNodeHandler.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/processes/AbstractNodeHandler.java
@@ -140,7 +140,7 @@ public abstract class AbstractNodeHandler extends BaseAbstractHandler implements
             org.w3c.dom.Node xmlNode = nodeList.item(i);
             String nodeName = xmlNode.getNodeName();
             if (nodeName.equals(type)) {
-                List<DroolsAction> actions = new ArrayList<DroolsAction>();
+                List<DroolsAction> actions = new ArrayList<>();
                 NodeList subNodeList = xmlNode.getChildNodes();
                 for (int j = 0; j < subNodeList.getLength(); j++) {
                     Element subXmlNode = (Element) subNodeList.item(j);
@@ -265,7 +265,7 @@ public abstract class AbstractNodeHandler extends BaseAbstractHandler implements
     public void writeTimers(final Map<Timer, DroolsAction> timers, final StringBuilder xmlDump) {
         if (timers != null && !timers.isEmpty()) {
             xmlDump.append("      <timers>" + EOL);
-            List<Timer> timerList = new ArrayList<Timer>(timers.keySet());
+            List<Timer> timerList = new ArrayList<>(timers.keySet());
             Collections.sort(timerList, new Comparator<Timer>() {
                 public int compare(Timer o1, Timer o2) {
                     return (int) (o2.getId() - o1.getId());

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/processes/CompositeNodeHandler.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/processes/CompositeNodeHandler.java
@@ -107,7 +107,7 @@ public class CompositeNodeHandler extends AbstractNodeHandler {
 
     protected List<Node> getSubNodes(CompositeNode compositeNode) {
         List<Node> subNodes =
-                new ArrayList<Node>();
+                new ArrayList<>();
         for (org.kie.api.definition.process.Node subNode : compositeNode.getNodes()) {
             // filter out composite start and end nodes as they can be regenerated
             if ((!(subNode instanceof CompositeNode.CompositeNodeStart)) &&
@@ -119,7 +119,7 @@ public class CompositeNodeHandler extends AbstractNodeHandler {
     }
 
     protected List<Connection> getSubConnections(CompositeNode compositeNode) {
-        List<Connection> connections = new ArrayList<Connection>();
+        List<Connection> connections = new ArrayList<>();
         for (org.kie.api.definition.process.Node subNode : compositeNode.getNodes()) {
             // filter out composite start and end nodes as they can be regenerated
             if (!(subNode instanceof CompositeNode.CompositeNodeEnd)) {

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/processes/FunctionImportHandler.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/processes/FunctionImportHandler.java
@@ -56,7 +56,7 @@ public class FunctionImportHandler extends BaseAbstractHandler
 
         java.util.List<String> list = process.getFunctionImports();
         if (list == null) {
-            list = new ArrayList<String>();
+            list = new ArrayList<>();
             process.setFunctionImports(list);
         }
         list.add(name);

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/processes/GlobalHandler.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/processes/GlobalHandler.java
@@ -61,7 +61,7 @@ public class GlobalHandler extends BaseAbstractHandler
 
         Map<String, String> map = process.getGlobals();
         if (map == null) {
-            map = new HashMap<String, String>();
+            map = new HashMap<>();
             process.setGlobals(map);
         }
         map.put(identifier, type);

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/processes/ImportHandler.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/processes/ImportHandler.java
@@ -55,7 +55,7 @@ public class ImportHandler extends BaseAbstractHandler
 
         java.util.Set<String> list = process.getImports();
         if (list == null) {
-            list = new HashSet<String>();
+            list = new HashSet<>();
             process.setImports(list);
         }
         list.add(name);

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/processes/VariableHandler.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/processes/VariableHandler.java
@@ -60,7 +60,7 @@ public class VariableHandler extends BaseAbstractHandler
             variable.setName(name);
             List<Variable> variables = variableScope.getVariables();
             if (variables == null) {
-                variables = new ArrayList<Variable>();
+                variables = new ArrayList<>();
                 variableScope.setVariables(variables);
             }
             variables.add(variable);

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/processes/WorkItemNodeHandler.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/processes/WorkItemNodeHandler.java
@@ -100,7 +100,7 @@ public class WorkItemNodeHandler extends AbstractNodeHandler {
         if (work != null) {
             xmlDump.append("      <work name=\"" + work.getName() + "\" >" + EOL);
             List<ParameterDefinition> parameterDefinitions =
-                    new ArrayList<ParameterDefinition>(work.getParameterDefinitions());
+                    new ArrayList<>(work.getParameterDefinitions());
             Collections.sort(parameterDefinitions, new Comparator<ParameterDefinition>() {
                 public int compare(ParameterDefinition o1,
                         ParameterDefinition o2) {

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/ActionNodeBuilder.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/ActionNodeBuilder.java
@@ -45,7 +45,7 @@ public class ActionNodeBuilder extends ExtendedNodeBuilder {
         dialect.getActionBuilder().build(context, action, actionDescr, actionNode);
 
         WorkflowProcess wfProcess = (WorkflowProcess) process;
-        Map<String, Object> parameters = new HashMap<String, Object>();
+        Map<String, Object> parameters = new HashMap<>();
         parameters.put("imports", wfProcess.getImports());
         parameters.put("classloader", context.getConfiguration().getClassLoader());
 

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/EventNodeBuilder.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/EventNodeBuilder.java
@@ -33,7 +33,7 @@ public class EventNodeBuilder implements ProcessNodeBuilder {
         Transformation transformation = (Transformation) node.getMetaData().get("Transformation");
         if (transformation != null) {
             WorkflowProcess wfProcess = (WorkflowProcess) process;
-            Map<String, Object> parameters = new HashMap<String, Object>();
+            Map<String, Object> parameters = new HashMap<>();
             parameters.put("imports", wfProcess.getImports());
             parameters.put("classloader", context.getConfiguration().getClassLoader());
 

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/MultiConditionalSequenceFlowNodeBuilder.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/MultiConditionalSequenceFlowNodeBuilder.java
@@ -47,7 +47,7 @@ public class MultiConditionalSequenceFlowNodeBuilder implements ProcessNodeBuild
         }
 
         // we need to clone the map, so we can update the original while iterating.
-        Map<ConnectionRef, Constraint> map = new HashMap<ConnectionRef, Constraint>(constraints);
+        Map<ConnectionRef, Constraint> map = new HashMap<>(constraints);
         for (Iterator<Map.Entry<ConnectionRef, Constraint>> it = map.entrySet().iterator(); it.hasNext();) {
             Map.Entry<ConnectionRef, Constraint> entry = it.next();
             ConnectionRef connection = entry.getKey();

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/ProcessNodeBuilderRegistry.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/ProcessNodeBuilderRegistry.java
@@ -47,7 +47,7 @@ public class ProcessNodeBuilderRegistry {
     private Map<Class<? extends Node>, ProcessNodeBuilder> registry;
 
     public ProcessNodeBuilderRegistry() {
-        this.registry = new HashMap<Class<? extends Node>, ProcessNodeBuilder>();
+        this.registry = new HashMap<>();
 
         register(StartNode.class,
                 new StartNodeBuilder());

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/RuleSetNodeBuilder.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/RuleSetNodeBuilder.java
@@ -30,7 +30,7 @@ public class RuleSetNodeBuilder extends EventBasedNodeBuilder {
     public void build(Process process, ProcessDescr processDescr, ProcessBuildContext context, Node node) {
         super.build(process, processDescr, context, node);
         WorkflowProcess wfProcess = (WorkflowProcess) process;
-        Map<String, Object> parameters = new HashMap<String, Object>();
+        Map<String, Object> parameters = new HashMap<>();
         parameters.put("imports", wfProcess.getImports());
         parameters.put("classloader", context.getConfiguration().getClassLoader());
 

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/SplitNodeBuilder.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/SplitNodeBuilder.java
@@ -47,7 +47,7 @@ public class SplitNodeBuilder implements ProcessNodeBuilder {
             return;
         }
         // we need to clone the map, so we can update the original while iterating.
-        Map<ConnectionRef, Constraint> map = new HashMap<ConnectionRef, Constraint>(splitNode.getConstraints());
+        Map<ConnectionRef, Constraint> map = new HashMap<>(splitNode.getConstraints());
         for (Iterator<Map.Entry<ConnectionRef, Constraint>> it = map.entrySet().iterator(); it.hasNext();) {
             Map.Entry<ConnectionRef, Constraint> entry = it.next();
             ConnectionRef connection = entry.getKey();

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/StartNodeBuilder.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/StartNodeBuilder.java
@@ -31,7 +31,7 @@ public class StartNodeBuilder extends ExtendedNodeBuilder {
         super.build(process, processDescr, context, node);
 
         WorkflowProcess wfProcess = (WorkflowProcess) process;
-        Map<String, Object> parameters = new HashMap<String, Object>();
+        Map<String, Object> parameters = new HashMap<>();
         parameters.put("imports", wfProcess.getImports());
         parameters.put("classloader", context.getConfiguration().getClassLoader());
 

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/SubProcessNodeBuilder.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/SubProcessNodeBuilder.java
@@ -30,7 +30,7 @@ public class SubProcessNodeBuilder extends EventBasedNodeBuilder {
     public void build(Process process, ProcessDescr processDescr, ProcessBuildContext context, Node node) {
         super.build(process, processDescr, context, node);
         WorkflowProcess wfProcess = (WorkflowProcess) process;
-        Map<String, Object> parameters = new HashMap<String, Object>();
+        Map<String, Object> parameters = new HashMap<>();
         parameters.put("imports", wfProcess.getImports());
         parameters.put("classloader", context.getConfiguration().getClassLoader());
 

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/WorkItemNodeBuilder.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/WorkItemNodeBuilder.java
@@ -30,7 +30,7 @@ public class WorkItemNodeBuilder extends EventBasedNodeBuilder {
             ProcessBuildContext context, Node node) {
         super.build(process, processDescr, context, node);
         WorkflowProcess wfProcess = (WorkflowProcess) process;
-        Map<String, Object> parameters = new HashMap<String, Object>();
+        Map<String, Object> parameters = new HashMap<>();
         parameters.put("imports", wfProcess.getImports());
         parameters.put("classloader", context.getConfiguration().getClassLoader());
 

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/dialect/ProcessDialectRegistry.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/dialect/ProcessDialectRegistry.java
@@ -27,7 +27,7 @@ public class ProcessDialectRegistry {
     private static ConcurrentMap<String, ProcessDialect> dialects;
 
     static {
-        dialects = new ConcurrentHashMap<String, ProcessDialect>();
+        dialects = new ConcurrentHashMap<>();
         dialects.put("java", new JavaProcessDialect());
         dialects.put("mvel", new MVELProcessDialect());
         dialects.put("FEEL", new FeelProcessDialect());

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/dialect/java/AbstractJavaProcessBuilder.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/dialect/java/AbstractJavaProcessBuilder.java
@@ -108,7 +108,7 @@ public class AbstractJavaProcessBuilder {
             final Set<String> unboundIdentifiers,
             final ContextResolver contextResolver) {
         Map map = createVariableContext(className, text, context, globals);
-        List<String> variables = new ArrayList<String>();
+        List<String> variables = new ArrayList<>();
         final List variableTypes = new ArrayList(globals.length);
         for (String variableName : unboundIdentifiers) {
             VariableScope variableScope = (VariableScope) contextResolver.resolveContext(VariableScope.VARIABLE_SCOPE, variableName);
@@ -149,8 +149,8 @@ public class AbstractJavaProcessBuilder {
 
     protected void collectTypes(String key, AnalysisResult analysis, ProcessBuildContext context) {
         if (context.getProcess() != null) {
-            Set<String> referencedTypes = new HashSet<String>();
-            Set<String> unqualifiedClasses = new HashSet<String>();
+            Set<String> referencedTypes = new HashSet<>();
+            Set<String> unqualifiedClasses = new HashSet<>();
 
             JavaAnalysisResult javaAnalysis = (JavaAnalysisResult) analysis;
             LOCAL_VAR: for (JavaLocalDeclarationDescr localDeclDescr : javaAnalysis.getLocalVariablesMap().values()) {

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/dialect/java/JavaActionBuilder.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/dialect/java/JavaActionBuilder.java
@@ -63,7 +63,7 @@ public class JavaActionBuilder extends AbstractJavaProcessBuilder
             final ActionDescr actionDescr) {
         JavaDialect dialect = (JavaDialect) context.getDialect("java");
 
-        Map<String, Class<?>> variables = new HashMap<String, Class<?>>();
+        Map<String, Class<?>> variables = new HashMap<>();
         BoundIdentifiers boundIdentifiers = new BoundIdentifiers(variables, context);
         AnalysisResult analysis = dialect.analyzeBlock(context,
                 actionDescr,

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/dialect/java/JavaProcessClassBuilder.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/dialect/java/JavaProcessClassBuilder.java
@@ -28,7 +28,7 @@ public class JavaProcessClassBuilder
         implements
         ProcessClassBuilder {
 
-    protected static List<String> systemImports = new ArrayList<String>();
+    protected static List<String> systemImports = new ArrayList<>();
     static {
         systemImports.add(org.drools.core.util.KieFunctions.class.getName());
     }

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/dialect/java/JavaReturnValueEvaluatorBuilder.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/dialect/java/JavaReturnValueEvaluatorBuilder.java
@@ -69,7 +69,7 @@ public class JavaReturnValueEvaluatorBuilder extends AbstractJavaProcessBuilder
 
         JavaDialect dialect = (JavaDialect) context.getDialect("java");
 
-        Map<String, Class<?>> variables = new HashMap<String, Class<?>>();
+        Map<String, Class<?>> variables = new HashMap<>();
         BoundIdentifiers boundIdentifiers = new BoundIdentifiers(variables, context);
         AnalysisResult analysis = dialect.analyzeBlock(context,
                 descr,

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/dialect/mvel/AbstractMVELBuilder.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/dialect/mvel/AbstractMVELBuilder.java
@@ -111,7 +111,7 @@ public class AbstractMVELBuilder {
 
     protected void collectTypes(String key, AnalysisResult analysis, ProcessBuildContext context) {
         if (context.getProcess() != null) {
-            Set<String> referencedTypes = new HashSet<String>();
+            Set<String> referencedTypes = new HashSet<>();
 
             MVELAnalysisResult mvelAnalysis = (MVELAnalysisResult) analysis;
 

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/dialect/mvel/MVELActionBuilder.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/dialect/mvel/MVELActionBuilder.java
@@ -37,7 +37,7 @@ import org.mvel2.MacroProcessor;
 
 public class MVELActionBuilder extends AbstractMVELBuilder implements ActionBuilder {
 
-    private static final Map<String, Macro> macros = new HashMap<String, Macro>(5);
+    private static final Map<String, Macro> macros = new HashMap<>(5);
     static {
         macros.put("insert",
                 new Macro() {
@@ -63,7 +63,7 @@ public class MVELActionBuilder extends AbstractMVELBuilder implements ActionBuil
             final ContextResolver contextResolver) {
 
         String text = processMacros(actionDescr.getText());
-        Map<String, Class<?>> variables = new HashMap<String, Class<?>>();
+        Map<String, Class<?>> variables = new HashMap<>();
 
         try {
             MVELDialect dialect = (MVELDialect) context.getDialect("mvel");

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/dialect/mvel/MVELReturnValueEvaluatorBuilder.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/dialect/mvel/MVELReturnValueEvaluatorBuilder.java
@@ -47,7 +47,7 @@ public class MVELReturnValueEvaluatorBuilder extends AbstractMVELBuilder
             final ContextResolver contextResolver) {
 
         String text = descr.getText();
-        Map<String, Class<?>> variables = new HashMap<String, Class<?>>();
+        Map<String, Class<?>> variables = new HashMap<>();
 
         try {
             MVELDialect dialect = (MVELDialect) context.getDialect("mvel");

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/workitem/WorkItemRepository.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/workitem/WorkItemRepository.java
@@ -45,7 +45,7 @@ public class WorkItemRepository {
     }
 
     public static Map<String, WorkDefinitionImpl> getWorkDefinitions(String path, String[] definitionNames, String widName) {
-        Map<String, WorkDefinitionImpl> workDefinitions = new HashMap<String, WorkDefinitionImpl>();
+        Map<String, WorkDefinitionImpl> workDefinitions = new HashMap<>();
         List<Map<String, Object>> workDefinitionsMaps = getAllWorkDefinitionsMap(path, widName);
         for (Map<String, Object> workDefinitionMap : workDefinitionsMaps) {
             if (workDefinitionMap != null) {
@@ -58,7 +58,7 @@ public class WorkItemRepository {
                 workDefinition.setPath((String) workDefinitionMap.get("path"));
                 workDefinition.setFile((String) workDefinitionMap.get("file"));
                 workDefinition.setDocumentation((String) workDefinitionMap.get("documentation"));
-                Set<ParameterDefinition> parameters = new HashSet<ParameterDefinition>();
+                Set<ParameterDefinition> parameters = new HashSet<>();
                 Map<String, DataType> parameterMap = (Map<String, DataType>) workDefinitionMap.get("parameters");
                 if (parameterMap != null) {
                     for (Map.Entry<String, DataType> entry : parameterMap.entrySet()) {
@@ -71,7 +71,7 @@ public class WorkItemRepository {
                     workDefinition.setParameterValues((Map<String, Object>) workDefinitionMap.get("parameterValues"));
                 }
 
-                Set<ParameterDefinition> results = new HashSet<ParameterDefinition>();
+                Set<ParameterDefinition> results = new HashSet<>();
                 Map<String, DataType> resultMap = (Map<String, DataType>) workDefinitionMap.get("results");
                 if (resultMap != null) {
                     for (Map.Entry<String, DataType> entry : resultMap.entrySet()) {
@@ -118,7 +118,7 @@ public class WorkItemRepository {
     }
 
     private static List<Map<String, Object>> getAllWorkDefinitionsMap(String directory, String widName) {
-        List<Map<String, Object>> workDefinitions = new ArrayList<Map<String, Object>>();
+        List<Map<String, Object>> workDefinitions = new ArrayList<>();
         if (widName != null) {
             workDefinitions.addAll(getWorkDefinitionsMapForSingleDir(directory, widName));
         } else {

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/context/exception/ExceptionScope.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/context/exception/ExceptionScope.java
@@ -31,7 +31,7 @@ public class ExceptionScope extends AbstractContext {
 
     public static final String EXCEPTION_SCOPE = "ExceptionScope";
 
-    protected Map<String, ExceptionHandler> exceptionHandlers = new HashMap<String, ExceptionHandler>();
+    protected Map<String, ExceptionHandler> exceptionHandlers = new HashMap<>();
     private transient Collection<ExceptionHandlerPolicy> policies = ExceptionHandlerPolicyFactory.getHandlerPolicies();
 
     @Override

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/context/swimlane/SwimlaneContext.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/context/swimlane/SwimlaneContext.java
@@ -29,7 +29,7 @@ public class SwimlaneContext extends AbstractContext {
 
     public static final String SWIMLANE_SCOPE = "SwimlaneScope";
 
-    private Map<String, Swimlane> swimlanes = new HashMap<String, Swimlane>();
+    private Map<String, Swimlane> swimlanes = new HashMap<>();
 
     public String getType() {
         return SWIMLANE_SCOPE;
@@ -48,7 +48,7 @@ public class SwimlaneContext extends AbstractContext {
     }
 
     public Collection<Swimlane> getSwimlanes() {
-        return new ArrayList<Swimlane>(swimlanes.values());
+        return new ArrayList<>(swimlanes.values());
     }
 
     public void setSwimlanes(Collection<Swimlane> swimlanes) {

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/context/variable/Variable.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/context/variable/Variable.java
@@ -56,7 +56,7 @@ public class Variable implements TypeObject, ValueObject, Serializable {
     private String sanitizedName;
     private DataType type;
     private Object value;
-    private Map<String, Object> metaData = new HashMap<String, Object>();
+    private Map<String, Object> metaData = new HashMap<>();
 
     private List<String> tags = new ArrayList<>();
 

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/type/EnumDataType.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/type/EnumDataType.java
@@ -103,7 +103,7 @@ public class EnumDataType implements DataType {
     public Map<String, Object> getValueMap(ClassLoader classLoader) {
         if (this.valueMap == null) {
             try {
-                this.valueMap = new HashMap<String, Object>();
+                this.valueMap = new HashMap<>();
                 if (className == null) {
                     return null;
                 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/impl/ContextContainerImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/impl/ContextContainerImpl.java
@@ -31,8 +31,8 @@ public class ContextContainerImpl implements Serializable, ContextContainer {
 
     private static final long serialVersionUID = 510l;
 
-    private Map<String, Context> defaultContexts = new HashMap<String, Context>();
-    private Map<String, List<Context>> subContexts = new HashMap<String, List<Context>>();
+    private Map<String, Context> defaultContexts = new HashMap<>();
+    private Map<String, List<Context>> subContexts = new HashMap<>();
     private long lastContextId;
 
     public List<Context> getContexts(String contextType) {
@@ -42,7 +42,7 @@ public class ContextContainerImpl implements Serializable, ContextContainer {
     public void addContext(Context context) {
         List<Context> list = this.subContexts.get(context.getType());
         if (list == null) {
-            list = new ArrayList<Context>();
+            list = new ArrayList<>();
             this.subContexts.put(context.getType(), list);
         }
         if (!list.contains(context)) {

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/impl/ProcessImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/impl/ProcessImpl.java
@@ -50,8 +50,8 @@ public class ProcessImpl implements Process, Serializable, ContextResolver {
     private String packageName;
     private Resource resource;
     private ContextContainer contextContainer = new ContextContainerImpl();
-    private Map<String, Object> metaData = new HashMap<String, Object>();
-    private transient Map<String, Object> runtimeMetaData = new HashMap<String, Object>();
+    private Map<String, Object> metaData = new HashMap<>();
+    private transient Map<String, Object> runtimeMetaData = new HashMap<>();
     private Set<String> imports = new HashSet<>();
     private Map<String, String> globals;
     private List<String> functionImports = new ArrayList<>();
@@ -209,7 +209,7 @@ public class ProcessImpl implements Process, Serializable, ContextResolver {
     }
 
     public String[] getGlobalNames() {
-        final List<String> result = new ArrayList<String>();
+        final List<String> result = new ArrayList<>();
         if (this.globals != null) {
             for (Iterator<String> iterator = this.globals.keySet().iterator(); iterator.hasNext();) {
                 result.add(iterator.next());
@@ -239,6 +239,6 @@ public class ProcessImpl implements Process, Serializable, ContextResolver {
      */
     private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
         in.defaultReadObject();
-        this.runtimeMetaData = new HashMap<String, Object>();
+        this.runtimeMetaData = new HashMap<>();
     }
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/impl/WorkDefinitionImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/impl/WorkDefinitionImpl.java
@@ -30,8 +30,8 @@ public class WorkDefinitionImpl implements WorkDefinition, Serializable {
     private static final long serialVersionUID = 510l;
 
     private String name;
-    private Map<String, ParameterDefinition> parameters = new HashMap<String, ParameterDefinition>();
-    private Map<String, ParameterDefinition> results = new HashMap<String, ParameterDefinition>();
+    private Map<String, ParameterDefinition> parameters = new HashMap<>();
+    private Map<String, ParameterDefinition> results = new HashMap<>();
 
     public String getName() {
         return name;
@@ -42,7 +42,7 @@ public class WorkDefinitionImpl implements WorkDefinition, Serializable {
     }
 
     public Set<ParameterDefinition> getParameters() {
-        return new HashSet<ParameterDefinition>(parameters.values());
+        return new HashSet<>(parameters.values());
     }
 
     public void setParameters(Set<ParameterDefinition> parameters) {
@@ -70,7 +70,7 @@ public class WorkDefinitionImpl implements WorkDefinition, Serializable {
     }
 
     public Set<ParameterDefinition> getResults() {
-        return new HashSet<ParameterDefinition>(results.values());
+        return new HashSet<>(results.values());
     }
 
     public void setResults(Set<ParameterDefinition> results) {

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/impl/WorkImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/impl/WorkImpl.java
@@ -37,8 +37,8 @@ public class WorkImpl implements Work, Serializable {
     private static final long serialVersionUID = 510l;
 
     private String name;
-    private Map<String, Object> parameters = new LinkedHashMap<String, Object>();
-    private Map<String, ParameterDefinition> parameterDefinitions = new LinkedHashMap<String, ParameterDefinition>();
+    private Map<String, Object> parameters = new LinkedHashMap<>();
+    private Map<String, ParameterDefinition> parameterDefinitions = new LinkedHashMap<>();
 
     private Collection<DeadlineInfo<Map<String, Object>>> startDeadlines;
     private Collection<DeadlineInfo<Map<String, Object>>> endDeadlines;
@@ -85,7 +85,7 @@ public class WorkImpl implements Work, Serializable {
         if (parameters == null) {
             throw new NullPointerException();
         }
-        this.parameters = new HashMap<String, Object>(parameters);
+        this.parameters = new HashMap<>(parameters);
     }
 
     @Override

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/timer/BusinessCalendarImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/timer/BusinessCalendarImpl.java
@@ -80,7 +80,7 @@ public class BusinessCalendarImpl implements BusinessCalendar {
     private String timezone;
 
     private List<TimePeriod> holidays;
-    private List<Integer> weekendDays = new ArrayList<Integer>();
+    private List<Integer> weekendDays = new ArrayList<>();
     private SessionClock clock;
 
     private static final int SIM_WEEK = 3;
@@ -343,7 +343,7 @@ public class BusinessCalendarImpl implements BusinessCalendar {
 
     protected List<TimePeriod> parseHolidays() {
         String holidaysString = businessCalendarConfiguration.getProperty(HOLIDAYS);
-        List<TimePeriod> holidays = new ArrayList<TimePeriod>();
+        List<TimePeriod> holidays = new ArrayList<>();
         int currentYear = Calendar.getInstance().get(Calendar.YEAR);
         if (holidaysString != null) {
             String[] hPeriods = holidaysString.split(",");

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/validation/ProcessValidatorRegistry.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/validation/ProcessValidatorRegistry.java
@@ -29,8 +29,8 @@ public class ProcessValidatorRegistry {
 
     private static ProcessValidatorRegistry instance;
 
-    private Map<String, ProcessValidator> defaultValidators = new ConcurrentHashMap<String, ProcessValidator>();
-    private Set<ProcessValidator> additionalValidators = new CopyOnWriteArraySet<ProcessValidator>();
+    private Map<String, ProcessValidator> defaultValidators = new ConcurrentHashMap<>();
+    private Set<ProcessValidator> additionalValidators = new CopyOnWriteArraySet<>();
 
     private ProcessValidatorRegistry() {
         defaultValidators.put(KogitoWorkflowProcess.RULEFLOW_TYPE, RuleFlowProcessValidator.getInstance());

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/ProcessInstanceFactoryRegistry.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/ProcessInstanceFactoryRegistry.java
@@ -30,7 +30,7 @@ public class ProcessInstanceFactoryRegistry {
     private Map<Class<? extends Process>, ProcessInstanceFactory> registry;
 
     private ProcessInstanceFactoryRegistry() {
-        this.registry = new HashMap<Class<? extends Process>, ProcessInstanceFactory>();
+        this.registry = new HashMap<>();
 
         // hard wired nodes:
         register(RuleFlowProcess.class,

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/command/MigrateProcessInstanceCommand.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/command/MigrateProcessInstanceCommand.java
@@ -113,7 +113,7 @@ public class MigrateProcessInstanceCommand implements ExecutableCommand<Void>, K
             processInstance.disconnect();
             processInstance.setProcess(oldProcess);
             if (nodeMapping == null) {
-                nodeMapping = new HashMap<String, Long>();
+                nodeMapping = new HashMap<>();
             }
             updateNodeInstances(processInstance, nodeMapping);
             processInstance.setKnowledgeRuntime((InternalKnowledgeRuntime) runtime);

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/context/exception/CompensationScopeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/context/exception/CompensationScopeInstance.java
@@ -45,7 +45,7 @@ public class CompensationScopeInstance extends ExceptionScopeInstance {
 
     private static final long serialVersionUID = 510l;
 
-    private Stack<NodeInstance> compensationInstances = new Stack<NodeInstance>();
+    private Stack<NodeInstance> compensationInstances = new Stack<>();
 
     public String getContextType() {
         return CompensationScope.COMPENSATION_SCOPE;

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/context/swimlane/SwimlaneContextInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/context/swimlane/SwimlaneContextInstance.java
@@ -25,7 +25,7 @@ public class SwimlaneContextInstance extends AbstractContextInstance {
 
     private static final long serialVersionUID = 510l;
 
-    private Map<String, String> swimlaneActors = new HashMap<String, String>();
+    private Map<String, String> swimlaneActors = new HashMap<>();
 
     public String getContextType() {
         return SwimlaneContext.SWIMLANE_SCOPE;

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/context/variable/VariableScopeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/context/variable/VariableScopeInstance.java
@@ -39,7 +39,7 @@ public class VariableScopeInstance extends AbstractContextInstance {
 
     private static final long serialVersionUID = 510l;
 
-    private Map<String, Object> variables = new HashMap<String, Object>();
+    private Map<String, Object> variables = new HashMap<>();
     private transient String variableIdPrefix = null;
     private transient String variableInstanceIdPrefix = null;
 

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/event/DefaultSignalManager.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/event/DefaultSignalManager.java
@@ -37,7 +37,7 @@ import org.kie.kogito.signal.SignalManager;
 
 public class DefaultSignalManager implements SignalManager {
 
-    private Map<String, List<EventListener>> processEventListeners = new ConcurrentHashMap<String, List<EventListener>>();
+    private Map<String, List<EventListener>> processEventListeners = new ConcurrentHashMap<>();
     private InternalKnowledgeRuntime kruntime;
 
     public DefaultSignalManager(InternalKnowledgeRuntime kruntime) {
@@ -51,7 +51,7 @@ public class DefaultSignalManager implements SignalManager {
             synchronized (processEventListeners) {
                 eventListeners = processEventListeners.get(type);
                 if (eventListeners == null) {
-                    eventListeners = new CopyOnWriteArrayList<EventListener>();
+                    eventListeners = new CopyOnWriteArrayList<>();
                     processEventListeners.put(type, eventListeners);
                 }
             }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/ProcessInstanceImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/ProcessInstanceImpl.java
@@ -46,10 +46,10 @@ public abstract class ProcessInstanceImpl implements ProcessInstance,
     private transient Process process;
     private String processXml;
     private int state = STATE_PENDING;
-    private Map<String, ContextInstance> contextInstances = new HashMap<String, ContextInstance>();
-    private Map<String, List<ContextInstance>> subContextInstances = new HashMap<String, List<ContextInstance>>();
+    private Map<String, ContextInstance> contextInstances = new HashMap<>();
+    private Map<String, List<ContextInstance>> subContextInstances = new HashMap<>();
     private transient InternalKnowledgeRuntime kruntime;
-    private Map<String, Object> metaData = new HashMap<String, Object>();
+    private Map<String, Object> metaData = new HashMap<>();
     private String outcome;
     private String parentProcessInstanceId;
     private String rootProcessInstanceId;

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/demo/UIWorkItemHandler.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/demo/UIWorkItemHandler.java
@@ -123,7 +123,7 @@ public class UIWorkItemHandler extends JFrame implements KogitoWorkItemHandler {
     }
 
     private void reloadWorkItemsList() {
-        List<WorkItemWrapper> result = new ArrayList<WorkItemWrapper>();
+        List<WorkItemWrapper> result = new ArrayList<>();
         for (KogitoWorkItem workItem : workItems.keySet()) {
             result.add(new WorkItemWrapper(workItem));
         }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/demo/UIWorkItemHandlerDialog.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/demo/UIWorkItemHandlerDialog.java
@@ -42,7 +42,7 @@ public class UIWorkItemHandlerDialog extends JDialog {
 
     private static final long serialVersionUID = 510l;
 
-    private Map<String, Object> results = new HashMap<String, Object>();
+    private Map<String, Object> results = new HashMap<>();
     private UIWorkItemHandler handler;
     private KogitoWorkItem workItem;
     private JTextField resultNameTextField;

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/util/VariableUtil.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/util/VariableUtil.java
@@ -32,7 +32,7 @@ public class VariableUtil {
             return null;
         }
 
-        Map<String, String> replacements = new HashMap<String, String>();
+        Map<String, String> replacements = new HashMap<>();
         Matcher matcher = PatternConstants.PARAMETER_MATCHER.matcher(s);
         while (matcher.find()) {
             String paramName = matcher.group(1);

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/RuleFlowProcess.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/RuleFlowProcess.java
@@ -84,7 +84,7 @@ public class RuleFlowProcess extends WorkflowProcessImpl {
     }
 
     public static List<Node> getStartNodes(Node[] nodes) {
-        List<Node> startNodes = new ArrayList<Node>();
+        List<Node> startNodes = new ArrayList<>();
         for (Node node : nodes) {
             if (node instanceof StartNode) {
                 startNodes.add(node);
@@ -99,7 +99,7 @@ public class RuleFlowProcess extends WorkflowProcessImpl {
     }
 
     public static List<Node> getEndNodes(Node[] nodes) {
-        final List<Node> endNodes = new ArrayList<Node>();
+        final List<Node> endNodes = new ArrayList<>();
         for (Node node : nodes) {
             if (node instanceof EndNode || node instanceof FaultNode) {
                 endNodes.add(node);

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/RuleFlowProcessFactory.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/RuleFlowProcessFactory.java
@@ -169,7 +169,7 @@ public class RuleFlowProcessFactory extends RuleFlowNodeContainerFactory<RuleFlo
     public RuleFlowProcessFactory global(String name, String type) {
         Map<String, String> globals = getRuleFlowProcess().getGlobals();
         if (globals == null) {
-            globals = new HashMap<String, String>();
+            globals = new HashMap<>();
             getRuleFlowProcess().setGlobals(globals);
         }
         globals.put(name, type);

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/DroolsAction.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/DroolsAction.java
@@ -30,7 +30,7 @@ public class DroolsAction implements Externalizable, Wireable {
     private static final long serialVersionUID = 510l;
 
     private String name;
-    private Map<String, Object> metaData = new HashMap<String, Object>();
+    private Map<String, Object> metaData = new HashMap<>();
 
     public void wire(Object object) {
         setMetaData("Action",

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/impl/ConnectionImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/impl/ConnectionImpl.java
@@ -36,7 +36,7 @@ public class ConnectionImpl implements Connection, Serializable {
     private org.kie.api.definition.process.Node to;
     private String fromType;
     private String toType;
-    private Map<String, Object> metaData = new HashMap<String, Object>();
+    private Map<String, Object> metaData = new HashMap<>();
 
     public ConnectionImpl() {
     }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/impl/ConstraintImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/impl/ConstraintImpl.java
@@ -29,7 +29,7 @@ public class ConstraintImpl implements Constraint, Serializable {
 
     private static final long serialVersionUID = 510l;
 
-    private Map<String, Object> metaData = new HashMap<String, Object>();
+    private Map<String, Object> metaData = new HashMap<>();
 
     private String name;
     private String constraint;

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/impl/NodeImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/impl/NodeImpl.java
@@ -48,7 +48,7 @@ public abstract class NodeImpl implements Node, ContextResolver, Mappable {
     private Map<String, Context> contexts = new HashMap<>();
     private Map<String, Object> metaData = new HashMap<>();
 
-    protected Map<ConnectionRef, Constraint> constraints = new HashMap<ConnectionRef, Constraint>();
+    protected Map<ConnectionRef, Constraint> constraints = new HashMap<>();
 
     private IOSpecification ioSpecification;
     private MultiInstanceSpecification multiInstanceSpecification;
@@ -164,7 +164,7 @@ public abstract class NodeImpl implements Node, ContextResolver, Mappable {
         validateAddIncomingConnection(type, connection);
         List<Connection> connections = this.incomingConnections.get(type);
         if (connections == null) {
-            connections = new ArrayList<Connection>();
+            connections = new ArrayList<>();
             this.incomingConnections.put(type, connections);
         }
         connections.add(connection);
@@ -182,7 +182,7 @@ public abstract class NodeImpl implements Node, ContextResolver, Mappable {
     public List<Connection> getIncomingConnections(String type) {
         List<Connection> result = incomingConnections.get(type);
         if (result == null) {
-            return new ArrayList<Connection>();
+            return new ArrayList<>();
         }
         return result;
     }
@@ -191,7 +191,7 @@ public abstract class NodeImpl implements Node, ContextResolver, Mappable {
         validateAddOutgoingConnection(type, connection);
         List<Connection> connections = this.outgoingConnections.get(type);
         if (connections == null) {
-            connections = new ArrayList<Connection>();
+            connections = new ArrayList<>();
             this.outgoingConnections.put(type, connections);
         }
         connections.add(connection);
@@ -209,7 +209,7 @@ public abstract class NodeImpl implements Node, ContextResolver, Mappable {
     public List<Connection> getOutgoingConnections(String type) {
         List<Connection> result = outgoingConnections.get(type);
         if (result == null) {
-            return new ArrayList<Connection>();
+            return new ArrayList<>();
         }
         return result;
     }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/impl/WorkflowProcessImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/impl/WorkflowProcessImpl.java
@@ -55,7 +55,7 @@ public class WorkflowProcessImpl extends ProcessImpl implements WorkflowProcess,
     private transient BiFunction<String, ProcessInstance, String> expressionEvaluator = (expression, p) -> {
 
         String evaluatedValue = expression;
-        Map<String, String> replacements = new HashMap<String, String>();
+        Map<String, String> replacements = new HashMap<>();
         Matcher matcher = PatternConstants.PARAMETER_MATCHER.matcher(evaluatedValue);
         while (matcher.find()) {
             String paramName = matcher.group(1);
@@ -196,7 +196,7 @@ public class WorkflowProcessImpl extends ProcessImpl implements WorkflowProcess,
     public List<StartNode> getTimerStart() {
         org.kie.api.definition.process.Node[] nodes = getNodes();
 
-        List<StartNode> timerStartNodes = new ArrayList<StartNode>();
+        List<StartNode> timerStartNodes = new ArrayList<>();
         for (int i = 0; i < nodes.length; i++) {
             if (nodes[i] instanceof StartNode && ((StartNode) nodes[i]).getTimer() != null) {
                 timerStartNodes.add((StartNode) nodes[i]);

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/Assignment.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/Assignment.java
@@ -28,7 +28,7 @@ public class Assignment implements Serializable {
     private String dialect;
     private DataDefinition from; // this is an expression
     private DataDefinition to; // this is another expression
-    private Map<String, Object> metaData = new HashMap<String, Object>();
+    private Map<String, Object> metaData = new HashMap<>();
 
     public Assignment(String dialect, DataDefinition from, DataDefinition to) {
         this.dialect = dialect;

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/AsyncEventNode.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/AsyncEventNode.java
@@ -47,7 +47,7 @@ public class AsyncEventNode extends EventNode {
 
     @Override
     public Map<String, Object> getMetaData() {
-        Map<String, Object> metaData = new HashMap<String, Object>(node.getMetaData());
+        Map<String, Object> metaData = new HashMap<>(node.getMetaData());
         metaData.put("hidden", "true");
         return metaData;
     }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/CompositeNode.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/CompositeNode.java
@@ -34,8 +34,8 @@ public class CompositeNode extends StateBasedNode implements NodeContainer, Even
     private static final long serialVersionUID = 510l;
 
     private NodeContainer nodeContainer;
-    private Map<String, CompositeNode.NodeAndType> inConnectionMap = new HashMap<String, CompositeNode.NodeAndType>();
-    private Map<String, CompositeNode.NodeAndType> outConnectionMap = new HashMap<String, CompositeNode.NodeAndType>();
+    private Map<String, CompositeNode.NodeAndType> inConnectionMap = new HashMap<>();
+    private Map<String, CompositeNode.NodeAndType> outConnectionMap = new HashMap<>();
     private boolean cancelRemainingInstances = true;
     private boolean autoComplete = true;
 
@@ -61,7 +61,7 @@ public class CompositeNode extends StateBasedNode implements NodeContainer, Even
     }
 
     public org.kie.api.definition.process.Node[] getNodes() {
-        List<org.kie.api.definition.process.Node> subNodes = new ArrayList<org.kie.api.definition.process.Node>();
+        List<org.kie.api.definition.process.Node> subNodes = new ArrayList<>();
         for (org.kie.api.definition.process.Node node : nodeContainer.getNodes()) {
             if (!(node instanceof CompositeNode.CompositeNodeStart) &&
                     !(node instanceof CompositeNode.CompositeNodeEnd)) {

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/EventNode.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/EventNode.java
@@ -29,7 +29,7 @@ public class EventNode extends ExtendedNodeImpl implements EventNodeInterface {
 
     private static final long serialVersionUID = 510l;
 
-    private List<EventFilter> filters = new ArrayList<EventFilter>();
+    private List<EventFilter> filters = new ArrayList<>();
     private String inputVariableName;
     private String variableName;
     private String scope;

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/EventSubProcessNode.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/EventSubProcessNode.java
@@ -28,8 +28,8 @@ public class EventSubProcessNode extends CompositeContextNode {
 
     private static final long serialVersionUID = 2200928773922042238L;
 
-    private List<String> events = new ArrayList<String>();
-    private List<EventTypeFilter> eventTypeFilters = new ArrayList<EventTypeFilter>();
+    private List<String> events = new ArrayList<>();
+    private List<EventTypeFilter> eventTypeFilters = new ArrayList<>();
     private boolean keepActive = true;
 
     public void addEvent(EventTypeFilter filter) {

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/EventTrigger.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/EventTrigger.java
@@ -24,7 +24,7 @@ public class EventTrigger extends Trigger {
 
     private static final long serialVersionUID = 510l;
 
-    private List<EventFilter> filters = new ArrayList<EventFilter>();
+    private List<EventFilter> filters = new ArrayList<>();
 
     public void addEventFilter(EventFilter eventFilter) {
         filters.add(eventFilter);

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/ForEachNode.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/ForEachNode.java
@@ -242,7 +242,7 @@ public class ForEachNode extends CompositeContextNode {
         VariableScope variableScope = (VariableScope) compositeContextNode.getDefaultContext(VariableScope.VARIABLE_SCOPE);
         List<Variable> variables = variableScope.getVariables();
         if (variables == null) {
-            variables = new ArrayList<Variable>();
+            variables = new ArrayList<>();
             variableScope.setVariables(variables);
         }
         Variable variable = new Variable();

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/HumanTaskNode.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/HumanTaskNode.java
@@ -33,7 +33,7 @@ public class HumanTaskNode extends WorkItemNode {
     public HumanTaskNode() {
         Work work = new WorkImpl();
         work.setName("Human Task");
-        Set<ParameterDefinition> parameterDefinitions = new HashSet<ParameterDefinition>();
+        Set<ParameterDefinition> parameterDefinitions = new HashSet<>();
         parameterDefinitions.add(new ParameterDefinitionImpl("TaskName", new StringDataType()));
         parameterDefinitions.add(new ParameterDefinitionImpl("ActorId", new StringDataType()));
         parameterDefinitions.add(new ParameterDefinitionImpl("Priority", new StringDataType()));

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/RuleSetNode.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/RuleSetNode.java
@@ -184,7 +184,7 @@ public class RuleSetNode extends StateBasedNode implements ContextContainer {
 
     private RuleType ruleType;
 
-    private Map<String, Object> parameters = new HashMap<String, Object>();
+    private Map<String, Object> parameters = new HashMap<>();
 
     private Supplier<DecisionModel> decisionModel;
     private Supplier<KieRuntime> kieRuntime;

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/StartNode.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/StartNode.java
@@ -41,7 +41,7 @@ public class StartNode extends ExtendedNodeImpl {
 
     public void addTrigger(Trigger trigger) {
         if (triggers == null) {
-            triggers = new ArrayList<Trigger>();
+            triggers = new ArrayList<>();
         }
         triggers.add(trigger);
     }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/StateBasedNode.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/StateBasedNode.java
@@ -38,7 +38,7 @@ public class StateBasedNode extends ExtendedNodeImpl {
 
     public void addTimer(Timer timer, DroolsAction action) {
         if (timers == null) {
-            timers = new HashMap<Timer, DroolsAction>();
+            timers = new HashMap<>();
         }
         if (timer.getId() == 0) {
             long id = 0;
@@ -60,7 +60,7 @@ public class StateBasedNode extends ExtendedNodeImpl {
 
     public void addBoundaryEvents(String boundaryEvent) {
         if (this.boundaryEvents == null) {
-            this.boundaryEvents = new ArrayList<String>();
+            this.boundaryEvents = new ArrayList<>();
         }
         this.boundaryEvents.add(boundaryEvent);
     }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/StateNode.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/StateNode.java
@@ -26,7 +26,7 @@ public class StateNode extends CompositeContextNode implements Constrainable {
 
     private static final long serialVersionUID = 510l;
 
-    private Map<ConnectionRef, Constraint> constraints = new HashMap<ConnectionRef, Constraint>();
+    private Map<ConnectionRef, Constraint> constraints = new HashMap<>();
 
     public void setConstraints(Map<ConnectionRef, Constraint> constraints) {
         this.constraints = constraints;

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/Trigger.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/Trigger.java
@@ -30,7 +30,7 @@ public class Trigger implements Mappable, Serializable {
 
     private static final long serialVersionUID = 510l;
 
-    private List<DataAssociation> inMapping = new LinkedList<DataAssociation>();
+    private List<DataAssociation> inMapping = new LinkedList<>();
 
     public void addInMapping(String mapping) {
         addInMapping(mapping, mapping);
@@ -41,7 +41,7 @@ public class Trigger implements Mappable, Serializable {
     }
 
     public void setInMappings(Map<String, String> inMapping) {
-        this.inMapping = new LinkedList<DataAssociation>();
+        this.inMapping = new LinkedList<>();
         for (Map.Entry<String, String> entry : inMapping.entrySet()) {
             addInMapping(entry.getKey(), entry.getValue());
         }
@@ -52,7 +52,7 @@ public class Trigger implements Mappable, Serializable {
     }
 
     public Map<String, String> getInMappings() {
-        Map<String, String> in = new HashMap<String, String>();
+        Map<String, String> in = new HashMap<>();
         for (DataAssociation a : inMapping) {
             if (a.getSources().size() == 1 && (a.getAssignments() == null || a.getAssignments().isEmpty()) && a.getTransformation() == null) {
                 in.put(a.getSources().get(0).getLabel(), a.getTarget().getLabel());

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/WorkflowProcessInstanceUpgrader.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/WorkflowProcessInstanceUpgrader.java
@@ -36,7 +36,7 @@ public class WorkflowProcessInstanceUpgrader {
     public static void upgradeProcessInstance(KogitoProcessRuntime kruntime, String processInstanceId, String processId,
             Map<String, Long> nodeMapping) {
         if (nodeMapping == null) {
-            nodeMapping = new HashMap<String, Long>();
+            nodeMapping = new HashMap<>();
         }
         WorkflowProcessInstanceImpl processInstance = (WorkflowProcessInstanceImpl) kruntime.getProcessInstance(processInstanceId);
         if (processInstance == null) {
@@ -72,7 +72,7 @@ public class WorkflowProcessInstanceUpgrader {
             String toProcessId,
             Map<String, String> nodeNamesMapping) {
 
-        Map<String, Long> nodeIdMapping = new HashMap<String, Long>();
+        Map<String, Long> nodeIdMapping = new HashMap<>();
 
         String fromProcessIdString = kruntime.getProcessInstance(fromProcessId).getProcessId();
         Process processFrom = kruntime.getKieBase().getProcess(fromProcessIdString);
@@ -109,7 +109,7 @@ public class WorkflowProcessInstanceUpgrader {
 
     private static String getNodeId(org.kie.api.definition.process.Node[] nodes, String nodeName, boolean unique) {
 
-        Stack<org.kie.api.definition.process.Node> nodeStack = new Stack<org.kie.api.definition.process.Node>();
+        Stack<org.kie.api.definition.process.Node> nodeStack = new Stack<>();
         for (org.kie.api.definition.process.Node node : nodes) {
             nodeStack.push(node);
         }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/WorkflowRuntimeException.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/WorkflowRuntimeException.java
@@ -76,7 +76,7 @@ public class WorkflowRuntimeException extends RuntimeException {
         if (variableScope != null) {
             this.variables = variableScope.getVariables();
         } else {
-            this.variables = new HashMap<String, Object>(0);
+            this.variables = new HashMap<>(0);
         }
     }
 

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/CompensationEventListener.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/CompensationEventListener.java
@@ -145,8 +145,8 @@ class CompensationEventListener implements KogitoEventListener {
     }
 
     private Stack<NodeInstance> createNodeInstanceContainers(org.kie.api.definition.process.Node toCompensateNode, boolean generalCompensation) {
-        Stack<NodeContainer> nestedNodes = new Stack<NodeContainer>();
-        Stack<NodeInstance> generatedInstances = new Stack<NodeInstance>();
+        Stack<NodeContainer> nestedNodes = new Stack<>();
+        Stack<NodeInstance> generatedInstances = new Stack<>();
 
         NodeContainer parentContainer = ((Node) toCompensateNode).getParentContainer();
         while (!(parentContainer instanceof RuleFlowProcess)) {

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/NodeInstanceResolverFactory.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/NodeInstanceResolverFactory.java
@@ -31,7 +31,7 @@ public class NodeInstanceResolverFactory extends ImmutableDefaultFactory {
 
     private NodeInstance nodeInstance;
 
-    private Map<String, Object> extraParameters = new HashMap<String, Object>();
+    private Map<String, Object> extraParameters = new HashMap<>();
 
     public NodeInstanceResolverFactory(NodeInstance nodeInstance) {
         this.nodeInstance = nodeInstance;

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/VariableScopeResolverFactory.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/VariableScopeResolverFactory.java
@@ -28,7 +28,7 @@ public class VariableScopeResolverFactory extends ImmutableDefaultFactory {
     private static final long serialVersionUID = 510l;
 
     private VariableScopeInstance variableScope;
-    private Map<String, Object> extraParameters = new HashMap<String, Object>();
+    private Map<String, Object> extraParameters = new HashMap<>();
 
     public VariableScopeResolverFactory(VariableScopeInstance variableScope) {
         this.variableScope = variableScope;

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/CompositeContextNodeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/CompositeContextNodeInstance.java
@@ -34,8 +34,8 @@ public class CompositeContextNodeInstance extends CompositeNodeInstance implemen
 
     private static final long serialVersionUID = 510l;
 
-    private Map<String, ContextInstance> contextInstances = new HashMap<String, ContextInstance>();
-    private Map<String, List<ContextInstance>> subContextInstances = new HashMap<String, List<ContextInstance>>();
+    private Map<String, ContextInstance> contextInstances = new HashMap<>();
+    private Map<String, List<ContextInstance>> subContextInstances = new HashMap<>();
 
     protected CompositeContextNode getCompositeContextNode() {
         return (CompositeContextNode) getNode();
@@ -69,7 +69,7 @@ public class CompositeContextNodeInstance extends CompositeNodeInstance implemen
     public void addContextInstance(String contextId, ContextInstance contextInstance) {
         List<ContextInstance> list = this.subContextInstances.get(contextId);
         if (list == null) {
-            list = new ArrayList<ContextInstance>();
+            list = new ArrayList<>();
             this.subContextInstances.put(contextId, list);
         }
         list.add(contextInstance);

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/JoinInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/JoinInstance.java
@@ -49,7 +49,7 @@ public class JoinInstance extends NodeInstanceImpl {
 
     private static final long serialVersionUID = 510l;
 
-    private Map<Long, Integer> triggers = new HashMap<Long, Integer>();
+    private Map<Long, Integer> triggers = new HashMap<>();
 
     protected Join getJoin() {
         return (Join) getNode();
@@ -177,7 +177,7 @@ public class JoinInstance extends NodeInstanceImpl {
     private boolean existsActiveDirectFlow(NodeInstanceContainer nodeInstanceContainer, final org.kie.api.definition.process.Node lookFor) {
 
         Collection<NodeInstance> activeNodeInstancesOrig = nodeInstanceContainer.getNodeInstances();
-        List<NodeInstance> activeNodeInstances = new ArrayList<NodeInstance>(activeNodeInstancesOrig);
+        List<NodeInstance> activeNodeInstances = new ArrayList<>(activeNodeInstancesOrig);
         // sort active instances in the way that lookFor nodeInstance will be last to not finish too early
         Collections.sort(activeNodeInstances, new Comparator<NodeInstance>() {
 
@@ -198,7 +198,7 @@ public class JoinInstance extends NodeInstanceImpl {
                 continue;
             }
             org.kie.api.definition.process.Node node = nodeInstance.getNode();
-            Set<Long> vistedNodes = new HashSet<Long>();
+            Set<Long> vistedNodes = new HashSet<>();
             checkNodes(vistedNodes, node, node, lookFor);
             if (vistedNodes.contains(lookFor.getId()) && !vistedNodes.contains(node.getId())) {
                 return true;
@@ -225,7 +225,7 @@ public class JoinInstance extends NodeInstanceImpl {
                 return false;
             }
             for (Connection conn : connections) {
-                Set<Long> xorCopy = new HashSet<Long>(vistedNodes);
+                Set<Long> xorCopy = new HashSet<>(vistedNodes);
 
                 org.kie.api.definition.process.Node nextNode = conn.getTo();
                 if (nextNode == null) {

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/LambdaSubProcessNodeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/LambdaSubProcessNodeInstance.java
@@ -229,7 +229,7 @@ public class LambdaSubProcessNodeInstance extends StateBasedNodeInstance impleme
     public void addContextInstance(String contextId, ContextInstance contextInstance) {
         List<ContextInstance> list = this.subContextInstances.get(contextId);
         if (list == null) {
-            list = new ArrayList<ContextInstance>();
+            list = new ArrayList<>();
             this.subContextInstances.put(contextId, list);
         }
         list.add(contextInstance);

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/SplitInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/SplitInstance.java
@@ -122,8 +122,8 @@ public class SplitInstance extends NodeInstanceImpl {
                 outgoing = split.getDefaultOutgoingConnections();
                 boolean found = false;
                 List<NodeInstanceTrigger> nodeInstances =
-                        new ArrayList<NodeInstanceTrigger>();
-                List<Connection> outgoingCopy = new ArrayList<Connection>(outgoing);
+                        new ArrayList<>();
+                List<Connection> outgoingCopy = new ArrayList<>(outgoing);
                 while (!outgoingCopy.isEmpty()) {
                     priority = Integer.MAX_VALUE;
                     Connection selectedConnection = null;
@@ -193,7 +193,7 @@ public class SplitInstance extends NodeInstanceImpl {
                         throw new IllegalArgumentException(
                                 "An Exclusive AND is only possible if the parent is a context instance container");
                     }
-                    Map<org.jbpm.workflow.instance.NodeInstance, String> nodeInstancesMap = new HashMap<org.jbpm.workflow.instance.NodeInstance, String>();
+                    Map<org.jbpm.workflow.instance.NodeInstance, String> nodeInstancesMap = new HashMap<>();
                     for (Connection connection : connections) {
                         nodeInstancesMap.put(followConnection(connection), connection.getToType());
                     }
@@ -228,7 +228,7 @@ public class SplitInstance extends NodeInstanceImpl {
     }
 
     protected boolean hasLoop(org.kie.api.definition.process.Node startAt, final org.kie.api.definition.process.Node lookFor) {
-        Set<Long> vistedNodes = new HashSet<Long>();
+        Set<Long> vistedNodes = new HashSet<>();
 
         return checkNodes(startAt, lookFor, vistedNodes);
 

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/SubProcessNodeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/SubProcessNodeInstance.java
@@ -58,7 +58,7 @@ public class SubProcessNodeInstance extends StateBasedNodeInstance implements Ev
     private static final Logger logger = LoggerFactory.getLogger(SubProcessNodeInstance.class);
 
     // NOTE: ContextInstances are not persisted as current functionality (exception scope) does not require it
-    private Map<String, ContextInstance> contextInstances = new HashMap<String, ContextInstance>();
+    private Map<String, ContextInstance> contextInstances = new HashMap<>();
     private Map<String, List<ContextInstance>> subContextInstances = new HashMap<>();
 
     private String processInstanceId;
@@ -117,7 +117,7 @@ public class SubProcessNodeInstance extends StateBasedNodeInstance implements Ev
             if (getProcessInstance().getCorrelationKey() != null) {
                 // in case there is correlation key on parent instance pass it along to child so it can be easily correlated 
                 // since correlation key must be unique for active instances it appends processId and timestamp
-                List<String> businessKeys = new ArrayList<String>();
+                List<String> businessKeys = new ArrayList<>();
                 businessKeys.add(getProcessInstance().getCorrelationKey());
                 businessKeys.add(processId);
                 businessKeys.add(String.valueOf(System.currentTimeMillis()));

--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/persistence/proto/ProtoMessage.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/persistence/proto/ProtoMessage.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 public class ProtoMessage extends ProtoComponent {
 
-    private List<ProtoField> fields = new ArrayList<ProtoField>();
+    private List<ProtoField> fields = new ArrayList<>();
 
     public ProtoMessage(String name, String javaPackageOption) {
         super(name, javaPackageOption);

--- a/kogito-codegen-modules/kogito-codegen-rules/src/main/java/org/kie/kogito/codegen/rules/QueryGenerator.java
+++ b/kogito-codegen-modules/kogito-codegen-rules/src/main/java/org/kie/kogito/codegen/rules/QueryGenerator.java
@@ -183,7 +183,7 @@ public class QueryGenerator implements RuleFileGenerator {
     }
 
     private void generateResultClass(ClassOrInterfaceDeclaration clazz, MethodDeclaration toResultMethod) {
-        ClassOrInterfaceDeclaration resultClass = new ClassOrInterfaceDeclaration(new NodeList<Modifier>(Modifier.publicModifier(), Modifier.staticModifier()), false, "Result");
+        ClassOrInterfaceDeclaration resultClass = new ClassOrInterfaceDeclaration(new NodeList<>(Modifier.publicModifier(), Modifier.staticModifier()), false, "Result");
         clazz.addMember(resultClass);
 
         ConstructorDeclaration constructor = resultClass.addConstructor(Modifier.Keyword.PUBLIC);


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-7943

Goal here is to reduce the number of code smells in Kogito-runtimes.

Addressed in this PR is the code smell, "(Java) The diamond operator ("<>") should be used (199)"
https://sonarcloud.io/project/issues?resolved=false&rules=java%3AS2293&id=org.kie.kogito%3Akogito-runtimes

I have remedied this by removing the constructor arguments as Java 7 introduced the <> constructor which infers the arguments from the declaration, as per Sonarcloud's recommendation.


<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

<b>Jenkins retest this</b>

</details>
