### PR TITLE
Kogito-7952 Sonarcloud - (Java) "Static" base class members should not be accessed via derived types (78)

### DIFF
--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/AbstractNodeHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/AbstractNodeHandler.java
@@ -697,8 +697,8 @@ public abstract class AbstractNodeHandler extends BaseAbstractHandler implements
         nodeTarget.getMetaData().put("UniqueId", uniqueId + ":1");
         forEachNode.setMetaData("UniqueId", uniqueId);
         forEachNode.addNode(nodeTarget);
-        forEachNode.linkIncomingConnections(NodeImpl.CONNECTION_DEFAULT_TYPE, nodeTarget.getId(), NodeImpl.CONNECTION_DEFAULT_TYPE);
-        forEachNode.linkOutgoingConnections(nodeTarget.getId(), NodeImpl.CONNECTION_DEFAULT_TYPE, NodeImpl.CONNECTION_DEFAULT_TYPE);
+        forEachNode.linkIncomingConnections(Node.CONNECTION_DEFAULT_TYPE, nodeTarget.getId(), Node.CONNECTION_DEFAULT_TYPE);
+        forEachNode.linkOutgoingConnections(nodeTarget.getId(), Node.CONNECTION_DEFAULT_TYPE, Node.CONNECTION_DEFAULT_TYPE);
         return forEachNode;
     }
 

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/EndEventHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/EndEventHandler.java
@@ -30,6 +30,7 @@ import org.jbpm.ruleflow.core.Metadata;
 import org.jbpm.workflow.core.DroolsAction;
 import org.jbpm.workflow.core.Node;
 import org.jbpm.workflow.core.impl.DroolsConsequenceAction;
+import org.jbpm.workflow.core.impl.ExtendedNodeImpl;
 import org.jbpm.workflow.core.impl.IOSpecification;
 import org.jbpm.workflow.core.impl.NodeImpl;
 import org.jbpm.workflow.core.node.EndNode;
@@ -166,7 +167,7 @@ public class EndEventHandler extends AbstractNodeHandler {
 
                 List<DroolsAction> actions = new ArrayList<DroolsAction>();
                 actions.add(action);
-                endNode.setActions(EndNode.EVENT_NODE_ENTER, actions);
+                endNode.setActions(ExtendedNodeImpl.EVENT_NODE_ENTER, actions);
             }
             xmlNode = xmlNode.getNextSibling();
         }
@@ -199,7 +200,7 @@ public class EndEventHandler extends AbstractNodeHandler {
                 DroolsConsequenceAction action = createJavaAction(new HandleMessageAction(message.getType(), variable));
 
                 actions.add(action);
-                endNode.setActions(EndNode.EVENT_NODE_ENTER, actions);
+                endNode.setActions(ExtendedNodeImpl.EVENT_NODE_ENTER, actions);
             }
             xmlNode = xmlNode.getNextSibling();
         }

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/EndNodeHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/EndNodeHandler.java
@@ -22,6 +22,7 @@ import org.jbpm.process.core.context.exception.CompensationScope;
 import org.jbpm.workflow.core.DroolsAction;
 import org.jbpm.workflow.core.Node;
 import org.jbpm.workflow.core.impl.DroolsConsequenceAction;
+import org.jbpm.workflow.core.impl.ExtendedNodeImpl;
 import org.jbpm.workflow.core.node.EndNode;
 import org.xml.sax.Attributes;
 
@@ -51,7 +52,7 @@ public class EndNodeHandler extends AbstractNodeHandler {
             endNode("endEvent", xmlDump);
         } else {
             String scope = (String) endNode.getMetaData("customScope");
-            List<DroolsAction> actions = endNode.getActions(EndNode.EVENT_NODE_ENTER);
+            List<DroolsAction> actions = endNode.getActions(ExtendedNodeImpl.EVENT_NODE_ENTER);
             if (actions != null && !actions.isEmpty()) {
                 if (actions.size() == 1) {
                     DroolsConsequenceAction action = (DroolsConsequenceAction) actions.get(0);

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/ProcessHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/ProcessHandler.java
@@ -293,8 +293,8 @@ public class ProcessHandler extends BaseAbstractHandler implements Handler {
                                 throwLink.getUniqueId());
                         if (throwNode != null) {
                             Connection result = new ConnectionImpl(throwNode,
-                                    NodeImpl.CONNECTION_DEFAULT_TYPE, catchNode,
-                                    NodeImpl.CONNECTION_DEFAULT_TYPE);
+                                                                   org.jbpm.workflow.core.Node.CONNECTION_DEFAULT_TYPE, catchNode,
+                                                                   org.jbpm.workflow.core.Node.CONNECTION_DEFAULT_TYPE);
                             result.setMetaData("linkNodeHidden", "yes");
                         }
                     }
@@ -404,8 +404,8 @@ public class ProcessHandler extends BaseAbstractHandler implements Handler {
                 Node target = findNodeByIdOrUniqueIdInMetadata(nodeContainer, targetRef, "Could not find target node for connection:" + targetRef);
 
                 Connection result = new ConnectionImpl(
-                        source, NodeImpl.CONNECTION_DEFAULT_TYPE,
-                        target, NodeImpl.CONNECTION_DEFAULT_TYPE);
+                        source, org.jbpm.workflow.core.Node.CONNECTION_DEFAULT_TYPE,
+                        target, org.jbpm.workflow.core.Node.CONNECTION_DEFAULT_TYPE);
                 result.setMetaData("bendpoints", connection.getBendpoints());
                 result.setMetaData("UniqueId", connection.getId());
 
@@ -413,7 +413,7 @@ public class ProcessHandler extends BaseAbstractHandler implements Handler {
                     NodeImpl nodeImpl = (NodeImpl) source;
                     Constraint constraint = buildConstraint(connection, nodeImpl);
                     if (constraint != null) {
-                        nodeImpl.addConstraint(new ConnectionRef(connection.getId(), target.getId(), NodeImpl.CONNECTION_DEFAULT_TYPE),
+                        nodeImpl.addConstraint(new ConnectionRef(connection.getId(), target.getId(), org.jbpm.workflow.core.Node.CONNECTION_DEFAULT_TYPE),
                                 constraint);
                     }
 
@@ -421,7 +421,7 @@ public class ProcessHandler extends BaseAbstractHandler implements Handler {
                     Split split = (Split) source;
                     Constraint constraint = buildConstraint(connection, split);
                     split.addConstraint(
-                            new ConnectionRef(connection.getId(), target.getId(), NodeImpl.CONNECTION_DEFAULT_TYPE),
+                            new ConnectionRef(connection.getId(), target.getId(), org.jbpm.workflow.core.Node.CONNECTION_DEFAULT_TYPE),
                             constraint);
                 }
             }
@@ -487,14 +487,14 @@ public class ProcessHandler extends BaseAbstractHandler implements Handler {
         }
 
         if (cancelActivity) {
-            List<DroolsAction> actions = ((EventNode) node).getActions(EndNode.EVENT_NODE_EXIT);
+            List<DroolsAction> actions = ((EventNode) node).getActions(ExtendedNodeImpl.EVENT_NODE_EXIT);
             if (actions == null) {
                 actions = new ArrayList<DroolsAction>();
             }
             DroolsConsequenceAction cancelAction = new DroolsConsequenceAction("java", "");
             cancelAction.setMetaData("Action", new CancelNodeInstanceAction(attachedTo));
             actions.add(cancelAction);
-            ((EventNode) node).setActions(EndNode.EVENT_NODE_EXIT, actions);
+            ((EventNode) node).setActions(ExtendedNodeImpl.EVENT_NODE_EXIT, actions);
         }
     }
 
@@ -521,14 +521,14 @@ public class ProcessHandler extends BaseAbstractHandler implements Handler {
             exceptionScope.setExceptionHandler(errorStructureRef, exceptionHandler);
         }
 
-        List<DroolsAction> actions = ((EventNode) node).getActions(EndNode.EVENT_NODE_EXIT);
+        List<DroolsAction> actions = ((EventNode) node).getActions(ExtendedNodeImpl.EVENT_NODE_EXIT);
         if (actions == null) {
             actions = new ArrayList<DroolsAction>();
         }
         DroolsConsequenceAction cancelAction = new DroolsConsequenceAction("java", null);
         cancelAction.setMetaData("Action", new CancelNodeInstanceAction(attachedTo));
         actions.add(cancelAction);
-        ((EventNode) node).setActions(EndNode.EVENT_NODE_EXIT, actions);
+        ((EventNode) node).setActions(ExtendedNodeImpl.EVENT_NODE_EXIT, actions);
     }
 
     private static void linkBoundaryTimerEvent(NodeContainer nodeContainer, Node node, String attachedTo, Node attachedNode) {
@@ -569,13 +569,13 @@ public class ProcessHandler extends BaseAbstractHandler implements Handler {
         }
 
         if (cancelActivity) {
-            List<DroolsAction> actions = ((EventNode) node).getActions(EndNode.EVENT_NODE_EXIT);
+            List<DroolsAction> actions = ((EventNode) node).getActions(ExtendedNodeImpl.EVENT_NODE_EXIT);
             if (actions == null) {
                 actions = new ArrayList<DroolsAction>();
             }
             DroolsConsequenceAction action = createJavaAction(new CancelNodeInstanceAction(attachedTo));
             actions.add(action);
-            ((EventNode) node).setActions(EndNode.EVENT_NODE_EXIT, actions);
+            ((EventNode) node).setActions(ExtendedNodeImpl.EVENT_NODE_EXIT, actions);
         }
     }
 
@@ -601,13 +601,13 @@ public class ProcessHandler extends BaseAbstractHandler implements Handler {
     private static void linkBoundarySignalEvent(NodeContainer nodeContainer, Node node, String attachedTo, Node attachedNode) {
         boolean cancelActivity = (Boolean) node.getMetaData().get("CancelActivity");
         if (cancelActivity) {
-            List<DroolsAction> actions = ((EventNode) node).getActions(EndNode.EVENT_NODE_EXIT);
+            List<DroolsAction> actions = ((EventNode) node).getActions(ExtendedNodeImpl.EVENT_NODE_EXIT);
             if (actions == null) {
                 actions = new ArrayList<DroolsAction>();
             }
             DroolsConsequenceAction action = createJavaAction(new CancelNodeInstanceAction(attachedTo));
             actions.add(action);
-            ((EventNode) node).setActions(EndNode.EVENT_NODE_EXIT, actions);
+            ((EventNode) node).setActions(ExtendedNodeImpl.EVENT_NODE_EXIT, actions);
         }
     }
 
@@ -617,13 +617,13 @@ public class ProcessHandler extends BaseAbstractHandler implements Handler {
         ((EventTypeFilter) ((EventNode) node).getEventFilters().get(0)).setType(eventType);
         boolean cancelActivity = (Boolean) node.getMetaData().get("CancelActivity");
         if (cancelActivity) {
-            List<DroolsAction> actions = ((EventNode) node).getActions(EndNode.EVENT_NODE_EXIT);
+            List<DroolsAction> actions = ((EventNode) node).getActions(ExtendedNodeImpl.EVENT_NODE_EXIT);
             if (actions == null) {
                 actions = new ArrayList<DroolsAction>();
             }
             DroolsConsequenceAction action = createJavaAction(new CancelNodeInstanceAction(attachedTo));
             actions.add(action);
-            ((EventNode) node).setActions(EndNode.EVENT_NODE_EXIT, actions);
+            ((EventNode) node).setActions(ExtendedNodeImpl.EVENT_NODE_EXIT, actions);
         }
     }
 
@@ -674,7 +674,7 @@ public class ProcessHandler extends BaseAbstractHandler implements Handler {
                     }
 
                     // connect boundary event to compensation activity
-                    ConnectionImpl connection = new ConnectionImpl(sourceNode, NodeImpl.CONNECTION_DEFAULT_TYPE, targetNode, NodeImpl.CONNECTION_DEFAULT_TYPE);
+                    ConnectionImpl connection = new ConnectionImpl(sourceNode, org.jbpm.workflow.core.Node.CONNECTION_DEFAULT_TYPE, targetNode, org.jbpm.workflow.core.Node.CONNECTION_DEFAULT_TYPE);
                     connection.setMetaData("UniqueId", null);
                     connection.setMetaData("hidden", true);
                     connection.setMetaData("association", true);
@@ -1095,7 +1095,7 @@ public class ProcessHandler extends BaseAbstractHandler implements Handler {
             } else if (throwEventNode instanceof EndNode) {
                 List<DroolsAction> actions = new ArrayList<>();
                 actions.add(compensationAction);
-                ((EndNode) throwEventNode).setActions(EndNode.EVENT_NODE_ENTER, actions);
+                ((EndNode) throwEventNode).setActions(ExtendedNodeImpl.EVENT_NODE_ENTER, actions);
             }
         }
     }

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/ProcessHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/ProcessHandler.java
@@ -293,8 +293,8 @@ public class ProcessHandler extends BaseAbstractHandler implements Handler {
                                 throwLink.getUniqueId());
                         if (throwNode != null) {
                             Connection result = new ConnectionImpl(throwNode,
-                                                                   org.jbpm.workflow.core.Node.CONNECTION_DEFAULT_TYPE, catchNode,
-                                                                   org.jbpm.workflow.core.Node.CONNECTION_DEFAULT_TYPE);
+                                    org.jbpm.workflow.core.Node.CONNECTION_DEFAULT_TYPE, catchNode,
+                                    org.jbpm.workflow.core.Node.CONNECTION_DEFAULT_TYPE);
                             result.setMetaData("linkNodeHidden", "yes");
                         }
                     }

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/SubProcessHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/SubProcessHandler.java
@@ -25,7 +25,6 @@ import org.jbpm.compiler.xml.Parser;
 import org.jbpm.process.core.context.variable.VariableScope;
 import org.jbpm.workflow.core.Node;
 import org.jbpm.workflow.core.NodeContainer;
-import org.jbpm.workflow.core.impl.NodeImpl;
 import org.jbpm.workflow.core.node.CompositeContextNode;
 import org.jbpm.workflow.core.node.EventSubProcessNode;
 import org.jbpm.workflow.core.node.ForEachNode;
@@ -117,7 +116,7 @@ public class SubProcessHandler extends AbstractNodeHandler {
     protected void applyAsync(Node node, boolean isAsync) {
         for (org.kie.api.definition.process.Node subNode : ((CompositeContextNode) node).getNodes()) {
             if (isAsync) {
-                List<Connection> incoming = subNode.getIncomingConnections(NodeImpl.CONNECTION_DEFAULT_TYPE);
+                List<Connection> incoming = subNode.getIncomingConnections(Node.CONNECTION_DEFAULT_TYPE);
                 if (incoming != null) {
                     for (Connection con : incoming) {
                         if (con.getFrom() instanceof StartNode) {

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/XmlWorkflowProcessDumper.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/XmlWorkflowProcessDumper.java
@@ -33,7 +33,6 @@ import org.jbpm.process.core.datatype.DataType;
 import org.jbpm.process.core.datatype.impl.type.ObjectDataType;
 import org.jbpm.workflow.core.DroolsAction;
 import org.jbpm.workflow.core.Node;
-import org.jbpm.workflow.core.impl.NodeImpl;
 import org.kie.api.definition.process.Connection;
 import org.kie.api.definition.process.WorkflowProcess;
 
@@ -248,11 +247,11 @@ public class XmlWorkflowProcessDumper {
 
     public void visitConnection(Connection connection, StringBuilder xmlDump, boolean includeMeta) {
         xmlDump.append("    <connection from=\"" + connection.getFrom().getId() + "\" ");
-        if (!NodeImpl.CONNECTION_DEFAULT_TYPE.equals(connection.getFromType())) {
+        if (!Node.CONNECTION_DEFAULT_TYPE.equals(connection.getFromType())) {
             xmlDump.append("fromType=\"" + connection.getFromType() + "\" ");
         }
         xmlDump.append("to=\"" + connection.getTo().getId() + "\" ");
-        if (!NodeImpl.CONNECTION_DEFAULT_TYPE.equals(connection.getToType())) {
+        if (!Node.CONNECTION_DEFAULT_TYPE.equals(connection.getToType())) {
             xmlDump.append("toType=\"" + connection.getToType() + "\" ");
         }
         if (includeMeta) {

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/processes/ConnectionHandler.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/processes/ConnectionHandler.java
@@ -23,7 +23,6 @@ import org.jbpm.compiler.xml.core.BaseAbstractHandler;
 import org.jbpm.workflow.core.Connection;
 import org.jbpm.workflow.core.NodeContainer;
 import org.jbpm.workflow.core.impl.ConnectionImpl;
-import org.jbpm.workflow.core.impl.NodeImpl;
 import org.kie.api.definition.process.Node;
 import org.w3c.dom.Element;
 import org.xml.sax.Attributes;
@@ -57,11 +56,11 @@ public class ConnectionHandler extends BaseAbstractHandler implements Handler {
 
         String fromType = attrs.getValue("fromType");
         if (fromType == null || fromType.trim().length() == 0) {
-            fromType = NodeImpl.CONNECTION_DEFAULT_TYPE;
+            fromType = org.jbpm.workflow.core.Node.CONNECTION_DEFAULT_TYPE;
         }
         String toType = attrs.getValue("toType");
         if (toType == null || toType.trim().length() == 0) {
-            toType = NodeImpl.CONNECTION_DEFAULT_TYPE;
+            toType = org.jbpm.workflow.core.Node.CONNECTION_DEFAULT_TYPE;
         }
 
         NodeContainer nodeContainer = (NodeContainer) parser.getParent();

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/processes/ConstraintHandler.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/processes/ConstraintHandler.java
@@ -21,9 +21,9 @@ import org.jbpm.compiler.xml.Handler;
 import org.jbpm.compiler.xml.Parser;
 import org.jbpm.compiler.xml.core.BaseAbstractHandler;
 import org.jbpm.workflow.core.Constraint;
+import org.jbpm.workflow.core.Node;
 import org.jbpm.workflow.core.impl.ConnectionRef;
 import org.jbpm.workflow.core.impl.ConstraintImpl;
-import org.jbpm.workflow.core.impl.NodeImpl;
 import org.jbpm.workflow.core.node.Constrainable;
 import org.w3c.dom.Element;
 import org.w3c.dom.Text;
@@ -67,7 +67,7 @@ public class ConstraintHandler extends BaseAbstractHandler implements Handler {
         if (toNodeIdString != null && toNodeIdString.trim().length() > 0) {
             int toNodeId = new Integer(toNodeIdString);
             if (toType == null || toType.trim().length() == 0) {
-                toType = NodeImpl.CONNECTION_DEFAULT_TYPE;
+                toType = Node.CONNECTION_DEFAULT_TYPE;
             }
             connectionRef = new ConnectionRef(toNodeId, toType);
         }

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/processes/ExceptionHandlerHandler.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/processes/ExceptionHandlerHandler.java
@@ -70,7 +70,7 @@ public class ExceptionHandlerHandler extends BaseAbstractHandler implements Hand
             org.w3c.dom.Node xmlNode = element.getFirstChild();
             if (xmlNode instanceof Element) {
                 Element actionXml = (Element) xmlNode;
-                DroolsAction action = ActionNodeHandler.extractAction(actionXml);
+                DroolsAction action = AbstractNodeHandler.extractAction(actionXml);
                 ((ActionExceptionHandler) exceptionHandler).setAction(action);
             }
         } else {

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/ProcessInstanceImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/ProcessInstanceImpl.java
@@ -32,6 +32,7 @@ import org.jbpm.process.instance.ProcessInstance;
 import org.jbpm.workflow.core.WorkflowProcess;
 import org.kie.api.definition.process.Process;
 import org.kie.api.runtime.rule.Agenda;
+import org.kie.kogito.internal.process.runtime.KogitoProcessInstance;
 
 /**
  * Default implementation of a process instance.
@@ -249,10 +250,10 @@ public abstract class ProcessInstanceImpl implements ProcessInstance,
     @Override
     public void start(String trigger) {
         synchronized (this) {
-            if (getState() != ProcessInstanceImpl.STATE_PENDING) {
+            if (getState() != KogitoProcessInstance.STATE_PENDING) {
                 throw new IllegalArgumentException("A process instance can only be started once");
             }
-            setState(ProcessInstanceImpl.STATE_ACTIVE);
+            setState(KogitoProcessInstance.STATE_ACTIVE);
             internalStart(trigger);
         }
     }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/validation/RuleFlowProcessValidator.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/validation/RuleFlowProcessValidator.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 
-import org.drools.core.time.impl.CronExpression;
+import org.drools.core.time.impl.KieCronExpression;
 import org.jbpm.process.core.ContextContainer;
 import org.jbpm.process.core.Work;
 import org.jbpm.process.core.context.exception.CompensationScope;
@@ -78,6 +78,7 @@ import org.kie.api.definition.process.Connection;
 import org.kie.api.definition.process.NodeContainer;
 import org.kie.api.definition.process.Process;
 import org.kie.api.io.Resource;
+import org.kie.kogito.internal.process.runtime.KogitoWorkflowProcess;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -989,7 +990,7 @@ public class RuleFlowProcessValidator implements ProcessValidator {
                 try {
                     switch (timer.getTimeType()) {
                         case Timer.TIME_CYCLE:
-                            if (!CronExpression.isValidExpression(timer.getDelay())) {
+                            if (!KieCronExpression.isValidExpression(timer.getDelay())) {
                                 // when using ISO date/time period is not set
                                 DateTimeUtils.parseRepeatableDateTime(timer.getDelay());
                             }
@@ -1013,7 +1014,7 @@ public class RuleFlowProcessValidator implements ProcessValidator {
         }
         if (timer.getPeriod() != null && !timer.getPeriod().contains("#{")) {
             try {
-                if (!CronExpression.isValidExpression(timer.getPeriod())) {
+                if (!KieCronExpression.isValidExpression(timer.getPeriod())) {
                     // when using ISO date/time period is not set
                     DateTimeUtils.parseRepeatableDateTime(timer.getPeriod());
                 }
@@ -1150,7 +1151,7 @@ public class RuleFlowProcessValidator implements ProcessValidator {
 
     @Override
     public boolean accept(Process process, Resource resource) {
-        return RuleFlowProcess.BPMN_TYPE.equals(process.getType()) || RuleFlowProcess.RULEFLOW_TYPE.equals(process.getType());
+        return KogitoWorkflowProcess.BPMN_TYPE.equals(process.getType()) || KogitoWorkflowProcess.RULEFLOW_TYPE.equals(process.getType());
     }
 
     protected void validateCompensationIntermediateOrEndEvent(org.kie.api.definition.process.Node node,

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/AsyncEventNodeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/AsyncEventNodeInstance.java
@@ -21,7 +21,6 @@ import java.util.Objects;
 import java.util.Optional;
 
 import org.jbpm.process.instance.InternalProcessRuntime;
-import org.jbpm.workflow.core.impl.NodeImpl;
 import org.jbpm.workflow.instance.NodeInstanceContainer;
 import org.jbpm.workflow.instance.node.EventNodeInstance;
 import org.kie.api.definition.process.Node;
@@ -164,7 +163,7 @@ public class AsyncEventNodeInstance extends EventNodeInstance {
 
         NodeInstance actualInstance = instanceContainer.getNodeInstance(getNode());
         //trigger the actual node
-        triggerNodeInstance((org.jbpm.workflow.instance.NodeInstance) actualInstance, NodeImpl.CONNECTION_DEFAULT_TYPE);
+        triggerNodeInstance((org.jbpm.workflow.instance.NodeInstance) actualInstance, org.jbpm.workflow.core.Node.CONNECTION_DEFAULT_TYPE);
         clearAsyncStatus();
     }
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/NodeInstanceImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/NodeInstanceImpl.java
@@ -36,7 +36,6 @@ import org.jbpm.process.core.context.variable.VariableScope;
 import org.jbpm.process.instance.ContextInstance;
 import org.jbpm.process.instance.ContextInstanceContainer;
 import org.jbpm.process.instance.InternalProcessRuntime;
-import org.jbpm.process.instance.ProcessInstance;
 import org.jbpm.process.instance.context.exception.ExceptionScopeInstance;
 import org.jbpm.process.instance.context.exclusive.ExclusiveGroupInstance;
 import org.jbpm.process.instance.context.variable.VariableScopeInstance;
@@ -56,6 +55,7 @@ import org.kie.kogito.internal.process.runtime.KogitoNode;
 import org.kie.kogito.internal.process.runtime.KogitoNodeInstance;
 import org.kie.kogito.internal.process.runtime.KogitoNodeInstanceContainer;
 import org.kie.kogito.internal.process.runtime.KogitoProcessContext;
+import org.kie.kogito.internal.process.runtime.KogitoProcessInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -81,7 +81,7 @@ public abstract class NodeInstanceImpl implements org.jbpm.workflow.instance.Nod
     private Map<String, Object> metaData = new HashMap<>();
     private int level;
 
-    protected int slaCompliance = ProcessInstance.SLA_NA;
+    protected int slaCompliance = KogitoProcessInstance.SLA_NA;
     protected Date slaDueDate;
     protected String slaTimerId;
     protected Date triggerTime;

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/DynamicUtils.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/DynamicUtils.java
@@ -38,6 +38,7 @@ import org.kie.api.runtime.ExecutableRunner;
 import org.kie.api.runtime.KieRuntime;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.process.NodeInstance;
+import org.kie.api.runtime.process.WorkItem;
 import org.kie.internal.KieInternalServices;
 import org.kie.internal.command.RegistryContext;
 import org.kie.internal.process.CorrelationKey;
@@ -47,7 +48,6 @@ import org.kie.internal.runtime.StatefulKnowledgeSession;
 import org.kie.kogito.internal.process.event.KogitoProcessEventSupport;
 import org.kie.kogito.internal.process.runtime.KogitoProcessInstance;
 import org.kie.kogito.internal.process.runtime.KogitoProcessRuntime;
-import org.kie.kogito.internal.process.runtime.KogitoWorkItem;
 import org.kie.kogito.process.workitems.InternalKogitoWorkItemManager;
 import org.kie.kogito.process.workitems.impl.KogitoWorkItemImpl;
 import org.slf4j.Logger;
@@ -91,7 +91,7 @@ public class DynamicUtils {
             String workItemName,
             Map<String, Object> parameters) {
         final KogitoWorkItemImpl workItem = new KogitoWorkItemImpl();
-        workItem.setState(KogitoWorkItem.ACTIVE);
+        workItem.setState(WorkItem.ACTIVE);
         workItem.setProcessInstanceId(processInstance.getStringId());
         workItem.setDeploymentId((String) ksession.getEnvironment().get(EnvironmentName.DEPLOYMENT_ID));
         workItem.setName(workItemName);

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/EventNodeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/EventNodeInstance.java
@@ -27,7 +27,6 @@ import java.util.regex.Matcher;
 import org.jbpm.process.core.context.variable.Variable;
 import org.jbpm.process.core.context.variable.VariableScope;
 import org.jbpm.process.instance.InternalProcessRuntime;
-import org.jbpm.process.instance.ProcessInstance;
 import org.jbpm.util.PatternConstants;
 import org.jbpm.workflow.core.Node;
 import org.jbpm.workflow.core.impl.NodeIoHelper;
@@ -37,6 +36,7 @@ import org.jbpm.workflow.instance.impl.ExtendedNodeInstanceImpl;
 import org.jbpm.workflow.instance.impl.WorkflowProcessInstanceImpl;
 import org.kie.kogito.internal.process.event.KogitoEventListener;
 import org.kie.kogito.internal.process.runtime.KogitoNodeInstance;
+import org.kie.kogito.internal.process.runtime.KogitoProcessInstance;
 import org.kie.kogito.jobs.JobsService;
 import org.kie.kogito.process.BaseEventDescription;
 import org.kie.kogito.process.EventDescription;
@@ -93,18 +93,18 @@ public class EventNodeInstance extends ExtendedNodeInstanceImpl implements Kogit
             if (timer != null) {
                 this.slaTimerId = timer.getId();
                 this.slaDueDate = new Date(System.currentTimeMillis() + timer.getDelay());
-                this.slaCompliance = ProcessInstance.SLA_PENDING;
+                this.slaCompliance = KogitoProcessInstance.SLA_PENDING;
                 logger.debug("SLA for node instance {} is PENDING with due date {}", this.getStringId(), this.slaDueDate);
             }
         }
     }
 
     protected void handleSLAViolation() {
-        if (slaCompliance == ProcessInstance.SLA_PENDING) {
+        if (slaCompliance == KogitoProcessInstance.SLA_PENDING) {
             InternalProcessRuntime processRuntime = ((InternalProcessRuntime) getProcessInstance().getKnowledgeRuntime().getProcessRuntime());
             processRuntime.getProcessEventSupport().fireBeforeSLAViolated(getProcessInstance(), this, getProcessInstance().getKnowledgeRuntime());
             logger.debug("SLA violated on node instance {}", getStringId());
-            this.slaCompliance = ProcessInstance.SLA_VIOLATED;
+            this.slaCompliance = KogitoProcessInstance.SLA_VIOLATED;
             this.slaTimerId = null;
             processRuntime.getProcessEventSupport().fireAfterSLAViolated(getProcessInstance(), this, getProcessInstance().getKnowledgeRuntime());
         }
@@ -138,12 +138,12 @@ public class EventNodeInstance extends ExtendedNodeInstanceImpl implements Kogit
     public void triggerCompleted() {
         getProcessInstance().removeEventListener(getEventType(), getEventListener(), true);
         removeTimerListeners();
-        if (this.slaCompliance == ProcessInstance.SLA_PENDING) {
+        if (this.slaCompliance == KogitoProcessInstance.SLA_PENDING) {
             if (System.currentTimeMillis() > slaDueDate.getTime()) {
                 // completion of the node instance is after expected SLA due date, mark it accordingly
-                this.slaCompliance = ProcessInstance.SLA_VIOLATED;
+                this.slaCompliance = KogitoProcessInstance.SLA_VIOLATED;
             } else {
-                this.slaCompliance = ProcessInstance.STATE_COMPLETED;
+                this.slaCompliance = KogitoProcessInstance.STATE_COMPLETED;
             }
         }
         cancelSlaTimer();
@@ -155,12 +155,12 @@ public class EventNodeInstance extends ExtendedNodeInstanceImpl implements Kogit
     public void cancel() {
         getProcessInstance().removeEventListener(getEventType(), getEventListener(), true);
         removeTimerListeners();
-        if (this.slaCompliance == ProcessInstance.SLA_PENDING) {
+        if (this.slaCompliance == KogitoProcessInstance.SLA_PENDING) {
             if (System.currentTimeMillis() > slaDueDate.getTime()) {
                 // completion of the process instance is after expected SLA due date, mark it accordingly
-                this.slaCompliance = ProcessInstance.SLA_VIOLATED;
+                this.slaCompliance = KogitoProcessInstance.SLA_VIOLATED;
             } else {
-                this.slaCompliance = ProcessInstance.SLA_ABORTED;
+                this.slaCompliance = KogitoProcessInstance.SLA_ABORTED;
             }
         }
         removeTimerListeners();

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/EventSubProcessNodeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/EventSubProcessNodeInstance.java
@@ -26,6 +26,7 @@ import org.jbpm.workflow.instance.NodeInstanceContainer;
 import org.kie.api.definition.process.NodeContainer;
 import org.kie.api.runtime.process.NodeInstance;
 import org.kie.kogito.internal.process.runtime.KogitoNodeInstance;
+import org.kie.kogito.internal.process.runtime.KogitoProcessInstance;
 
 public class EventSubProcessNodeInstance extends CompositeContextNodeInstance {
 
@@ -77,9 +78,9 @@ public class EventSubProcessNodeInstance extends CompositeContextNodeInstance {
                         faultName = (String) startNode.getMetaData("FaultCode");
                     }
                     if (getNodeInstanceContainer() instanceof ProcessInstance) {
-                        ((ProcessInstance) getProcessInstance()).setState(ProcessInstance.STATE_ABORTED, faultName);
+                        ((ProcessInstance) getProcessInstance()).setState(KogitoProcessInstance.STATE_ABORTED, faultName);
                     } else {
-                        ((NodeInstanceContainer) getNodeInstanceContainer()).setState(ProcessInstance.STATE_ABORTED);
+                        ((NodeInstanceContainer) getNodeInstanceContainer()).setState(KogitoProcessInstance.STATE_ABORTED);
                     }
 
                 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/FaultNodeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/FaultNodeInstance.java
@@ -33,6 +33,7 @@ import org.jbpm.workflow.instance.impl.NodeInstanceImpl;
 import org.kie.api.runtime.process.NodeInstance;
 import org.kie.api.runtime.process.WorkflowProcessInstance;
 import org.kie.kogito.internal.process.runtime.KogitoNodeInstance;
+import org.kie.kogito.internal.process.runtime.KogitoProcessInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -99,7 +100,7 @@ public class FaultNodeInstance extends NodeInstanceImpl {
             }
         } else {
 
-            ((ProcessInstance) getProcessInstance()).setState(ProcessInstance.STATE_ABORTED, faultName, getFaultData());
+            ((ProcessInstance) getProcessInstance()).setState(KogitoProcessInstance.STATE_ABORTED, faultName, getFaultData());
 
         }
     }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/LambdaSubProcessNodeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/LambdaSubProcessNodeInstance.java
@@ -40,6 +40,7 @@ import org.jbpm.workflow.core.node.SubProcessFactory;
 import org.jbpm.workflow.core.node.SubProcessNode;
 import org.kie.kogito.internal.process.event.KogitoEventListener;
 import org.kie.kogito.internal.process.runtime.KogitoNodeInstance;
+import org.kie.kogito.internal.process.runtime.KogitoProcessInstance;
 import org.kie.kogito.internal.process.runtime.KogitoProcessRuntime;
 import org.kie.kogito.process.impl.AbstractProcessInstance;
 
@@ -96,7 +97,7 @@ public class LambdaSubProcessNodeInstance extends StateBasedNodeInstance impleme
 
         if (!getSubProcessNode().isWaitForCompletion()) {
             triggerCompleted();
-        } else if (processInstance.status() == ProcessInstance.STATE_COMPLETED || processInstance.status() == ProcessInstance.STATE_ABORTED) {
+        } else if (processInstance.status() == KogitoProcessInstance.STATE_COMPLETED || processInstance.status() == KogitoProcessInstance.STATE_ABORTED) {
             processInstanceCompleted((ProcessInstanceImpl) pi);
         } else {
             addProcessListener();
@@ -121,7 +122,7 @@ public class LambdaSubProcessNodeInstance extends StateBasedNodeInstance impleme
             processInstance = (ProcessInstance) kruntime.getProcessInstance(processInstanceId);
 
             if (processInstance != null) {
-                processInstance.setState(ProcessInstance.STATE_ABORTED);
+                processInstance.setState(KogitoProcessInstance.STATE_ABORTED);
             }
         }
     }
@@ -171,7 +172,7 @@ public class LambdaSubProcessNodeInstance extends StateBasedNodeInstance impleme
     public void processInstanceCompleted(ProcessInstance processInstance) {
         removeEventListeners();
         handleOutMappings(processInstance);
-        if (processInstance.getState() == ProcessInstance.STATE_ABORTED) {
+        if (processInstance.getState() == KogitoProcessInstance.STATE_ABORTED) {
             String faultName = processInstance.getOutcome() == null ? "" : processInstance.getOutcome();
             // handle exception as sub process failed with error code
             ExceptionScopeInstance exceptionScopeInstance = (ExceptionScopeInstance) resolveContextInstance(ExceptionScope.EXCEPTION_SCOPE, faultName);
@@ -187,7 +188,7 @@ public class LambdaSubProcessNodeInstance extends StateBasedNodeInstance impleme
                 }
                 return;
             } else if (getSubProcessNode() != null && !getSubProcessNode().isIndependent() && getSubProcessNode().isAbortParent()) {
-                getProcessInstance().setState(ProcessInstance.STATE_ABORTED, faultName);
+                getProcessInstance().setState(KogitoProcessInstance.STATE_ABORTED, faultName);
                 return;
             }
 

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/SplitInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/SplitInstance.java
@@ -28,7 +28,6 @@ import org.drools.core.common.InternalKnowledgeRuntime;
 import org.jbpm.process.core.context.exclusive.ExclusiveGroup;
 import org.jbpm.process.instance.ContextInstanceContainer;
 import org.jbpm.process.instance.InternalProcessRuntime;
-import org.jbpm.process.instance.ProcessInstance;
 import org.jbpm.process.instance.context.exclusive.ExclusiveGroupInstance;
 import org.jbpm.process.instance.impl.ConstraintEvaluator;
 import org.jbpm.workflow.core.Node;
@@ -38,6 +37,7 @@ import org.jbpm.workflow.instance.WorkflowRuntimeException;
 import org.jbpm.workflow.instance.impl.NodeInstanceImpl;
 import org.kie.api.definition.process.Connection;
 import org.kie.kogito.internal.process.runtime.KogitoNodeInstance;
+import org.kie.kogito.internal.process.runtime.KogitoProcessInstance;
 
 /**
  * Runtime counterpart of a split node.
@@ -154,7 +154,7 @@ public class SplitInstance extends NodeInstanceImpl {
 
                 for (NodeInstanceTrigger nodeInstance : nodeInstances) {
                     // stop if this process instance has been aborted / completed
-                    if (getProcessInstance().getState() != ProcessInstance.STATE_ACTIVE) {
+                    if (getProcessInstance().getState() != KogitoProcessInstance.STATE_ACTIVE) {
                         return;
                     }
                     triggerNodeInstance(nodeInstance.getNodeInstance(), nodeInstance.getToType());
@@ -202,7 +202,7 @@ public class SplitInstance extends NodeInstanceImpl {
                     }
                     for (Map.Entry<org.jbpm.workflow.instance.NodeInstance, String> entry : nodeInstancesMap.entrySet()) {
                         // stop if this process instance has been aborted / completed
-                        if (getProcessInstance().getState() != ProcessInstance.STATE_ACTIVE) {
+                        if (getProcessInstance().getState() != KogitoProcessInstance.STATE_ACTIVE) {
                             return;
                         }
                         boolean hidden = false;

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/StateNodeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/StateNodeInstance.java
@@ -18,8 +18,8 @@ package org.jbpm.workflow.instance.node;
 import org.drools.core.common.InternalAgenda;
 import org.drools.core.rule.consequence.Activation;
 import org.jbpm.workflow.core.Constraint;
+import org.jbpm.workflow.core.Node;
 import org.jbpm.workflow.core.impl.ExtendedNodeImpl;
-import org.jbpm.workflow.core.impl.NodeImpl;
 import org.jbpm.workflow.core.node.StateNode;
 import org.jbpm.workflow.instance.NodeInstanceContainer;
 import org.kie.api.definition.process.Connection;
@@ -46,7 +46,7 @@ public class StateNodeInstance extends CompositeContextNodeInstance implements E
         StateNode stateNode = getStateNode();
         Connection selected = null;
         int priority = Integer.MAX_VALUE;
-        for (Connection connection : stateNode.getOutgoingConnections(NodeImpl.CONNECTION_DEFAULT_TYPE)) {
+        for (Connection connection : stateNode.getOutgoingConnections(Node.CONNECTION_DEFAULT_TYPE)) {
             Constraint constraint = stateNode.getConstraint(connection);
             if (constraint != null && constraint.getPriority() < priority) {
                 String rule = "RuleFlowStateNode-" + getProcessInstance().getProcessId() + "-" +
@@ -77,7 +77,7 @@ public class StateNodeInstance extends CompositeContextNodeInstance implements E
     public void signalEvent(String type, Object event) {
         if ("signal".equals(type)) {
             if (event instanceof String) {
-                for (Connection connection : getStateNode().getOutgoingConnections(NodeImpl.CONNECTION_DEFAULT_TYPE)) {
+                for (Connection connection : getStateNode().getOutgoingConnections(Node.CONNECTION_DEFAULT_TYPE)) {
                     boolean selected = false;
                     Constraint constraint = getStateNode().getConstraint(connection);
                     if (constraint == null) {
@@ -137,7 +137,7 @@ public class StateNodeInstance extends CompositeContextNodeInstance implements E
 
     public void activationCreated(MatchCreatedEvent event) {
         Connection selected = null;
-        for (Connection connection : getNode().getOutgoingConnections(NodeImpl.CONNECTION_DEFAULT_TYPE)) {
+        for (Connection connection : getNode().getOutgoingConnections(Node.CONNECTION_DEFAULT_TYPE)) {
             Constraint constraint = getStateNode().getConstraint(connection);
             if (constraint != null) {
                 String constraintName = getActivationEventType() + "-"

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/SubProcessNodeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/SubProcessNodeInstance.java
@@ -44,6 +44,7 @@ import org.kie.internal.process.CorrelationAwareProcessRuntime;
 import org.kie.internal.process.CorrelationKey;
 import org.kie.internal.process.CorrelationKeyFactory;
 import org.kie.kogito.internal.process.runtime.KogitoNodeInstance;
+import org.kie.kogito.internal.process.runtime.KogitoProcessInstance;
 import org.kie.kogito.internal.process.runtime.KogitoProcessRuntime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -104,7 +105,7 @@ public class SubProcessNodeInstance extends StateBasedNodeInstance implements Ev
         if (process == null) {
             logger.error("Could not find process {}", processId);
             logger.error("Aborting process");
-            getProcessInstance().setState(ProcessInstance.STATE_ABORTED);
+            getProcessInstance().setState(KogitoProcessInstance.STATE_ABORTED);
             throw new RuntimeException("Could not find process " + processId);
         } else {
             KogitoProcessRuntime kruntime = InternalProcessRuntime.asKogitoProcessRuntime(getProcessInstance().getKnowledgeRuntime());
@@ -141,8 +142,8 @@ public class SubProcessNodeInstance extends StateBasedNodeInstance implements Ev
             kruntime.startProcessInstance(processInstance.getStringId());
             if (!getSubProcessNode().isWaitForCompletion()) {
                 triggerCompleted();
-            } else if (processInstance.getState() == ProcessInstance.STATE_COMPLETED
-                    || processInstance.getState() == ProcessInstance.STATE_ABORTED) {
+            } else if (processInstance.getState() == KogitoProcessInstance.STATE_COMPLETED
+                    || processInstance.getState() == KogitoProcessInstance.STATE_ABORTED) {
                 processInstanceCompleted(processInstance);
             } else {
                 addProcessListener();
@@ -159,7 +160,7 @@ public class SubProcessNodeInstance extends StateBasedNodeInstance implements Ev
             ProcessInstance processInstance = (ProcessInstance) kruntime.getProcessInstance(processInstanceId);
 
             if (processInstance != null) {
-                processInstance.setState(ProcessInstance.STATE_ABORTED);
+                processInstance.setState(KogitoProcessInstance.STATE_ABORTED);
             }
         }
     }
@@ -206,7 +207,7 @@ public class SubProcessNodeInstance extends StateBasedNodeInstance implements Ev
         Map<String, Object> outputSet = processInstance.getVariables();
         NodeIoHelper.processOutputs(this, varRef -> outputSet.get(varRef), varName -> this.getVariable(varName));
 
-        if (processInstance.getState() == ProcessInstance.STATE_ABORTED) {
+        if (processInstance.getState() == KogitoProcessInstance.STATE_ABORTED) {
             String faultName = processInstance.getOutcome() == null ? "" : processInstance.getOutcome();
             // handle exception as sub process failed with error code
             ExceptionScopeInstance exceptionScopeInstance = (ExceptionScopeInstance) resolveContextInstance(ExceptionScope.EXCEPTION_SCOPE, faultName);
@@ -223,7 +224,7 @@ public class SubProcessNodeInstance extends StateBasedNodeInstance implements Ev
                 }
                 return;
             } else if (getSubProcessNode() != null && !getSubProcessNode().isIndependent() && getSubProcessNode().isAbortParent()) {
-                getProcessInstance().setState(ProcessInstance.STATE_ABORTED, faultName);
+                getProcessInstance().setState(KogitoProcessInstance.STATE_ABORTED, faultName);
                 return;
             }
         }

--- a/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/AbstractKieMojo.java
+++ b/kogito-maven-plugin/src/main/java/org/kie/kogito/maven/plugin/AbstractKieMojo.java
@@ -32,6 +32,7 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.drools.codegen.common.AppPaths;
+import org.drools.codegen.common.DroolsModelBuildContext;
 import org.drools.codegen.common.GeneratedFile;
 import org.kie.kogito.KogitoGAV;
 import org.kie.kogito.codegen.api.Generator;
@@ -143,7 +144,7 @@ public abstract class AbstractKieMojo extends AbstractMojo {
     }
 
     protected String appPackageName() {
-        return KogitoBuildContext.DEFAULT_PACKAGE_NAME;
+        return DroolsModelBuildContext.DEFAULT_PACKAGE_NAME;
     }
 
     private void additionalProperties(KogitoBuildContext context) {
@@ -151,13 +152,13 @@ public abstract class AbstractKieMojo extends AbstractMojo {
         classToCheckForREST().ifPresent(restClass -> {
             if (!context.hasClassAvailable(restClass)) {
                 getLog().info("Disabling REST generation because class '" + restClass + "' is not available");
-                context.setApplicationProperty(KogitoBuildContext.KOGITO_GENERATE_REST, "false");
+                context.setApplicationProperty(DroolsModelBuildContext.KOGITO_GENERATE_REST, "false");
             }
         });
         classToCheckForDI().ifPresent(diClass -> {
             if (!context.hasClassAvailable(diClass)) {
                 getLog().info("Disabling dependency injection generation because class '" + diClass + "' is not available");
-                context.setApplicationProperty(KogitoBuildContext.KOGITO_GENERATE_DI, "false");
+                context.setApplicationProperty(DroolsModelBuildContext.KOGITO_GENERATE_DI, "false");
             }
         });
 

--- a/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoAssetsProcessor.java
+++ b/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoAssetsProcessor.java
@@ -31,6 +31,7 @@ import java.util.stream.Stream;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import org.drools.codegen.common.DroolsModelBuildContext;
 import org.drools.codegen.common.GeneratedFile;
 import org.drools.codegen.common.GeneratedFileType;
 import org.jboss.jandex.DotName;
@@ -242,7 +243,7 @@ public class KogitoAssetsProcessor {
         // disable REST if OptaPlanner capability is available but REST is not (user can override via property)
         if (hasOptaPlannerCapability && !hasRestCapabilities &&
                 kogitoGenerateRest(context).isEmpty()) {
-            context.setApplicationProperty(KogitoBuildContext.KOGITO_GENERATE_REST, "false");
+            context.setApplicationProperty(DroolsModelBuildContext.KOGITO_GENERATE_REST, "false");
             LOGGER.info("Disabling Kogito REST generation because OptaPlanner extension is available, specify `kogito.generate.rest = true` to re-enable it");
         }
 
@@ -252,7 +253,7 @@ public class KogitoAssetsProcessor {
     }
 
     private Optional<Boolean> kogitoGenerateRest(KogitoBuildContext context) {
-        return context.getApplicationProperty(KogitoBuildContext.KOGITO_GENERATE_REST)
+        return context.getApplicationProperty(DroolsModelBuildContext.KOGITO_GENERATE_REST)
                 .map("true"::equalsIgnoreCase);
     }
 

--- a/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoQuarkusResourceUtils.java
+++ b/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoQuarkusResourceUtils.java
@@ -28,6 +28,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.drools.codegen.common.AppPaths;
+import org.drools.codegen.common.DroolsModelBuildContext;
 import org.drools.codegen.common.GeneratedFile;
 import org.drools.codegen.common.GeneratedFileType;
 import org.drools.util.PortablePath;
@@ -100,11 +101,11 @@ public class KogitoQuarkusResourceUtils {
 
         if (!context.hasClassAvailable(QuarkusKogitoBuildContext.QUARKUS_REST)) {
             LOGGER.info("Disabling REST generation because class '" + QuarkusKogitoBuildContext.QUARKUS_REST + "' is not available");
-            context.setApplicationProperty(KogitoBuildContext.KOGITO_GENERATE_REST, "false");
+            context.setApplicationProperty(DroolsModelBuildContext.KOGITO_GENERATE_REST, "false");
         }
         if (!context.hasClassAvailable(QuarkusKogitoBuildContext.QUARKUS_DI)) {
             LOGGER.info("Disabling dependency injection generation because class '" + QuarkusKogitoBuildContext.QUARKUS_DI + "' is not available");
-            context.setApplicationProperty(KogitoBuildContext.KOGITO_GENERATE_DI, "false");
+            context.setApplicationProperty(DroolsModelBuildContext.KOGITO_GENERATE_DI, "false");
         }
         return context;
     }

--- a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes/src/main/java/org/kie/kogito/core/process/incubation/quarkus/support/HumanTaskServiceImpl.java
+++ b/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes/src/main/java/org/kie/kogito/core/process/incubation/quarkus/support/HumanTaskServiceImpl.java
@@ -33,6 +33,7 @@ import org.kie.kogito.auth.SecurityPolicy;
 import org.kie.kogito.incubation.common.*;
 import org.kie.kogito.incubation.processes.*;
 import org.kie.kogito.incubation.processes.services.contexts.Policy;
+import org.kie.kogito.incubation.processes.services.contexts.ProcessMetaDataContext;
 import org.kie.kogito.incubation.processes.services.contexts.TaskMetaDataContext;
 import org.kie.kogito.incubation.processes.services.humantask.HumanTaskService;
 import org.kie.kogito.internal.process.runtime.KogitoNode;
@@ -104,7 +105,7 @@ class HumanTaskServiceImpl implements HumanTaskService {
                 .orElseThrow();
 
         MapDataContext dataContext = MapDataContext.from(workItem);
-        return ExtendedDataContext.of(TaskMetaDataContext.of(taskId), dataContext);
+        return ExtendedDataContext.of(ProcessMetaDataContext.of(taskId), dataContext);
     }
 
     @Override


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-7952

Goal here is to reduce the number of code smells in Kogito-runtimes.

Addressed in this PR is the code smell, (Java) "Static" base class members should not be accessed via derived types (78)
https://sonarcloud.io/project/issues?resolved=false&rules=java%3AS3252&id=org.kie.kogito%3Akogito-runtimes

I have remedied this by always addressing the static member directly, rather than a derived type's name.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

<b>Jenkins retest this</b>

</details>
