### PR TITLE
Kogito-7942 Sonarcloud - (Java) Sections of code should not be commented out (38)

### DIFF
--- a/api/kogito-api-incubation-processes/src/main/java/org/kie/kogito/incubation/processes/ProcessIdParser.java
+++ b/api/kogito-api-incubation-processes/src/main/java/org/kie/kogito/incubation/processes/ProcessIdParser.java
@@ -130,7 +130,7 @@ public final class ProcessIdParser {
     }
 
     public static <T extends LocalId> T select(LocalId id, Class<T> expected) {
-        // the proper way to do this is by "visiting" the structured value;
+        // the proper way to do this is by "visiting" the structured value
         // we are taking this as a shortcut for now
         return parse(id.asLocalUri().path(), expected);
     }

--- a/api/kogito-timer/src/main/java/org/kie/kogito/timer/impl/CronExpression.java
+++ b/api/kogito-timer/src/main/java/org/kie/kogito/timer/impl/CronExpression.java
@@ -1127,7 +1127,6 @@ public class CronExpression implements Serializable, Cloneable {
         // loop until we've computed the next time, or we've past the endTime
         while (!gotOne) {
 
-            //if (endTime != null && cl.getTime().after(endTime)) return null;
             if (cl.get(Calendar.YEAR) > 2999) { // prevent endless loop...
                 return null;
             }
@@ -1499,7 +1498,7 @@ public class CronExpression implements Serializable, Cloneable {
             cl.set(Calendar.YEAR, year);
 
             gotOne = true;
-        } // while( !done )
+        }
 
         return cl.getTime();
     }

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/ActionNodeHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/ActionNodeHandler.java
@@ -141,7 +141,7 @@ public class ActionNodeHandler extends AbstractNodeHandler {
 
                 String activityRef = "";
                 int begin = 12; // : Compensation
-                int end = s.length() - 3; // ");
+                int end = s.length() - 3;
                 String compensationEvent = s.substring(begin,
                         end);
                 if (!compensationEvent.startsWith(CompensationScope.IMPLICIT_COMPENSATION_PREFIX)) {

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/ProcessHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/ProcessHandler.java
@@ -936,7 +936,7 @@ public class ProcessHandler extends BaseAbstractHandler implements Handler {
                                 }
                             }
                         }
-                    } // for( Node subNode : nodes) 
+                    }
                 }
                 postProcessNodes(process, (NodeContainer) node);
             } else if (node instanceof EndNode) {

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xpath/XPATHActionBuilder.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xpath/XPATHActionBuilder.java
@@ -39,27 +39,6 @@ public class XPATHActionBuilder
                         return "kcontext.getKieRuntime().insert";
                     }
                 });
-
-        //        macros.put( "insertLogical",
-        //                    new Macro() {
-        //                        public String doMacro() {
-        //                            return "kcontext.getKnowledgeRuntime()..insertLogical";
-        //                        }
-        //                    } );
-
-        //        macros.put( "update",
-        //                    new Macro() {
-        //                        public String doMacro() {
-        //                            return "kcontext.getKnowledgeRuntime().update";
-        //                        }
-        //                    } );
-
-        //        macros.put( "retract",
-        //                    new Macro() {
-        //                        public String doMacro() {
-        //                            return "kcontext.getKnowledgeRuntime().retract";
-        //                        }
-        //                    } );;
     }
 
     public XPATHActionBuilder() {
@@ -74,55 +53,6 @@ public class XPATHActionBuilder
         String text = processMacros(actionDescr.getText());
 
         try {
-            //            XPATHDialect dialect = (XPATHDialect) context.getDialect( "XPath" );
-            //
-            //            Map<String, Class<?>> variables = new HashMap<String,Class<?>>();
-            //            variables.put("kcontext", ProcessContext.class);
-            //            variables.put("context", ProcessContext.class);
-            //            Dialect.AnalysisResult analysis = dialect.analyzeBlock( context,
-            //                                                                    actionDescr,
-            //                                                                    dialect.getInterceptors(),
-            //                                                                    text,
-            //                                                                    new Map[]{variables, context.getPackageBuilder().getGlobals()},
-            //                                                                    null );                       
-            //
-            //
-            //            List<String> variableNames = analysis.getNotBoundedIdentifiers();
-            //            if (contextResolver != null) {
-            //	            for (String variableName: variableNames) {
-            //	            	VariableScope variableScope = (VariableScope) contextResolver.resolveContext(VariableScope.VARIABLE_SCOPE, variableName);
-            //	            	if (variableScope == null) {
-            //	            		context.getErrors().add(
-            //	        				new DescrBuildError(
-            //	    						context.getParentDescr(),
-            //	                            actionDescr,
-            //	                            null,
-            //	                            "Could not find variable '" + variableName + "' for action '" + actionDescr.getText() + "'" ) );            		
-            //	            	} else {
-            //	            		variables.put(variableName,
-            //            				context.getDialect().getTypeResolver().resolveType(
-            //        						variableScope.findVariable(variableName).getType().getStringType()));
-            //	            	}
-            //	            }
-            //            }
-            //
-            //            MVELCompilationUnit unit = dialect.getMVELCompilationUnit( text,
-            //                                                                       analysis,
-            //                                                                       null,
-            //                                                                       null,
-            //                                                                       variables,
-            //                                                                       context );              
-            //            MVELAction expr = new MVELAction( unit, context.getDialect().getId() );
-            //            expr.setVariableNames(variableNames);
-            //            
-            //            
-            //            action.setMetaData("Action",  expr );
-            //            
-            //            MVELDialectRuntimeData data = (MVELDialectRuntimeData) context.getPkg().getDialectRuntimeRegistry().getDialectData( dialect.getId() );            
-            //            data.addCompileable( action,
-            //                                  expr );  
-            //            
-            //            expr.compile( context.getPackageBuilder().getRootClassLoader() );
         } catch (final Exception e) {
             context.getErrors().add(new DescrBuildError(context.getParentDescr(),
                     actionDescr,

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/assembler/DuplicateProcess.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/assembler/DuplicateProcess.java
@@ -16,7 +16,7 @@
 /*
 * Copyright 2011 Red Hat, Inc. and/or its affiliates.
 *
-* Licensed under the Apache License, Version 2.0 (the "License");
+* Licensed under the Apache License, Version 2.0 (the "License")
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/descriptors/ExpressionUtils.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/descriptors/ExpressionUtils.java
@@ -128,7 +128,7 @@ public class ExpressionUtils {
             objectClass = objectClass.getSuperclass();
         }
         if (objectClass != null) {
-            // will generate TypeConverterRegistry.get().forType("JsonNode.class").apply("{\"dog\":\"perro\"}"));
+            // will generate TypeConverterRegistry.get().forType("JsonNode.class").apply("{\"dog\":\"perro\"}"))
             return new MethodCallExpr(new MethodCallExpr(new MethodCallExpr(new TypeExpr(StaticJavaParser.parseClassOrInterfaceType(TypeConverterRegistry.class.getName())), "get"), "forType",
                     NodeList.nodeList(new StringLiteralExpr(objectClass.getName()))), "apply",
                     NodeList.nodeList(new StringLiteralExpr().setString(TypeConverterRegistry.get().forTypeReverse(object).apply((object)))));

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/XmlDumper.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/compiler/XmlDumper.java
@@ -123,9 +123,6 @@ public class XmlDumper extends ReflectiveVisitor
 
     public void visitExprConstraintDescr(final ExprConstraintDescr descr) {
         this.template = "<expr>" + XmlDumper.eol + StringUtils.escapeXmlString(descr.getExpression()) + XmlDumper.eol + "</expr>";
-        //        if ( !descr.getRestrictions().isEmpty() ) {
-        //            this.template = "<field-constraint field-name=\"" + descr.getFieldName() + "\"> " + XmlDumper.eol + processFieldConstraint( descr.getRestrictions() ) + XmlDumper.eol + "</field-constraint>";
-        //        }
     }
 
     public void visitCollectDescr(final CollectDescr descr) {
@@ -283,28 +280,6 @@ public class XmlDumper extends ReflectiveVisitor
 
         return ruleList + XmlDumper.eol;
     }
-
-    //    private String processFieldConstraint(final List list) {
-    //        String descrString = "";
-    //        for ( final Iterator it = list.iterator(); it.hasNext(); ) {
-    //            final Object temp = it.next();
-    //            visit( temp );
-    //            descrString += this.template;
-    //        }
-    //        return descrString;
-    //    }
-    //
-    //    public void visitRestrictionConnectiveDescr(final RestrictionConnectiveDescr descr) {
-    //        this.template = new String();
-    //        final List restrictions = descr.getRestrictions();
-    //        final String xmlTag = descr.getConnective() == RestrictionConnectiveDescr.OR ? RestrictionConnectiveHandler.OR : RestrictionConnectiveHandler.AND;
-    //
-    //        if ( restrictions != Collections.EMPTY_LIST ) {
-    //            this.template = "<" + xmlTag + ">";
-    //            this.template += processDescrList( restrictions );
-    //            this.template += "</" + xmlTag + ">";
-    //        }
-    //    }
 
     private String processDescrList(final List descr) {
         String descrString = "";

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/core/ExtensibleXmlParser.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/core/ExtensibleXmlParser.java
@@ -91,8 +91,6 @@ public class ExtensibleXmlParser extends DefaultHandler implements Parser {
     /** Locator for errors. */
     private Locator locator;
 
-    // private Map repo;
-
     /** Stack of configurations. */
     private LinkedList configurationStack;
 
@@ -537,8 +535,6 @@ public class ExtensibleXmlParser extends DefaultHandler implements Parser {
         this.characters = new StringBuilder();
 
         final Element element = this.document.createElement(tagName);
-
-        //final DefaultConfiguration config = new DefaultConfiguration( tagName );
 
         final int numAttrs = attrs.getLength();
 

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/processes/GlobalHandler.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/processes/GlobalHandler.java
@@ -35,11 +35,8 @@ public class GlobalHandler extends BaseAbstractHandler
         if ((this.validParents == null) && (this.validPeers == null)) {
             this.validParents = new HashSet();
             this.validParents.add(Process.class);
-
             this.validPeers = new HashSet();
             this.validPeers.add(null);
-            //this.validPeers.add( ImportDescr.class );            
-
             this.allowNesting = false;
         }
     }

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/dialect/java/ProcessKnowledgeHelperFixer.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/dialect/java/ProcessKnowledgeHelperFixer.java
@@ -33,27 +33,6 @@ public class ProcessKnowledgeHelperFixer {
                         return "kcontext.getKieRuntime().insert";
                     }
                 });
-
-        //        macros.put( "insertLogical",
-        //                    new Macro() {
-        //                        public String doMacro() {
-        //                            return "drools.insertLogical";
-        //                        }
-        //                    } );         
-
-        //        macros.put( "update",
-        //                    new Macro() {
-        //                        public String doMacro() {
-        //                            return "drools.update";
-        //                        }
-        //                    } );
-
-        //        macros.put( "retract",
-        //                    new Macro() {
-        //                        public String doMacro() {
-        //                            return "drools.retract";
-        //                        }
-        //                    } );          
     }
 
     public static String fix(final String raw) {

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/dialect/mvel/MVELReturnValueEvaluatorBuilder.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/dialect/mvel/MVELReturnValueEvaluatorBuilder.java
@@ -116,11 +116,9 @@ public class MVELReturnValueEvaluatorBuilder extends AbstractMVELBuilder
                 org.kie.api.runtime.process.ProcessContext.class,
                 false,
                 MVELCompilationUnit.Scope.EXPRESSION);
-        // MVELReturnValueExpression expr = new MVELReturnValueExpression( unit, context.getDialect().getId() );
 
         MVELReturnValueEvaluator expr = new MVELReturnValueEvaluator(unit,
                 dialect.getId());
-        // expr.setVariableNames(variableNames);
 
         constraintNode.setEvaluator(expr);
 

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/LightProcessRuntime.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/LightProcessRuntime.java
@@ -423,7 +423,7 @@ public class LightProcessRuntime extends AbstractProcessRuntime {
     }
 
     public boolean isActive() {
-        // originally: kruntime.getEnvironment().get("Active");
+        // originally: kruntime.getEnvironment().get("Active")
         return runtimeContext.isActive();
     }
 

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/MVELAction.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/MVELAction.java
@@ -95,12 +95,6 @@ public class MVELAction
                 internalWorkingMemory,
                 (GlobalResolver) context.getKieRuntime().getGlobals());
 
-        //        KnowledgePackage pkg = context.getKnowledgeRuntime().getKnowledgeBase().getKnowledgePackage( "MAIN" );
-        //        if ( pkg != null && pkg instanceof KnowledgePackageImp) {
-        //            MVELDialectRuntimeData data = ( MVELDialectRuntimeData ) ((KnowledgePackageImp) pkg).pkg.getDialectRuntimeRegistry().getDialectData( id );
-        //            factory.setNextFactory( data.getFunctionFactory() );
-        //        }
-        //        
         MVELProcessHelper.evaluator().executeExpression(this.expr,
                 null,
                 factory);

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/XPATHReturnValueEvaluator.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/XPATHReturnValueEvaluator.java
@@ -57,12 +57,10 @@ public class XPATHReturnValueEvaluator
 
     public void readExternal(ObjectInput in) throws IOException,
             ClassNotFoundException {
-        //        id = in.readUTF();
         expression = (String) in.readObject();
     }
 
     public void writeExternal(ObjectOutput out) throws IOException {
-        //        out.writeUTF( id );
         out.writeObject(expression);
     }
 

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/Split.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/Split.java
@@ -59,7 +59,6 @@ public class Split extends NodeImpl implements Constrainable {
     private static final long serialVersionUID = 510l;
 
     private int type;
-    //    private Map<ConnectionRef, Constraint> constraints = new HashMap<ConnectionRef, Constraint>();
 
     public Split() {
         this.type = TYPE_UNDEFINED;

--- a/kogito-codegen-modules/kogito-codegen-decisions/src/main/java/org/kie/kogito/codegen/decision/DecisionValidation.java
+++ b/kogito-codegen-modules/kogito-codegen-decisions/src/main/java/org/kie/kogito/codegen/decision/DecisionValidation.java
@@ -106,7 +106,7 @@ public class DecisionValidation {
         }
         Optional<String> applicationProperty = context.getApplicationProperty(DecisionCodegen.VALIDATION_CONFIGURATION_KEY);
         if (!applicationProperty.isPresent()) {
-            return ValidationOption.ENABLED; // the default;
+            return ValidationOption.ENABLED; // the default
         }
         Optional<ValidationOption> configOption = Arrays.stream(ValidationOption.values())
                 .filter(e -> e.name().equalsIgnoreCase(applicationProperty.get()))

--- a/kogito-codegen-modules/kogito-codegen-sample/kogito-codegen-sample-generator/src/main/java/org/kie/kogito/codegen/sample/generator/SampleCodegen.java
+++ b/kogito-codegen-modules/kogito-codegen-sample/kogito-codegen-sample-generator/src/main/java/org/kie/kogito/codegen/sample/generator/SampleCodegen.java
@@ -136,7 +136,6 @@ public class SampleCodegen implements Generator {
     }
 
     private static void initializeSampleRuntimeField(FieldDeclaration fd) {
-        // new SampleRuntime(new Application());
         fd.getVariable(0).setInitializer(new ObjectCreationExpr().setType(SampleContainerGenerator.SAMPLE_RUNTIME_CLASSNAME)
                 .addArgument(new ObjectCreationExpr().setType("Application")));
     }

--- a/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions/src/main/java/org/kie/kogito/core/decision/incubation/quarkus/support/DecisionServiceImpl.java
+++ b/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions/src/main/java/org/kie/kogito/core/decision/incubation/quarkus/support/DecisionServiceImpl.java
@@ -51,7 +51,6 @@ class DecisionServiceImpl implements DecisionService {
             decisionServiceId = (LocalDecisionServiceId) decisionId;
             localDecisionId = (LocalDecisionId) decisionServiceId.decisionId();
         } else {
-            // LocalDecisionId.parse(decisionId);
             throw new IllegalArgumentException(
                     "Not a valid decision id " + decisionId.toLocalId().asLocalUri());
         }

--- a/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoQuarkusResourceUtils.java
+++ b/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoQuarkusResourceUtils.java
@@ -70,7 +70,7 @@ public class KogitoQuarkusResourceUtils {
     private static final Logger LOGGER = LoggerFactory.getLogger(KogitoQuarkusResourceUtils.class);
 
     // since quarkus-maven-plugin is later phase of maven-resources-plugin,
-    // need to manually late-provide the resource in the expected location for quarkus:dev phase --so not: writeGeneratedFile( f, resourcePath );
+    // need to manually late-provide the resource in the expected location for quarkus:dev phase --so not: writeGeneratedFile( f, resourcePath )
     private static final GeneratedFileWriter.Builder generatedFileWriterBuilder =
             new GeneratedFileWriter.Builder(
                     "target/classes",

--- a/quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions/src/main/java/org/kie/kogito/core/prediction/incubation/quarkus/support/PredictionServiceImpl.java
+++ b/quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions/src/main/java/org/kie/kogito/core/prediction/incubation/quarkus/support/PredictionServiceImpl.java
@@ -44,7 +44,6 @@ public class PredictionServiceImpl implements PredictionService {
         if (predictionId instanceof LocalPredictionId) {
             localPredictionId = (LocalPredictionId) predictionId;
         } else {
-            // LocalDecisionId.parse(predictionId);
             throw new IllegalArgumentException(
                     "Not a valid prediction id " + predictionId.toLocalId());
         }

--- a/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules/src/main/java/org/kie/kogito/core/rules/incubation/quarkus/support/RuleUnitServiceImpl.java
+++ b/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules/src/main/java/org/kie/kogito/core/rules/incubation/quarkus/support/RuleUnitServiceImpl.java
@@ -48,7 +48,6 @@ class RuleUnitServiceImpl implements RuleUnitService {
             queryId = (QueryId) id;
             ruleUnitId = queryId.ruleUnitId();
         } else {
-            // LocalDecisionId.parse(decisionId);
             throw new IllegalArgumentException(
                     "Not a valid query id " + id.toLocalId());
         }

--- a/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules/src/main/java/org/kie/kogito/core/rules/incubation/quarkus/support/StatefulRuleUnitServiceImpl.java
+++ b/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules/src/main/java/org/kie/kogito/core/rules/incubation/quarkus/support/StatefulRuleUnitServiceImpl.java
@@ -105,7 +105,6 @@ class StatefulRuleUnitServiceImpl implements StatefulRuleUnitService {
             queryId = (InstanceQueryId) localId;
             ruleUnitInstanceId = queryId.ruleUnitInstanceId();
         } else {
-            // LocalDecisionId.parse(decisionId);
             throw new IllegalArgumentException(
                     "Not a valid instance query id " + localId);
         }


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-7942

Goal here is to reduce the number of code smells in Kogito-runtimes.

Addressed in this PR is the code smell, (Java) Sections of code should not be commented out (38).
https://sonarcloud.io/project/issues?resolved=false&rules=java%3AS125&id=org.kie.kogito%3Akogito-runtimes

I have remedied this by deleting commented out code; in cases where Sonarcloud was flagging a comment as code, I removed the punctuation so it will be treated as a comment.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

</details>
