### PR TITLE
[KOGITO-7956] Changed to not generate workflowdata input schema when …

### DIFF
--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/src/main/java/org/kie/kogito/quarkus/serverless/workflow/deployment/ServerlessWorkflowAssetsProcessor.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/src/main/java/org/kie/kogito/quarkus/serverless/workflow/deployment/ServerlessWorkflowAssetsProcessor.java
@@ -19,6 +19,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -91,6 +92,8 @@ public class ServerlessWorkflowAssetsProcessor {
         Collection<OpenAPI> inputModelSchemas = getWorkflows(contextBuildItem.getKogitoBuildContext())
                 .map(OpenApiModelSchemaGenerator::new)
                 .map(OpenApiModelSchemaGenerator::generateOpenAPIModelSchema)
+                .filter(Optional::isPresent)
+                .map(Optional::orElseThrow)
                 .collect(Collectors.toList());
 
         openAPIProducer.produce(new AddToOpenAPIDefinitionBuildItem(new ServerlessWorkflowOASFilter(inputModelSchemas)));

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/src/main/java/org/kie/kogito/serverless/workflow/openapi/ServerlessWorkflowOASFilter.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/src/main/java/org/kie/kogito/serverless/workflow/openapi/ServerlessWorkflowOASFilter.java
@@ -16,9 +16,15 @@
 package org.kie.kogito.serverless.workflow.openapi;
 
 import java.util.Collection;
+import java.util.List;
 
+import org.eclipse.microprofile.openapi.OASFactory;
 import org.eclipse.microprofile.openapi.OASFilter;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.PathItem;
+import org.eclipse.microprofile.openapi.models.media.MediaType;
+import org.eclipse.microprofile.openapi.models.media.Schema;
+import org.kie.kogito.serverless.workflow.SWFConstants;
 
 import io.smallrye.openapi.api.util.MergeUtil;
 
@@ -34,6 +40,48 @@ public final class ServerlessWorkflowOASFilter implements OASFilter {
     public void filterOpenAPI(OpenAPI openAPI) {
         if (!inputModelSchemas.isEmpty()) {
             inputModelSchemas.forEach(modelSchema -> MergeUtil.merge(openAPI, modelSchema));
+            addWorkflowdataSchemaReferences(openAPI);
+        } else {
+            removeJsonModelInfoSchemaReferences(openAPI);
         }
+    }
+
+    private static void removeJsonModelInfoSchemaReferences(OpenAPI openAPI) {
+        openAPI.getPaths()
+                .getPathItems()
+                .values()
+                .forEach(pathItem -> getMediaTypes(pathItem).stream()
+                        .filter(mediaType -> mediaType.getSchema() != null)
+                        .filter(mediaType -> "#/components/schemas/JsonNodeModelInput".equals(mediaType.getSchema().getRef()))
+                        .forEach(mediaType -> mediaType.setSchema(null)));
+    }
+
+    private static void addWorkflowdataSchemaReferences(OpenAPI openAPI) {
+        Schema schema = OASFactory.createSchema().ref(SWFConstants.INPUT_MODEL_REF);
+
+        openAPI.getPaths()
+                .getPathItems()
+                .values()
+                .forEach(pathItem -> getMediaTypes(pathItem)
+                        .forEach(mediaType -> mediaType.setSchema(schema)));
+    }
+
+    private static Collection<MediaType> getMediaTypes(PathItem pathItem) {
+        if (pathItemHasPostMethodWithMediaTypes(pathItem)) {
+            return pathItem.getPOST()
+                    .getRequestBody()
+                    .getContent()
+                    .getMediaTypes()
+                    .values();
+        } else {
+            return List.of();
+        }
+    }
+
+    private static boolean pathItemHasPostMethodWithMediaTypes(PathItem pathItem) {
+        return pathItem.getPOST() != null
+                && pathItem.getPOST().getRequestBody() != null
+                && pathItem.getPOST().getRequestBody().getContent() != null
+                && pathItem.getPOST().getRequestBody().getContent().getMediaTypes() != null;
     }
 }

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/src/main/java/org/kie/kogito/serverless/workflow/openapi/ServerlessWorkflowOASFilter.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/src/main/java/org/kie/kogito/serverless/workflow/openapi/ServerlessWorkflowOASFilter.java
@@ -53,7 +53,7 @@ public final class ServerlessWorkflowOASFilter implements OASFilter {
                 .forEach(pathItem -> getMediaTypes(pathItem).stream()
                         .filter(mediaType -> mediaType.getSchema() != null)
                         .filter(mediaType -> "#/components/schemas/JsonNodeModelInput".equals(mediaType.getSchema().getRef()))
-                        .forEach(mediaType -> mediaType.setSchema(null)));
+                        .forEach(mediaType -> mediaType.setSchema(OASFactory.createSchema().type(Schema.SchemaType.OBJECT))));
     }
 
     private static void addWorkflowdataSchemaReferences(OpenAPI openAPI) {


### PR DESCRIPTION
…the user doesn't define an input schema in the workflow

JIRA: https://issues.redhat.com/browse/KOGITO-7956

There are two use cases that this change needs to consider:

1) The workflow doesn't have an input schema. In this case, the OpenAPI document declares that the request body should be an Object.

![Screenshot from 2022-10-03 16-59-52](https://user-images.githubusercontent.com/11776454/193667995-d78bda74-4408-4f6e-87ca-9c0271803614.png)

```yaml
    post:
      tags:
      - jsongreet
      summary: jsongreet
      description: ""
      operationId: createResource_jsongreet
      parameters:
      - name: businessKey
        in: query
        schema:
          default: ""
          type: string
      requestBody:
        content:
          application/json:
            schema:
              type: object
```

2) The workflow has an input schema. In this case, that schema needs to be present in the OpenAPI document. I kept the "workflowdata" name for that. The request body doesn't need to have a `workflowdata` property. It only needs to match the defined schema. The schema's name will change in the future with https://issues.redhat.com/browse/KOGITO-7647.

![Screenshot from 2022-10-03 16-50-06](https://user-images.githubusercontent.com/11776454/193666187-044db34a-f901-45d6-8c8e-0919edcd13dd.png)

![Screenshot from 2022-10-03 16-56-06](https://user-images.githubusercontent.com/11776454/193667336-1c773a5f-7a28-4eec-9b86-6047a0e3ec3a.png)

```yaml
    post:
      tags:
      - expression
      summary: expression
      description: ""
      operationId: createResource_expression
      parameters:
      - name: businessKey
        in: query
        schema:
          default: ""
          type: string
      requestBody:
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/workflowdata'

...

components:
  schemas:
    workflowdata:
      title: Expression
      description: Schema for expression test
      required:
      - numbers
      type: object
      properties:
        numbers:
          description: The array of numbers to be operated with
          type: array
          items:
            type: object
            properties:
              x:
                type: number
              "y":
                type: number
```
-----

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>

- for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] mandrel-lts</b>
 
- <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
