### PR TITLE
Kogito-8058 Sonarcloud - (Java) Throwable and Error should not be caught (22)

### DIFF
--- a/api/kogito-timer/src/main/java/org/kie/kogito/timer/Calendars.java
+++ b/api/kogito-timer/src/main/java/org/kie/kogito/timer/Calendars.java
@@ -16,6 +16,7 @@
 package org.kie.kogito.timer;
 
 public interface Calendars {
+    static final long serialVersionUID = -332085070627193383L;
 
     Calendar get(String identifier);
 

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/handler/AbstractExceptionHandlingTaskHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/handler/AbstractExceptionHandlingTaskHandler.java
@@ -42,7 +42,7 @@ public abstract class AbstractExceptionHandlingTaskHandler implements KogitoWork
     public void executeWorkItem(KogitoWorkItem workItem, KogitoWorkItemManager manager) {
         try {
             originalTaskHandler.executeWorkItem(workItem, manager);
-        } catch (Throwable cause) {
+        } catch (Exception cause) {
             handleExecuteException(cause, workItem, manager);
         }
     }

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/handler/ServiceTaskHandler.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/handler/ServiceTaskHandler.java
@@ -78,7 +78,7 @@ public class ServiceTaskHandler implements KogitoWorkItemHandler {
             Map<String, Object> results = new HashMap<>();
             results.put(resultVarName, result);
             manager.completeWorkItem(workItem.getStringId(), results);
-        } catch (Throwable cnfe) {
+        } catch (Exception cnfe) {
             handleException(cnfe, service, interfaceImplementationRef, operation, parameterType, parameter);
         }
     }

--- a/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/XmlBPMNProcessDumper.java
+++ b/jbpm/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/XmlBPMNProcessDumper.java
@@ -924,7 +924,7 @@ public class XmlBPMNProcessDumper implements XmlProcessDumper {
         try {
             List<Process> processes = xmlReader.read(new StringReader(processXml));
             return processes.get(0);
-        } catch (Throwable t) {
+        } catch (Exception t) {
             t.printStackTrace();
             return null;
         }

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/ProcessBuildData.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/ProcessBuildData.java
@@ -127,7 +127,7 @@ public class ProcessBuildData {
             for (ProcessDataEventListenerProvider provider : availableProviders) {
                 collected.add(provider);
             }
-        } catch (Throwable e) {
+        } catch (Exception e) {
             logger.debug("Unable to collect process data event listeners due to {}", e.getMessage());
         }
         return collected;

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/XmlRuleFlowProcessDumper.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/xml/XmlRuleFlowProcessDumper.java
@@ -50,7 +50,7 @@ public class XmlRuleFlowProcessDumper extends XmlWorkflowProcessDumper implement
         try {
             List<Process> processes = xmlReader.read(new StringReader(processXml));
             return processes.get(0);
-        } catch (Throwable t) {
+        } catch (Exception t) {
             t.printStackTrace();
             return null;
         }

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/workitem/WorkItemRepository.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/workitem/WorkItemRepository.java
@@ -125,7 +125,7 @@ public class WorkItemRepository {
             for (String s : getDirectories(directory)) {
                 try {
                     workDefinitions.addAll(getAllWorkDefinitionsMap(directory + "/" + s, null));
-                } catch (Throwable t) {
+                } catch (Exception t) {
                     logger.error("Error retrieving work definitions: " + t.getMessage());
                 }
                 workDefinitions.addAll(getWorkDefinitionsMap(directory, s));
@@ -176,7 +176,7 @@ public class WorkItemRepository {
                 wid.put("widType", "mvel");
             }
             return result;
-        } catch (Throwable t) {
+        } catch (Exception t) {
             throw new RuntimeException("Could not parse work definition as mvel.", t);
         }
     }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/audit/KogitoWorkingMemoryFileLogger.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/audit/KogitoWorkingMemoryFileLogger.java
@@ -137,7 +137,7 @@ public class KogitoWorkingMemoryFileLogger extends WorkingMemoryLogger implement
             writer.write(XMLSupport.get().toXml(log) + "\n");
         } catch (final FileNotFoundException exc) {
             throw new RuntimeException("Could not create the log file.  Please make sure that directory that the log file should be placed in does exist.");
-        } catch (final Throwable t) {
+        } catch (final Exception t) {
             logger.error("error", t);
         }
         if (terminate) {
@@ -157,7 +157,7 @@ public class KogitoWorkingMemoryFileLogger extends WorkingMemoryLogger implement
             initialized = true;
         } catch (final FileNotFoundException exc) {
             throw new RuntimeException("Could not create the log file.  Please make sure that directory that the log file should be placed in does exist.");
-        } catch (final Throwable t) {
+        } catch (final Exception t) {
             logger.error("error", t);
         }
     }
@@ -168,7 +168,7 @@ public class KogitoWorkingMemoryFileLogger extends WorkingMemoryLogger implement
             writer.append("</object-stream>\n");
         } catch (final FileNotFoundException exc) {
             throw new RuntimeException("Could not close the log file.  Please make sure that directory that the log file should be placed in does exist.");
-        } catch (final Throwable t) {
+        } catch (final Exception t) {
             logger.error("error", t);
         }
     }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/util/VariableUtil.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/util/VariableUtil.java
@@ -48,7 +48,7 @@ public class VariableUtil {
                         Object variableValue = MVELProcessHelper.evaluator().eval(paramName, new NodeInstanceResolverFactory((org.jbpm.workflow.instance.NodeInstance) nodeInstance));
                         String variableValueString = variableValue == null ? "" : variableValue.toString();
                         replacements.put(paramName, variableValueString);
-                    } catch (Throwable t) {
+                    } catch (Exception t) {
 
                     }
                 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/impl/NodeIoHelper.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/impl/NodeIoHelper.java
@@ -100,7 +100,7 @@ public class NodeIoHelper {
                 });
 
             }
-        } catch (Throwable th) {
+        } catch (Exception th) {
             logger.debug("there was an error during data association processing", th);
             throw th;
         }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/impl/WorkflowProcessImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/impl/WorkflowProcessImpl.java
@@ -64,7 +64,7 @@ public class WorkflowProcessImpl extends ProcessImpl implements WorkflowProcess,
                     String value = (String) MVELProcessHelper.evaluator()
                             .eval(paramName, new ProcessInstanceResolverFactory(((WorkflowProcessInstance) p)));
                     replacements.put(paramName, value);
-                } catch (Throwable t) {
+                } catch (Exception t) {
                     logger.error("Could not resolve, parameter {} while evaluating expression {}", paramName, expression, t);
                 }
             }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/NodeInstanceImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/NodeInstanceImpl.java
@@ -673,7 +673,7 @@ public abstract class NodeInstanceImpl implements org.jbpm.workflow.instance.Nod
                         try {
                             Object variableValue = MVELProcessHelper.evaluator().eval(paramName, new NodeInstanceResolverFactory(this));
                             replacements.put(paramName, variableValue);
-                        } catch (Throwable t) {
+                        } catch (Exception t) {
                             logger.error("Could not find variable scope for variable {}", paramName);
                             logger.error("when trying to replace variable in processId for node {}", getNodeName());
                             logger.error("Continuing without setting process id.");

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/WorkflowProcessInstanceImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/WorkflowProcessInstanceImpl.java
@@ -723,7 +723,7 @@ public abstract class WorkflowProcessInstanceImpl extends ProcessInstanceImpl im
                         variableValue = mvelEvaluator.eval(paramName, factory);
                         String variableValueString = variableValue == null ? "" : variableValue.toString();
                         replacements.put(paramName, variableValueString);
-                    } catch (Throwable t) {
+                    } catch (Exception t) {
                         logger.error("Could not find variable scope for variable {}", paramName);
                     }
                 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/DynamicUtils.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/DynamicUtils.java
@@ -109,7 +109,7 @@ public class DynamicUtils {
                         try {
                             variableValue = MVELProcessHelper.evaluator().eval(paramName,
                                     new ProcessInstanceResolverFactory(processInstance));
-                        } catch (Throwable t) {
+                        } catch (Exception t) {
                             logger.error("Could not find variable scope for variable {}",
                                     paramName);
                             logger.error("when trying to replace variable in string for Dynamic Work Item {}",

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/ForEachNodeInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/ForEachNodeInstance.java
@@ -192,7 +192,7 @@ public class ForEachNodeInstance extends CompositeContextNodeInstance {
                 try {
                     collection = MVELProcessHelper.evaluator().eval(collectionExpression, new NodeInstanceResolverFactory(
                             this));
-                } catch (Throwable t) {
+                } catch (Exception t) {
                     throw new IllegalArgumentException(
                             "Could not find collection " + collectionExpression);
                 }
@@ -332,7 +332,7 @@ public class ForEachNodeInstance extends CompositeContextNodeInstance {
                                 result + " for expression " + expression);
                     }
                     return ((Boolean) result).booleanValue();
-                } catch (Throwable t) {
+                } catch (Exception t) {
                     throw new IllegalArgumentException("Could not evaluate completion condition  " + expression, t);
                 }
             }

--- a/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/deployment/KogitoDevServicesProcessor.java
+++ b/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/deployment/KogitoDevServicesProcessor.java
@@ -137,7 +137,7 @@ public class KogitoDevServicesProcessor {
                 closeable = trustyService.getCloseable();
             }
             compressor.close();
-        } catch (Throwable t) {
+        } catch (Exception t) {
             compressor.closeAndDumpCaptured();
             throw new RuntimeException("Failed to start Kogito TrustyService DevServices", t);
         }
@@ -205,7 +205,7 @@ public class KogitoDevServicesProcessor {
         if (closeable != null) {
             try {
                 closeable.close();
-            } catch (Throwable e) {
+            } catch (Exception e) {
                 LOGGER.error("Failed to stop Kogito Data Index", e);
             } finally {
                 closeable = null;

--- a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-deployment/src/main/java/org/kie/kogito/quarkus/processes/deployment/KogitoDevServicesProcessor.java
+++ b/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-deployment/src/main/java/org/kie/kogito/quarkus/processes/deployment/KogitoDevServicesProcessor.java
@@ -157,7 +157,7 @@ public class KogitoDevServicesProcessor {
                 systemProperties.produce(new SystemPropertyBuildItem(KOGITO_DATA_INDEX, dataIndex.getUrl()));
             }
             compressor.close();
-        } catch (Throwable t) {
+        } catch (Exception t) {
             compressor.closeAndDumpCaptured();
             throw new RuntimeException("Failed to start Kogito Data Index Dev Services", t);
         }
@@ -189,7 +189,7 @@ public class KogitoDevServicesProcessor {
         if (closeable != null) {
             try {
                 closeable.close();
-            } catch (Throwable e) {
+            } catch (Exception e) {
                 LOGGER.error("Failed to stop Kogito Data Index", e);
             } finally {
                 closeable = null;


### PR DESCRIPTION
[Many thanks for submitting your Pull Request :heart:! ](https://issues.redhat.com/browse/KOGITO-8058)

Goal here is to reduce the number of code smells in Kogito-runtimes.

Addressed in this PR is the code smell - "(Java) Throwable and Error should not be caught" (22).

I have addressed this by replacing catch (Throwable) with catch (Exception) as per Sonarcloud's recommendation.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>

- for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] mandrel-lts</b>
 
- <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
