### PR TITLE
[KOGITO-8083] Set random port for tracing tests - Additional fix on Prediction Codegen

### DIFF
--- a/kogito-codegen-modules/kogito-codegen-predictions/src/main/java/org/kie/kogito/codegen/prediction/PredictionCodegen.java
+++ b/kogito-codegen-modules/kogito-codegen-predictions/src/main/java/org/kie/kogito/codegen/prediction/PredictionCodegen.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.drools.codegen.common.GeneratedFile;
-import org.kie.efesto.common.api.io.IndexFile;
+import org.kie.efesto.common.api.model.GeneratedResources;
 import org.kie.kogito.codegen.api.ApplicationSection;
 import org.kie.kogito.codegen.api.context.KogitoBuildContext;
 import org.kie.kogito.codegen.core.AbstractGenerator;
@@ -29,8 +29,7 @@ import org.kie.kogito.codegen.prediction.config.PredictionConfigGenerator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.kie.kogito.codegen.prediction.PredictionCodegenUtils.createIndexFiles;
-import static org.kie.kogito.codegen.prediction.PredictionCodegenUtils.generateModelFromIndexFile;
+import static org.kie.kogito.codegen.prediction.PredictionCodegenUtils.generateModelFromGeneratedResources;
 import static org.kie.kogito.codegen.prediction.PredictionCodegenUtils.generateModelsFromResource;
 
 public class PredictionCodegen extends AbstractGenerator {
@@ -73,9 +72,8 @@ public class PredictionCodegen extends AbstractGenerator {
         Collection<GeneratedFile> files = new ArrayList<>();
         for (PMMLResource resource : resources) {
             generateModelsFromResource(files, resource, this);
-            Map<String, IndexFile> indexFilesMap = createIndexFiles(resource.getGeneratedResourcesMap());
-            for (IndexFile indexFile : indexFilesMap.values()) {
-                generateModelFromIndexFile(files, indexFile);
+            for (Map.Entry<String, GeneratedResources> generatedResourcesEntry : resource.getGeneratedResourcesMap().entrySet()) {
+                generateModelFromGeneratedResources(files, generatedResourcesEntry);
             }
         }
         return files;

--- a/kogito-codegen-modules/kogito-codegen-predictions/src/test/java/org/kie/kogito/codegen/prediction/PredictionCodegenGenerateTest.java
+++ b/kogito-codegen-modules/kogito-codegen-predictions/src/test/java/org/kie/kogito/codegen/prediction/PredictionCodegenGenerateTest.java
@@ -26,7 +26,6 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import org.assertj.core.api.AbstractIntegerAssert;
 import org.drools.codegen.common.GeneratedFile;
 import org.drools.codegen.common.GeneratedFileType;
 import org.junit.jupiter.api.AfterAll;
@@ -85,7 +84,7 @@ class PredictionCodegenGenerateTest {
 
             PredictionCodegen codeGenerator = getPredictionCodegen(context, REGRESSION_FULL_SOURCE);
             Collection<GeneratedFile> generatedFiles = codeGenerator.generate();
-            Arguments toAdd = arguments(codeGenerator, generatedFiles, 5, 3, 1, false,
+            Arguments toAdd = arguments(codeGenerator, generatedFiles, 4, 3, 1, false,
                     context.hasRESTForGenerator(codeGenerator));
             testArguments.add(toAdd);
 
@@ -103,7 +102,7 @@ class PredictionCodegenGenerateTest {
 
             codeGenerator = getPredictionCodegen(context, MULTIPLE_FULL_SOURCE);
             generatedFiles = codeGenerator.generate();
-            toAdd = arguments(codeGenerator, generatedFiles, 88, 84, 2, false,
+            toAdd = arguments(codeGenerator, generatedFiles, 86, 84, 2, false,
                     context.hasRESTForGenerator(codeGenerator));
             testArguments.add(toAdd);
             return testArguments.stream();
@@ -181,26 +180,26 @@ class PredictionCodegenGenerateTest {
         commonVerifySectionAndCompilationUnit(codeGenerator);
     }
 
-    static AbstractIntegerAssert<?> commonVerifyTotalFiles(Collection<GeneratedFile> generatedFiles,
+    static void commonVerifyTotalFiles(Collection<GeneratedFile> generatedFiles,
             int expectedTotalFiles,
             int expectedRestEndpoints,
             boolean hasREST) {
-        int expectedGeneratedFilesSize = expectedTotalFiles - (hasREST ? 0 : expectedRestEndpoints * 2);
-        return assertThat(expectedGeneratedFilesSize).isEqualTo(generatedFiles.size());
+        int expectedGeneratedFilesSize = expectedTotalFiles + (hasREST ? expectedRestEndpoints * 2 : 0);
+        assertThat(generatedFiles).hasSize(expectedGeneratedFilesSize);
     }
 
-    static AbstractIntegerAssert<?> commonVerifyCompiledClasses(Collection<GeneratedFile> generatedFiles,
+    static void commonVerifyCompiledClasses(Collection<GeneratedFile> generatedFiles,
             int expectedCompiledClasses) {
-        return assertThat(expectedCompiledClasses).isEqualTo(generatedFiles.stream()
+        assertThat(expectedCompiledClasses).isEqualTo(generatedFiles.stream()
                 .filter(generatedFile -> generatedFile.category().equals(GeneratedFileType.Category.COMPILED_CLASS) &&
                         generatedFile.type().equals(COMPILED_CLASS))
                 .count());
     }
 
-    static AbstractIntegerAssert<?> commonVerifyReflectResource(Collection<GeneratedFile> generatedFiles,
+    static void commonVerifyReflectResource(Collection<GeneratedFile> generatedFiles,
             boolean assertReflect) {
         int expectedReflectResource = assertReflect ? 1 : 0;
-        return assertThat(expectedReflectResource).isEqualTo(generatedFiles.stream()
+        assertThat(expectedReflectResource).isEqualTo(generatedFiles.stream()
                 .filter(generatedFile -> generatedFile.category().equals(GeneratedFileType.Category.INTERNAL_RESOURCE) &&
                         generatedFile.type().name().equals(GeneratedFileType.INTERNAL_RESOURCE.name()) &&
                         generatedFile.relativePath().endsWith(REFLECT_JSON))

--- a/kogito-codegen-modules/kogito-codegen-predictions/src/test/java/org/kie/kogito/codegen/prediction/PredictionCodegenInternalGenerateTest.java
+++ b/kogito-codegen-modules/kogito-codegen-predictions/src/test/java/org/kie/kogito/codegen/prediction/PredictionCodegenInternalGenerateTest.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.kie.kogito.codegen.api.context.KogitoBuildContext;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.kie.efesto.common.api.constants.Constants.INDEXFILE_DIRECTORY_PROPERTY;
 import static org.kie.kogito.codegen.api.utils.KogitoContextTestUtils.contextBuilders;
@@ -69,7 +68,7 @@ class PredictionCodegenInternalGenerateTest {
 
             PredictionCodegen codeGenerator = getPredictionCodegen(context, REGRESSION_FULL_SOURCE);
             Collection<GeneratedFile> generatedFiles = codeGenerator.internalGenerate();
-            Arguments toAdd = arguments(codeGenerator, generatedFiles, 5, 3, 1, false,
+            Arguments toAdd = arguments(codeGenerator, generatedFiles, 4, 3, 1, false,
                     context.hasRESTForGenerator(codeGenerator));
             testArguments.add(toAdd);
 
@@ -87,7 +86,7 @@ class PredictionCodegenInternalGenerateTest {
 
             codeGenerator = getPredictionCodegen(context, MULTIPLE_FULL_SOURCE);
             generatedFiles = codeGenerator.internalGenerate();
-            toAdd = arguments(codeGenerator, generatedFiles, 88, 84, 2, false,
+            toAdd = arguments(codeGenerator, generatedFiles, 86, 84, 2, false,
                     context.hasRESTForGenerator(codeGenerator));
             testArguments.add(toAdd);
             return testArguments.stream();
@@ -103,7 +102,7 @@ class PredictionCodegenInternalGenerateTest {
             int expectedRestEndpoints,
             boolean assertReflect,
             boolean hasRest) {
-        assertThat(commonVerifyTotalFiles(generatedFiles, expectedTotalFiles, expectedRestEndpoints, hasRest)).isNotNull();
+        commonVerifyTotalFiles(generatedFiles, expectedTotalFiles, expectedRestEndpoints, hasRest);
     }
 
     @MethodSource({ "data" })
@@ -115,7 +114,7 @@ class PredictionCodegenInternalGenerateTest {
             int expectedRestEndpoints,
             boolean assertReflect,
             boolean hasRest) {
-        assertThat(commonVerifyCompiledClasses(generatedFiles, expectedCompiledClasses)).isNotNull();
+        commonVerifyCompiledClasses(generatedFiles, expectedCompiledClasses);
     }
 
     @MethodSource({ "data" })
@@ -127,7 +126,7 @@ class PredictionCodegenInternalGenerateTest {
             int expectedRestEndpoints,
             boolean assertReflect,
             boolean hasRest) {
-        assertThat(commonVerifyReflectResource(generatedFiles, assertReflect)).isNotNull();
+        commonVerifyReflectResource(generatedFiles, assertReflect);
     }
 
     @MethodSource({ "data" })

--- a/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/deployment/KogitoDevServicesBuildTimeConfig.java
+++ b/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/deployment/KogitoDevServicesBuildTimeConfig.java
@@ -70,4 +70,10 @@ public class KogitoDevServicesBuildTimeConfig {
     @ConfigItem(defaultValue = "kogito-trusty-service")
     public String serviceName;
 
+    /**
+     * Optional random port the dev service will listen to in tests.
+     */
+    @ConfigItem(defaultValue = "-1")
+    public Integer portToUseInTest;
+
 }

--- a/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/deployment/KogitoDevServicesBuildTimeConfig.java
+++ b/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/deployment/KogitoDevServicesBuildTimeConfig.java
@@ -74,6 +74,6 @@ public class KogitoDevServicesBuildTimeConfig {
      * Optional random port the dev service will listen to in tests.
      */
     @ConfigItem(defaultValue = "-1")
-    public Integer portToUseInTest;
+    public Integer portUsedByTest;
 
 }

--- a/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/deployment/KogitoDevServicesProcessor.java
+++ b/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/deployment/KogitoDevServicesProcessor.java
@@ -239,7 +239,8 @@ public class KogitoDevServicesProcessor {
                         DockerImageName.parse(config.imageName),
                         config.fixedExposedPort,
                         launchMode.getLaunchMode() == LaunchMode.DEVELOPMENT ? config.serviceName : null,
-                        useSharedNetwork);
+                        useSharedNetwork,
+                        config.portToUseInTest);
 
                 LOGGER.debug(String.format("TrustyService DataSource Kind: %s", devServicesConfig.getDataSourceKind()));
                 LOGGER.debug(String.format("TrustyService DataSource Username: %s", devServicesConfig.getDataSourceUserName()));
@@ -309,12 +310,18 @@ public class KogitoDevServicesProcessor {
         private final boolean shared;
         private final String serviceName;
 
+        /**
+         * In test mode, pick a random port
+         */
+        private final int portToUseInTest;
+
         public TrustyServiceDevServiceConfig(final KogitoDevServicesBuildTimeConfig config) {
             this.devServicesEnabled = config.enabled.orElse(true);
             this.imageName = config.imageName;
             this.fixedExposedPort = config.port.orElse(0);
             this.shared = config.shared;
             this.serviceName = config.serviceName;
+            this.portToUseInTest = config.portToUseInTest;
         }
 
         @Override

--- a/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/deployment/KogitoDevServicesProcessor.java
+++ b/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/deployment/KogitoDevServicesProcessor.java
@@ -240,7 +240,7 @@ public class KogitoDevServicesProcessor {
                         config.fixedExposedPort,
                         launchMode.getLaunchMode() == LaunchMode.DEVELOPMENT ? config.serviceName : null,
                         useSharedNetwork,
-                        config.portToUseInTest);
+                        config.portUsedByTest);
 
                 LOGGER.debug(String.format("TrustyService DataSource Kind: %s", devServicesConfig.getDataSourceKind()));
                 LOGGER.debug(String.format("TrustyService DataSource Username: %s", devServicesConfig.getDataSourceUserName()));
@@ -313,7 +313,7 @@ public class KogitoDevServicesProcessor {
         /**
          * In test mode, pick a random port
          */
-        private final int portToUseInTest;
+        private final int portUsedByTest;
 
         public TrustyServiceDevServiceConfig(final KogitoDevServicesBuildTimeConfig config) {
             this.devServicesEnabled = config.enabled.orElse(true);
@@ -321,7 +321,7 @@ public class KogitoDevServicesProcessor {
             this.fixedExposedPort = config.port.orElse(0);
             this.shared = config.shared;
             this.serviceName = config.serviceName;
-            this.portToUseInTest = config.portToUseInTest;
+            this.portUsedByTest = config.portUsedByTest;
         }
 
         @Override

--- a/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/devservices/TrustyServiceInMemoryContainer.java
+++ b/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/devservices/TrustyServiceInMemoryContainer.java
@@ -41,7 +41,7 @@ public class TrustyServiceInMemoryContainer extends GenericContainer<TrustyServi
     private final int fixedExposedPort;
     private final boolean useSharedNetwork;
 
-    private int portToUseInTest;
+    private final int portUsedByTest;
 
     private String hostName = null;
 
@@ -49,11 +49,11 @@ public class TrustyServiceInMemoryContainer extends GenericContainer<TrustyServi
             final int fixedExposedPort,
             final String serviceName,
             final boolean useSharedNetwork,
-            final int portToUseInTest) {
+            final int portUsedByTest) {
         super(dockerImageName);
         this.fixedExposedPort = fixedExposedPort;
         this.useSharedNetwork = useSharedNetwork;
-        this.portToUseInTest = portToUseInTest;
+        this.portUsedByTest = portUsedByTest;
 
         // Only adds the label in dev mode.
         if (serviceName != null) {
@@ -90,9 +90,9 @@ public class TrustyServiceInMemoryContainer extends GenericContainer<TrustyServi
     }
 
     private int getPortToUse() {
-        LOGGER.info("portToUseInTest " + portToUseInTest);
-        if (portToUseInTest > 0) {
-            return useSharedNetwork ? portToUseInTest : getMappedPort(portToUseInTest);
+        LOGGER.debug("portUsedByTest " + portUsedByTest);
+        if (portUsedByTest > 0) {
+            return useSharedNetwork ? portUsedByTest : getMappedPort(portUsedByTest);
         } else {
             return useSharedNetwork ? PORT : getMappedPort(PORT);
         }

--- a/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/devservices/TrustyServiceInMemoryContainer.java
+++ b/quarkus/addons/tracing-decision/deployment/src/main/java/org/kie/kogito/tracing/decision/quarkus/devservices/TrustyServiceInMemoryContainer.java
@@ -41,15 +41,19 @@ public class TrustyServiceInMemoryContainer extends GenericContainer<TrustyServi
     private final int fixedExposedPort;
     private final boolean useSharedNetwork;
 
+    private int portToUseInTest;
+
     private String hostName = null;
 
     public TrustyServiceInMemoryContainer(final DockerImageName dockerImageName,
             final int fixedExposedPort,
             final String serviceName,
-            final boolean useSharedNetwork) {
+            final boolean useSharedNetwork,
+            final int portToUseInTest) {
         super(dockerImageName);
         this.fixedExposedPort = fixedExposedPort;
         this.useSharedNetwork = useSharedNetwork;
+        this.portToUseInTest = portToUseInTest;
 
         // Only adds the label in dev mode.
         if (serviceName != null) {
@@ -86,7 +90,11 @@ public class TrustyServiceInMemoryContainer extends GenericContainer<TrustyServi
     }
 
     private int getPortToUse() {
-        return useSharedNetwork ? PORT : getMappedPort(PORT);
+        LOGGER.info("portToUseInTest " + portToUseInTest);
+        if (portToUseInTest > 0) {
+            return useSharedNetwork ? portToUseInTest : getMappedPort(portToUseInTest);
+        } else {
+            return useSharedNetwork ? PORT : getMappedPort(PORT);
+        }
     }
-
 }

--- a/quarkus/addons/tracing-decision/integration-tests/pom.xml
+++ b/quarkus/addons/tracing-decision/integration-tests/pom.xml
@@ -29,6 +29,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-test-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5-internal</artifactId>
       <scope>test</scope>

--- a/quarkus/addons/tracing-decision/integration-tests/src/test/java/org/kie/kogito/tracing/QuarkusTracingAddonDevServicesIT.java
+++ b/quarkus/addons/tracing-decision/integration-tests/src/test/java/org/kie/kogito/tracing/QuarkusTracingAddonDevServicesIT.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.kie.kogito.test.utils.SocketUtils;
 import org.kie.kogito.tracing.decision.TrustyConstants;
 
 import io.quarkus.test.QuarkusDevModeTest;
@@ -49,11 +50,20 @@ public class QuarkusTracingAddonDevServicesIT {
     @RegisterExtension
     public static QuarkusDevModeTest test = new QuarkusDevModeTest()
             .withApplicationRoot(jar -> {
-                jar.addAsResource(new StringAsset(loadResource("/application.properties")),
+                jar.addAsResource(new StringAsset(applicationProperties()),
                         "application.properties");
                 jar.addAsResource(new StringAsset(loadResource("/LoanEligibility.dmn")),
                         "LoanEligibility.dmn");
             });
+
+    private static String applicationProperties() {
+        String loadedResource = loadResource("/application.properties");
+        String replacement = String.format("quarkus.kogito.dev-services-trusty.port-to-use-in-test=%s",
+                SocketUtils.findAvailablePort());
+        String toReturn = loadedResource.replace("quarkus.kogito.dev-services-trusty.port-to-use-in-test=-1",
+                replacement);
+        return toReturn;
+    }
 
     @Test
     public void testEvaluateLoanEligibility() {

--- a/quarkus/addons/tracing-decision/integration-tests/src/test/resources/application.properties
+++ b/quarkus/addons/tracing-decision/integration-tests/src/test/resources/application.properties
@@ -14,4 +14,4 @@ mp.messaging.outgoing.kogito-tracing-model.auto.offset.reset=earliest
 
 quarkus.kogito.dev-services-trusty.image-name=quay.io/kiegroup/kogito-trusty-postgresql:latest
 #quarkus.kogito.dev-services-trusty.image-name=org.kie.kogito/trusty-service-postgresql:2.0.0-SNAPSHOT
-quarkus.kogito.dev-services-trusty.port-to-use-in-test=-1
+quarkus.kogito.dev-services-trusty.port-used-by-test=-1

--- a/quarkus/addons/tracing-decision/integration-tests/src/test/resources/application.properties
+++ b/quarkus/addons/tracing-decision/integration-tests/src/test/resources/application.properties
@@ -14,3 +14,4 @@ mp.messaging.outgoing.kogito-tracing-model.auto.offset.reset=earliest
 
 quarkus.kogito.dev-services-trusty.image-name=quay.io/kiegroup/kogito-trusty-postgresql:latest
 #quarkus.kogito.dev-services-trusty.image-name=org.kie.kogito/trusty-service-postgresql:2.0.0-SNAPSHOT
+quarkus.kogito.dev-services-trusty.port-to-use-in-test=-1


### PR DESCRIPTION
@ricardozanini @evacchi @danielezonca 

See https://issues.redhat.com/browse/KOGITO-8083

Requirements/issues for this PR:
1) I want to reduce the impact as much as possible
2) I want to reuse `SocketUtils.findAvailablePort()` (from `kogito-test-utils`)
3)  `TrustyServiceInMemoryContainer` and `KogitoDevServicesProcessor` are defined in the `deployment` module, that does not depends (of course) on `integration-tests`)
4) I tried to define an optional "BuildItem", add it to `KogitoDevServicesProcessor.startTrustyServiceDevService(...)` and create the "builder" in the `integration-tests` moduile, but that builder is not invoked
5) following the above, I couldnot find a way to "programmatically" add a configuration (the randomly chosen port) to one of the parameters of the above method
6) the only solution to all the above that came to my mind has been to "manually" modifying the `portToUseInTest` property defined in the "application.properties" during test initialization (`QuarkusTracingAddonDevServicesIT`)  since it already uses a `String` here:

`jar.addAsResource(new StringAsset(applicationProperties()),
                        "application.properties");`
                        
                        

I do not like that solution, but with my knowledge of Quarkus and the other constraints, I could not find a better idea. Any suggestion (feasible and matching the requirements) is welcome.


<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>

- for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] mandrel-lts</b>
 
- <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
