### PR TITLE
[KOGITO-7647] Added workflow ID as a prefix for OpenAPI input schemas

### DIFF
--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/ServerlessWorkflowParser.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/ServerlessWorkflowParser.java
@@ -37,6 +37,7 @@ import org.kie.kogito.serverless.workflow.operationid.WorkflowOperationIdFactory
 import org.kie.kogito.serverless.workflow.parser.handlers.StateHandler;
 import org.kie.kogito.serverless.workflow.parser.handlers.StateHandlerFactory;
 import org.kie.kogito.serverless.workflow.parser.handlers.validation.WorkflowValidator;
+import org.kie.kogito.serverless.workflow.parser.schema.OpenApiModelSchemaUtil;
 import org.kie.kogito.serverless.workflow.suppliers.DataInputSchemaValidatorSupplier;
 import org.kie.kogito.serverless.workflow.utils.ServerlessWorkflowUtils;
 
@@ -115,7 +116,7 @@ public class ServerlessWorkflowParser {
         }
 
         if (workflowHasDataInputSchema()) {
-            factory.metaData(Metadata.DATA_INPUT_SCHEMA_REF, SWFConstants.INPUT_MODEL_REF);
+            factory.metaData(Metadata.DATA_INPUT_SCHEMA_REF, OpenApiModelSchemaUtil.getInputModelRef(workflow.getId()));
         }
 
         return new GeneratedInfo<>(factory.validate().getProcess(), parserContext.generatedFiles());

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/schema/OpenApiModelSchemaGenerator.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/schema/OpenApiModelSchemaGenerator.java
@@ -29,7 +29,6 @@ import org.everit.json.schema.loader.SchemaLoader;
 import org.json.JSONObject;
 import org.json.JSONTokener;
 import org.kie.kogito.jackson.utils.ObjectMapperFactory;
-import org.kie.kogito.serverless.workflow.SWFConstants;
 import org.kie.kogito.serverless.workflow.utils.ServerlessWorkflowUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -97,7 +96,7 @@ public final class OpenApiModelSchemaGenerator {
 
     public static Optional<OpenAPI> generateOpenAPIModelSchema(Workflow workflow) {
         return generateInputModel(workflow).map(inputModel -> OASFactory.createOpenAPI()
-                .components(OASFactory.createComponents().addSchema(workflow.getId() + '_' + SWFConstants.DEFAULT_WORKFLOW_VAR, inputModel))
+                .components(OASFactory.createComponents().addSchema(workflow.getId(), inputModel))
                 .openapi(workflow.getId() + '_' + "workflowmodelschema"));
     }
 

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/schema/OpenApiModelSchemaGenerator.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/schema/OpenApiModelSchemaGenerator.java
@@ -39,17 +39,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.serverlessworkflow.api.Workflow;
 
-public class OpenApiModelSchemaGenerator {
+public final class OpenApiModelSchemaGenerator {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OpenApiModelSchemaGenerator.class);
 
-    private final Workflow workflow;
-
-    public OpenApiModelSchemaGenerator(Workflow workflow) {
-        this.workflow = workflow;
+    private OpenApiModelSchemaGenerator() {
     }
 
-    private Optional<Schema> generateInputModel() {
+    private static Optional<Schema> generateInputModel(Workflow workflow) {
         if (workflow.getDataInputSchema() == null ||
                 workflow.getDataInputSchema().getSchema() == null ||
                 workflow.getDataInputSchema().getSchema().isEmpty()) {
@@ -57,7 +54,7 @@ public class OpenApiModelSchemaGenerator {
         }
         try {
             final URI inputSchemaURI = new URI(workflow.getDataInputSchema().getSchema());
-            return fromJsonSchemaToOpenApiSchema(inputSchemaURI.toString(), "");
+            return fromJsonSchemaToOpenApiSchema(workflow, inputSchemaURI.toString(), "");
         } catch (URISyntaxException e) {
             LOGGER.warn("Invalid Data Input Schema for workflow {}. Only valid URIs are supported at this time.", workflow.getId());
             return Optional.empty();
@@ -70,11 +67,12 @@ public class OpenApiModelSchemaGenerator {
      * It will try to load the file into bytes, load all the schema inheritance and provide the caller
      * with a reference to an OpenAPI Schema object.
      *
+     * @param workflow the workflow
      * @param jsonSchemaURI the given JSON Schema URI
      * @param authRef the Authentication Reference information to fetch the JSON Schema URI if needed
      * @return The @{@link Schema} object
      */
-    private Optional<Schema> fromJsonSchemaToOpenApiSchema(String jsonSchemaURI, String authRef) {
+    private static Optional<Schema> fromJsonSchemaToOpenApiSchema(Workflow workflow, String jsonSchemaURI, String authRef) {
         if (jsonSchemaURI != null) {
             final Optional<byte[]> bytes = ServerlessWorkflowUtils.loadResourceFile(workflow, Optional.empty(), jsonSchemaURI, authRef);
             if (bytes.isPresent()) {
@@ -97,10 +95,10 @@ public class OpenApiModelSchemaGenerator {
         return Optional.empty();
     }
 
-    public Optional<OpenAPI> generateOpenAPIModelSchema() {
-        return generateInputModel().map(inputModel -> OASFactory.createOpenAPI()
-                .components(OASFactory.createComponents().addSchema(SWFConstants.DEFAULT_WORKFLOW_VAR, inputModel))
-                .openapi("workflowmodelschema"));
+    public static Optional<OpenAPI> generateOpenAPIModelSchema(Workflow workflow) {
+        return generateInputModel(workflow).map(inputModel -> OASFactory.createOpenAPI()
+                .components(OASFactory.createComponents().addSchema(workflow.getId() + '_' + SWFConstants.DEFAULT_WORKFLOW_VAR, inputModel))
+                .openapi(workflow.getId() + '_' + "workflowmodelschema"));
     }
 
 }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/schema/OpenApiModelSchemaUtil.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/schema/OpenApiModelSchemaUtil.java
@@ -15,8 +15,6 @@
  */
 package org.kie.kogito.serverless.workflow.parser.schema;
 
-import org.kie.kogito.serverless.workflow.SWFConstants;
-
 public final class OpenApiModelSchemaUtil {
 
     private OpenApiModelSchemaUtil() {
@@ -29,6 +27,6 @@ public final class OpenApiModelSchemaUtil {
      *      Location And Formats</a>
      */
     public static String getInputModelRef(String workflowId) {
-        return "#/components/schemas/" + workflowId + '_' + SWFConstants.DEFAULT_WORKFLOW_VAR;
+        return "#/components/schemas/" + workflowId;
     }
 }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/schema/OpenApiModelSchemaUtil.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/schema/OpenApiModelSchemaUtil.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.serverless.workflow.parser.schema;
+
+import org.kie.kogito.serverless.workflow.SWFConstants;
+
+public final class OpenApiModelSchemaUtil {
+
+    private OpenApiModelSchemaUtil() {
+    }
+
+    /**
+     * Path to save the partial OpenAPI file with the additional model provided by the Workflow definition
+     *
+     * @see <a href="https://github.com/eclipse/microprofile-open-api/blob/master/spec/src/main/asciidoc/microprofile-openapi-spec.asciidoc#location-and-formats">MicroProfile OpenAPI Specification -
+     *      Location And Formats</a>
+     */
+    public static String getInputModelRef(String workflowId) {
+        return "#/components/schemas/" + workflowId + '_' + SWFConstants.DEFAULT_WORKFLOW_VAR;
+    }
+}

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/java/org/kie/kogito/serverless/workflow/ServerlessWorkflowParsingTest.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/java/org/kie/kogito/serverless/workflow/ServerlessWorkflowParsingTest.java
@@ -39,6 +39,7 @@ import org.kie.api.definition.process.Node;
 import org.kie.api.definition.process.Process;
 import org.kie.kogito.codegen.api.context.impl.JavaKogitoBuildContext;
 import org.kie.kogito.serverless.workflow.parser.ServerlessWorkflowParser;
+import org.kie.kogito.serverless.workflow.parser.schema.OpenApiModelSchemaUtil;
 
 import io.serverlessworkflow.api.Workflow;
 import io.serverlessworkflow.api.end.End;
@@ -640,7 +641,7 @@ public class ServerlessWorkflowParsingTest extends AbstractServerlessWorkflowPar
         assertThat(process).isNotNull();
         assertThat(process.getId()).isNotNull();
 
-        assertThat(process.getMetaData(Metadata.DATA_INPUT_SCHEMA_REF)).isEqualTo(SWFConstants.INPUT_MODEL_REF);
+        assertThat(process.getMetaData(Metadata.DATA_INPUT_SCHEMA_REF)).isEqualTo(OpenApiModelSchemaUtil.getInputModelRef(process.getId()));
     }
 
     @Test

--- a/kogito-serverless-workflow/kogito-serverless-workflow-runtime/src/main/java/org/kie/kogito/serverless/workflow/SWFConstants.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-runtime/src/main/java/org/kie/kogito/serverless/workflow/SWFConstants.java
@@ -23,12 +23,4 @@ public class SWFConstants {
 
     public static final String DEFAULT_WORKFLOW_VAR = "workflowdata";
     public static final String MODEL_WORKFLOW_VAR = "_INPUT_MODEL";
-
-    /**
-     * Path to save the partial OpenAPI file with the additional model provided by the Workflow definition
-     *
-     * @see <a href="https://github.com/eclipse/microprofile-open-api/blob/master/spec/src/main/asciidoc/microprofile-openapi-spec.asciidoc#location-and-formats">MicroProfile OpenAPI Specification -
-     *      Location And Formats</a>
-     */
-    public static final String INPUT_MODEL_REF = "#/components/schemas/" + SWFConstants.DEFAULT_WORKFLOW_VAR;
 }

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/src/main/java/org/kie/kogito/quarkus/serverless/workflow/deployment/ServerlessWorkflowAssetsProcessor.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/src/main/java/org/kie/kogito/quarkus/serverless/workflow/deployment/ServerlessWorkflowAssetsProcessor.java
@@ -99,9 +99,8 @@ public class ServerlessWorkflowAssetsProcessor {
 
     private static ServerlessWorkflowOASFilter.SchemaInfo workflowToSchemaInfo(Workflow workflow) {
         return OpenApiModelSchemaGenerator.generateOpenAPIModelSchema(workflow)
-                .map(openAPI -> 
-                    new ServerlessWorkflowOASFilter.SchemaInfo(workflow.getId(), openAPI, OpenApiModelSchemaUtil.getInputModelRef(workflow.getId()))
-                ).orElse(null);
+                .map(openAPI -> new ServerlessWorkflowOASFilter.SchemaInfo(workflow.getId(), openAPI, OpenApiModelSchemaUtil.getInputModelRef(workflow.getId())))
+                .orElse(null);
     }
 
     private static Stream<Workflow> getWorkflows(KogitoBuildContext kogitoBuildContext) {

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/src/main/java/org/kie/kogito/quarkus/serverless/workflow/deployment/ServerlessWorkflowAssetsProcessor.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/src/main/java/org/kie/kogito/quarkus/serverless/workflow/deployment/ServerlessWorkflowAssetsProcessor.java
@@ -99,10 +99,9 @@ public class ServerlessWorkflowAssetsProcessor {
 
     private static ServerlessWorkflowOASFilter.SchemaInfo workflowToSchemaInfo(Workflow workflow) {
         return OpenApiModelSchemaGenerator.generateOpenAPIModelSchema(workflow)
-                .map(openAPI -> {
-                    String inputModelRef = OpenApiModelSchemaUtil.getInputModelRef(workflow.getId());
-                    return new ServerlessWorkflowOASFilter.SchemaInfo(workflow.getId(), openAPI, inputModelRef);
-                }).orElse(null);
+                .map(openAPI -> 
+                    new ServerlessWorkflowOASFilter.SchemaInfo(workflow.getId(), openAPI, OpenApiModelSchemaUtil.getInputModelRef(workflow.getId()))
+                ).orElse(null);
     }
 
     private static Stream<Workflow> getWorkflows(KogitoBuildContext kogitoBuildContext) {

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/src/main/java/org/kie/kogito/quarkus/serverless/workflow/deployment/ServerlessWorkflowAssetsProcessor.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/src/main/java/org/kie/kogito/quarkus/serverless/workflow/deployment/ServerlessWorkflowAssetsProcessor.java
@@ -19,12 +19,11 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Optional;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.drools.codegen.common.GeneratedFile;
-import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.jboss.jandex.IndexView;
 import org.kie.kogito.codegen.api.context.KogitoBuildContext;
 import org.kie.kogito.codegen.core.io.CollectedResourceProducer;
@@ -40,6 +39,7 @@ import org.kie.kogito.serverless.workflow.openapi.ServerlessWorkflowOASFilter;
 import org.kie.kogito.serverless.workflow.parser.FunctionNamespace;
 import org.kie.kogito.serverless.workflow.parser.FunctionTypeHandler;
 import org.kie.kogito.serverless.workflow.parser.schema.OpenApiModelSchemaGenerator;
+import org.kie.kogito.serverless.workflow.parser.schema.OpenApiModelSchemaUtil;
 import org.kie.kogito.serverless.workflow.rpc.FileDescriptorHolder;
 
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -89,14 +89,20 @@ public class ServerlessWorkflowAssetsProcessor {
 
     @BuildStep
     void addOpenAPIModelSchema(KogitoBuildContextBuildItem contextBuildItem, BuildProducer<AddToOpenAPIDefinitionBuildItem> openAPIProducer) {
-        Collection<OpenAPI> inputModelSchemas = getWorkflows(contextBuildItem.getKogitoBuildContext())
-                .map(OpenApiModelSchemaGenerator::new)
-                .map(OpenApiModelSchemaGenerator::generateOpenAPIModelSchema)
-                .filter(Optional::isPresent)
-                .map(Optional::orElseThrow)
+        Collection<ServerlessWorkflowOASFilter.SchemaInfo> inputModelSchemaInfos = getWorkflows(contextBuildItem.getKogitoBuildContext())
+                .map(ServerlessWorkflowAssetsProcessor::workflowToSchemaInfo)
+                .filter(Objects::nonNull)
                 .collect(Collectors.toList());
 
-        openAPIProducer.produce(new AddToOpenAPIDefinitionBuildItem(new ServerlessWorkflowOASFilter(inputModelSchemas)));
+        openAPIProducer.produce(new AddToOpenAPIDefinitionBuildItem(new ServerlessWorkflowOASFilter(inputModelSchemaInfos)));
+    }
+
+    private static ServerlessWorkflowOASFilter.SchemaInfo workflowToSchemaInfo(Workflow workflow) {
+        return OpenApiModelSchemaGenerator.generateOpenAPIModelSchema(workflow)
+                .map(openAPI -> {
+                    String inputModelRef = OpenApiModelSchemaUtil.getInputModelRef(workflow.getId());
+                    return new ServerlessWorkflowOASFilter.SchemaInfo(workflow.getId(), openAPI, inputModelRef);
+                }).orElse(null);
     }
 
     private static Stream<Workflow> getWorkflows(KogitoBuildContext kogitoBuildContext) {

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/src/main/java/org/kie/kogito/serverless/workflow/openapi/ServerlessWorkflowOASFilter.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/src/main/java/org/kie/kogito/serverless/workflow/openapi/ServerlessWorkflowOASFilter.java
@@ -40,12 +40,12 @@ public final class ServerlessWorkflowOASFilter implements OASFilter {
 
     @Override
     public void filterOpenAPI(OpenAPI openAPI) {
-        inputModelSchemaInfos.stream()
-                .filter(schemaInfo -> schemaInfo.openAPI != null)
-                .forEach(schemaInfo -> {
-                    MergeUtil.merge(openAPI, schemaInfo.openAPI);
-                    addWorkflowdataSchemaRefs(schemaInfo, openAPI);
-                });
+        for (SchemaInfo inputModelSchemaInfo : inputModelSchemaInfos) {
+            if (inputModelSchemaInfo.openAPI != null) {
+                MergeUtil.merge(openAPI, inputModelSchemaInfo.openAPI);
+                addWorkflowdataSchemaRefs(inputModelSchemaInfo, openAPI);
+            }
+        }
 
         removeJsonModelInfoSchemaReferences(openAPI);
     }

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/src/main/java/org/kie/kogito/serverless/workflow/openapi/ServerlessWorkflowOASFilter.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/src/main/java/org/kie/kogito/serverless/workflow/openapi/ServerlessWorkflowOASFilter.java
@@ -88,10 +88,11 @@ public final class ServerlessWorkflowOASFilter implements OASFilter {
     private static void addWorkflowdataSchemaRefs(SchemaInfo schemaInfo, OpenAPI openAPI) {
         Schema schema = OASFactory.createSchema().ref(schemaInfo.inputModelRef);
 
-        openAPI.getPaths()
-                .getPathItems()
-                .values().stream()
-                .filter(pathItem -> pathItemHasWorkflowId(pathItem, schemaInfo.workflowId)).map(ServerlessWorkflowOASFilter::getMediaTypes).forEach(schema::setSchema);
+        for (PathItem pathItem : openAPI.getPaths().getPathItems().values()) {
+            if (pathItemHasWorkflowId(pathItem, schemaInfo.workflowId)) {
+                getMediaTypes(pathItem).forEach(mediaType -> mediaType.setSchema(schema));
+            }
+        }
     }
 
     private static Collection<MediaType> getMediaTypes(PathItem pathItem) {

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/src/main/java/org/kie/kogito/serverless/workflow/openapi/ServerlessWorkflowOASFilter.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/src/main/java/org/kie/kogito/serverless/workflow/openapi/ServerlessWorkflowOASFilter.java
@@ -17,6 +17,7 @@ package org.kie.kogito.serverless.workflow.openapi;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.eclipse.microprofile.openapi.OASFactory;
 import org.eclipse.microprofile.openapi.OASFilter;
@@ -24,46 +25,74 @@ import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.eclipse.microprofile.openapi.models.PathItem;
 import org.eclipse.microprofile.openapi.models.media.MediaType;
 import org.eclipse.microprofile.openapi.models.media.Schema;
-import org.kie.kogito.serverless.workflow.SWFConstants;
 
 import io.smallrye.openapi.api.util.MergeUtil;
 
+import static java.util.function.Predicate.not;
+
 public final class ServerlessWorkflowOASFilter implements OASFilter {
 
-    private final Collection<OpenAPI> inputModelSchemas;
+    private final Collection<SchemaInfo> inputModelSchemaInfos;
 
-    public ServerlessWorkflowOASFilter(Collection<OpenAPI> inputModelSchemas) {
-        this.inputModelSchemas = inputModelSchemas;
+    public ServerlessWorkflowOASFilter(Collection<SchemaInfo> inputModelSchemaInfos) {
+        this.inputModelSchemaInfos = inputModelSchemaInfos;
     }
 
     @Override
     public void filterOpenAPI(OpenAPI openAPI) {
-        if (!inputModelSchemas.isEmpty()) {
-            inputModelSchemas.forEach(modelSchema -> MergeUtil.merge(openAPI, modelSchema));
-            addWorkflowdataSchemaReferences(openAPI);
-        } else {
-            removeJsonModelInfoSchemaReferences(openAPI);
-        }
+        inputModelSchemaInfos.stream()
+                .filter(schemaInfo -> schemaInfo.openAPI != null)
+                .forEach(schemaInfo -> {
+                    MergeUtil.merge(openAPI, schemaInfo.openAPI);
+                    addWorkflowdataSchemaRefs(schemaInfo, openAPI);
+                });
+
+        removeJsonModelInfoSchemaReferences(openAPI);
     }
 
-    private static void removeJsonModelInfoSchemaReferences(OpenAPI openAPI) {
-        openAPI.getPaths()
-                .getPathItems()
-                .values()
-                .forEach(pathItem -> getMediaTypes(pathItem).stream()
-                        .filter(mediaType -> mediaType.getSchema() != null)
-                        .filter(mediaType -> "#/components/schemas/JsonNodeModelInput".equals(mediaType.getSchema().getRef()))
-                        .forEach(mediaType -> mediaType.setSchema(OASFactory.createSchema().type(Schema.SchemaType.OBJECT))));
+    private void removeJsonModelInfoSchemaReferences(OpenAPI openAPI) {
+        getPathItemsWithoutDefinedSchema(openAPI)
+                .forEach(pathItem -> getMediaTypesThatHaveJsonNodeModelInputSchema(pathItem)
+                        .forEach(this::setObjectSchema));
     }
 
-    private static void addWorkflowdataSchemaReferences(OpenAPI openAPI) {
-        Schema schema = OASFactory.createSchema().ref(SWFConstants.INPUT_MODEL_REF);
+    private void setObjectSchema(MediaType mediaType) {
+        mediaType.setSchema(OASFactory.createSchema().type(Schema.SchemaType.OBJECT));
+    }
+
+    private Stream<MediaType> getMediaTypesThatHaveJsonNodeModelInputSchema(PathItem pathItem) {
+        return getMediaTypes(pathItem).stream().filter(this::mediaTypeHasJsonNodeModelInputSchema);
+    }
+
+    private boolean mediaTypeHasJsonNodeModelInputSchema(MediaType mediaType) {
+        return mediaType != null && "#/components/schemas/JsonNodeModelInput".equals(mediaType.getSchema().getRef());
+    }
+
+    private Stream<PathItem> getPathItemsWithoutDefinedSchema(OpenAPI openAPI) {
+        return openAPI.getPaths()
+                .getPathItems()
+                .values().stream()
+                .filter(not(this::doesExistSchemaForPathItem));
+    }
+
+    private boolean doesExistSchemaForPathItem(PathItem pathItem) {
+        return inputModelSchemaInfos.stream().anyMatch(schemaInfo -> pathItemHasWorkflowId(pathItem, schemaInfo.workflowId));
+    }
+
+    private static boolean pathItemHasWorkflowId(PathItem pathItem, String workflowId) {
+        return pathItem.getPOST() != null
+                && pathItem.getPOST().getOperationId() != null
+                && pathItem.getPOST().getOperationId().matches("createResource_" + workflowId);
+    }
+
+    private static void addWorkflowdataSchemaRefs(SchemaInfo schemaInfo, OpenAPI openAPI) {
+        Schema schema = OASFactory.createSchema().ref(schemaInfo.inputModelRef);
 
         openAPI.getPaths()
                 .getPathItems()
-                .values()
-                .forEach(pathItem -> getMediaTypes(pathItem)
-                        .forEach(mediaType -> mediaType.setSchema(schema)));
+                .values().stream()
+                .filter(pathItem -> pathItemHasWorkflowId(pathItem, schemaInfo.workflowId))
+                .forEach(pathItem -> getMediaTypes(pathItem).forEach(mediaType -> mediaType.setSchema(schema)));
     }
 
     private static Collection<MediaType> getMediaTypes(PathItem pathItem) {
@@ -83,5 +112,20 @@ public final class ServerlessWorkflowOASFilter implements OASFilter {
                 && pathItem.getPOST().getRequestBody() != null
                 && pathItem.getPOST().getRequestBody().getContent() != null
                 && pathItem.getPOST().getRequestBody().getContent().getMediaTypes() != null;
+    }
+
+    public static final class SchemaInfo {
+
+        private final String workflowId;
+
+        private final OpenAPI openAPI;
+
+        private final String inputModelRef;
+
+        public SchemaInfo(String workflowId, OpenAPI openAPI, String inputModelRef) {
+            this.workflowId = workflowId;
+            this.openAPI = openAPI;
+            this.inputModelRef = inputModelRef;
+        }
     }
 }

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/src/main/java/org/kie/kogito/serverless/workflow/openapi/ServerlessWorkflowOASFilter.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/src/main/java/org/kie/kogito/serverless/workflow/openapi/ServerlessWorkflowOASFilter.java
@@ -91,8 +91,7 @@ public final class ServerlessWorkflowOASFilter implements OASFilter {
         openAPI.getPaths()
                 .getPathItems()
                 .values().stream()
-                .filter(pathItem -> pathItemHasWorkflowId(pathItem, schemaInfo.workflowId))
-                .forEach(pathItem -> getMediaTypes(pathItem).forEach(mediaType -> mediaType.setSchema(schema)));
+                .filter(pathItem -> pathItemHasWorkflowId(pathItem, schemaInfo.workflowId)).map(ServerlessWorkflowOASFilter::getMediaTypes).forEach(schema::setSchema);
     }
 
     private static Collection<MediaType> getMediaTypes(PathItem pathItem) {


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/KOGITO-7647

Example of OpenAPI document for a project that has three workflows:

| Workflow ID | Input Schema |
|--------|---------|
| expression | expression.json |
| expression_alt | expression_alt.json |
| jsongreet | - |

Open API document:

```yaml
...

paths:
  /expression:
    ...
    post:
      tags:
      - expression
      summary: expression
      description: ""
      operationId: createResource_expression
      parameters:
      - name: businessKey
        in: query
        schema:
          default: ""
          type: string
      requestBody:
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/expression_workflowdata'
      responses:
        "200":
          description: OK

...

  /expression_alt:
    ...
    post:
      tags:
      - expression_alt
      summary: expression_alt
      description: ""
      operationId: createResource_expression_alt
      parameters:
      - name: businessKey
        in: query
        schema:
          default: ""
          type: string
      requestBody:
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/expression_alt_workflowdata'
      responses:
        "200":
          description: OK

...

  /jsongreet:
    ...
    post:
      tags:
      - jsongreet
      summary: jsongreet
      description: ""
      operationId: createResource_jsongreet
      parameters:
      - name: businessKey
        in: query
        schema:
          default: ""
          type: string
      requestBody:
        content:
          application/json:
            schema:
              type: object
      responses:
        "200":
          description: OK

...
```


------

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>

- for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] mandrel-lts</b>
 
- <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
