### PR TITLE
Kogito-8085 Sonarcloud - Addressing code smells related to unchained, incorrectly structured, and incompatible type assertThat statements 

### DIFF
--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/EndEventTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/EndEventTest.java
@@ -103,7 +103,6 @@ public class EndEventTest extends JbpmBpmn2TestCase {
         long nodeId = workItem.getNodeId();
         String deploymentId = workItem.getDeploymentId();
 
-        assertNotNull(nodeId);
         assertTrue(nodeId > 0);
         assertNotNull(nodeInstanceId);
         assertNull(deploymentId);
@@ -120,7 +119,6 @@ public class EndEventTest extends JbpmBpmn2TestCase {
         nodeInstanceId = workItem.getNodeInstanceStringId();
         nodeId = workItem.getNodeId();
 
-        assertNotNull(nodeId);
         assertTrue(nodeId > 0);
         assertNotNull(nodeInstanceId);
     }

--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/IntermediateEventTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/IntermediateEventTest.java
@@ -1002,7 +1002,6 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         String nodeInstanceId = ((InternalKogitoWorkItem) workItem).getNodeInstanceStringId();
         long nodeId = ((InternalKogitoWorkItem) workItem).getNodeId();
 
-        assertThat(nodeId).isNotNull();
         assertThat(nodeId > 0).isTrue();
         assertThat(nodeInstanceId).isNotNull();
     }
@@ -1024,11 +1023,11 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         long nodeId = ((InternalKogitoWorkItem) workItem).getNodeId();
         String deploymentId = ((InternalKogitoWorkItem) workItem).getDeploymentId();
 
-        assertThat(nodeId).isNotNull();
         assertThat(nodeId > 0).isTrue();
         assertThat(nodeInstanceId).isNotNull();
         assertThat(deploymentId).isNull();
     }
+        assert contextContainer instanceof NodeContainer
 
     @Test
     public void testMessageBoundaryEventOnTask() throws Exception {
@@ -1873,8 +1872,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         assertProcessInstanceFinished(processInstance, kruntime);
         assertNodeTriggered(processInstance.getStringId(), "StartProcess", "UserTask", "EndProcess", "event");
         String var = getProcessVarValue(processInstance, "x");
-        assertThat(var).isNotNull();
-        assertThat(var).isEqualTo("SOMEVALUE");
+        assertThat(var).isNotNull().isEqualTo("SOMEVALUE");
     }
 
     @Test
@@ -1890,8 +1888,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         kruntime.signalEvent("Message-HelloMessage", "SomeValue", processInstance.getStringId());
         assertProcessInstanceFinished(processInstance, kruntime);
         String var = getProcessVarValue(processInstance, "x");
-        assertThat(var).isNotNull();
-        assertThat(var).isEqualTo("SOMEVALUE");
+        assertThat(var).isNotNull().isEqualTo("SOMEVALUE");
     }
 
     @Test
@@ -1911,9 +1908,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
                 "Sub Process 1", "start-sub", "end-sub");
 
         String var = getProcessVarValue(processInstance, "x");
-        assertThat(var).isNotNull();
-        assertThat(var).isEqualTo("JOHN");
-
+        assertThat(var).isNotNull().isEqualTo("JOHN");
     }
 
     @Test

--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/IntermediateEventTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/IntermediateEventTest.java
@@ -1027,7 +1027,6 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         assertThat(nodeInstanceId).isNotNull();
         assertThat(deploymentId).isNull();
     }
-        assert contextContainer instanceof NodeContainer
 
     @Test
     public void testMessageBoundaryEventOnTask() throws Exception {

--- a/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/StandaloneBPMNProcessTest.java
+++ b/jbpm/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/StandaloneBPMNProcessTest.java
@@ -515,7 +515,7 @@ public class StandaloneBPMNProcessTest extends JbpmBpmn2TestCase {
         kruntime.getKogitoWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
         kruntime.getKieSession().fireAllRules();
         workItem = workItemHandler.getWorkItem();
-        assertThat(workItem).isNotNull().withFailMessage("KogitoWorkItem should not be null.");
+        assertThat(workItem).withFailMessage("KogitoWorkItem should not be null.").isNotNull();
         kruntime.getKogitoWorkItemManager().registerWorkItemHandler("Human Task", workItemHandler);
         kruntime.getKogitoWorkItemManager().completeWorkItem(workItem.getStringId(), null);
         assertProcessInstanceCompleted(processInstance.getStringId(), kruntime);
@@ -760,7 +760,7 @@ public class StandaloneBPMNProcessTest extends JbpmBpmn2TestCase {
         assertThat(workItem).isNotNull();
         kruntime.getKogitoWorkItemManager().completeWorkItem(workItem.getStringId(), null);
         // Check that event was passed to Event SubProcess (and grabbed by WorkItemHandler);
-        assertThat(caughtEventObjectHolder[0] != null && caughtEventObjectHolder[0] instanceof KogitoWorkItem).isTrue().withFailMessage("Event was not passed to Event Subprocess.");
+        assertThat(caughtEventObjectHolder[0] != null && caughtEventObjectHolder[0] instanceof KogitoWorkItem).withFailMessage("Event was not passed to Event Subprocess.").isTrue();
         workItem = (KogitoWorkItem) caughtEventObjectHolder[0];
         Object throwObj = workItem.getParameter(ExceptionService.exceptionParameterName);
         assertThat(throwObj).withFailMessage("KogitoWorkItem doesn't contain Throwable.").isInstanceOf(Throwable.class);
@@ -768,7 +768,7 @@ public class StandaloneBPMNProcessTest extends JbpmBpmn2TestCase {
 
         // Complete process
         processInstance = kruntime.getProcessInstance(processInstance.getStringId());
-        assertThat(processInstance == null || processInstance.getState() == KogitoProcessInstance.STATE_ABORTED).isTrue().withFailMessage("Process instance has not been aborted.");
+        assertThat(processInstance == null || processInstance.getState() == KogitoProcessInstance.STATE_ABORTED).withFailMessage("Process instance has not been aborted.").isTrue();
 
     }
 
@@ -851,18 +851,18 @@ public class StandaloneBPMNProcessTest extends JbpmBpmn2TestCase {
         KogitoProcessInstance processInstance = kruntime.startProcess("ServiceProcess", params);
 
         // Check that event was passed to Event SubProcess (and grabbed by WorkItemHandler);
-        assertThat(caughtEventObjectHolder[0] != null && caughtEventObjectHolder[0] instanceof KogitoWorkItem).isTrue().withFailMessage("Event was not passed to Event Subprocess.");
+        assertThat(caughtEventObjectHolder[0] != null && caughtEventObjectHolder[0] instanceof KogitoWorkItem).withFailMessage("Event was not passed to Event Subprocess.").isTrue();
         KogitoWorkItem workItem = (KogitoWorkItem) caughtEventObjectHolder[0];
         Object throwObj = workItem.getParameter(ExceptionService.exceptionParameterName);
         assertThat(throwObj).withFailMessage("KogitoWorkItem doesn't contain Throwable.").isInstanceOf(Throwable.class);
         assertThat(((Throwable) throwObj).getMessage()).withFailMessage("Exception message does not match service input.").endsWith(input);
 
         // Complete process
-        assertThat(processInstance.getState()).isEqualTo(KogitoProcessInstance.STATE_ACTIVE).withFailMessage("Process instance is not active.");
+        assertThat(processInstance.getState()).withFailMessage("Process instance is not active.").isEqualTo(KogitoProcessInstance.STATE_ACTIVE);
         kruntime.getKogitoWorkItemManager().completeWorkItem(workItem.getStringId(), null);
         processInstance = kruntime.getProcessInstance(processInstance.getStringId());
         if (processInstance != null) {
-            assertThat(processInstance.getState()).isEqualTo(KogitoProcessInstance.STATE_COMPLETED).withFailMessage("Process instance is not completed.");
+            assertThat(processInstance.getState()).withFailMessage("Process instance is not completed.").isEqualTo(KogitoProcessInstance.STATE_COMPLETED);
         } // otherwise, persistence use => processInstance == null => process is completed
     }
 

--- a/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/process/persistence/marshaller/AbstractMarshallerGeneratorTest.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/process/persistence/marshaller/AbstractMarshallerGeneratorTest.java
@@ -73,8 +73,7 @@ public abstract class AbstractMarshallerGeneratorTest<T> {
         MarshallerGenerator marshallerGenerator = withGenerator(Person.class);
 
         List<CompilationUnit> classes = marshallerGenerator.generate(proto.serialize());
-        assertThat(classes).isNotNull();
-        assertThat(classes).hasSize(1);
+        assertThat(classes).isNotNull().hasSize(1);
 
         Optional<ClassOrInterfaceDeclaration> marshallerClass = classes.get(0).getClassByName("PersonMessageMarshaller");
         assertThat(marshallerClass).isPresent();
@@ -91,8 +90,7 @@ public abstract class AbstractMarshallerGeneratorTest<T> {
         MarshallerGenerator marshallerGenerator = withGenerator(PersonWithList.class);
 
         List<CompilationUnit> classes = marshallerGenerator.generate(proto.serialize());
-        assertThat(classes).isNotNull();
-        assertThat(classes).hasSize(1);
+        assertThat(classes).isNotNull().hasSize(1);
 
         Optional<ClassOrInterfaceDeclaration> marshallerClass = classes.get(0).getClassByName("PersonWithListMessageMarshaller");
         assertThat(marshallerClass).isPresent();
@@ -109,8 +107,7 @@ public abstract class AbstractMarshallerGeneratorTest<T> {
         MarshallerGenerator marshallerGenerator = withGenerator(PersonWithAddresses.class);
 
         List<CompilationUnit> classes = marshallerGenerator.generate(proto.serialize());
-        assertThat(classes).isNotNull();
-        assertThat(classes).hasSize(2);
+        assertThat(classes).isNotNull().hasSize(2);
 
         Optional<ClassOrInterfaceDeclaration> marshallerClass = classes.get(0).getClassByName("AddressMessageMarshaller");
         assertThat(marshallerClass).isPresent();
@@ -129,8 +126,7 @@ public abstract class AbstractMarshallerGeneratorTest<T> {
         MarshallerGenerator marshallerGenerator = withGenerator(PersonWithAddresses.class);
 
         List<CompilationUnit> classes = marshallerGenerator.generate(proto.serialize());
-        assertThat(classes).isNotNull();
-        assertThat(classes).hasSize(2);
+        assertThat(classes).isNotNull().hasSize(2);
 
         Optional<ClassOrInterfaceDeclaration> marshallerClass = classes.get(0).getClassByName("AddressMessageMarshaller");
         assertThat(marshallerClass).isPresent();

--- a/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/process/persistence/proto/AbstractProtoGeneratorTest.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/process/persistence/proto/AbstractProtoGeneratorTest.java
@@ -695,9 +695,7 @@ public abstract class AbstractProtoGeneratorTest<T> {
         byte[] list = listFile.contents();
         final ObjectMapper mapper = new ObjectMapper();
         List<String> files = mapper.readValue(list, List.class);
-        assertThat(files).isNotEmpty();
-        assertThat(files)
-                .hasAtLeastOneElementOfType(String.class)
+        assertThat(files).isNotEmpty().hasAtLeastOneElementOfType(String.class)
                 .contains("protofile.0.proto")
                 .hasSize(5);
     }

--- a/quarkus/integration-tests/integration-tests-quarkus-processes/src/test/java/org/kie/kogito/integrationtests/quarkus/ManagementAddOnIT.java
+++ b/quarkus/integration-tests/integration-tests-quarkus-processes/src/test/java/org/kie/kogito/integrationtests/quarkus/ManagementAddOnIT.java
@@ -119,8 +119,7 @@ class ManagementAddOnIT {
 
         // since node instance was retriggered it must have different ids
         List<String> newNodeInstanceIds = whenGetNodeInstances(pid);
-        assertThat(newNodeInstanceIds).isNotEmpty();
-        assertThat(newNodeInstanceIds).doesNotContainAnyElementsOf(nodeInstanceIds);
+        assertThat(newNodeInstanceIds).isNotEmpty().doesNotContainAnyElementsOf(nodeInstanceIds);
     }
 
     private String givenGreetingsProcess() {

--- a/quarkus/integration-tests/integration-tests-quarkus-processes/src/test/java/org/kie/kogito/integrationtests/quarkus/MonitoringIT.java
+++ b/quarkus/integration-tests/integration-tests-quarkus-processes/src/test/java/org/kie/kogito/integrationtests/quarkus/MonitoringIT.java
@@ -56,9 +56,9 @@ public class MonitoringIT {
                 .extract().body().asString();
 
         assertThat(response).contains(format("kogito_process_instance_started_total{app_id=\"default-process-monitoring-listener\",artifactId=\"%s\",process_id=\"monitoring\",version=\"%s\",} 1.0",
-                ARTIFACT_ID, VERSION));
-        assertThat(response).contains(format("kogito_process_instance_running_total{app_id=\"default-process-monitoring-listener\",artifactId=\"%s\",process_id=\"monitoring\",version=\"%s\",} 1.0",
-                ARTIFACT_ID, VERSION));
+                ARTIFACT_ID, VERSION))
+                .contains(format("kogito_process_instance_running_total{app_id=\"default-process-monitoring-listener\",artifactId=\"%s\",process_id=\"monitoring\",version=\"%s\",} 1.0",
+                        ARTIFACT_ID, VERSION));
 
         String taskId = given()
                 .contentType(ContentType.JSON)
@@ -90,24 +90,20 @@ public class MonitoringIT {
                 .statusCode(200)
                 .extract().body().asString();
 
-        assertThat(response).contains(format("kogito_work_item_duration_seconds_max{artifactId=\"%s\",name=\"MonitoringTask\",version=\"%s\",}", ARTIFACT_ID, VERSION));
-        assertThat(response)
-                .contains(format("kogito_work_item_duration_seconds_count{artifactId=\"%s\",name=\"MonitoringTask\",version=\"%s\",} 1.0", ARTIFACT_ID, VERSION));
-        assertThat(response).contains(format("kogito_work_item_duration_seconds_sum{artifactId=\"%s\",name=\"MonitoringTask\",version=\"%s\",}", ARTIFACT_ID, VERSION));
-
-        assertThat(response)
+        assertThat(response).contains(format("kogito_work_item_duration_seconds_max{artifactId=\"%s\",name=\"MonitoringTask\",version=\"%s\",}", ARTIFACT_ID, VERSION))
+                .contains(format("kogito_work_item_duration_seconds_count{artifactId=\"%s\",name=\"MonitoringTask\",version=\"%s\",} 1.0", ARTIFACT_ID, VERSION))
+                .contains(format("kogito_work_item_duration_seconds_sum{artifactId=\"%s\",name=\"MonitoringTask\",version=\"%s\",}", ARTIFACT_ID, VERSION))
                 .contains(format(
                         "kogito_process_instance_completed_total{app_id=\"default-process-monitoring-listener\",artifactId=\"%s\",node_name=\"2\",process_id=\"monitoring\",version=\"%s\",} 1.0",
-                        ARTIFACT_ID, VERSION));
-        assertThat(response).contains(format("kogito_process_instance_running_total{app_id=\"default-process-monitoring-listener\",artifactId=\"%s\",process_id=\"monitoring\",version=\"%s\",} 0.0",
-                ARTIFACT_ID, VERSION));
-        assertThat(response).contains(format("kogito_process_instance_duration_seconds_max{app_id=\"default-process-monitoring-listener\",artifactId=\"%s\",process_id=\"monitoring\",version=\"%s\",}",
-                ARTIFACT_ID, VERSION));
-        assertThat(response)
+                        ARTIFACT_ID, VERSION))
+                .contains(format("kogito_process_instance_running_total{app_id=\"default-process-monitoring-listener\",artifactId=\"%s\",process_id=\"monitoring\",version=\"%s\",} 0.0",
+                        ARTIFACT_ID, VERSION))
+                .contains(format("kogito_process_instance_duration_seconds_max{app_id=\"default-process-monitoring-listener\",artifactId=\"%s\",process_id=\"monitoring\",version=\"%s\",}",
+                        ARTIFACT_ID, VERSION))
                 .contains(format("kogito_process_instance_duration_seconds_count{app_id=\"default-process-monitoring-listener\",artifactId=\"%s\",process_id=\"monitoring\",version=\"%s\",} 1.0",
+                        ARTIFACT_ID, VERSION))
+                .contains(format("kogito_process_instance_duration_seconds_sum{app_id=\"default-process-monitoring-listener\",artifactId=\"%s\",process_id=\"monitoring\",version=\"%s\",}",
                         ARTIFACT_ID, VERSION));
-        assertThat(response).contains(format("kogito_process_instance_duration_seconds_sum{app_id=\"default-process-monitoring-listener\",artifactId=\"%s\",process_id=\"monitoring\",version=\"%s\",}",
-                ARTIFACT_ID, VERSION));
     }
 
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-8085

Goal here is to reduce the number of code smells in Kogito-runtimes.

Addressed in this PR are the following code smells:

1) (Java) Consecutive AssertJ "assertThat" statements should be chained (11): https://sonarcloud.io/project/issues?resolved=false&rules=java%3AS5853&id=org.kie.kogito%3Akogito-runtimes
I have addressed this by chaining AssertJ statements that are targeting the same object.

2) (Java) AssertJ methods setting the assertion context should come before an assertion (6):  https://sonarcloud.io/project/issues?resolved=false&rules=java%3AS5833&id=org.kie.kogito%3Akogito-runtimes 
I have addressed this by modifying AssertJ statements that called .withFailMessage after the assertion instead of before.

3) (Java) Assertions comparing incompatible types should not be made (4): https://sonarcloud.io/project/issues?resolved=false&rules=java%3AS5845&id=org.kie.kogito%3Akogito-runtimes
I have addressed this by removing assertions of incompatible types that always pass

- [ ] You have read the [contributors guide](CONTRIBUTING.md)
- [ ] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>

- for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] mandrel-lts</b>
 
- <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
