### PR TITLE
DROOLS-6946 Remove deprecated method PackageBuildContext#init

### DIFF
--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/ProcessBuildContext.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/ProcessBuildContext.java
@@ -15,7 +15,7 @@
  */
 package org.jbpm.process.builder;
 
-import org.drools.compiler.builder.DroolsAssemblerContext;
+import org.drools.compiler.builder.impl.KnowledgeBuilderImpl;
 import org.drools.compiler.compiler.Dialect;
 import org.drools.compiler.compiler.DialectCompiletimeRegistry;
 import org.drools.compiler.rule.builder.PackageBuildContext;
@@ -30,7 +30,7 @@ public class ProcessBuildContext extends PackageBuildContext {
     private ProcessDescr processDescr;
     private DialectCompiletimeRegistry dialectRegistry;
 
-    public ProcessBuildContext(final DroolsAssemblerContext assemblerContext,
+    public ProcessBuildContext(final KnowledgeBuilderImpl assemblerContext,
             final InternalKnowledgePackage pkg,
             final Process process,
             final BaseDescr processDescr,
@@ -39,7 +39,7 @@ public class ProcessBuildContext extends PackageBuildContext {
         this.process = process;
         this.processDescr = (ProcessDescr) processDescr;
         this.dialectRegistry = dialectRegistry;
-        init(assemblerContext,
+        initContext(assemblerContext,
                 pkg,
                 processDescr,
                 dialectRegistry,

--- a/jbpm/jbpm-flow-builder/src/test/java/org/jbpm/process/builder/JavaActionBuilderTest.java
+++ b/jbpm/jbpm-flow-builder/src/test/java/org/jbpm/process/builder/JavaActionBuilderTest.java
@@ -65,7 +65,7 @@ public class JavaActionBuilderTest extends AbstractBaseTest {
 
         ProcessBuildContext context = new ProcessBuildContext(builder, builder.getPackage("pkg1"), null, processDescr, dialectRegistry, javaDialect);
 
-        context.init(builder, pkg, null, dialectRegistry, javaDialect, null);
+        context.initContext(builder, pkg, null, dialectRegistry, javaDialect, null);
 
         builder.addPackageFromDrl(new StringReader("package pkg1;\nglobal java.util.List list;\n"));
 

--- a/jbpm/jbpm-flow-builder/src/test/java/org/jbpm/process/builder/MVELActionBuilderTest.java
+++ b/jbpm/jbpm-flow-builder/src/test/java/org/jbpm/process/builder/MVELActionBuilderTest.java
@@ -56,7 +56,7 @@ public class MVELActionBuilderTest extends AbstractBaseTest {
         MVELDialect mvelDialect = (MVELDialect) dialectRegistry.getDialect("mvel");
 
         PackageBuildContext context = new PackageBuildContext();
-        context.init(builder, pkg, null, dialectRegistry, mvelDialect, null);
+        context.initContext(builder, pkg, null, dialectRegistry, mvelDialect, null);
 
         builder.addPackageFromDrl(new StringReader("package pkg1;\nglobal java.util.List list;\n"));
 

--- a/jbpm/jbpm-flow-builder/src/test/java/org/jbpm/process/builder/MVELDecisionBuilderTest.java
+++ b/jbpm/jbpm-flow-builder/src/test/java/org/jbpm/process/builder/MVELDecisionBuilderTest.java
@@ -57,7 +57,7 @@ public class MVELDecisionBuilderTest extends AbstractBaseTest {
         MVELDialect mvelDialect = (MVELDialect) pkgReg.getDialectCompiletimeRegistry().getDialect("mvel");
 
         PackageBuildContext context = new PackageBuildContext();
-        context.init(builder, pkg, null, pkgReg.getDialectCompiletimeRegistry(), mvelDialect, null);
+        context.initContext(builder, pkg, null, pkgReg.getDialectCompiletimeRegistry(), mvelDialect, null);
 
         builder.addPackageFromDrl(new StringReader("package pkg1;\nglobal java.util.List list;\n"));
 

--- a/jbpm/jbpm-flow-builder/src/test/java/org/jbpm/process/builder/MVELReturnValueConstraintEvaluatorBuilderTest.java
+++ b/jbpm/jbpm-flow-builder/src/test/java/org/jbpm/process/builder/MVELReturnValueConstraintEvaluatorBuilderTest.java
@@ -53,7 +53,7 @@ public class MVELReturnValueConstraintEvaluatorBuilderTest extends AbstractBaseT
         MVELDialect mvelDialect = (MVELDialect) dialectRegistry.getDialect("mvel");
 
         PackageBuildContext context = new PackageBuildContext();
-        context.init(builder,
+        context.initContext(builder,
                 pkg,
                 null,
                 dialectRegistry,


### PR DESCRIPTION
`PackageBuildContext#init` is an internal method that has been deprecated for a while. Remove all references and use the new `initContext`.

- https://github.com/kiegroup/drools/pull/4739
- https://github.com/kiegroup/kogito-runtimes/pull/2549
