### PR TITLE
Kogito-8133 Migrate test assertions in kogito-test-utils module to AssertJ assertions

### DIFF
--- a/kogito-test-utils/pom.xml
+++ b/kogito-test-utils/pom.xml
@@ -88,6 +88,10 @@
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+    </dependency>
 
   </dependencies>
 

--- a/kogito-test-utils/src/test/java/org/kie/kogito/test/resources/ConditionHolderTest.java
+++ b/kogito-test-utils/src/test/java/org/kie/kogito/test/resources/ConditionHolderTest.java
@@ -18,8 +18,7 @@ package org.kie.kogito.test.resources;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ConditionHolderTest {
 
@@ -35,27 +34,27 @@ public class ConditionHolderTest {
 
     @Test
     public void shouldBeEnabledByDefault() {
-        assertTrue(condition.isEnabled());
+        assertThat(condition.isEnabled()).isTrue();
     }
 
     @Test
     public void shouldBeDisabledIfSystemPropertyDoesNotExist() {
         System.clearProperty(RESOURCE_PROPERTY);
         condition.enableConditional();
-        assertFalse(condition.isEnabled());
+        assertThat(condition.isEnabled()).isFalse();
     }
 
     @Test
     public void shouldBeDisabledIfSystemPropertyIsNotTrue() {
         System.setProperty(RESOURCE_PROPERTY, "anything");
         condition.enableConditional();
-        assertFalse(condition.isEnabled());
+        assertThat(condition.isEnabled()).isFalse();
     }
 
     @Test
     public void shouldBeEnabledIfSystemPropertyIsTrue() {
         System.setProperty(RESOURCE_PROPERTY, "true");
         condition.enableConditional();
-        assertTrue(condition.isEnabled());
+        assertThat(condition.isEnabled()).isTrue();
     }
 }

--- a/kogito-test-utils/src/test/java/org/kie/kogito/test/utils/SocketUtilsTest.java
+++ b/kogito-test-utils/src/test/java/org/kie/kogito/test/utils/SocketUtilsTest.java
@@ -17,7 +17,7 @@ package org.kie.kogito.test.utils;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.kogito.test.utils.SocketUtils.PORT_RANGE_MAX;
 import static org.kie.kogito.test.utils.SocketUtils.PORT_RANGE_MIN;
 
@@ -26,8 +26,8 @@ public class SocketUtilsTest {
     @Test
     public void findAvailablePortTest() {
         int availablePort = SocketUtils.findAvailablePort();
-        assertTrue(availablePort <= PORT_RANGE_MAX);
-        assertTrue(availablePort >= PORT_RANGE_MIN);
+        assertThat(availablePort).isLessThanOrEqualTo(PORT_RANGE_MAX)
+                .isGreaterThanOrEqualTo(PORT_RANGE_MIN);
     }
 
 }

--- a/kogito-test-utils/src/test/java/org/kie/kogito/testcontainers/InfinispanContainerTest.java
+++ b/kogito-test-utils/src/test/java/org/kie/kogito/testcontainers/InfinispanContainerTest.java
@@ -18,8 +18,7 @@ package org.kie.kogito.testcontainers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.kogito.testcontainers.Constants.CONTAINER_NAME_PREFIX;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -42,18 +41,18 @@ public class InfinispanContainerTest {
 
     @Test
     public void shouldAddDefaultSettings() {
-        assertTrue(container.getExposedPorts().contains(KogitoInfinispanContainer.PORT));
+        assertThat(container.getExposedPorts()).contains(KogitoInfinispanContainer.PORT);
     }
 
     @Test
     public void shouldGetResourceName() {
-        assertEquals(KogitoInfinispanContainer.NAME, container.getResourceName());
+        assertThat(container.getResourceName()).isEqualTo(KogitoInfinispanContainer.NAME);
     }
 
     @Test
     public void shouldGetMapperPort() {
         doReturn(MAPPED_PORT).when(container).getMappedPort(KogitoInfinispanContainer.PORT);
-        assertEquals(MAPPED_PORT, container.getMappedPort());
+        assertThat(container.getMappedPort()).isEqualTo(MAPPED_PORT);
     }
 
 }

--- a/kogito-test-utils/src/test/java/org/kie/kogito/testcontainers/KeycloakContainerTest.java
+++ b/kogito-test-utils/src/test/java/org/kie/kogito/testcontainers/KeycloakContainerTest.java
@@ -18,8 +18,7 @@ package org.kie.kogito.testcontainers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.kogito.testcontainers.Constants.CONTAINER_NAME_PREFIX;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -42,20 +41,20 @@ public class KeycloakContainerTest {
 
     @Test
     public void shouldAddDefaultSettings() {
-        assertTrue(container.getExposedPorts().contains(KogitoKeycloakContainer.PORT));
-        assertEquals("admin", container.getEnvMap().get("KEYCLOAK_USER"));
-        assertEquals("admin", container.getEnvMap().get("KEYCLOAK_PASSWORD"));
+        assertThat(container.getExposedPorts()).contains(KogitoKeycloakContainer.PORT);
+        assertThat(container.getEnvMap()).containsEntry("KEYCLOAK_USER", "admin")
+                .containsEntry("KEYCLOAK_PASSWORD", "admin");
     }
 
     @Test
     public void shouldGetResourceName() {
-        assertEquals(KogitoKeycloakContainer.NAME, container.getResourceName());
+        assertThat(container.getResourceName()).isEqualTo(KogitoKeycloakContainer.NAME);
     }
 
     @Test
     public void shouldGetMapperPort() {
         doReturn(MAPPED_PORT).when(container).getMappedPort(KogitoKeycloakContainer.PORT);
-        assertEquals(MAPPED_PORT, container.getMappedPort());
+        assertThat(container.getMappedPort()).isEqualTo(MAPPED_PORT);
     }
 
 }

--- a/kogito-test-utils/src/test/java/org/kie/kogito/testcontainers/KogitoKafkaContainerTest.java
+++ b/kogito-test-utils/src/test/java/org/kie/kogito/testcontainers/KogitoKafkaContainerTest.java
@@ -18,7 +18,7 @@ package org.kie.kogito.testcontainers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
@@ -40,13 +40,13 @@ public class KogitoKafkaContainerTest {
 
     @Test
     public void shouldGetResourceName() {
-        assertEquals(KogitoKafkaContainer.NAME, container.getResourceName());
+        assertThat(container.getResourceName()).isEqualTo(KogitoKafkaContainer.NAME);
     }
 
     @Test
     public void shouldGetMapperPort() {
         doReturn(MAPPED_PORT).when(container).getMappedPort(KogitoKafkaContainer.KAFKA_PORT);
-        assertEquals(MAPPED_PORT, container.getMappedPort());
+        assertThat(container.getMappedPort()).isEqualTo(MAPPED_PORT);
     }
 
 }

--- a/kogito-test-utils/src/test/java/org/kie/kogito/testcontainers/KogitoMongoDBContainerTest.java
+++ b/kogito-test-utils/src/test/java/org/kie/kogito/testcontainers/KogitoMongoDBContainerTest.java
@@ -18,7 +18,7 @@ package org.kie.kogito.testcontainers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
@@ -37,17 +37,17 @@ class KogitoMongoDBContainerTest {
 
     @Test
     void shouldGetResourceName() {
-        assertEquals(KogitoMongoDBContainer.NAME, container.getResourceName());
+        assertThat(container.getResourceName()).isEqualTo(KogitoMongoDBContainer.NAME);
     }
 
     @Test
     void shouldGetMapperPort() {
         doReturn(MAPPED_PORT).when(container).getMappedPort(KogitoMongoDBContainer.MONGODB_INTERNAL_PORT);
-        assertEquals(MAPPED_PORT, container.getMappedPort());
+        assertThat(container.getMappedPort()).isEqualTo(MAPPED_PORT);
     }
 
     @Test
     void shouldGetDockerImageName() {
-        assertEquals(System.getProperty(Constants.CONTAINER_NAME_PREFIX + KogitoMongoDBContainer.NAME), container.getDockerImageName());
+        assertThat(container.getDockerImageName()).isEqualTo(System.getProperty(Constants.CONTAINER_NAME_PREFIX + KogitoMongoDBContainer.NAME));
     }
 }

--- a/kogito-test-utils/src/test/java/org/kie/kogito/testcontainers/KogitoRedisSearchContainerTest.java
+++ b/kogito-test-utils/src/test/java/org/kie/kogito/testcontainers/KogitoRedisSearchContainerTest.java
@@ -18,8 +18,7 @@ package org.kie.kogito.testcontainers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.kogito.testcontainers.Constants.CONTAINER_NAME_PREFIX;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -42,18 +41,18 @@ public class KogitoRedisSearchContainerTest {
 
     @Test
     public void shouldAddDefaultSettings() {
-        assertTrue(container.getExposedPorts().contains(KogitoRedisSearchContainer.PORT));
+        assertThat(container.getExposedPorts()).contains(KogitoRedisSearchContainer.PORT);
     }
 
     @Test
     public void shouldGetResourceName() {
-        assertEquals(KogitoRedisSearchContainer.NAME, container.getResourceName());
+        assertThat(container.getResourceName()).isEqualTo(KogitoRedisSearchContainer.NAME);
     }
 
     @Test
     public void shouldGetMapperPort() {
         doReturn(MAPPED_PORT).when(container).getMappedPort(KogitoRedisSearchContainer.PORT);
-        assertEquals(MAPPED_PORT, container.getMappedPort());
+        assertThat(container.getMappedPort()).isEqualTo(MAPPED_PORT);
     }
 
 }


### PR DESCRIPTION
issue: https://issues.redhat.com/browse/KOGITO-8133

This patch migrates kogito-runtime tests inside the kogito-test-utils module to assertj assertions.

It removes use of junit assertions.

Where possible it simplifies the assertion using assertj features.

This patch is part of the ongoing effort to standardize kogito-runtime tests to assertj.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>

- for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] mandrel-lts</b>
 
- <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
