### PR TITLE
Kogito-8134 Migrate test assertions in kogito-workitems module to AssertJ assertions	

### DIFF
--- a/kogito-workitems/kogito-jackson-utils/src/test/java/org/kie/kogito/jackson/utils/JsonNodeConverterTest.java
+++ b/kogito-workitems/kogito-jackson-utils/src/test/java/org/kie/kogito/jackson/utils/JsonNodeConverterTest.java
@@ -17,11 +17,11 @@ package org.kie.kogito.jackson.utils;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class JsonNodeConverterTest {
     @Test
     void testJsonStringConverter() {
-        assertEquals(ObjectMapperFactory.get().createObjectNode().put("name", "javierito"), new JsonNodeConverter().apply("{\"name\":\"javierito\"}"));
+        assertThat(new JsonNodeConverter().apply("{\"name\":\"javierito\"}")).isEqualTo(ObjectMapperFactory.get().createObjectNode().put("name", "javierito"));
     }
 }

--- a/kogito-workitems/kogito-jackson-utils/src/test/java/org/kie/kogito/jackson/utils/JsonNodeVisitorTest.java
+++ b/kogito-workitems/kogito-jackson-utils/src/test/java/org/kie/kogito/jackson/utils/JsonNodeVisitorTest.java
@@ -19,33 +19,32 @@ import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class JsonNodeVisitorTest {
     @Test
     void testSimpleObjectNodeVisitor() {
         ObjectNode source = ObjectMapperFactory.get().createObjectNode().put("name", "no javierito");
-        assertEquals(ObjectMapperFactory.get().createObjectNode().put("name", "javierito"), JsonNodeVisitor.transformTextNode(source, n -> JsonObjectUtils.fromValue("javierito")));
+        assertThat(JsonNodeVisitor.transformTextNode(source, n -> JsonObjectUtils.fromValue("javierito"))).isEqualTo(ObjectMapperFactory.get().createObjectNode().put("name", "javierito"));
     }
 
     @Test
     void testComplextObjectNodeVisitor() {
         ObjectNode source = ObjectMapperFactory.get().createObjectNode().set("embedded", ObjectMapperFactory.get().createObjectNode().put("name", "no javierito"));
-        assertEquals(ObjectMapperFactory.get().createObjectNode().set("embedded", ObjectMapperFactory.get().createObjectNode().put("name", "javierito")),
-                JsonNodeVisitor.transformTextNode(source, n -> JsonObjectUtils.fromValue("javierito")));
+        assertThat(JsonNodeVisitor.transformTextNode(source, n -> JsonObjectUtils.fromValue("javierito")))
+                .isEqualTo(ObjectMapperFactory.get().createObjectNode().set("embedded", ObjectMapperFactory.get().createObjectNode().put("name", "javierito")));
     }
 
     @Test
     void testArrayNodeVisitor() {
         ObjectNode source =
                 ObjectMapperFactory.get().createObjectNode().set("embedded", ObjectMapperFactory.get().createArrayNode().add(ObjectMapperFactory.get().createObjectNode().put("name", "no javierito")));
-        assertEquals(
-                ObjectMapperFactory.get().createObjectNode().set("embedded", ObjectMapperFactory.get().createArrayNode().add(ObjectMapperFactory.get().createObjectNode().put("name", "javierito"))),
-                JsonNodeVisitor.transformTextNode(source, n -> JsonObjectUtils.fromValue("javierito")));
+        assertThat(JsonNodeVisitor.transformTextNode(source, n -> JsonObjectUtils.fromValue("javierito"))).isEqualTo(
+                ObjectMapperFactory.get().createObjectNode().set("embedded", ObjectMapperFactory.get().createArrayNode().add(ObjectMapperFactory.get().createObjectNode().put("name", "javierito"))));
     }
 
     @Test
     void testStringNodeVisitor() {
-        assertEquals("pepa", JsonNodeVisitor.transformTextNode(JsonObjectUtils.fromValue("pepa"), p -> p).asText());
+        assertThat(JsonNodeVisitor.transformTextNode(JsonObjectUtils.fromValue("pepa"), p -> p).asText()).isEqualTo("pepa");
     }
 }

--- a/kogito-workitems/kogito-jackson-utils/src/test/java/org/kie/kogito/jackson/utils/JsonObjectUtilsTest.java
+++ b/kogito-workitems/kogito-jackson-utils/src/test/java/org/kie/kogito/jackson/utils/JsonObjectUtilsTest.java
@@ -26,57 +26,57 @@ import com.fasterxml.jackson.databind.node.FloatNode;
 import com.fasterxml.jackson.databind.node.IntNode;
 import com.fasterxml.jackson.databind.node.NullNode;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class JsonObjectUtilsTest {
 
     @Test
     void testPojo() {
-        assertEquals(ObjectMapperFactory.get().createObjectNode().put("name", "javierito"), JsonObjectUtils.fromValue(new Person("javierito")));
+        assertThat(JsonObjectUtils.fromValue(new Person("javierito"))).isEqualTo(ObjectMapperFactory.get().createObjectNode().put("name", "javierito"));
     }
 
     @Test
     void testArrayOfPojo() {
-        assertEquals(ObjectMapperFactory.get().createArrayNode().add(ObjectMapperFactory.get().createObjectNode().put("name", "javierito"))
-                .add(ObjectMapperFactory.get().createObjectNode().put("name", "fulanito")), JsonObjectUtils.fromValue(Arrays.asList(new Person("javierito"), new Person("fulanito"))));
+        assertThat(JsonObjectUtils.fromValue(Arrays.asList(new Person("javierito"), new Person("fulanito"))))
+                .isEqualTo(ObjectMapperFactory.get().createArrayNode().add(ObjectMapperFactory.get().createObjectNode().put("name", "javierito"))
+                        .add(ObjectMapperFactory.get().createObjectNode().put("name", "fulanito")));
     }
 
     @Test
     void testJavaArray() {
-        assertEquals(Arrays.asList(Collections.singletonMap("name", "javierito"), Collections.singletonMap("name", "fulanito")), JsonObjectUtils.toJavaValue(ObjectMapperFactory.get().createArrayNode()
-                .add(ObjectMapperFactory.get().createObjectNode().put("name", "javierito")).add(ObjectMapperFactory.get().createObjectNode().put("name", "fulanito"))));
+        assertThat(JsonObjectUtils.toJavaValue(ObjectMapperFactory.get().createArrayNode()
+                .add(ObjectMapperFactory.get().createObjectNode().put("name", "javierito")).add(ObjectMapperFactory.get().createObjectNode().put("name", "fulanito"))))
+                        .isEqualTo(Arrays.asList(Collections.singletonMap("name", "javierito"), Collections.singletonMap("name", "fulanito")));
     }
 
     @Test
     void testJavaObject() {
-        assertEquals(Collections.singletonMap("name", "javierito"), JsonObjectUtils.toJavaValue(ObjectMapperFactory.get().createObjectNode().put("name", "javierito")));
+        assertThat(JsonObjectUtils.toJavaValue(ObjectMapperFactory.get().createObjectNode().put("name", "javierito"))).isEqualTo(Collections.singletonMap("name", "javierito"));
     }
 
     @Test
     void testNullObject() {
-        assertNull(JsonObjectUtils.toJavaValue(NullNode.getInstance()));
+        assertThat(JsonObjectUtils.toJavaValue(NullNode.getInstance())).isNull();
     }
 
     @Test
     void testJavaInt() {
-        assertEquals(5, JsonObjectUtils.toJavaValue(new IntNode(5)));
+        assertThat(JsonObjectUtils.toJavaValue(new IntNode(5))).isEqualTo(5);
     }
 
     @Test
     void testJavaDouble() {
-        assertEquals(5.0, JsonObjectUtils.toJavaValue(new DoubleNode(5.0f)));
+        assertThat(JsonObjectUtils.toJavaValue(new DoubleNode(5.0f))).isEqualTo(5.0);
     }
 
     @Test
     void testJavaFloat() {
-        assertEquals(5.0f, JsonObjectUtils.toJavaValue(new FloatNode(5.0f)));
+        assertThat(JsonObjectUtils.toJavaValue(new FloatNode(5.0f))).isEqualTo(5.0f);
     }
 
     @Test
     void testJavaByteArray() {
         byte[] bytes = { 1, 2, 3, 4 };
-        assertArrayEquals(bytes, (byte[]) JsonObjectUtils.toJavaValue(BinaryNode.valueOf(bytes)));
+        assertThat((byte[]) JsonObjectUtils.toJavaValue(BinaryNode.valueOf(bytes))).isEqualTo(bytes);
     }
 }

--- a/kogito-workitems/kogito-jackson-utils/src/test/java/org/kie/kogito/jackson/utils/ListenerAwareTest.java
+++ b/kogito-workitems/kogito-jackson-utils/src/test/java/org/kie/kogito/jackson/utils/ListenerAwareTest.java
@@ -25,9 +25,8 @@ import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -89,20 +88,20 @@ public class ListenerAwareTest {
     @Test
     void testObjectClone() {
         ObjectNode node = ObjectMapperFactory.listenerAware().createObjectNode().put("name", "Javierito");
-        assertTrue(node instanceof ObjectNodeListenerAware);
+        assertThat(node).isInstanceOf(ObjectNodeListenerAware.class);
         ObjectNode cloned = node.deepCopy();
-        assertTrue(cloned instanceof ObjectNodeListenerAware);
+        assertThat(cloned).isInstanceOf(ObjectNodeListenerAware.class);
         assertNotSame(node, cloned);
-        assertEquals(node, cloned);
+        assertThat(cloned).isEqualTo(node);
     }
 
     @Test
     void testArrayClone() {
         ArrayNode node = ObjectMapperFactory.listenerAware().getNodeFactory().arrayNode(2).add("Javierito");
-        assertTrue(node instanceof ArrayNodeListenerAware);
+        assertThat(node).isInstanceOf(ArrayNodeListenerAware.class);
         ArrayNode cloned = node.deepCopy();
-        assertTrue(cloned instanceof ArrayNodeListenerAware);
+        assertThat(cloned).isInstanceOf(ArrayNodeListenerAware.class);
         assertNotSame(node, cloned);
-        assertEquals(node, cloned);
+        assertThat(cloned).isEqualTo(node);
     }
 }

--- a/kogito-workitems/kogito-jackson-utils/src/test/java/org/kie/kogito/jackson/utils/ListenerAwareTest.java
+++ b/kogito-workitems/kogito-jackson-utils/src/test/java/org/kie/kogito/jackson/utils/ListenerAwareTest.java
@@ -26,7 +26,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -90,9 +89,9 @@ public class ListenerAwareTest {
         ObjectNode node = ObjectMapperFactory.listenerAware().createObjectNode().put("name", "Javierito");
         assertThat(node).isInstanceOf(ObjectNodeListenerAware.class);
         ObjectNode cloned = node.deepCopy();
-        assertThat(cloned).isInstanceOf(ObjectNodeListenerAware.class);
-        assertNotSame(node, cloned);
-        assertThat(cloned).isEqualTo(node);
+        assertThat(cloned).isInstanceOf(ObjectNodeListenerAware.class)
+                .isNotSameAs(node)
+                .isEqualTo(node);
     }
 
     @Test
@@ -100,8 +99,8 @@ public class ListenerAwareTest {
         ArrayNode node = ObjectMapperFactory.listenerAware().getNodeFactory().arrayNode(2).add("Javierito");
         assertThat(node).isInstanceOf(ArrayNodeListenerAware.class);
         ArrayNode cloned = node.deepCopy();
-        assertThat(cloned).isInstanceOf(ArrayNodeListenerAware.class);
-        assertNotSame(node, cloned);
-        assertThat(cloned).isEqualTo(node);
+        assertThat(cloned).isInstanceOf(ArrayNodeListenerAware.class)
+                .isNotSameAs(node)
+                .isEqualTo(node);
     }
 }

--- a/kogito-workitems/kogito-jackson-utils/src/test/java/org/kie/kogito/jackson/utils/MergeUtilsTest.java
+++ b/kogito-workitems/kogito-jackson-utils/src/test/java/org/kie/kogito/jackson/utils/MergeUtilsTest.java
@@ -25,36 +25,36 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.IntNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MergeUtilsTest {
 
     @Test
     void testSrcTargetArray() {
-        assertEquals(Arrays.asList(1, 2, 3, 4, 5, 6),
-                JsonObjectUtils
-                        .toJavaValue(MergeUtils.merge(ObjectMapperFactory.get().createArrayNode().add(4).add(5).add(6), ObjectMapperFactory.get().createArrayNode().add(1).add(2).add(3), true)));
+        assertThat(JsonObjectUtils
+                .toJavaValue(MergeUtils.merge(ObjectMapperFactory.get().createArrayNode().add(4).add(5).add(6), ObjectMapperFactory.get().createArrayNode().add(1).add(2).add(3), true)))
+                        .isEqualTo(Arrays.asList(1, 2, 3, 4, 5, 6));
     }
 
     @Test
     void testTargetArraySrcInt() {
-        assertEquals(Arrays.asList(1, 2, 3, 4), JsonObjectUtils.toJavaValue(MergeUtils.merge(new IntNode(4), ObjectMapperFactory.get().createArrayNode().add(1).add(2).add(3))));
+        assertThat(JsonObjectUtils.toJavaValue(MergeUtils.merge(new IntNode(4), ObjectMapperFactory.get().createArrayNode().add(1).add(2).add(3)))).isEqualTo(Arrays.asList(1, 2, 3, 4));
     }
 
     @Test
     void testTargetIntSrcArray() {
-        assertEquals(Arrays.asList(4, 1, 2, 3), JsonObjectUtils.toJavaValue(MergeUtils.merge(ObjectMapperFactory.get().createArrayNode().add(1).add(2).add(3), new IntNode(4), false)));
+        assertThat(JsonObjectUtils.toJavaValue(MergeUtils.merge(ObjectMapperFactory.get().createArrayNode().add(1).add(2).add(3), new IntNode(4), false))).isEqualTo(Arrays.asList(4, 1, 2, 3));
     }
 
     @Test
     void testTargetObjectSrcInt() {
-        assertEquals(Collections.singletonMap("response", 3), JsonObjectUtils.toJavaValue(MergeUtils.merge(new IntNode(3), ObjectMapperFactory.get().createObjectNode(), false)));
+        assertThat(JsonObjectUtils.toJavaValue(MergeUtils.merge(new IntNode(3), ObjectMapperFactory.get().createObjectNode(), false))).isEqualTo(Collections.singletonMap("response", 3));
     }
 
     @Test
     void testTargetObjectSrcArray() {
-        assertEquals(Collections.singletonMap("response", Arrays.asList(1, 2, 3)),
-                JsonObjectUtils.toJavaValue(MergeUtils.merge(ObjectMapperFactory.get().createArrayNode().add(1).add(2).add(3), ObjectMapperFactory.get().createObjectNode(), false)));
+        assertThat(JsonObjectUtils.toJavaValue(MergeUtils.merge(ObjectMapperFactory.get().createArrayNode().add(1).add(2).add(3), ObjectMapperFactory.get().createObjectNode(), false)))
+                .isEqualTo(Collections.singletonMap("response", Arrays.asList(1, 2, 3)));
     }
 
     @Test
@@ -63,8 +63,8 @@ public class MergeUtilsTest {
         ObjectNode vipCustomer = getCustomer("Messi", 69, 1221312.2, true, "Islas virgenes", Arrays.asList("Isla paradisiaca anonima", "Palacio presidencial S/N"));
         JsonNode merged =
                 MergeUtils.merge(ObjectMapperFactory.get().createObjectNode().set("dummyCustomer", dummyCustomer), ObjectMapperFactory.get().createObjectNode().set("vipCustomer", vipCustomer));
-        assertEquals(dummyCustomer, merged.get("dummyCustomer"));
-        assertEquals(vipCustomer, merged.get("vipCustomer"));
+        assertThat(merged.get("dummyCustomer")).isEqualTo(dummyCustomer);
+        assertThat(merged.get("vipCustomer")).isEqualTo(vipCustomer);
     }
 
     @Test
@@ -73,7 +73,7 @@ public class MergeUtilsTest {
         ObjectNode vipCustomer = getCustomer("Messi", 69, 1221312.2, true, "Parla", Arrays.asList("Isla paradisiaca anonima", "Palacio presidencial S/N"));
         JsonNode expectedMerged =
                 getCustomer("Fulanito", 23, 999.9, false, "Parla", Arrays.asList("Isla paradisiaca anonima", "Palacio presidencial S/N", "percebe 13", "casa de mis padres en Mostoles"));
-        assertEquals(expectedMerged, MergeUtils.merge(dummyCustomer, vipCustomer, true));
+        assertThat(MergeUtils.merge(dummyCustomer, vipCustomer, true)).isEqualTo(expectedMerged);
     }
 
     @Test
@@ -81,9 +81,9 @@ public class MergeUtilsTest {
         ObjectNode dummyCustomer = getCustomer("Fulanito", 23, 999.9, false, "Parla", Arrays.asList("percebe 13", "casa de mis padres en Mostoles"));
         ObjectNode vipCustomer = getCustomer("Messi", 69, 1221312.2, true, "Islas Virgenes", Arrays.asList("Isla paradisiaca anonima", "Palacio presidencial S/N"));
         ArrayNode merged = (ArrayNode) MergeUtils.merge(ObjectMapperFactory.get().createArrayNode().add(dummyCustomer), ObjectMapperFactory.get().createArrayNode().add(vipCustomer), true);
-        assertEquals(2, merged.size());
-        assertEquals(vipCustomer, merged.get(0));
-        assertEquals(dummyCustomer, merged.get(1));
+        assertThat(merged.size()).isEqualTo(2);
+        assertThat(merged.get(0)).isEqualTo(vipCustomer);
+        assertThat(merged.get(1)).isEqualTo(dummyCustomer);
     }
 
     @Test
@@ -92,15 +92,15 @@ public class MergeUtilsTest {
         ObjectNode vipCustomer = getCustomer("Messi", 69, 1221312.2, true, "Islas Virgenes", Arrays.asList("Isla paradisiaca anonima", "Palacio presidencial S/N"));
         ArrayNode merged =
                 (ArrayNode) MergeUtils.merge(ObjectMapperFactory.get().createArrayNode().add(dummyCustomer), ObjectMapperFactory.get().createArrayNode().add(vipCustomer).add(dummyCustomer), true);
-        assertEquals(2, merged.size());
-        assertEquals(vipCustomer, merged.get(0));
-        assertEquals(dummyCustomer, merged.get(1));
+        assertThat(merged.size()).isEqualTo(2);
+        assertThat(merged.get(0)).isEqualTo(vipCustomer);
+        assertThat(merged.get(1)).isEqualTo(dummyCustomer);
     }
 
     @Test
     void testNullMerge() {
         JsonNode srcNode = ObjectMapperFactory.get().createObjectNode().put("name", "javierito");
-        assertEquals(srcNode, MergeUtils.merge(srcNode, null));
+        assertThat(MergeUtils.merge(srcNode, null)).isEqualTo(srcNode);
     }
 
     private static class Person {
@@ -127,7 +127,7 @@ public class MergeUtilsTest {
     void testMergeWithPojo() {
         Person person = new Person("javierito");
         ObjectNode target = ObjectMapperFactory.get().createObjectNode().put("name", "fulanito");
-        assertEquals(ObjectMapperFactory.get().createObjectNode().put("name", "javierito"), MergeUtils.merge(JsonObjectUtils.fromValue(person), target));
+        assertThat(MergeUtils.merge(JsonObjectUtils.fromValue(person), target)).isEqualTo(ObjectMapperFactory.get().createObjectNode().put("name", "javierito"));
 
     }
 

--- a/kogito-workitems/kogito-rest-workitem/src/test/java/org/kogito/workitem/rest/RestWorkItemHandlerTest.java
+++ b/kogito-workitems/kogito-rest-workitem/src/test/java/org/kogito/workitem/rest/RestWorkItemHandlerTest.java
@@ -54,9 +54,6 @@ import io.vertx.mutiny.ext.web.client.HttpResponse;
 import io.vertx.mutiny.ext.web.client.WebClient;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.kogito.workitem.rest.RestWorkItemHandler.BODY_BUILDER;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -159,7 +156,7 @@ public class RestWorkItemHandlerTest {
         RestWorkItemHandlerResult resultHandler = new DefaultRestWorkItemHandlerResult();
         HttpResponse<Buffer> response = mock(HttpResponse.class);
         when(response.bodyAsJson(ObjectNode.class)).thenReturn(objectNode);
-        assertSame(objectNode, resultHandler.apply(response, ObjectNode.class));
+        assertThat(resultHandler.apply(response, ObjectNode.class)).isSameAs(objectNode);
     }
 
     @Test
@@ -187,7 +184,7 @@ public class RestWorkItemHandlerTest {
 
         verify(manager).completeWorkItem(anyString(), argCaptor.capture());
         Map<String, Object> results = argCaptor.getValue();
-        assertEquals(1, results.size());
+        assertThat(results).hasSize(1);
     }
 
     @Test
@@ -201,8 +198,8 @@ public class RestWorkItemHandlerTest {
 
         verify(request).sendJsonAndAwait(bodyCaptor.capture());
         Map<String, Object> bodyMap = bodyCaptor.getValue();
-        assertEquals(26, bodyMap.get("id"));
-        assertEquals("pepe", bodyMap.get("name"));
+        assertThat(bodyMap).containsEntry("id", 26)
+                .containsEntry("name", "pepe");
 
         assertResult(manager, argCaptor);
     }
@@ -218,8 +215,8 @@ public class RestWorkItemHandlerTest {
         ArgumentCaptor<ObjectNode> bodyCaptor = ArgumentCaptor.forClass(ObjectNode.class);
         verify(request).sendJsonAndAwait(bodyCaptor.capture());
         ObjectNode bodyMap = bodyCaptor.getValue();
-        assertEquals(26, bodyMap.get("id").asInt());
-        assertEquals("pepe", bodyMap.get("name").asText());
+        assertThat(bodyMap.get("id").asInt()).isEqualTo(26);
+        assertThat(bodyMap.get("name").asText()).isEqualTo("pepe");
 
         assertResult(manager, argCaptor);
     }
@@ -252,10 +249,10 @@ public class RestWorkItemHandlerTest {
         verify(request).sendJsonAndAwait(bodyCaptor.capture());
 
         Map<String, Object> bodyMap = bodyCaptor.getValue();
-        assertThat(bodyMap.get("id")).isEqualTo(123);
-        assertThat(bodyMap.get("name")).isEqualTo("tiago");
-        //assert the evaluated expression with a process variable
-        assertThat(bodyMap.get(customParameter)).isEqualTo(workflowData);
+        assertThat(bodyMap).containsEntry("id", 123)
+                .containsEntry("name", "tiago")
+                //assert the evaluated expression with a process variable
+                .containsEntry(customParameter, workflowData);
 
         assertResult(manager, argCaptor);
     }
@@ -270,8 +267,8 @@ public class RestWorkItemHandlerTest {
         ArgumentCaptor<ObjectNode> bodyCaptor = ArgumentCaptor.forClass(ObjectNode.class);
         verify(request).sendJsonAndAwait(bodyCaptor.capture());
         ObjectNode bodyMap = bodyCaptor.getValue();
-        assertEquals(26, bodyMap.get("id").asInt());
-        assertEquals("pepe", bodyMap.get("name").asText());
+        assertThat(bodyMap.get("id").asInt()).isEqualTo(26);
+        assertThat(bodyMap.get("name").asText()).isEqualTo("pepe");
 
         assertResult(manager, argCaptor);
     }
@@ -279,10 +276,10 @@ public class RestWorkItemHandlerTest {
     public void assertResult(KogitoWorkItemManager manager, ArgumentCaptor<Map<String, Object>> argCaptor) {
         verify(manager).completeWorkItem(anyString(), argCaptor.capture());
         Map<String, Object> results = argCaptor.getValue();
-        assertEquals(1, results.size());
-        assertTrue(results.containsKey(RestWorkItemHandler.RESULT));
+        assertThat(results).hasSize(1)
+                .containsKey(RestWorkItemHandler.RESULT);
         Object result = results.get(RestWorkItemHandler.RESULT);
-        assertTrue(result instanceof ObjectNode);
-        assertEquals(1, ((ObjectNode) result).get("num").asInt());
+        assertThat(result).isInstanceOf(ObjectNode.class);
+        assertThat(((ObjectNode) result).get("num").asInt()).isOne();
     }
 }

--- a/kogito-workitems/kogito-rest-workitem/src/test/java/org/kogito/workitem/rest/pathresolvers/DefaultPathParamResolverTest.java
+++ b/kogito-workitems/kogito-rest-workitem/src/test/java/org/kogito/workitem/rest/pathresolvers/DefaultPathParamResolverTest.java
@@ -22,9 +22,8 @@ import java.util.Map;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 public class DefaultPathParamResolverTest {
 
@@ -39,9 +38,7 @@ public class DefaultPathParamResolverTest {
     public void testReplaceTemplateTrivial() {
         Map<String, Object> parameters = Collections.emptyMap();
         String endPoint = "http://pepe:password@www.google.com/results/id/?user=pepe#at_point";
-        assertEquals(
-                "http://pepe:password@www.google.com/results/id/?user=pepe#at_point",
-                pathParamResolver.apply(endPoint, parameters));
+        assertThat(pathParamResolver.apply(endPoint, parameters)).isEqualTo("http://pepe:password@www.google.com/results/id/?user=pepe#at_point");
     }
 
     @Test
@@ -50,9 +47,7 @@ public class DefaultPathParamResolverTest {
         // no use singletonMap here since the map must be mutable
         parameters.put("id", "pepe");
         String endPoint = "http://pepe:password@www.google.com/results/{id}/?user=pepe#at_point";
-        assertEquals(
-                "http://pepe:password@www.google.com/results/pepe/?user=pepe#at_point",
-                pathParamResolver.apply(endPoint, parameters));
+        assertThat(pathParamResolver.apply(endPoint, parameters)).isEqualTo("http://pepe:password@www.google.com/results/pepe/?user=pepe#at_point");
     }
 
     @Test
@@ -61,9 +56,7 @@ public class DefaultPathParamResolverTest {
         parameters.put("veryVeryLongId", 26);
         parameters.put("name", "pepe");
         String endPoint = "http://pepe:password@www.google.com/results/{veryVeryLongId}/names/{name}/?user=pepe#at_point";
-        assertEquals(
-                "http://pepe:password@www.google.com/results/26/names/pepe/?user=pepe#at_point",
-                pathParamResolver.apply(endPoint, parameters));
+        assertThat(pathParamResolver.apply(endPoint, parameters)).isEqualTo("http://pepe:password@www.google.com/results/26/names/pepe/?user=pepe#at_point");
     }
 
     @Test
@@ -71,12 +64,7 @@ public class DefaultPathParamResolverTest {
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("id", 26);
         String endPoint = "http://pepe:password@www.google.com/results/{id}/names/{name}/?user=pepe#at_point";
-        assertTrue(
-                assertThrows(
-                        IllegalArgumentException.class,
-                        () -> pathParamResolver.apply(endPoint, parameters))
-                                .getMessage()
-                                .contains("name"));
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> pathParamResolver.apply(endPoint, parameters)).withMessageContaining("name");
     }
 
     @Test
@@ -85,12 +73,7 @@ public class DefaultPathParamResolverTest {
         parameters.put("id", 26);
         parameters.put("name", "pepe");
         String endPoint = "http://pepe:password@www.google.com/results/{id}/names/{name/?user=pepe#at_point";
-        assertTrue(
-                assertThrows(
-                        IllegalArgumentException.class,
-                        () -> pathParamResolver.apply(endPoint, parameters))
-                                .getMessage()
-                                .contains("}"));
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> pathParamResolver.apply(endPoint, parameters)).withMessageContaining("}");
     }
 
 }

--- a/kogito-workitems/pom.xml
+++ b/kogito-workitems/pom.xml
@@ -16,5 +16,12 @@
     <module>kogito-rest-workitem</module>
     <module>kogito-jackson-utils</module>
   </modules>
+  <dependencies>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 
 </project>


### PR DESCRIPTION
issue: https://issues.redhat.com/browse/KOGITO-8134

This patch migrates kogito-runtime tests inside the kogito-workitems module to assertj assertions.

It removes use of junit assertions.

Where possible it simplifies the assertion using assertj features.

This patch is part of the ongoing effort to standardize kogito-runtime tests to assertj.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>

- for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] mandrel-lts</b>
 
- <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
