### PR TITLE
Kogito-8155 Migrate test assertions in api module to AssertJ assertions

### DIFF
--- a/api/kogito-api-incubation-common/src/test/java/org/kie/kogito/incubation/common/DataContextTest.java
+++ b/api/kogito-api-incubation-common/src/test/java/org/kie/kogito/incubation/common/DataContextTest.java
@@ -25,9 +25,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class DataContextTest {
     @Test
@@ -37,8 +34,8 @@ public class DataContextTest {
         ctx.set("lastName", "McCartney");
 
         User u = ctx.as(User.class);
-        assertEquals("Paul", u.firstName);
-        assertEquals("McCartney", u.lastName);
+        assertThat(u.firstName).isEqualTo("Paul");
+        assertThat(u.lastName).isEqualTo("McCartney");
     }
 
     @Test
@@ -48,12 +45,12 @@ public class DataContextTest {
         u.lastName = "McCartney";
 
         MapLikeDataContext ctx = u.as(MapLikeDataContext.class);
-        assertEquals("Paul", ctx.get("firstName"));
-        assertEquals("McCartney", ctx.get("lastName"));
+        assertThat(ctx.get("firstName")).isEqualTo("Paul");
+        assertThat(ctx.get("lastName")).isEqualTo("McCartney");
 
         MapLikeDataContext ctx2 = u.as(MapDataContext.class);
-        assertEquals("Paul", ctx2.get("firstName"));
-        assertEquals("McCartney", ctx2.get("lastName"));
+        assertThat(ctx2.get("firstName")).isEqualTo("Paul");
+        assertThat(ctx2.get("lastName")).isEqualTo("McCartney");
     }
 
     @Test
@@ -65,9 +62,9 @@ public class DataContextTest {
         u.addr.street = "Abbey Rd.";
 
         MapDataContext ctx = u.as(MapDataContext.class);
-        assertNotEquals(Address.class, ctx.get("addr").getClass());
+        assertThat(ctx.get("addr").getClass()).isNotEqualTo(Address.class);
         Address addr = InternalObjectMapper.objectMapper().convertValue(ctx.get("addr"), Address.class);
-        assertEquals("Abbey Rd.", addr.street);
+        assertThat(addr.street).isEqualTo("Abbey Rd.");
     }
 
     @Test
@@ -81,8 +78,8 @@ public class DataContextTest {
         MapDataContext mdc = MapDataContext.of(Map.of("Paul", u));
         User paul = (User) mdc.get("Paul");
         User user = mdc.get("Paul", User.class);
-        assertNotNull(user);
-        assertEquals(paul, user);
+        assertThat(user).isNotNull()
+                .isEqualTo(paul);
     }
 
     @Test
@@ -96,6 +93,6 @@ public class DataContextTest {
     @Test
     public void shouldAllowEmptyMetaDataContext() throws JsonProcessingException {
         MetaDataContext mdc = EmptyMetaDataContext.Instance;
-        assertEquals("{}", new ObjectMapper().writeValueAsString(mdc));
+        assertThat(new ObjectMapper().writeValueAsString(mdc)).isEqualTo("{}");
     }
 }

--- a/api/kogito-api-incubation-common/src/test/java/org/kie/kogito/incubation/common/ExtendedDataContextTest.java
+++ b/api/kogito-api-incubation-common/src/test/java/org/kie/kogito/incubation/common/ExtendedDataContextTest.java
@@ -18,8 +18,7 @@ package org.kie.kogito.incubation.common;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ExtendedDataContextTest {
 
@@ -36,8 +35,7 @@ public class ExtendedDataContextTest {
 
         ExtendedDataContext ctx = ExtendedDataContext.of(meta, data);
 
-        assertEquals(ctx.data().as(MapDataContext.class), ctx.as(MapDataContext.class),
-                "Converting an ExtendedContext should be equivalent to converting its data section");
+        assertThat(ctx.as(MapDataContext.class)).as("Converting an ExtendedContext should be equivalent to converting its data section").isEqualTo(ctx.data().as(MapDataContext.class));
 
     }
 
@@ -54,11 +52,10 @@ public class ExtendedDataContextTest {
 
         ExtendedDataContext ctx = ExtendedDataContext.of(meta, data);
 
-        assertSame(ctx, ctx.as(DataContext.class));
-        assertSame(ctx, ctx.as(ExtendedDataContext.class));
+        assertThat(ctx.as(DataContext.class)).isSameAs(ctx);
+        assertThat(ctx.as(ExtendedDataContext.class)).isSameAs(ctx);
 
-        assertEquals(ctx.data().as(MapDataContext.class), ctx.as(MapDataContext.class),
-                "Converting an ExtendedContext should be equivalent to converting its data section");
+        assertThat(ctx.as(MapDataContext.class)).as("Converting an ExtendedContext should be equivalent to converting its data section").isEqualTo(ctx.data().as(MapDataContext.class));
 
     }
 
@@ -71,7 +68,7 @@ public class ExtendedDataContextTest {
         data.addr.street = "Abbey Rd.";
 
         ExtendedDataContext edc = data.as(ExtendedDataContext.class);
-        assertEquals(data, edc.data());
+        assertThat(edc.data()).isEqualTo(data);
     }
 
     @Test
@@ -84,7 +81,7 @@ public class ExtendedDataContextTest {
 
         MapDataContext mapData = data.as(MapDataContext.class);
         ExtendedDataContext edc = mapData.as(ExtendedDataContext.class);
-        assertEquals(mapData, edc.data());
+        assertThat(edc.data()).isEqualTo(mapData);
     }
 
     @Test
@@ -100,10 +97,10 @@ public class ExtendedDataContextTest {
 
         ExtendedDataContext ctx = ExtendedDataContext.of(meta, data);
 
-        assertEquals(meta, ctx.meta());
+        assertThat(ctx.meta()).isEqualTo(meta);
 
         MapDataContext fromMeta = MapDataContext.from(ctx.meta());
-        assertEquals(meta, fromMeta);
+        assertThat(fromMeta).isEqualTo(meta);
 
     }
 
@@ -120,10 +117,10 @@ public class ExtendedDataContextTest {
 
         ExtendedDataContext ctx = ExtendedDataContext.of(meta, data);
 
-        assertEquals(meta, ctx.meta());
+        assertThat(ctx.meta()).isEqualTo(meta);
 
         MapDataContext fromMeta = MapDataContext.from(ctx.meta());
-        assertEquals(meta.value, fromMeta.get("value"));
+        assertThat(fromMeta.get("value")).isEqualTo(meta.value);
     }
 
 }

--- a/api/kogito-api-incubation-common/src/test/java/org/kie/kogito/incubation/common/LocalUriTest.java
+++ b/api/kogito-api-incubation-common/src/test/java/org/kie/kogito/incubation/common/LocalUriTest.java
@@ -18,19 +18,20 @@ package org.kie.kogito.incubation.common;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 public class LocalUriTest {
     @Test
     public void testToString() {
         LocalUri hpath = LocalUri.Root.append("example").append("some-id").append("instances").append("some-instance-id");
-        assertEquals("/example/some-id/instances/some-instance-id", hpath.path());
+        assertThat(hpath.path()).isEqualTo("/example/some-id/instances/some-instance-id");
     }
 
     @Test
     public void testStartsWith() {
         LocalUri hpath = LocalUri.Root.append("example").append("some-id").append("instances").append("some-instance-id");
-        assertTrue(hpath.startsWith("example"));
+        assertThat(hpath.startsWith("example")).isTrue();
     }
 
     @Test
@@ -38,7 +39,7 @@ public class LocalUriTest {
         String path = "/example/some-id/instances/some-instance-id";
         LocalUri hpath = LocalUri.Root.append("example").append("some-id").append("instances").append("some-instance-id");
         LocalUri parsedHPath = LocalUri.parse(path);
-        assertEquals(hpath, parsedHPath);
+        assertThat(parsedHPath).isEqualTo(hpath);
 
     }
 
@@ -47,26 +48,26 @@ public class LocalUriTest {
         String path = "/example////some-id//instances/some-instance-id";
         LocalUri hpath = LocalUri.Root.append("example").append("some-id").append("instances").append("some-instance-id");
         LocalUri parsedHPath = LocalUri.parse(path);
-        assertEquals(hpath, parsedHPath);
+        assertThat(parsedHPath).isEqualTo(hpath);
     }
 
     @Test
     public void testParseMalformedRelative() {
         String path = "example////some-id//instances/some-instance-id";
-        assertThrows(IllegalArgumentException.class, () -> LocalUri.parse(path));
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> LocalUri.parse(path));
     }
 
     @Test
     public void testUrlEncoding() {
         LocalUri path = LocalUri.Root.append("URL unsafe").append("??").append("Compon/ents").append("are \\ encoded");
-        assertEquals("/URL+unsafe/%3F%3F/Compon%2Fents/are+%5C+encoded", path.path());
+        assertThat(path.path()).isEqualTo("/URL+unsafe/%3F%3F/Compon%2Fents/are+%5C+encoded");
     }
 
     @Test
     public void testUriConversion() {
         String path = "/example/some-id/instances/some-instance-id";
         LocalUri parsed = LocalUri.parse(path);
-        assertEquals(parsed.toUri().toString(), String.format("%s://%s", LocalUri.SCHEME, parsed.path()));
+        assertThat(String.format("%s://%s", LocalUri.SCHEME, parsed.path())).isEqualTo(parsed.toUri().toString());
     }
 
 }

--- a/api/kogito-api-incubation-common/src/test/java/org/kie/kogito/incubation/common/PathLocalIdTest.java
+++ b/api/kogito-api-incubation-common/src/test/java/org/kie/kogito/incubation/common/PathLocalIdTest.java
@@ -18,8 +18,7 @@ package org.kie.kogito.incubation.common;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PathLocalIdTest {
 
@@ -28,19 +27,19 @@ public class PathLocalIdTest {
     @Test
     public void testId() {
         ExampleLocalId exampleLocalId = exampleRoot.get("some-id");
-        assertEquals("/example/some-id", exampleLocalId.asLocalUri().path());
+        assertThat(exampleLocalId.asLocalUri().path()).isEqualTo("/example/some-id");
     }
 
     @Test
     public void testIdNested() {
         ExampleInstanceLocalId exampleLocalId = exampleRoot.get("some-id").instances().get("some-instance-id");
-        assertEquals("/example/some-id/instances/some-instance-id", exampleLocalId.asLocalUri().path());
+        assertThat(exampleLocalId.asLocalUri().path()).isEqualTo("/example/some-id/instances/some-instance-id");
     }
 
     @Test
     public void testStartsWith() {
         ExampleInstanceLocalId exampleLocalId = exampleRoot.get("some-id").instances().get("some-instance-id");
-        assertTrue(exampleLocalId.asLocalUri().startsWith("example"));
+        assertThat(exampleLocalId.asLocalUri().startsWith("example")).isTrue();
     }
 
     static class ExampleRoot implements ComponentRoot {

--- a/api/kogito-api-incubation-decisions-services/pom.xml
+++ b/api/kogito-api-incubation-decisions-services/pom.xml
@@ -60,6 +60,10 @@
             <artifactId>kogito-api-incubation-application</artifactId>
             <scope>test</scope>
         </dependency>
+      <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+      </dependency>
 
     </dependencies>
 

--- a/api/kogito-api-incubation-decisions-services/src/test/java/org/kie/kogito/incubation/decisions/services/TestTypes.java
+++ b/api/kogito-api-incubation-decisions-services/src/test/java/org/kie/kogito/incubation/decisions/services/TestTypes.java
@@ -23,7 +23,7 @@ import org.kie.kogito.incubation.decisions.DecisionIds;
 import org.kie.kogito.incubation.decisions.LocalDecisionId;
 import org.kie.kogito.incubation.decisions.LocalDecisionServiceId;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestTypes {
     public static class MyDataContext implements DataContext, DefaultCastable {
@@ -50,11 +50,9 @@ public class TestTypes {
         ReflectiveAppRoot appRoot = new ReflectiveAppRoot();
         LocalDecisionId decisionId = appRoot.get(DecisionIds.class).get(namespace, modelName);
 
-        assertEquals(
-                "/decisions" +
-                        "/http%3A%2F%2Fwww.redhat.com%2F_c7328033-c355-43cd-b616-0aceef80e52a" +
-                        "%23" + "dmn-movieticket-ageclassification",
-                decisionId.toLocalId().asLocalUri().path());
+        assertThat(decisionId.toLocalId().asLocalUri().path()).isEqualTo("/decisions" +
+                "/http%3A%2F%2Fwww.redhat.com%2F_c7328033-c355-43cd-b616-0aceef80e52a" +
+                "%23" + "dmn-movieticket-ageclassification");
 
         // set a context using a Map-like interface
         ctx.set("someParam", 1);
@@ -65,18 +63,16 @@ public class TestTypes {
 
         // bind the data in the result to a typed bean
         MyDataContext mdc = result.as(MyDataContext.class);
-        assertEquals(1, mdc.someParam);
+        assertThat(mdc.someParam).isOne();
 
         // the same method is used for services
         String serviceName = "my-service";
         // LocalDecisionServiceId decisionServiceId = new LocalDecisionServiceId(decisionId, serviceName);
         LocalDecisionServiceId decisionServiceId = decisionId.services().get(serviceName);
-        assertEquals(
-                "/decisions" +
-                        "/http%3A%2F%2Fwww.redhat.com%2F_c7328033-c355-43cd-b616-0aceef80e52a" +
-                        "%23" + "dmn-movieticket-ageclassification" +
-                        "/services/" + serviceName,
-                decisionServiceId.toLocalId().asLocalUri().path());
+        assertThat(decisionServiceId.toLocalId().asLocalUri().path()).isEqualTo("/decisions" +
+                "/http%3A%2F%2Fwww.redhat.com%2F_c7328033-c355-43cd-b616-0aceef80e52a" +
+                "%23" + "dmn-movieticket-ageclassification" +
+                "/services/" + serviceName);
 
     }
 }

--- a/api/kogito-api-incubation-predictions-services/src/test/java/org/kie/kogito/incubation/predictions/services/TestTypes.java
+++ b/api/kogito-api-incubation-predictions-services/src/test/java/org/kie/kogito/incubation/predictions/services/TestTypes.java
@@ -22,7 +22,7 @@ import org.kie.kogito.incubation.common.*;
 import org.kie.kogito.incubation.predictions.LocalPredictionId;
 import org.kie.kogito.incubation.predictions.PredictionIds;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestTypes {
     public static class MyDataContext implements DataContext, DefaultCastable {
@@ -53,10 +53,8 @@ public class TestTypes {
         // LocalPredictionId decisionId = new LocalPredictionId(modelName);
         LocalPredictionId decisionId = appRoot.get(PredictionIds.class).get(fileNameNoSuffix, modelName);
 
-        assertEquals(
-                "/predictions" +
-                        "/%2Fmypath%2Fto%2FsomePrediction.pmml",
-                decisionId.toLocalId().asLocalUri().path());
+        assertThat(decisionId.toLocalId().asLocalUri().path()).isEqualTo("/predictions" +
+                "/%2Fmypath%2Fto%2FsomePrediction.pmml");
 
         // set a context using a Map-like interface
         ctx.set("someParam", 1);
@@ -67,7 +65,7 @@ public class TestTypes {
 
         // bind the data in the result to a typed bean
         MyDataContext mdc = result.as(MyDataContext.class);
-        assertEquals(1, mdc.someParam);
+        assertThat(mdc.someParam).isOne();
 
     }
 }

--- a/api/kogito-api-incubation-processes-services/src/test/java/org/kie/kogito/incubation/processes/services/ProcessServiceTypeTest.java
+++ b/api/kogito-api-incubation-processes-services/src/test/java/org/kie/kogito/incubation/processes/services/ProcessServiceTypeTest.java
@@ -22,7 +22,7 @@ import org.kie.kogito.incubation.processes.LocalProcessId;
 import org.kie.kogito.incubation.processes.ProcessInstanceId;
 import org.kie.kogito.incubation.processes.TaskId;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ProcessServiceTypeTest {
     public static class MyDataContext implements DataContext, DefaultCastable {
@@ -55,11 +55,10 @@ public class ProcessServiceTypeTest {
 
         MapLikeDataContext map = mdc.as(MapLikeDataContext.class);
 
-        assertEquals(1, mdc.someParam); // get the typed value from the POJO
-        assertEquals(1, map.get("someParam")); // get the object value from map-like
+        assertThat(mdc.someParam).isOne(); // get the typed value from the POJO
+        assertThat(map.get("someParam")).isEqualTo(1); // get the object value from map-like
 
-        assertEquals("/processes/some.process",
-                someProcessId.toLocalId().asLocalUri().path());
+        assertThat(someProcessId.toLocalId().asLocalUri().path()).isEqualTo("/processes/some.process");
 
     }
 
@@ -106,13 +105,11 @@ public class ProcessServiceTypeTest {
 
         ProcessInstanceId processInstanceId = someProcessId.instances().get("some.instance.id");
 
-        assertEquals("/processes/some.process/instances/some.instance.id",
-                processInstanceId.toLocalId().asLocalUri().path());
+        assertThat(processInstanceId.toLocalId().asLocalUri().path()).isEqualTo("/processes/some.process/instances/some.instance.id");
 
         TaskId taskId = processInstanceId.tasks().get("some.task.id");
 
-        assertEquals("/processes/some.process/instances/some.instance.id/tasks/some.task.id",
-                taskId.toLocalId().asLocalUri().path());
+        assertThat(taskId.toLocalId().asLocalUri().path()).isEqualTo("/processes/some.process/instances/some.instance.id/tasks/some.task.id");
 
     }
 }

--- a/api/kogito-api-incubation-processes/pom.xml
+++ b/api/kogito-api-incubation-processes/pom.xml
@@ -50,6 +50,10 @@
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
+      <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+      </dependency>
     </dependencies>
 
     <build>

--- a/api/kogito-api-incubation-processes/src/test/java/org/kie/kogito/incubation/processes/ProcessIdParserTest.java
+++ b/api/kogito-api-incubation-processes/src/test/java/org/kie/kogito/incubation/processes/ProcessIdParserTest.java
@@ -18,54 +18,52 @@ package org.kie.kogito.incubation.processes;
 import org.junit.jupiter.api.Test;
 import org.kie.kogito.incubation.common.LocalId;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 public class ProcessIdParserTest {
     @Test
     public void testProcessId() {
         LocalProcessId processId = ProcessIdParser.parse("/processes/p", LocalProcessId.class);
-        assertEquals(processId, new LocalProcessId("p"));
+        assertThat(new LocalProcessId("p")).isEqualTo(processId);
     }
 
     @Test
     public void testInvalidProcessId() {
-        assertThrows(IllegalArgumentException.class,
-                () -> ProcessIdParser.parse("/processes", LocalProcessId.class));
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> ProcessIdParser.parse("/processes", LocalProcessId.class));
     }
 
     @Test
     public void testProcessIdPart() {
         LocalProcessId processId = ProcessIdParser.parse("/processes/p/instances/pi", LocalProcessId.class);
-        assertEquals(processId, new LocalProcessId("p"));
+        assertThat(new LocalProcessId("p")).isEqualTo(processId);
     }
 
     @Test
     public void testProcessInstanceId() {
         ProcessInstanceId instanceId = ProcessIdParser.parse("/processes/p/instances/pi", ProcessInstanceId.class);
-        assertEquals(instanceId, new LocalProcessId("p").instances().get("pi"));
+        assertThat(new LocalProcessId("p").instances().get("pi")).isEqualTo(instanceId);
     }
 
     @Test
     public void testInvalidProcessInstanceId() {
-        assertThrows(IllegalArgumentException.class,
-                () -> ProcessIdParser.parse("/processes/p", ProcessInstanceId.class));
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> ProcessIdParser.parse("/processes/p", ProcessInstanceId.class));
     }
 
     @Test
     public void testTaskId() {
         TaskId taskId = ProcessIdParser.parse("/processes/p/instances/pi/tasks/t", TaskId.class);
-        assertEquals(taskId, new LocalProcessId("p").instances().get("pi").tasks().get("t"));
+        assertThat(new LocalProcessId("p").instances().get("pi").tasks().get("t")).isEqualTo(taskId);
     }
 
     @Test
     public void testCommentId() {
         String id = "/processes/p/instances/pi/tasks/t/instances/ti/comments/c";
         CommentId commentId = ProcessIdParser.parse(id, CommentId.class);
-        assertEquals(commentId, new LocalProcessId("p").instances().get("pi").tasks().get("t").instances().get("ti").comments().get("c"));
+        assertThat(new LocalProcessId("p").instances().get("pi").tasks().get("t").instances().get("ti").comments().get("c")).isEqualTo(commentId);
 
         TaskId taskId = ProcessIdParser.parse(id, TaskId.class);
-        assertEquals(taskId, new LocalProcessId("p").instances().get("pi").tasks().get("t"));
+        assertThat(new LocalProcessId("p").instances().get("pi").tasks().get("t")).isEqualTo(taskId);
 
     }
 
@@ -73,32 +71,32 @@ public class ProcessIdParserTest {
     public void testTaskInstanceId() {
         String id = "/processes/p/instances/pi/tasks/t/instances/ti";
         TaskInstanceId taskInstanceId = ProcessIdParser.parse(id, TaskInstanceId.class);
-        assertEquals(taskInstanceId, new LocalProcessId("p").instances().get("pi").tasks().get("t").instances().get("ti"));
+        assertThat(new LocalProcessId("p").instances().get("pi").tasks().get("t").instances().get("ti")).isEqualTo(taskInstanceId);
 
         TaskId taskId = ProcessIdParser.parse(id, TaskId.class);
-        assertEquals(taskId, new LocalProcessId("p").instances().get("pi").tasks().get("t"));
+        assertThat(new LocalProcessId("p").instances().get("pi").tasks().get("t")).isEqualTo(taskId);
     }
 
     @Test
     public void testAttachmentId() {
         String id = "/processes/p/instances/pi/tasks/t/instances/ti/attachments/a";
         AttachmentId attachmentId = ProcessIdParser.parse(id, AttachmentId.class);
-        assertEquals(attachmentId, new LocalProcessId("p").instances().get("pi").tasks().get("t").instances().get("ti").attachments().get("a"));
+        assertThat(new LocalProcessId("p").instances().get("pi").tasks().get("t").instances().get("ti").attachments().get("a")).isEqualTo(attachmentId);
 
         TaskId taskId = ProcessIdParser.parse(id, TaskId.class);
-        assertEquals(taskId, new LocalProcessId("p").instances().get("pi").tasks().get("t"));
+        assertThat(new LocalProcessId("p").instances().get("pi").tasks().get("t")).isEqualTo(taskId);
     }
 
     @Test
     public void testSignalId() {
         SignalId signalId = ProcessIdParser.parse("/processes/p/instances/pi/signals/s", SignalId.class);
-        assertEquals(signalId, new LocalProcessId("p").instances().get("pi").signals().get("s"));
+        assertThat(new LocalProcessId("p").instances().get("pi").signals().get("s")).isEqualTo(signalId);
     }
 
     @Test
     public void testLocalId() {
         LocalId id = ProcessIdParser.parse("/processes/p/instances/pi/tasks/t", LocalId.class);
-        assertEquals(id, new LocalProcessId("p").instances().get("pi").tasks().get("t"));
+        assertThat(new LocalProcessId("p").instances().get("pi").tasks().get("t")).isEqualTo(id);
     }
 
 }

--- a/api/kogito-api-incubation-rules-services/pom.xml
+++ b/api/kogito-api-incubation-rules-services/pom.xml
@@ -60,6 +60,10 @@
             <artifactId>kogito-api-incubation-application</artifactId>
             <scope>test</scope>
         </dependency>
+      <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+      </dependency>
 
     </dependencies>
 

--- a/api/kogito-api-incubation-rules-services/src/test/java/org/kie/kogito/incubation/rules/services/RuleUnitServiceInterfaceTest.java
+++ b/api/kogito-api-incubation-rules-services/src/test/java/org/kie/kogito/incubation/rules/services/RuleUnitServiceInterfaceTest.java
@@ -29,7 +29,7 @@ import org.kie.kogito.incubation.rules.QueryId;
 import org.kie.kogito.incubation.rules.RuleUnitIds;
 import org.kie.kogito.incubation.rules.RuleUnitInstanceId;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class RuleUnitServiceInterfaceTest {
     public static class MyRuleUnitDefinition {
@@ -67,10 +67,9 @@ public class RuleUnitServiceInterfaceTest {
         // bind the data in the result to a typed bean
         Stream<MyDataContext> mdcs = result.map(r -> r.as(MyDataContext.class));
 
-        assertEquals("/rule-units" +
+        assertThat(someQuery.toLocalId().asLocalUri().path()).isEqualTo("/rule-units" +
                 "/" + MyRuleUnitDefinition.class.getCanonicalName() +
-                "/queries/someQuery",
-                someQuery.toLocalId().asLocalUri().path());
+                "/queries/someQuery");
 
     }
 
@@ -78,13 +77,13 @@ public class RuleUnitServiceInterfaceTest {
     public void ruleUnitInstances() {
         ReflectiveAppRoot appRoot = new ReflectiveAppRoot();
         RuleUnitInstanceId instance = appRoot.get(RuleUnitIds.class).get("my-rule-unit").instances().get("my-instance-id");
-        assertEquals("/rule-units/my-rule-unit/instances/my-instance-id", instance.asLocalUri().path());
+        assertThat(instance.asLocalUri().path()).isEqualTo("/rule-units/my-rule-unit/instances/my-instance-id");
     }
 
     @Test
     public void ruleUnitInstanceQuery() {
         ReflectiveAppRoot appRoot = new ReflectiveAppRoot();
         InstanceQueryId query = appRoot.get(RuleUnitIds.class).get("my-rule-unit").instances().get("my-instance-id").queries().get("my-query");
-        assertEquals("/rule-units/my-rule-unit/instances/my-instance-id/queries/my-query", query.asLocalUri().path());
+        assertThat(query.asLocalUri().path()).isEqualTo("/rule-units/my-rule-unit/instances/my-instance-id/queries/my-query");
     }
 }

--- a/api/kogito-api-incubation-rules/pom.xml
+++ b/api/kogito-api-incubation-rules/pom.xml
@@ -45,6 +45,10 @@
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
+      <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+      </dependency>
     </dependencies>
 
     <build>

--- a/api/kogito-api-incubation-rules/src/test/java/org/kie/kogito/incubation/rules/RuleUnitIdParserTest.java
+++ b/api/kogito-api-incubation-rules/src/test/java/org/kie/kogito/incubation/rules/RuleUnitIdParserTest.java
@@ -17,36 +17,36 @@ package org.kie.kogito.incubation.rules;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class RuleUnitIdParserTest {
 
     @Test
     void parseRuleUnitId() {
-        assertEquals(RuleUnitId.class, RuleUnitIdParser.parse("/rule-units/u").getClass());
-        assertEquals("u", RuleUnitIdParser.parse("/rule-units/u", RuleUnitId.class).ruleUnitId());
+        assertThat(RuleUnitIdParser.parse("/rule-units/u").getClass()).isEqualTo(RuleUnitId.class);
+        assertThat(RuleUnitIdParser.parse("/rule-units/u", RuleUnitId.class).ruleUnitId()).isEqualTo("u");
     }
 
     @Test
     void parseQueryId() {
-        assertEquals(QueryId.class, RuleUnitIdParser.parse("/rule-units/u/queries/q").getClass());
-        assertEquals("u", RuleUnitIdParser.parse("/rule-units/u/queries/q", RuleUnitId.class).ruleUnitId());
-        assertEquals("q", RuleUnitIdParser.parse("/rule-units/u/queries/q", QueryId.class).queryId());
+        assertThat(RuleUnitIdParser.parse("/rule-units/u/queries/q").getClass()).isEqualTo(QueryId.class);
+        assertThat(RuleUnitIdParser.parse("/rule-units/u/queries/q", RuleUnitId.class).ruleUnitId()).isEqualTo("u");
+        assertThat(RuleUnitIdParser.parse("/rule-units/u/queries/q", QueryId.class).queryId()).isEqualTo("q");
     }
 
     @Test
     void parseRuleUnitInstanceId() {
-        assertEquals(RuleUnitInstanceId.class, RuleUnitIdParser.parse("/rule-units/u/instances/ui").getClass());
-        assertEquals("u", RuleUnitIdParser.parse("/rule-units/u/instances/ui", RuleUnitId.class).ruleUnitId());
-        assertEquals("ui", RuleUnitIdParser.parse("/rule-units/u/instances/ui", RuleUnitInstanceId.class).ruleUnitInstanceId());
+        assertThat(RuleUnitIdParser.parse("/rule-units/u/instances/ui").getClass()).isEqualTo(RuleUnitInstanceId.class);
+        assertThat(RuleUnitIdParser.parse("/rule-units/u/instances/ui", RuleUnitId.class).ruleUnitId()).isEqualTo("u");
+        assertThat(RuleUnitIdParser.parse("/rule-units/u/instances/ui", RuleUnitInstanceId.class).ruleUnitInstanceId()).isEqualTo("ui");
     }
 
     @Test
     void parseInstanceQueryId() {
-        assertEquals(InstanceQueryId.class, RuleUnitIdParser.parse("/rule-units/u/instances/ui/queries/q").getClass());
-        assertEquals("u", RuleUnitIdParser.parse("/rule-units/u/instances/ui/queries/q", RuleUnitId.class).ruleUnitId());
-        assertEquals("ui", RuleUnitIdParser.parse("/rule-units/u/instances/ui/queries/q", RuleUnitInstanceId.class).ruleUnitInstanceId());
-        assertEquals("q", RuleUnitIdParser.parse("/rule-units/u/instances/ui/queries/q", InstanceQueryId.class).queryId());
+        assertThat(RuleUnitIdParser.parse("/rule-units/u/instances/ui/queries/q").getClass()).isEqualTo(InstanceQueryId.class);
+        assertThat(RuleUnitIdParser.parse("/rule-units/u/instances/ui/queries/q", RuleUnitId.class).ruleUnitId()).isEqualTo("u");
+        assertThat(RuleUnitIdParser.parse("/rule-units/u/instances/ui/queries/q", RuleUnitInstanceId.class).ruleUnitInstanceId()).isEqualTo("ui");
+        assertThat(RuleUnitIdParser.parse("/rule-units/u/instances/ui/queries/q", InstanceQueryId.class).queryId()).isEqualTo("q");
     }
 
 }

--- a/api/kogito-api/src/test/java/org/kie/kogito/KogitoGAVTest.java
+++ b/api/kogito-api/src/test/java/org/kie/kogito/KogitoGAVTest.java
@@ -20,8 +20,7 @@ import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class KogitoGAVTest {
 
@@ -33,10 +32,10 @@ class KogitoGAVTest {
 
         KogitoGAV processedGav = MAPPER.readValue(MAPPER.writeValueAsString(originalGav), KogitoGAV.class);
 
-        assertNotNull(processedGav);
-        assertEquals(originalGav.getGroupId(), processedGav.getGroupId());
-        assertEquals(originalGav.getArtifactId(), processedGav.getArtifactId());
-        assertEquals(originalGav.getVersion(), processedGav.getVersion());
-        assertEquals(originalGav, processedGav);
+        assertThat(processedGav).isNotNull();
+        assertThat(processedGav.getGroupId()).isEqualTo(originalGav.getGroupId());
+        assertThat(processedGav.getArtifactId()).isEqualTo(originalGav.getArtifactId());
+        assertThat(processedGav.getVersion()).isEqualTo(originalGav.getVersion());
+        assertThat(processedGav).isEqualTo(originalGav);
     }
 }

--- a/api/kogito-api/src/test/java/org/kie/kogito/decision/DecisionExecutionIdUtilsTest.java
+++ b/api/kogito-api/src/test/java/org/kie/kogito/decision/DecisionExecutionIdUtilsTest.java
@@ -24,7 +24,7 @@ import org.kie.dmn.api.core.DMNContext;
 import org.kie.dmn.api.core.DMNMetadata;
 import org.kie.kogito.ExecutionIdSupplier;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DecisionExecutionIdUtilsTest {
 
@@ -34,7 +34,7 @@ public class DecisionExecutionIdUtilsTest {
         final ExecutionIdSupplier supplier = () -> dummyId;
         final DMNContext ctx = new TestDMNContext();
 
-        assertEquals(dummyId, DecisionExecutionIdUtils.get(DecisionExecutionIdUtils.inject(ctx, supplier)));
+        assertThat(DecisionExecutionIdUtils.get(DecisionExecutionIdUtils.inject(ctx, supplier))).isEqualTo(dummyId);
     }
 
     private static class TestDMNContext implements DMNContext {

--- a/api/kogito-api/src/test/java/org/kie/kogito/internal/utils/ConversionUtilsTest.java
+++ b/api/kogito-api/src/test/java/org/kie/kogito/internal/utils/ConversionUtilsTest.java
@@ -17,9 +17,7 @@ package org.kie.kogito.internal.utils;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.kogito.internal.utils.ConversionUtils.concatPaths;
 import static org.kie.kogito.internal.utils.ConversionUtils.convert;
 import static org.kie.kogito.internal.utils.ConversionUtils.toCamelCase;
@@ -28,24 +26,24 @@ class ConversionUtilsTest {
 
     @Test
     void testConvert() {
-        assertEquals(5, convert("5", Integer.class));
-        assertFalse(convert("5", Boolean.class));
+        assertThat(convert("5", Integer.class)).isEqualTo(5);
+        assertThat(convert("5", Boolean.class)).isFalse();
     }
 
     @Test
     void testCamelCase() {
-        assertEquals("myappCreate", toCamelCase("myapp.create"));
-        assertEquals("getByName1", toCamelCase("getByName_1"));
-        assertNotEquals("myappcreate", toCamelCase("myapp.create"));
+        assertThat(toCamelCase("myapp.create")).isEqualTo("myappCreate");
+        assertThat(toCamelCase("getByName_1")).isEqualTo("getByName1");
+        assertThat(toCamelCase("myapp.create")).isNotEqualTo("myappcreate");
     }
 
     @Test
     public void testConcatPaths() {
         final String expected = "http:localhost:8080/pepe/pepa/pepi";
-        assertEquals(expected, concatPaths("http:localhost:8080/pepe/", "/pepa/pepi"));
-        assertEquals(expected, concatPaths("http:localhost:8080/pepe", "pepa/pepi"));
-        assertEquals(expected, concatPaths("http:localhost:8080/pepe/", "pepa/pepi"));
-        assertEquals(expected, concatPaths("http:localhost:8080/pepe", "/pepa/pepi"));
+        assertThat(concatPaths("http:localhost:8080/pepe/", "/pepa/pepi")).isEqualTo(expected);
+        assertThat(concatPaths("http:localhost:8080/pepe", "pepa/pepi")).isEqualTo(expected);
+        assertThat(concatPaths("http:localhost:8080/pepe/", "pepa/pepi")).isEqualTo(expected);
+        assertThat(concatPaths("http:localhost:8080/pepe", "/pepa/pepi")).isEqualTo(expected);
 
     }
 }

--- a/api/kogito-api/src/test/java/org/kie/kogito/process/workitem/PoliciesTest.java
+++ b/api/kogito-api/src/test/java/org/kie/kogito/process/workitem/PoliciesTest.java
@@ -20,16 +20,16 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 import org.kie.kogito.auth.IdentityProvider;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class PoliciesTest {
 
     @Test
     void testPolicies() {
-        assertEquals(0, Policies.of(null).length);
+        assertThat(Policies.of(null)).isEmpty();
         Policy<IdentityProvider>[] policies = Policies.of("pepe", Arrays.asList("chief", "of", "the", "universe"));
-        assertEquals(1, policies.length);
-        assertEquals("pepe", policies[0].value().getName());
-        assertEquals(4, policies[0].value().getRoles().size());
+        assertThat(policies).hasSize(1);
+        assertThat(policies[0].value().getName()).isEqualTo("pepe");
+        assertThat(policies[0].value().getRoles()).hasSize(4);
     }
 }

--- a/api/kogito-events-api/src/test/java/org/kie/kogito/event/cloudevents/extension/KogitoExtensionTest.java
+++ b/api/kogito-events-api/src/test/java/org/kie/kogito/event/cloudevents/extension/KogitoExtensionTest.java
@@ -24,9 +24,7 @@ import io.cloudevents.CloudEvent;
 import io.cloudevents.core.builder.CloudEventBuilder;
 import io.cloudevents.core.provider.ExtensionProvider;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class KogitoExtensionTest {
 
@@ -173,13 +171,13 @@ public class KogitoExtensionTest {
     }
 
     private void assertCloudEvent(CloudEvent event, String dmnEvaluateDecision, String executionId, Boolean dmnFullResult, Boolean dmnFilteredCtx) {
-        assertNotNull(event);
-        assertEquals(TEST_DMN_MODEL_NAME, event.getExtension(KogitoExtension.KOGITO_DMN_MODEL_NAME));
-        assertEquals(TEST_DMN_MODEL_NAMESPACE, event.getExtension(KogitoExtension.KOGITO_DMN_MODEL_NAMESPACE));
-        assertEquals(dmnEvaluateDecision, event.getExtension(KogitoExtension.KOGITO_DMN_EVALUATE_DECISION));
-        assertEquals(executionId, event.getExtension(KogitoExtension.KOGITO_EXECUTION_ID));
-        assertEquals(dmnFullResult, event.getExtension(KogitoExtension.KOGITO_DMN_FULL_RESULT));
-        assertEquals(dmnFilteredCtx, event.getExtension(KogitoExtension.KOGITO_DMN_FILTERED_CTX));
+        assertThat(event).isNotNull();
+        assertThat(event.getExtension(KogitoExtension.KOGITO_DMN_MODEL_NAME)).isEqualTo(TEST_DMN_MODEL_NAME);
+        assertThat(event.getExtension(KogitoExtension.KOGITO_DMN_MODEL_NAMESPACE)).isEqualTo(TEST_DMN_MODEL_NAMESPACE);
+        assertThat(event.getExtension(KogitoExtension.KOGITO_DMN_EVALUATE_DECISION)).isEqualTo(dmnEvaluateDecision);
+        assertThat(event.getExtension(KogitoExtension.KOGITO_EXECUTION_ID)).isEqualTo(executionId);
+        assertThat(event.getExtension(KogitoExtension.KOGITO_DMN_FULL_RESULT)).isEqualTo(dmnFullResult);
+        assertThat(event.getExtension(KogitoExtension.KOGITO_DMN_FILTERED_CTX)).isEqualTo(dmnFilteredCtx);
     }
 
     private KogitoExtension extensionObjectFromCloudEvent(String dmnEvaluateDecision, String executionId, Boolean dmnFullResult, Boolean dmnFilteredCtx) {
@@ -211,12 +209,12 @@ public class KogitoExtensionTest {
     }
 
     private void assertExtension(KogitoExtension kogitoExtension, String dmnEvaluateDecision, String executionId, Boolean dmnFullResult, Boolean dmnFilteredCtx) {
-        assertNotNull(kogitoExtension);
-        assertEquals(TEST_DMN_MODEL_NAME, kogitoExtension.getDmnModelName());
-        assertEquals(TEST_DMN_MODEL_NAMESPACE, kogitoExtension.getDmnModelNamespace());
-        assertEquals(dmnEvaluateDecision, kogitoExtension.getDmnEvaluateDecision());
-        assertEquals(executionId, kogitoExtension.getExecutionId());
-        assertSame(dmnFullResult, kogitoExtension.isDmnFullResult());
-        assertSame(dmnFilteredCtx, kogitoExtension.isDmnFilteredCtx());
+        assertThat(kogitoExtension).isNotNull();
+        assertThat(kogitoExtension.getDmnModelName()).isEqualTo(TEST_DMN_MODEL_NAME);
+        assertThat(kogitoExtension.getDmnModelNamespace()).isEqualTo(TEST_DMN_MODEL_NAMESPACE);
+        assertThat(kogitoExtension.getDmnEvaluateDecision()).isEqualTo(dmnEvaluateDecision);
+        assertThat(kogitoExtension.getExecutionId()).isEqualTo(executionId);
+        assertThat(kogitoExtension.isDmnFullResult()).isSameAs(dmnFullResult);
+        assertThat(kogitoExtension.isDmnFilteredCtx()).isSameAs(dmnFilteredCtx);
     }
 }

--- a/api/kogito-events-core/src/test/java/org/kie/kogito/event/cloudevents/utils/CloudEventUtilsTest.java
+++ b/api/kogito-events-core/src/test/java/org/kie/kogito/event/cloudevents/utils/CloudEventUtilsTest.java
@@ -33,9 +33,7 @@ import io.cloudevents.CloudEvent;
 import io.cloudevents.core.builder.CloudEventBuilder;
 import io.cloudevents.core.provider.ExtensionProvider;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -90,105 +88,104 @@ class CloudEventUtilsTest {
 
     @Test
     void testBuildDecisionSource() {
-        assertEquals(TEST_DECISION_URI_UNKNOWN, CloudEventUtils.buildDecisionSource(null));
-        assertEquals(TEST_DECISION_URI_UNKNOWN, CloudEventUtils.buildDecisionSource(""));
-        assertEquals(TEST_DECISION_URI_UNKNOWN, CloudEventUtils.buildDecisionSource(null, null));
-        assertEquals(TEST_DECISION_URI_UNKNOWN, CloudEventUtils.buildDecisionSource("", ""));
-        assertEquals(TEST_DECISION_URI_UNKNOWN, CloudEventUtils.buildDecisionSource(null, null, null));
-        assertEquals(TEST_DECISION_URI_UNKNOWN, CloudEventUtils.buildDecisionSource("", "", ""));
+        assertThat(CloudEventUtils.buildDecisionSource(null)).isEqualTo(TEST_DECISION_URI_UNKNOWN);
+        assertThat(CloudEventUtils.buildDecisionSource("")).isEqualTo(TEST_DECISION_URI_UNKNOWN);
+        assertThat(CloudEventUtils.buildDecisionSource(null, null)).isEqualTo(TEST_DECISION_URI_UNKNOWN);
+        assertThat(CloudEventUtils.buildDecisionSource("", "")).isEqualTo(TEST_DECISION_URI_UNKNOWN);
+        assertThat(CloudEventUtils.buildDecisionSource(null, null, null)).isEqualTo(TEST_DECISION_URI_UNKNOWN);
+        assertThat(CloudEventUtils.buildDecisionSource("", "", "")).isEqualTo(TEST_DECISION_URI_UNKNOWN);
 
-        assertEquals(TEST_DECISION_URI_ONLY_SERVICE, CloudEventUtils.buildDecisionSource(TEST_SERVICE_URL));
-        assertEquals(TEST_DECISION_URI_ONLY_SERVICE, CloudEventUtils.buildDecisionSource(TEST_SERVICE_URL, null));
-        assertEquals(TEST_DECISION_URI_ONLY_SERVICE, CloudEventUtils.buildDecisionSource(TEST_SERVICE_URL, ""));
-        assertEquals(TEST_DECISION_URI_ONLY_SERVICE, CloudEventUtils.buildDecisionSource(TEST_SERVICE_URL, null, null));
-        assertEquals(TEST_DECISION_URI_ONLY_SERVICE, CloudEventUtils.buildDecisionSource(TEST_SERVICE_URL, "", ""));
+        assertThat(CloudEventUtils.buildDecisionSource(TEST_SERVICE_URL)).isEqualTo(TEST_DECISION_URI_ONLY_SERVICE);
+        assertThat(CloudEventUtils.buildDecisionSource(TEST_SERVICE_URL, null)).isEqualTo(TEST_DECISION_URI_ONLY_SERVICE);
+        assertThat(CloudEventUtils.buildDecisionSource(TEST_SERVICE_URL, "")).isEqualTo(TEST_DECISION_URI_ONLY_SERVICE);
+        assertThat(CloudEventUtils.buildDecisionSource(TEST_SERVICE_URL, null, null)).isEqualTo(TEST_DECISION_URI_ONLY_SERVICE);
+        assertThat(CloudEventUtils.buildDecisionSource(TEST_SERVICE_URL, "", "")).isEqualTo(TEST_DECISION_URI_ONLY_SERVICE);
 
-        assertEquals(TEST_DECISION_URI_SERVICE_AND_MODEL, CloudEventUtils.buildDecisionSource(TEST_SERVICE_URL, TEST_DECISION_MODEL_NAME));
-        assertEquals(TEST_DECISION_URI_SERVICE_AND_MODEL, CloudEventUtils.buildDecisionSource(TEST_SERVICE_URL, TEST_DECISION_MODEL_NAME, null));
-        assertEquals(TEST_DECISION_URI_SERVICE_AND_MODEL, CloudEventUtils.buildDecisionSource(TEST_SERVICE_URL, TEST_DECISION_MODEL_NAME, ""));
+        assertThat(CloudEventUtils.buildDecisionSource(TEST_SERVICE_URL, TEST_DECISION_MODEL_NAME)).isEqualTo(TEST_DECISION_URI_SERVICE_AND_MODEL);
+        assertThat(CloudEventUtils.buildDecisionSource(TEST_SERVICE_URL, TEST_DECISION_MODEL_NAME, null)).isEqualTo(TEST_DECISION_URI_SERVICE_AND_MODEL);
+        assertThat(CloudEventUtils.buildDecisionSource(TEST_SERVICE_URL, TEST_DECISION_MODEL_NAME, "")).isEqualTo(TEST_DECISION_URI_SERVICE_AND_MODEL);
 
-        assertEquals(TEST_DECISION_URI_FULL, CloudEventUtils.buildDecisionSource(TEST_SERVICE_URL, TEST_DECISION_MODEL_NAME, TEST_DECISION_SERVICE_NAME));
+        assertThat(CloudEventUtils.buildDecisionSource(TEST_SERVICE_URL, TEST_DECISION_MODEL_NAME, TEST_DECISION_SERVICE_NAME)).isEqualTo(TEST_DECISION_URI_FULL);
     }
 
     @Test
     void testBuildSuccess() {
-        assertTrue(CloudEventUtils.build(TEST_ID, TEST_URI, TEST_DATA, TEST_DATA_CLASS).isPresent());
+        assertThat(CloudEventUtils.build(TEST_ID, TEST_URI, TEST_DATA, TEST_DATA_CLASS)).isPresent();
     }
 
     @Test
     void testBuildFailure() throws Exception {
-        runWithMockedCloudEventUtilsMapper(() -> assertFalse(CloudEventUtils.build(TEST_ID, TEST_URI, TEST_DATA, TEST_DATA_CLASS).isPresent()));
+        runWithMockedCloudEventUtilsMapper(() -> assertThat(CloudEventUtils.build(TEST_ID, TEST_URI, TEST_DATA, TEST_DATA_CLASS).isPresent()).isFalse());
     }
 
     @Test
     void testBuildWithExtensionSuccess() {
         Optional<CloudEvent> optCE = CloudEventUtils.build(TEST_ID, TEST_URI, TEST_DATA_CLASS.getSimpleName(), TEST_SUBJECT, TEST_DATA, TEST_EXTENSION);
-        assertTrue(optCE.isPresent());
-        assertEquals(TEST_EXTENSION, ExtensionProvider.getInstance().parseExtension(KogitoExtension.class, optCE.get()));
+        assertThat(optCE).isPresent();
+        assertThat(ExtensionProvider.getInstance().parseExtension(KogitoExtension.class, optCE.get())).isEqualTo(TEST_EXTENSION);
     }
 
     @Test
     void testBuildWithExtensionFailure() throws Exception {
-        runWithMockedCloudEventUtilsMapper(() -> assertFalse(CloudEventUtils.build(TEST_ID, TEST_URI, TEST_DATA_CLASS.getSimpleName(), TEST_SUBJECT, TEST_DATA, TEST_EXTENSION).isPresent()));
+        runWithMockedCloudEventUtilsMapper(() -> assertThat(CloudEventUtils.build(TEST_ID, TEST_URI, TEST_DATA_CLASS.getSimpleName(), TEST_SUBJECT, TEST_DATA, TEST_EXTENSION).isPresent()).isFalse());
     }
 
     @Test
     void testDecodeDataSuccess() {
         Optional<String> optData = CloudEventUtils.decodeData(TEST_CLOUDEVENT, String.class);
-        assertTrue(optData.isPresent());
-        assertEquals(TEST_DATA, optData.get());
+        assertThat(optData).contains(TEST_DATA);
     }
 
     @Test
     void testDecodeDataFailure() {
         Optional<Integer> optData = CloudEventUtils.decodeData(TEST_CLOUDEVENT, Integer.class);
-        assertFalse(optData.isPresent());
+        assertThat(optData).isNotPresent();
     }
 
     @Test
     void testEncodeSuccess() {
-        assertTrue(CloudEventUtils.encode(TEST_CLOUDEVENT).isPresent());
+        assertThat(CloudEventUtils.encode(TEST_CLOUDEVENT)).isPresent();
         System.out.println(CloudEventUtils.encode(TEST_CLOUDEVENT).get());
     }
 
     @Test
     void testEncodeFailure() throws Exception {
-        runWithMockedCloudEventUtilsMapper(() -> assertFalse(CloudEventUtils.encode(TEST_CLOUDEVENT).isPresent()));
+        runWithMockedCloudEventUtilsMapper(() -> assertThat(CloudEventUtils.encode(TEST_CLOUDEVENT).isPresent()).isFalse());
     }
 
     @Test
     void testDecodeSuccess() {
-        assertTrue(CloudEventUtils.decode(TEST_CORRECT_JSON).isPresent());
+        assertThat(CloudEventUtils.decode(TEST_CORRECT_JSON)).isPresent();
     }
 
     @Test
     void testDecodeFailure() {
-        assertFalse(CloudEventUtils.decode(TEST_MALFORMED_JSON).isPresent());
+        assertThat(CloudEventUtils.decode(TEST_MALFORMED_JSON)).isNotPresent();
     }
 
     @Test
     void testUrlEncodedStringFromSuccess() {
-        assertTrue(CloudEventUtils.urlEncodedStringFrom(TEST_URI_STRING).isPresent());
+        assertThat(CloudEventUtils.urlEncodedStringFrom(TEST_URI_STRING)).isPresent();
     }
 
     @Test
     void testUrlEncodedStringFromFailure() throws Exception {
         try (MockedStatic<URLEncoder> mockedStaticURLEncoder = mockStatic(URLEncoder.class)) {
             mockedStaticURLEncoder.when(() -> URLEncoder.encode(any(String.class), any(String.class))).thenThrow(new UnsupportedEncodingException());
-            assertFalse(CloudEventUtils.urlEncodedStringFrom(TEST_URI_STRING).isPresent());
+            assertThat(CloudEventUtils.urlEncodedStringFrom(TEST_URI_STRING)).isNotPresent();
         }
     }
 
     @Test
     void testUrlEncodedURIFromSuccess() {
-        assertTrue(CloudEventUtils.urlEncodedURIFrom(TEST_URI_STRING).isPresent());
+        assertThat(CloudEventUtils.urlEncodedURIFrom(TEST_URI_STRING)).isPresent();
     }
 
     @Test
     void testUrlEncodedURIFromFailure() {
         try (MockedStatic<URI> mockedStaticURLEncoder = mockStatic(URI.class)) {
             mockedStaticURLEncoder.when(() -> URI.create(any(String.class))).thenThrow(new IllegalArgumentException());
-            assertFalse(CloudEventUtils.urlEncodedURIFrom(TEST_URI_STRING).isPresent());
+            assertThat(CloudEventUtils.urlEncodedURIFrom(TEST_URI_STRING)).isNotPresent();
         }
     }
 
@@ -197,7 +194,7 @@ class CloudEventUtilsTest {
         LocalDate localDate = LocalDate.of(2021, 12, 21);
         String marshalled = CloudEventUtils.Mapper.mapper().writeValueAsString(localDate);
         LocalDate unmarshalled = CloudEventUtils.Mapper.mapper().readValue(marshalled, LocalDate.class);
-        assertEquals(localDate, unmarshalled);
+        assertThat(unmarshalled).isEqualTo(localDate);
     }
 
     private static ObjectMapper getFailingMockedObjectMapper() throws Exception {

--- a/api/kogito-events-core/src/test/java/org/kie/kogito/event/impl/DataEventFactoryTest.java
+++ b/api/kogito-events-core/src/test/java/org/kie/kogito/event/impl/DataEventFactoryTest.java
@@ -30,8 +30,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.cloudevents.core.builder.CloudEventBuilder;
 import io.cloudevents.jackson.JsonCloudEventData;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DataEventFactoryTest {
 
@@ -43,8 +42,8 @@ public class DataEventFactoryTest {
         DataEvent<JsonNode> dataEvent = DataEventFactory.from(builder.build(), ced -> objectMapper.readTree(ced.toBytes()));
         JsonNode deserialized = objectMapper.readTree(objectMapper.writeValueAsBytes(dataEvent));
         JsonNode data = deserialized.get("data");
-        assertNotNull(data);
-        assertEquals("Javierito", data.get("name").asText());
-        assertEquals("type", deserialized.get("type").asText());
+        assertThat(data).isNotNull();
+        assertThat(data.get("name").asText()).isEqualTo("Javierito");
+        assertThat(deserialized.get("type").asText()).isEqualTo("type");
     }
 }

--- a/api/kogito-events-core/src/test/java/org/kie/kogito/event/impl/ProcessEventDispatcherTest.java
+++ b/api/kogito-events-core/src/test/java/org/kie/kogito/event/impl/ProcessEventDispatcherTest.java
@@ -45,8 +45,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -104,9 +102,9 @@ class ProcessEventDispatcherTest {
 
         verify(processService, times(1)).signalProcessInstance(Mockito.any(Process.class), processInstanceId.capture(), Mockito.any(Object.class), signal.capture());
 
-        assertEquals("Message-" + DUMMY_TOPIC, signal.getValue());
-        assertEquals("1", processInstanceId.getValue());
-        assertEquals(instance, processInstance);
+        assertThat(signal.getValue()).isEqualTo("Message-" + DUMMY_TOPIC);
+        assertThat(processInstanceId.getValue()).isEqualTo("1");
+        assertThat(processInstance).isEqualTo(instance);
     }
 
     @Test
@@ -121,9 +119,9 @@ class ProcessEventDispatcherTest {
         verify(processService, never()).signalProcessInstance(eq(process), any(), any(), signal.capture());
         verify(processService, times(1)).createProcessInstance(eq(process), any(), any(DummyModel.class), any(), signal.capture(), referenceId.capture(), isNull());
 
-        assertEquals(DUMMY_TOPIC, signal.getValue());
-        assertEquals("1", referenceId.getValue());
-        assertEquals(instance, processInstance);
+        assertThat(signal.getValue()).isEqualTo(DUMMY_TOPIC);
+        assertThat(referenceId.getValue()).isEqualTo("1");
+        assertThat(processInstance).isEqualTo(instance);
     }
 
     @Test
@@ -138,9 +136,9 @@ class ProcessEventDispatcherTest {
         verify(processService, never()).signalProcessInstance(eq(process), any(), any(), signal.capture());
         verify(processService, times(1)).createProcessInstance(eq(process), any(), any(DummyModel.class), any(), signal.capture(), referenceId.capture(), isNull());
 
-        assertEquals(DUMMY_TOPIC, signal.getValue());
-        assertEquals("1", referenceId.getValue());
-        assertEquals(instance, processInstance);
+        assertThat(signal.getValue()).isEqualTo(DUMMY_TOPIC);
+        assertThat(referenceId.getValue()).isEqualTo("1");
+        assertThat(processInstance).isEqualTo(instance);
     }
 
     @Test
@@ -150,8 +148,8 @@ class ProcessEventDispatcherTest {
 
         ArgumentCaptor<String> signal = ArgumentCaptor.forClass(String.class);
         verify(processService, times(1)).createProcessInstance(eq(process), any(), any(DummyModel.class), any(), signal.capture(), isNull(), isNull());
-        assertEquals(DUMMY_TOPIC, signal.getValue());
-        assertEquals(instance, processInstance);
+        assertThat(signal.getValue()).isEqualTo(DUMMY_TOPIC);
+        assertThat(processInstance).isEqualTo(instance);
     }
 
     @Test
@@ -159,7 +157,7 @@ class ProcessEventDispatcherTest {
         EventDispatcher<DummyModel, Object> dispatcher = new ProcessEventDispatcher<>(process, Optional.empty(), processService, executor, null, o -> o.getData());
         final String payload = "{ a = b }";
         ProcessInstance<DummyModel> result = dispatcher.dispatch(DUMMY_TOPIC, DataEventFactory.from(payload)).toCompletableFuture().get();
-        assertNull(result);
+        assertThat(result).isNull();
     }
 
     @Test
@@ -173,10 +171,10 @@ class ProcessEventDispatcherTest {
 
         verify(processService, times(1)).signalProcessInstance(Mockito.any(Process.class), processInstanceId.capture(), signalObject.capture(), signal.capture());
 
-        assertEquals("Message-" + DUMMY_TOPIC, signal.getValue());
-        assertEquals("pepe", signalObject.getValue());
-        assertEquals("1", processInstanceId.getValue());
-        assertEquals(instance, processInstance);
+        assertThat(signal.getValue()).isEqualTo("Message-" + DUMMY_TOPIC);
+        assertThat(signalObject.getValue()).isEqualTo("pepe");
+        assertThat(processInstanceId.getValue()).isEqualTo("1");
+        assertThat(processInstance).isEqualTo(instance);
     }
 
     @Test
@@ -184,7 +182,7 @@ class ProcessEventDispatcherTest {
         EventDispatcher<DummyModel, DummyEvent> dispatcher = new ProcessEventDispatcher<>(process, modelConverter(), processService, executor, null, o -> o.getData());
         final DummyCloudEvent payload = new DummyCloudEvent(new DummyEvent("test"), "differentTopic", "differentSource");
         ProcessInstance<DummyModel> result = dispatcher.dispatch(DUMMY_TOPIC, payload).toCompletableFuture().get();
-        assertNull(result);
+        assertThat(result).isNull();
     }
 
     @Test
@@ -208,9 +206,9 @@ class ProcessEventDispatcherTest {
 
         verify(processService, times(1)).createProcessInstance(eq(process), any(), any(DummyModel.class), any(), signal.capture(), referenceId.capture(), correlationCaptor.capture());
 
-        assertEquals(DUMMY_TOPIC, signal.getValue());
-        assertEquals("1", referenceId.getValue());
-        assertEquals(instance, processInstance);
+        assertThat(signal.getValue()).isEqualTo(DUMMY_TOPIC);
+        assertThat(referenceId.getValue()).isEqualTo("1");
+        assertThat(processInstance).isEqualTo(instance);
 
         CompositeCorrelation correlation = correlationCaptor.getValue();
         Set<? extends Correlation<?>> correlations = correlation.getValue();
@@ -246,8 +244,8 @@ class ProcessEventDispatcherTest {
         verify(correlationService).find(compositeCorrelation);
         verify(processService).signalProcessInstance(Mockito.any(Process.class), processInstanceId.capture(), Mockito.any(Object.class), signal.capture());
 
-        assertEquals("Message-" + DUMMY_TOPIC, signal.getValue());
-        assertEquals("1", processInstanceId.getValue());
-        assertEquals(instance, processInstance);
+        assertThat(signal.getValue()).isEqualTo("Message-" + DUMMY_TOPIC);
+        assertThat(processInstanceId.getValue()).isEqualTo("1");
+        assertThat(processInstance).isEqualTo(instance);
     }
 }

--- a/api/kogito-events-core/src/test/java/org/kie/kogito/event/impl/StringEventMarshallerTest.java
+++ b/api/kogito-events-core/src/test/java/org/kie/kogito/event/impl/StringEventMarshallerTest.java
@@ -21,8 +21,7 @@ import org.kie.kogito.event.EventMarshaller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class StringEventMarshallerTest {
 
@@ -31,15 +30,13 @@ class StringEventMarshallerTest {
     @Test
     void testDataMarshaller() {
         DummyEvent dataEvent = new DummyEvent("pepe");
-        assertEquals(
-                "{\"dummyField\":\"pepe\"}",
-                marshaller.marshall(dataEvent));
+        assertThat(marshaller.marshall(dataEvent)).isEqualTo("{\"dummyField\":\"pepe\"}");
     }
 
     @Test
     void testEventMarshaller() {
         DummyEvent dataEvent = new DummyEvent("pepe");
         String jsonString = marshaller.marshall(dataEvent);
-        assertTrue(jsonString.contains("\"dummyField\":\"pepe\""));
+        assertThat(jsonString).contains("\"dummyField\":\"pepe\"");
     }
 }

--- a/api/kogito-services/src/test/java/org/kie/kogito/services/jobs/impl/TriggerJobCommandTest.java
+++ b/api/kogito-services/src/test/java/org/kie/kogito/services/jobs/impl/TriggerJobCommandTest.java
@@ -29,8 +29,7 @@ import org.kie.kogito.uow.UnitOfWorkManager;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
@@ -69,7 +68,7 @@ class TriggerJobCommandTest {
         doReturn(unitOfWork).when(unitOfWorkManager).newUnitOfWork();
         doReturn(instances).when(process).instances();
         doReturn(Optional.empty()).when(instances).findById(PROCESS_INSTANCE_ID);
-        assertFalse(command.execute());
+        assertThat(command.execute()).isFalse();
     }
 
     @Test
@@ -77,7 +76,7 @@ class TriggerJobCommandTest {
         doReturn(unitOfWork).when(unitOfWorkManager).newUnitOfWork();
         doReturn(instances).when(process).instances();
         doReturn(Optional.of(processInstance)).when(instances).findById(PROCESS_INSTANCE_ID);
-        assertTrue(command.execute());
+        assertThat(command.execute()).isTrue();
         verify(processInstance).send(any());
     }
 }


### PR DESCRIPTION
issue: https://issues.redhat.com/browse/KOGITO-8155

This patch migrates kogito-runtime tests inside the api module to assertj assertions.

It removes use of junit assertions.

Where possible it simplifies the assertion using assertj features.

This patch is part of the ongoing effort to standardize kogito-runtime tests to assertj.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>

- for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] mandrel-lts</b>
 
- <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
