### PR TITLE
[KOGITO-8158] Changing fromType to fromClass

### DIFF
--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/AbstractNodeVisitor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/AbstractNodeVisitor.java
@@ -41,6 +41,7 @@ import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.Parameter;
 import com.github.javaparser.ast.expr.AssignExpr;
 import com.github.javaparser.ast.expr.CastExpr;
+import com.github.javaparser.ast.expr.ClassExpr;
 import com.github.javaparser.ast.expr.EnclosedExpr;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.LambdaExpr;
@@ -104,10 +105,8 @@ public abstract class AbstractNodeVisitor<T extends Node> extends AbstractVisito
     }
 
     public Expression buildDataResolver(String type) {
-        MethodCallExpr currentThread = new MethodCallExpr(null, "java.lang.Thread.currentThread");
-        MethodCallExpr classLoaderMethodCallExpr = new MethodCallExpr(currentThread, "getContextClassLoader");
-        return new MethodCallExpr(null, "org.jbpm.process.core.datatype.DataTypeResolver.fromType",
-                new NodeList<>(new StringLiteralExpr(type), classLoaderMethodCallExpr));
+        return new MethodCallExpr(null, "org.jbpm.process.core.datatype.DataTypeResolver.fromClass",
+                new NodeList<>(new ClassExpr(parseClassOrInterfaceType(type))));
     }
 
     protected AssignExpr getAssignedFactoryMethod(String factoryField, Class<?> typeClass, String variableName, String methodName, Type parentType, Expression... args) {

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/RuleFlowProcessFactory.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/RuleFlowProcessFactory.java
@@ -177,7 +177,7 @@ public class RuleFlowProcessFactory extends RuleFlowNodeContainerFactory<RuleFlo
     }
 
     public RuleFlowProcessFactory variable(String name, Class<?> clazz) {
-        return variable(name, DataTypeResolver.fromType(clazz.getName(), clazz.getClassLoader()), null);
+        return variable(name, DataTypeResolver.fromClass(clazz), null);
     }
 
     @Override


### PR DESCRIPTION
The idea is that the classes that cannot be loaded are not loaded but directly reference by generated code
This is a good change regardless the native issue that triggered it (which is after all fixed in later releases)