### PR TITLE
[KOGITO-8161] Fixing CloudEvent conversion to json node in native

### DIFF
--- a/kogito-serverless-workflow/kogito-serverless-workflow-runtime/src/main/java/org/kie/kogito/serverless/workflow/rpc/RPCWorkItemHandler.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-runtime/src/main/java/org/kie/kogito/serverless/workflow/rpc/RPCWorkItemHandler.java
@@ -34,6 +34,7 @@ import org.kie.kogito.jackson.utils.JsonObjectUtils;
 import org.kie.kogito.serverless.workflow.WorkflowWorkItemHandler;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.NullNode;
 import com.google.protobuf.DescriptorProtos.FileDescriptorSet;
 import com.google.protobuf.DescriptorProtos.MethodDescriptorProto;
 import com.google.protobuf.Descriptors.DescriptorValidationException;
@@ -111,7 +112,7 @@ public abstract class RPCWorkItemHandler extends WorkflowWorkItemHandler {
 
             if (methodType == MethodType.CLIENT_STREAMING) {
                 return asyncStreamingCall(parameters, methodDesc, responseObserver -> ClientCalls.asyncClientStreamingCall(call, responseObserver),
-                        nodes -> nodes.isEmpty() ? JsonObjectUtils.fromValue(null) : nodes.get(0));
+                        nodes -> nodes.isEmpty() ? NullNode.instance : nodes.get(0));
             } else if (methodType == MethodType.BIDI_STREAMING) {
                 return asyncStreamingCall(parameters, methodDesc, responseObserver -> ClientCalls.asyncBidiStreamingCall(call, responseObserver), JsonObjectUtils::fromValue);
             } else if (methodType == MethodType.SERVER_STREAMING) {

--- a/kogito-workitems/kogito-jackson-utils/pom.xml
+++ b/kogito-workitems/kogito-jackson-utils/pom.xml
@@ -17,10 +17,7 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
-     <dependency>
-      <groupId>io.cloudevents</groupId>
-      <artifactId>cloudevents-json-jackson</artifactId>
-    </dependency>
+    
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>

--- a/kogito-workitems/kogito-jackson-utils/src/main/java/org/kie/kogito/jackson/utils/JsonObjectUtils.java
+++ b/kogito-workitems/kogito-jackson-utils/src/main/java/org/kie/kogito/jackson/utils/JsonObjectUtils.java
@@ -23,6 +23,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 
+import org.kie.kogito.event.DataEvent;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -77,6 +79,34 @@ public class JsonObjectUtils {
         } else {
             return ObjectMapperFactory.listenerAware().convertValue(value, JsonNode.class);
         }
+    }
+
+    public static JsonNode fromValue(DataEvent<JsonNode> dataEvent) {
+        ObjectNode node = ObjectMapperFactory.listenerAware().createObjectNode();
+        if (dataEvent.getData() != null) {
+            node.set("data", dataEvent.getData());
+        }
+        node.put("id", dataEvent.getId());
+        if (dataEvent.getSource() != null) {
+            node.put("source", dataEvent.getSource().toString());
+        }
+        if (dataEvent.getSpecVersion() != null) {
+            node.put("specversion", dataEvent.getSpecVersion().toString());
+        }
+        node.put("type", dataEvent.getType());
+        if (dataEvent.getDataContentType() != null) {
+            node.put("datacontenttype", dataEvent.getDataContentType());
+        }
+        if (dataEvent.getDataSchema() != null) {
+            node.put("dataschema", dataEvent.getDataContentType());
+        }
+        if (dataEvent.getSubject() != null) {
+            node.put("subject", dataEvent.getDataContentType());
+        }
+        if (dataEvent.getTime() != null) {
+            node.put("time", dataEvent.getTime().toString());
+        }
+        return node;
     }
 
     public static Object toJavaValue(JsonNode jsonNode) {

--- a/kogito-workitems/kogito-jackson-utils/src/main/java/org/kie/kogito/jackson/utils/JsonObjectUtils.java
+++ b/kogito-workitems/kogito-jackson-utils/src/main/java/org/kie/kogito/jackson/utils/JsonObjectUtils.java
@@ -81,6 +81,7 @@ public class JsonObjectUtils {
         }
     }
 
+    // see: https://issues.redhat.com/browse/KOGITO-8161 why we are not using the CloudEvent SDK
     public static JsonNode fromValue(DataEvent<JsonNode> dataEvent) {
         ObjectNode node = ObjectMapperFactory.listenerAware().createObjectNode();
         if (dataEvent.getData() != null) {

--- a/kogito-workitems/kogito-jackson-utils/src/main/java/org/kie/kogito/jackson/utils/ObjectMapperFactory.java
+++ b/kogito-workitems/kogito-jackson-utils/src/main/java/org/kie/kogito/jackson/utils/ObjectMapperFactory.java
@@ -21,8 +21,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 
-import io.cloudevents.jackson.JsonFormat;
-
 public class ObjectMapperFactory {
 
     private ObjectMapperFactory() {
@@ -34,10 +32,6 @@ public class ObjectMapperFactory {
                 .build()
                 .setSerializationInclusion(JsonInclude.Include.NON_NULL)
                 .setTypeFactory(TypeFactory.defaultInstance().withClassLoader(Thread.currentThread().getContextClassLoader()))
-                // native mode is not working properly in older versions
-                // so explicitly registering the cloud event module is needed for them
-                // this can be removed when we update Mandrel version
-                .registerModule(JsonFormat.getCloudEventJacksonModule())
                 .findAndRegisterModules();
     }
 


### PR DESCRIPTION
Since mandrel is failing in old version and this is pretty specific scenario (dataOnly = true in the flow), it is better to implement a custom method to generate the json node from a DataEvent holding a json node for that specific scenarion.

That will work for both mandrel versions and actually be faster

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](CONTRIBUTING.md)
- [ ] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>

- for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] mandrel-lts</b>
 
- <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
