### PR TITLE
[mac_contributing_info] Add instructions for Native Image build on MAC

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,6 +138,7 @@ If you have not done so on this machine, you need to:
 * Install Git and configure your GitHub access
 * Install Java SDK (OpenJDK recommended)
 * For Native Image, follow Quarkus instructions at [GraalVM](https://quarkus.io/guides/building-native-image)
+* On MAC, check [Setup MAC for Native image build](./Develop_on_Mac.md) for further instructions.
 
 Docker is not strictly necessary, but it is a required to run some of the integration tests. 
 These tests can be skipped (see the [Build](#build) section), but we recommend to install it to run these tests locally.

--- a/Develop_on_Mac.md
+++ b/Develop_on_Mac.md
@@ -1,0 +1,10 @@
+Setup MAC for Native image build
+================================
+
+1. install sdkman: curl -s "https://get.sdkman.io" | bash 
+2. install brew: /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+3. manually install Graal 22.3-11: brew install --cask graalvm/tap/graalvm-ce-java11 
+4. link Graal inside sdk: sdk install java 22.3.r11-grl /Library/Java/JavaVirtualMachines/graalvm-ce-java11-22.3.0/Contents/Home 
+5. cd kogito-apps/jitexecutor 
+6. use Graal vm: sdk use java 22.3.r11-grl 
+7. issue build: mvn clean package -Pnative

--- a/Develop_on_Mac.md
+++ b/Develop_on_Mac.md
@@ -1,10 +1,12 @@
 Setup MAC for Native image build
 ================================
 
-1. install sdkman: curl -s "https://get.sdkman.io" | bash 
-2. install brew: /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-3. manually install Graal 22.3-11: brew install --cask graalvm/tap/graalvm-ce-java11 
-4. link Graal inside sdk: sdk install java 22.3.r11-grl /Library/Java/JavaVirtualMachines/graalvm-ce-java11-22.3.0/Contents/Home 
-5. cd kogito-apps/jitexecutor 
-6. use Graal vm: sdk use java 22.3.r11-grl 
-7. issue build: mvn clean package -Pnative
+The following instructions use sdkman as jvm manager. While it is not mandatory, it is recommended to ease jvm switching during development. 
+
+1. install sdkman: `curl -s "https://get.sdkman.io" | bash` 
+2. install brew: `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`
+3. manually install GraalVM (Note: check [Quarkus documentation](https://quarkus.io/guides/building-native-image#configuring-graalvm) to get current supported version): `brew install --cask graalvm/tap/(*current_graalvm_version*)`
+4. link GraalVM inside sdkman: `sdk install java (*current_graalvm_version*)-grl /Library/Java/JavaVirtualMachines/(*current_graalvm_version*)/Contents/Home` 
+5. go to directory containing code for native build
+6. set sdkman to use GraalVM: `sdk use java (*current_graalvm_version*)-grl` 
+7. issue build: `mvn clean package -Pnative`


### PR DESCRIPTION
@danielezonca @yesamer @baldimir 

Add instructions for native image build on MAC

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](CONTRIBUTING.md)
- [ ] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] mandrel</b>

- for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] mandrel-lts</b>
 
- <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>
