### PR TITLE
[KOGITO-8351] Refining validate args

### DIFF
--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/functions/WorkItemFunctionNamespace.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/functions/WorkItemFunctionNamespace.java
@@ -34,7 +34,7 @@ public abstract class WorkItemFunctionNamespace extends WorkItemBuilder implemen
             RuleFlowNodeContainerFactory<?, ?> embeddedSubProcess,
             FunctionRef functionRef,
             VariableInfo varInfo) {
-        validateArgs(functionRef.getArguments());
+        validateArgs(functionRef);
         return addFunctionArgs(workflow,
                 fillWorkItemHandler(workflow, context, buildWorkItem(embeddedSubProcess, context, varInfo.getInputVar(), varInfo.getOutputVar()), functionRef).name(functionRef.getRefName()),
                 functionRef);

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/types/WorkItemTypeHandler.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/types/WorkItemTypeHandler.java
@@ -31,7 +31,7 @@ public abstract class WorkItemTypeHandler extends WorkItemBuilder implements Fun
     @Override
     public NodeFactory<?, ?> getActionNode(Workflow workflow, ParserContext context, RuleFlowNodeContainerFactory<?, ?> embeddedSubProcess, FunctionDefinition functionDef, FunctionRef functionRef,
             VariableInfo varInfo) {
-        validateArgs(functionRef.getArguments());
+        validateArgs(functionRef);
         return addFunctionArgs(workflow,
                 fillWorkItemHandler(workflow, context, buildWorkItem(embeddedSubProcess, context, varInfo.getInputVar(), varInfo.getOutputVar()).name(functionDef.getName()), functionDef),
                 functionRef);

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/utils/WorkItemBuilder.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/utils/WorkItemBuilder.java
@@ -51,9 +51,13 @@ public abstract class WorkItemBuilder {
      * Implementations should use this method to validate if provided function arguments are suitable
      * In case they are not they might throw an exception to interrupt build procedure or print an informative log
      * 
-     * @param functionArgs the arguments to validate
+     * @param ref the function reference containing the arguments and the function name
      */
-    protected void validateArgs(JsonNode functionArgs) {
+    protected void validateArgs(FunctionRef ref) {
+        validateArgs(ref.getArguments());
+    }
+
+    protected void validateArgs(JsonNode args) {
     }
 
     protected WorkItemNodeFactory<?> buildWorkItem(RuleFlowNodeContainerFactory<?, ?> embeddedSubProcess,


### PR DESCRIPTION
As @ricardozanini points out validate method needs the function name to be able to throw a meaningful exception. 
Also, it is interesting if in future we add more things to function ref in the spec. 