### PR TITLE
[KOGITO-8330] ForEach and subprocess

### DIFF
--- a/api/kogito-api/src/main/java/org/kie/kogito/internal/process/event/KogitoObjectListenerAware.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/internal/process/event/KogitoObjectListenerAware.java
@@ -16,16 +16,19 @@
 package org.kie.kogito.internal.process.event;
 
 import java.util.Collection;
+import java.util.Objects;
 
 public interface KogitoObjectListenerAware {
 
     default void fireEvent(String propertyName, Object oldValue, Object newValue, Runnable updater) {
-        if (newValue instanceof KogitoObjectListenerAware) {
-            ((KogitoObjectListenerAware) newValue).addKogitoObjectListener(new KogitoObjectListenerAwareListener(this, propertyName));
+        if (!Objects.equals(oldValue, newValue)) {
+            if (newValue instanceof KogitoObjectListenerAware) {
+                ((KogitoObjectListenerAware) newValue).addKogitoObjectListener(new KogitoObjectListenerAwareListener(this, propertyName));
+            }
+            listeners().forEach(l -> l.beforeValueChanged(this, propertyName, oldValue, newValue));
+            updater.run();
+            listeners().forEach(l -> l.afterValueChanged(this, propertyName, oldValue, newValue));
         }
-        listeners().forEach(l -> l.beforeValueChanged(this, propertyName, oldValue, newValue));
-        updater.run();
-        listeners().forEach(l -> l.afterValueChanged(this, propertyName, oldValue, newValue));
     }
 
     void addKogitoObjectListener(KogitoObjectListener listener);

--- a/api/kogito-api/src/main/java/org/kie/kogito/internal/process/event/KogitoObjectListenerAware.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/internal/process/event/KogitoObjectListenerAware.java
@@ -22,7 +22,7 @@ public interface KogitoObjectListenerAware {
 
     default void fireEvent(String propertyName, Object oldValue, Object newValue, Runnable updater) {
         if (!Objects.equals(oldValue, newValue)) {
-            if (newValue instanceof KogitoObjectListenerAware) {
+            if (newValue instanceof KogitoObjectListenerAware && !Objects.equals(this, newValue)) {
                 ((KogitoObjectListenerAware) newValue).addKogitoObjectListener(new KogitoObjectListenerAwareListener(this, propertyName));
             }
             listeners().forEach(l -> l.beforeValueChanged(this, propertyName, oldValue, newValue));

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/LambdaSubProcessNodeVisitor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/LambdaSubProcessNodeVisitor.java
@@ -22,12 +22,14 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.jbpm.process.core.context.variable.VariableScope;
+import org.jbpm.process.core.datatype.impl.coverter.CloneHelper;
 import org.jbpm.ruleflow.core.factory.SubProcessNodeFactory;
 import org.jbpm.workflow.core.impl.DataDefinition;
 import org.jbpm.workflow.core.node.SubProcessNode;
 import org.jbpm.workflow.instance.impl.NodeInstanceImpl;
 import org.kie.kogito.internal.process.runtime.KogitoWorkflowProcess;
 
+import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.Parameter;
 import com.github.javaparser.ast.expr.AssignExpr;
@@ -148,7 +150,10 @@ public class LambdaSubProcessNodeVisitor extends AbstractNodeVisitor<SubProcessN
                 continue;
             }
 
-            Expression getValueExpr = new MethodCallExpr(new NameExpr("inputs"), "get", nodeList(new StringLiteralExpr(inputDefinition.getLabel())));
+            Expression getValueExpr =
+                    new MethodCallExpr(
+                            new MethodCallExpr(new NameExpr(CloneHelper.class.getCanonicalName()), "get"), "clone", NodeList.nodeList(new MethodCallExpr(new NameExpr("inputs"),
+                                    "get", nodeList(new StringLiteralExpr(inputDefinition.getLabel())))));
             actionBody.addStatement(subProcessModel.callSetter("model", inputDefinition.getLabel(), getValueExpr));
         }
 

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/LambdaSubProcessNodeVisitor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/LambdaSubProcessNodeVisitor.java
@@ -100,7 +100,7 @@ public class LambdaSubProcessNodeVisitor extends AbstractNodeVisitor<SubProcessN
                     .forEach(t -> t.setName(subProcessModelClassName));
 
             retValueExpression.findFirst(MethodDeclaration.class, m -> m.getNameAsString().equals("bind"))
-                    .ifPresent(m -> m.setBody(bind(node, subProcessModel)));
+                    .ifPresent(m -> m.setBody(bind(subProcessModel)));
             retValueExpression.findFirst(MethodDeclaration.class, m -> m.getNameAsString().equals("createInstance"))
                     .ifPresent(m -> m.setBody(createInstance(node, metadata)));
             retValueExpression.findFirst(MethodDeclaration.class, m -> m.getNameAsString().equals("unbind"))
@@ -113,7 +113,7 @@ public class LambdaSubProcessNodeVisitor extends AbstractNodeVisitor<SubProcessN
         body.addStatement(getDoneMethod(getNodeId(node)));
     }
 
-    private BlockStmt bind(SubProcessNode subProcessNode, ModelMetaData subProcessModel) {
+    private BlockStmt bind(ModelMetaData subProcessModel) {
         BlockStmt actionBody = new BlockStmt();
         actionBody.addStatement(subProcessModel.newInstance("model"));
 

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ModelMetaData.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/ModelMetaData.java
@@ -146,6 +146,10 @@ public class ModelMetaData {
         return callSetter(targetVar, destField, new NameExpr(value));
     }
 
+    public MethodCallExpr callUpdateFromMap(String targetVar, String mapVar) {
+        return new MethodCallExpr(new NameExpr(targetVar), "update").addArgument(new NameExpr(mapVar));
+    }
+
     public MethodCallExpr callSetter(String targetVar, String destField, Expression value) {
         String name = variableScope.getTypes().get(destField).getSanitizedName();
         String type = variableScope.getType(destField);

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/descriptors/ExpressionUtils.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/descriptors/ExpressionUtils.java
@@ -30,6 +30,7 @@ import org.kie.kogito.process.expr.ExpressionHandlerFactory;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.BooleanLiteralExpr;
+import com.github.javaparser.ast.expr.CastExpr;
 import com.github.javaparser.ast.expr.CharLiteralExpr;
 import com.github.javaparser.ast.expr.ClassExpr;
 import com.github.javaparser.ast.expr.DoubleLiteralExpr;
@@ -137,9 +138,10 @@ public class ExpressionUtils {
         }
         if (objectClass != null) {
             // will generate TypeConverterRegistry.get().forType("JsonNode.class").apply("{\"dog\":\"perro\"}"))
-            return new MethodCallExpr(new MethodCallExpr(new MethodCallExpr(new TypeExpr(StaticJavaParser.parseClassOrInterfaceType(TypeConverterRegistry.class.getName())), "get"), "forType",
-                    NodeList.nodeList(new StringLiteralExpr(objectClass.getName()))), "apply",
-                    NodeList.nodeList(new StringLiteralExpr().setString(TypeConverterRegistry.get().forTypeReverse(object).apply((object)))));
+            return new CastExpr(StaticJavaParser.parseClassOrInterfaceType(object.getClass().getName()),
+                    new MethodCallExpr(new MethodCallExpr(new MethodCallExpr(new TypeExpr(StaticJavaParser.parseClassOrInterfaceType(TypeConverterRegistry.class.getName())), "get"), "forType",
+                            NodeList.nodeList(new StringLiteralExpr(objectClass.getName()))), "apply",
+                            NodeList.nodeList(new StringLiteralExpr().setString(TypeConverterRegistry.get().forTypeReverse(object).apply((object))))));
         } else {
             return new StringLiteralExpr().setString(object.toString());
         }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/coverter/DataTypeDeserializer.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/coverter/DataTypeDeserializer.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.process.core.datatype.impl.coverter;
+
+import java.io.IOException;
+
+import org.jbpm.process.core.datatype.DataType;
+import org.jbpm.process.core.datatype.DataTypeResolver;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+public class DataTypeDeserializer extends JsonDeserializer<DataType> {
+
+    @Override
+    public DataType deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JacksonException {
+        return DataTypeResolver.fromType(p.getValueAsString(), Thread.currentThread().getContextClassLoader());
+    }
+}

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/coverter/DataTypeDeserializer.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/coverter/DataTypeDeserializer.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import org.jbpm.process.core.datatype.DataType;
 import org.jbpm.process.core.datatype.DataTypeResolver;
 
-import com.fasterxml.jackson.core.JacksonException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
@@ -28,7 +27,7 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 public class DataTypeDeserializer extends JsonDeserializer<DataType> {
 
     @Override
-    public DataType deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JacksonException {
+    public DataType deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
         return DataTypeResolver.fromType(p.getValueAsString(), Thread.currentThread().getContextClassLoader());
     }
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/coverter/DataTypeSerializer.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/coverter/DataTypeSerializer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.process.core.datatype.impl.coverter;
+
+import java.io.IOException;
+
+import org.jbpm.process.core.datatype.DataType;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+public class DataTypeSerializer extends JsonSerializer<DataType> {
+
+    @Override
+    public void serialize(DataType value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        gen.writeString(value.getStringType());
+    }
+}

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/coverter/JacksonConverter.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/coverter/JacksonConverter.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.process.core.datatype.impl.coverter;
+
+import java.util.function.Function;
+
+import org.kie.kogito.jackson.utils.ObjectMapperFactory;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+public class JacksonConverter<T> implements Function<String, T> {
+
+    private Class<T> clazz;
+
+    public JacksonConverter(Class<T> clazz) {
+        this.clazz = clazz;
+    }
+
+    @Override
+    public T apply(String t) {
+        try {
+            return ObjectMapperFactory.get().readValue(t, clazz);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+}

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/coverter/JacksonConverter.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/coverter/JacksonConverter.java
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 
 public class JacksonConverter<T> implements Function<String, T> {
 
-    private Class<T> clazz;
+    private final Class<T> clazz;
 
     public JacksonConverter(Class<T> clazz) {
         this.clazz = clazz;

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/coverter/JacksonUnconverter.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/core/datatype/impl/coverter/JacksonUnconverter.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.process.core.datatype.impl.coverter;
+
+import java.util.function.Function;
+
+import org.kie.kogito.jackson.utils.ObjectMapperFactory;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+public class JacksonUnconverter<T> implements Function<T, String> {
+
+    @Override
+    public String apply(T t) {
+        try {
+            return ObjectMapperFactory.get().writeValueAsString(t);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+}

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/context/variable/VariableScopeListener.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/context/variable/VariableScopeListener.java
@@ -16,6 +16,7 @@
 package org.jbpm.process.instance.context.variable;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.jbpm.process.instance.InternalProcessRuntime;
 import org.jbpm.process.instance.ProcessInstance;
@@ -58,5 +59,24 @@ public class VariableScopeListener implements KogitoObjectListener {
 
     private KogitoProcessEventSupport getProcessEventSupport() {
         return ((InternalProcessRuntime) processInstance.getKnowledgeRuntime().getProcessRuntime()).getProcessEventSupport();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(processInstance, tags, variableIdPrefix, variableInstanceIdPrefix);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        VariableScopeListener other = (VariableScopeListener) obj;
+        return Objects.equals(processInstance, other.processInstance) && Objects.equals(tags, other.tags)
+                && Objects.equals(variableIdPrefix, other.variableIdPrefix)
+                && Objects.equals(variableInstanceIdPrefix, other.variableInstanceIdPrefix);
     }
 }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/CompositeContextNodeHandler.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/CompositeContextNodeHandler.java
@@ -24,11 +24,13 @@ import org.jbpm.ruleflow.core.RuleFlowNodeContainerFactory;
 import org.jbpm.ruleflow.core.factory.AbstractCompositeNodeFactory;
 import org.jbpm.ruleflow.core.factory.CompositeContextNodeFactory;
 import org.jbpm.ruleflow.core.factory.NodeFactory;
+import org.jbpm.ruleflow.core.factory.SubProcessNodeFactory;
 import org.jbpm.ruleflow.core.factory.TimerNodeFactory;
 import org.kie.kogito.serverless.workflow.parser.FunctionNamespaceFactory;
 import org.kie.kogito.serverless.workflow.parser.FunctionTypeHandlerFactory;
 import org.kie.kogito.serverless.workflow.parser.ParserContext;
 import org.kie.kogito.serverless.workflow.parser.VariableInfo;
+import org.kie.kogito.serverless.workflow.utils.JsonNodeContext;
 
 import io.serverlessworkflow.api.Workflow;
 import io.serverlessworkflow.api.actions.Action;
@@ -120,10 +122,12 @@ public abstract class CompositeContextNodeHandler<S extends State> extends State
             SubFlowRef subFlowRef,
             String inputVar,
             String outputVar) {
-        return subprocessNode(
+        SubProcessNodeFactory<?> subProcessNode = subprocessNode(
                 factory.subProcessNode(parserContext.newId()).name(subFlowRef.getWorkflowId()).processId(subFlowRef.getWorkflowId()).waitForCompletion(true),
                 inputVar,
                 outputVar);
+        JsonNodeContext.getEvalVariables(factory.getNode()).forEach(v -> subProcessNode.inMapping(v.getName(), v.getName()));
+        return subProcessNode;
     }
 
     private NodeFactory<?, ?> getActionNode(RuleFlowNodeContainerFactory<?, ?> embeddedSubProcess,

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/ForEachStateHandler.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/ForEachStateHandler.java
@@ -45,13 +45,13 @@ public class ForEachStateHandler extends CompositeContextNodeHandler<ForEachStat
                 factory.forEachNode(parserContext.newId()).sequential(false).waitForCompletion(true).expressionLanguage(workflow.getExpressionLang()).collectionExpression(state.getInputCollection())
                         .outputVariable(outputVarName, new ObjectDataType())
                         .metaData(Metadata.VARIABLE, ServerlessWorkflowParser.DEFAULT_WORKFLOW_VAR);
-        handleActions(result, state.getActions(), outputVarName, false);
         if (state.getIterationParam() != null) {
             result.variable(state.getIterationParam(), new ObjectDataType());
         }
         if (state.getOutputCollection() != null) {
             result.completionAction(new CollectorActionSupplier(workflow.getExpressionLang(), state.getOutputCollection(), DEFAULT_WORKFLOW_VAR, ForEachNodeInstance.TEMP_OUTPUT_VAR));
         }
+        handleActions(result, state.getActions(), outputVarName, false);
         return new MakeNodeResult(result);
     }
 

--- a/kogito-serverless-workflow/kogito-serverless-workflow-runtime/src/main/java/org/kie/kogito/serverless/workflow/models/JsonNodeModel.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-runtime/src/main/java/org/kie/kogito/serverless/workflow/models/JsonNodeModel.java
@@ -63,15 +63,18 @@ public class JsonNodeModel implements Model, MapInput, MapInputId, MapOutput, Ma
         return new JsonNodeModelOutput(id, workflowdata);
     }
 
+    @Override
     public void update(Map<String, Object> params) {
         Map<String, Object> copy = mutableMap(params);
         update((String) copy.remove("id"), copy);
     }
 
+    @Override
     public void fromMap(String id, Map<String, Object> params) {
         update(id, mutableMap(params));
     }
 
+    @Override
     public Map<String, Object> toMap() {
         Map<String, Object> map = new HashMap<>();
         map.put(SWFConstants.DEFAULT_WORKFLOW_VAR, workflowdata);

--- a/kogito-serverless-workflow/kogito-serverless-workflow-runtime/src/main/java/org/kie/kogito/serverless/workflow/models/JsonNodeModel.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-runtime/src/main/java/org/kie/kogito/serverless/workflow/models/JsonNodeModel.java
@@ -75,9 +75,6 @@ public class JsonNodeModel implements Model, MapInput, MapInputId, MapOutput, Ma
     public Map<String, Object> toMap() {
         Map<String, Object> map = new HashMap<>();
         map.put(SWFConstants.DEFAULT_WORKFLOW_VAR, workflowdata);
-        if (id != null) {
-            map.put("id", id);
-        }
         map.putAll(additionalProperties);
         return map;
     }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-runtime/src/main/java/org/kie/kogito/serverless/workflow/models/JsonNodeModel.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-runtime/src/main/java/org/kie/kogito/serverless/workflow/models/JsonNodeModel.java
@@ -15,19 +15,25 @@
  */
 package org.kie.kogito.serverless.workflow.models;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.kie.kogito.MapInput;
 import org.kie.kogito.MapInputId;
 import org.kie.kogito.MapOutput;
 import org.kie.kogito.MappableToModel;
 import org.kie.kogito.Model;
+import org.kie.kogito.jackson.utils.JsonObjectUtils;
+import org.kie.kogito.serverless.workflow.SWFConstants;
 
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.databind.JsonNode;
 
 public class JsonNodeModel implements Model, MapInput, MapInputId, MapOutput, MappableToModel<JsonNodeModelOutput> {
 
     private JsonNode workflowdata;
     private String id;
+    private Map<String, Object> additionalProperties = Collections.emptyMap();
 
     public JsonNodeModel() {
     }
@@ -44,7 +50,6 @@ public class JsonNodeModel implements Model, MapInput, MapInputId, MapOutput, Ma
         this.id = id;
     }
 
-    @JsonAnyGetter
     public JsonNode getWorkflowdata() {
         return workflowdata;
     }
@@ -56,5 +61,39 @@ public class JsonNodeModel implements Model, MapInput, MapInputId, MapOutput, Ma
     @Override
     public JsonNodeModelOutput toModel() {
         return new JsonNodeModelOutput(id, workflowdata);
+    }
+
+    public void update(Map<String, Object> params) {
+        Map<String, Object> copy = mutableMap(params);
+        update((String) copy.remove("id"), copy);
+    }
+
+    public void fromMap(String id, Map<String, Object> params) {
+        update(id, mutableMap(params));
+    }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put(SWFConstants.DEFAULT_WORKFLOW_VAR, workflowdata);
+        if (id != null) {
+            map.put("id", id);
+        }
+        map.putAll(additionalProperties);
+        return map;
+    }
+
+    private void update(String id, Map<String, Object> params) {
+        this.id = id;
+        if (params.containsKey(SWFConstants.DEFAULT_WORKFLOW_VAR)) {
+            this.workflowdata = JsonObjectUtils.fromValue(params.remove(SWFConstants.DEFAULT_WORKFLOW_VAR)).deepCopy();
+            this.additionalProperties = params;
+        } else {
+            this.workflowdata = JsonObjectUtils.fromValue(params);
+            this.additionalProperties = Collections.emptyMap();
+        }
+    }
+
+    private static Map<String, Object> mutableMap(Map<String, Object> map) {
+        return map instanceof HashMap ? map : new HashMap<>(map);
     }
 }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-utils/src/main/java/org/kie/kogito/serverless/workflow/utils/JsonNodeContext.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-utils/src/main/java/org/kie/kogito/serverless/workflow/utils/JsonNodeContext.java
@@ -70,7 +70,6 @@ public class JsonNodeContext implements AutoCloseable {
             }
         }
         return Collections.emptyMap();
-
     }
 
     private static boolean isEvalVariable(String varName, KogitoNodeInstance nodeInstance) {
@@ -83,7 +82,6 @@ public class JsonNodeContext implements AutoCloseable {
         VariableScopeInstance variableScope = (VariableScopeInstance) node.getContextInstance(VariableScope.VARIABLE_SCOPE);
         return variableScope.getVariables().entrySet().stream().filter(e -> isEvalVariable(e.getKey(), (KogitoNodeInstance) node))
                 .collect(Collectors.toMap(Entry::getKey, entry -> JsonObjectUtils.fromValue(entry.getValue())));
-
     }
 
     @Override

--- a/kogito-serverless-workflow/kogito-serverless-workflow-utils/src/main/java/org/kie/kogito/serverless/workflow/utils/JsonNodeContext.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-utils/src/main/java/org/kie/kogito/serverless/workflow/utils/JsonNodeContext.java
@@ -19,6 +19,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -100,15 +101,11 @@ public class JsonNodeContext implements AutoCloseable {
         if (variableScope != null) {
             Collection<String> evalVariables = getEvalVariables(node).map(Variable::getName).collect(Collectors.toList());
             for (Entry<String, Object> e : variableScope.getVariables().entrySet()) {
-                if (evalVariables.contains(e.getKey()) || shouldAdd(e, jsonNode, node)) {
+                if (evalVariables.contains(e.getKey()) || node instanceof WorkflowProcessInstance && !Objects.equals(jsonNode, e.getValue())) {
                     variables.putIfAbsent(e.getKey(), JsonObjectUtils.fromValue(e.getValue()));
                 }
             }
         }
-    }
-
-    private static boolean shouldAdd(Entry<String, Object> e, ObjectNode jsonNode, ContextableInstance node) {
-        return jsonNode != e.getValue() && node instanceof WorkflowProcessInstance && !e.getKey().equals("workflowdata");
     }
 
     @Override

--- a/kogito-serverless-workflow/kogito-serverless-workflow-utils/src/main/java/org/kie/kogito/serverless/workflow/utils/JsonNodeContext.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-utils/src/main/java/org/kie/kogito/serverless/workflow/utils/JsonNodeContext.java
@@ -99,11 +99,13 @@ public class JsonNodeContext implements AutoCloseable {
     }
 
     private static void getVariablesFromContext(Map<String, JsonNode> variables, ContextableInstance node) {
-        Map<String, Object> variableValues = ((VariableScopeInstance) node.getContextInstance(VariableScope.VARIABLE_SCOPE)).getVariables();
-        Collection<String> evalVariables = getEvalVariables(node).map(Variable::getName).collect(Collectors.toList());
-        for (Entry<String, Object> e : variableValues.entrySet()) {
-            if (evalVariables.contains(e.getKey()) || node instanceof WorkflowProcessInstance && !e.getKey().equals("workflowdata")) {
-                variables.putIfAbsent(e.getKey(), JsonObjectUtils.fromValue(e.getValue()));
+        VariableScopeInstance variableScope = (VariableScopeInstance) node.getContextInstance(VariableScope.VARIABLE_SCOPE);
+        if (variableScope != null) {
+            Collection<String> evalVariables = getEvalVariables(node).map(Variable::getName).collect(Collectors.toList());
+            for (Entry<String, Object> e : variableScope.getVariables().entrySet()) {
+                if (evalVariables.contains(e.getKey()) || node instanceof WorkflowProcessInstance && !e.getKey().equals("workflowdata")) {
+                    variables.putIfAbsent(e.getKey(), JsonObjectUtils.fromValue(e.getValue()));
+                }
             }
         }
     }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-utils/src/main/java/org/kie/kogito/serverless/workflow/utils/JsonNodeContext.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-utils/src/main/java/org/kie/kogito/serverless/workflow/utils/JsonNodeContext.java
@@ -15,18 +15,25 @@
  */
 package org.kie.kogito.serverless.workflow.utils;
 
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import org.jbpm.process.core.ContextResolver;
+import org.jbpm.process.core.ContextContainer;
+import org.jbpm.process.core.context.variable.Variable;
 import org.jbpm.process.core.context.variable.VariableScope;
+import org.jbpm.process.instance.ContextInstanceContainer;
 import org.jbpm.process.instance.ContextableInstance;
 import org.jbpm.process.instance.context.variable.VariableScopeInstance;
 import org.jbpm.ruleflow.core.Metadata;
-import org.kie.api.definition.process.Node;
+import org.jbpm.workflow.core.Node;
+import org.jbpm.workflow.core.node.ForEachNode;
+import org.jbpm.workflow.instance.WorkflowProcessInstance;
 import org.kie.api.runtime.process.NodeInstanceContainer;
 import org.kie.kogito.internal.process.runtime.KogitoNodeInstance;
 import org.kie.kogito.internal.process.runtime.KogitoProcessContext;
@@ -39,6 +46,25 @@ public class JsonNodeContext implements AutoCloseable {
 
     private final JsonNode jsonNode;
     private final Set<String> keys;
+
+    public static Stream<Variable> getEvalVariables(Node node) {
+        if (node instanceof ForEachNode) {
+            node = ((ForEachNode) node).getCompositeNode();
+        }
+        if (node instanceof ContextContainer) {
+            return getEvalVariables((ContextContainer) node);
+        }
+        return Stream.empty();
+    }
+
+    private static Stream<Variable> getEvalVariables(ContextableInstance containerInstance) {
+        return containerInstance instanceof ContextInstanceContainer ? getEvalVariables(((ContextInstanceContainer) containerInstance).getContextContainer()) : Stream.empty();
+    }
+
+    private static Stream<Variable> getEvalVariables(ContextContainer container) {
+        VariableScope variableScope = (VariableScope) container.getDefaultContext(VariableScope.VARIABLE_SCOPE);
+        return variableScope.getVariables().stream().filter(v -> v.getMetaData(Metadata.EVAL_VARIABLE) != null);
+    }
 
     public static JsonNodeContext from(JsonNode jsonNode, KogitoProcessContext context) {
         Map<String, JsonNode> map = Collections.emptyMap();
@@ -61,27 +87,25 @@ public class JsonNodeContext implements AutoCloseable {
 
     private static Map<String, JsonNode> addVariablesFromContext(KogitoProcessContext processInfo) {
         KogitoNodeInstance nodeInstance = processInfo.getNodeInstance();
-        if (nodeInstance instanceof ContextableInstance) {
-            return getVariablesFromContext((ContextableInstance) nodeInstance);
-        } else if (nodeInstance != null) {
-            NodeInstanceContainer container = nodeInstance.getNodeInstanceContainer();
-            if (container instanceof ContextableInstance && container instanceof KogitoNodeInstance) {
-                return getVariablesFromContext((ContextableInstance) container);
+        Map<String, JsonNode> variables = new HashMap<>();
+        if (nodeInstance != null) {
+            NodeInstanceContainer container = nodeInstance instanceof NodeInstanceContainer ? (NodeInstanceContainer) nodeInstance : nodeInstance.getNodeInstanceContainer();
+            while (container instanceof ContextableInstance) {
+                getVariablesFromContext(variables, (ContextableInstance) container);
+                container = container instanceof KogitoNodeInstance ? ((KogitoNodeInstance) container).getNodeInstanceContainer() : null;
             }
         }
-        return Collections.emptyMap();
+        return variables;
     }
 
-    private static boolean isEvalVariable(String varName, KogitoNodeInstance nodeInstance) {
-        Node node = nodeInstance.getNode();
-        VariableScope scope = (VariableScope) ((ContextResolver) node).resolveContext(VariableScope.VARIABLE_SCOPE, varName);
-        return scope.getVariables().stream().filter(v -> v.getName().equals(varName)).findAny().orElseThrow().getMetaData(Metadata.EVAL_VARIABLE) != null;
-    }
-
-    private static Map<String, JsonNode> getVariablesFromContext(ContextableInstance node) {
-        VariableScopeInstance variableScope = (VariableScopeInstance) node.getContextInstance(VariableScope.VARIABLE_SCOPE);
-        return variableScope.getVariables().entrySet().stream().filter(e -> isEvalVariable(e.getKey(), (KogitoNodeInstance) node))
-                .collect(Collectors.toMap(Entry::getKey, entry -> JsonObjectUtils.fromValue(entry.getValue())));
+    private static void getVariablesFromContext(Map<String, JsonNode> variables, ContextableInstance node) {
+        Map<String, Object> variableValues = ((VariableScopeInstance) node.getContextInstance(VariableScope.VARIABLE_SCOPE)).getVariables();
+        Collection<String> evalVariables = getEvalVariables(node).map(Variable::getName).collect(Collectors.toList());
+        for (Entry<String, Object> e : variableValues.entrySet()) {
+            if (evalVariables.contains(e.getKey()) || node instanceof WorkflowProcessInstance && !e.getKey().equals("workflowdata")) {
+                variables.putIfAbsent(e.getKey(), JsonObjectUtils.fromValue(e.getValue()));
+            }
+        }
     }
 
     @Override

--- a/kogito-workitems/kogito-jackson-utils/src/main/java/org/kie/kogito/jackson/utils/ArrayNodeListenerAware.java
+++ b/kogito-workitems/kogito-jackson-utils/src/main/java/org/kie/kogito/jackson/utils/ArrayNodeListenerAware.java
@@ -19,7 +19,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CopyOnWriteArraySet;
 
 import org.kie.kogito.internal.process.event.KogitoObjectListener;
 import org.kie.kogito.internal.process.event.KogitoObjectListenerAware;
@@ -34,7 +34,7 @@ public class ArrayNodeListenerAware extends ArrayNode implements KogitoObjectLis
 
     private static final long serialVersionUID = 1L;
 
-    private transient Collection<KogitoObjectListener> listeners = new CopyOnWriteArrayList<>();
+    private transient Collection<KogitoObjectListener> listeners = new CopyOnWriteArraySet<>();
 
     public ArrayNodeListenerAware(JsonNodeFactory nf) {
         super(nf);

--- a/kogito-workitems/kogito-jackson-utils/src/main/java/org/kie/kogito/jackson/utils/ObjectNodeListenerAware.java
+++ b/kogito-workitems/kogito-jackson-utils/src/main/java/org/kie/kogito/jackson/utils/ObjectNodeListenerAware.java
@@ -18,7 +18,7 @@ package org.kie.kogito.jackson.utils;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CopyOnWriteArraySet;
 
 import org.kie.kogito.internal.process.event.KogitoObjectListener;
 import org.kie.kogito.internal.process.event.KogitoObjectListenerAware;
@@ -33,7 +33,7 @@ public class ObjectNodeListenerAware extends ObjectNode implements KogitoObjectL
 
     private static final long serialVersionUID = 1L;
 
-    private transient Collection<KogitoObjectListener> listeners = new CopyOnWriteArrayList<>();
+    private transient Collection<KogitoObjectListener> listeners = new CopyOnWriteArraySet<>();
 
     public ObjectNodeListenerAware(JsonNodeFactory nc) {
         super(nc);

--- a/kogito-workitems/kogito-jackson-utils/src/test/java/org/kie/kogito/jackson/utils/ListenerAwareTest.java
+++ b/kogito-workitems/kogito-jackson-utils/src/test/java/org/kie/kogito/jackson/utils/ListenerAwareTest.java
@@ -39,6 +39,15 @@ public class ListenerAwareTest {
     }
 
     @Test
+    void selfAssignment() {
+        ObjectNodeListenerAware node = (ObjectNodeListenerAware) ObjectMapperFactory.listenerAware().createObjectNode();
+        node.addKogitoObjectListener(listener);
+        node.set("name", node);
+        verify(listener).beforeValueChanged(node, "name", NullNode.instance, node);
+        verify(listener).afterValueChanged(node, "name", NullNode.instance, node);
+    }
+
+    @Test
     void testObjectNodeChange() {
         ObjectNodeListenerAware node = (ObjectNodeListenerAware) ObjectMapperFactory.listenerAware().createObjectNode();
         node.addKogitoObjectListener(listener);

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/foreach_child.sw.json
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/foreach_child.sw.json
@@ -1,0 +1,34 @@
+{
+    "id": "foreach_child",
+    "version": "1.0",
+    "specVersion": "0.8",
+    "name": "Foreach child Workflow",
+    "description": "Foreach child Workflow Test",
+    "start": "multiply",
+    "functions": [
+        {
+            "name": "multiply",
+            "type": "expression",
+            "operation": ".number*.constant"
+        }
+    ],
+    "states": [
+        {
+            "name": "multiply",
+            "type": "operation",
+            "actions": [
+                {
+                    "name": "multiplyAction",
+                    "functionRef": "multiply",
+                    "actionDataFilter": {
+             			"toStateData" : ".response"
+                     }
+                }
+            ],
+            "stateDataFilter": {
+        		"output": ".response"
+      		},
+            "end": true
+        }
+    ]
+}

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/foreach_parent.sw.json
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/foreach_parent.sw.json
@@ -1,0 +1,31 @@
+{
+  "id": "foreach_parent",
+  "version": "1.0",
+  "specVersion": "0.8",
+  "name": "For Each Parent",
+  "description": "For Each Parent Sample",
+  "start": "For Each",
+  "functions": [
+    {
+      "name": "printMessage",
+      "type": "custom",
+      "operation": "sysout"
+    }
+  ],
+  "states": [
+    {
+      "name": "For Each",
+      "type": "foreach",
+      "mode": "sequential",
+      "inputCollection": ".numbers",
+      "iterationParam": "number",
+      "outputCollection": ".products",
+      "actions": [
+        {
+          "subFlowRef": "foreach_child"
+        }
+      ],
+      "end": true
+    }
+  ]
+}

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/ForEachRestIT.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/ForEachRestIT.java
@@ -41,4 +41,16 @@ class ForEachRestIT {
                 .body("workflowdata.output", is(Arrays.asList(2, 3, 4, 5, 6)))
                 .body("workflowdata.response", nullValue());
     }
+
+    @Test
+    void testForEachSubflow() {
+        given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .body("{\"numbers\" : [1,2,3,4,5], \"constant\": 2}}").when()
+                .post("/foreach_parent")
+                .then()
+                .statusCode(201)
+                .body("workflowdata.products", is(Arrays.asList(2, 4, 6, 8, 10)));
+    }
 }


### PR DESCRIPTION
This PR is:
- Cloning workflow data when passing it to the subprocess (and avoid recursivity in listener when assigning an object to itself)
- Making the iterationParameter accessible to the subprocess (the subprocess will still have access to the parent flow)
- Adding  @dmarrazzo use case that originates the JIRA to the set on integration

In order to achieve the second goal, after trying different approaches, I chose to map the variable name and do a small trick on JsonNodeContext to decide its inclusion in the jq scope (see https://github.com/eiiches/jackson-jq/issues/221, once this is available in JQ library, we can refactor this class and clean it up) 

