### PR TITLE
[KOGITO-8464] Improve error message when using an invalid uri

### DIFF
--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/operationid/AbstractWorkflowOperationIdFactory.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/operationid/AbstractWorkflowOperationIdFactory.java
@@ -52,11 +52,15 @@ public abstract class AbstractWorkflowOperationIdFactory implements WorkflowOper
             uri = URI.create(actionResource.getUri());
             fileName = getFileName(workflow, function, context, uri, actionResource.getOperation(), actionResource.getService());
         }
-        String packageName = onlyChars(removeExt(fileName.toLowerCase()));
-        if (packageName == null || packageName.isBlank()) {
+        if (fileName == null || fileName.isBlank()) {
             throw new IllegalArgumentException(
-                    format("Unable to define a package name for function named '%s', please consider using a different strategy defined in the kogito.sw.operationIdStrategy property.",
-                            function.getName()));
+                    format("Empty file name for function '%s', please review uri '%s' or consider using a different strategy defined in the kogito.sw.operationIdStrategy property",
+                            function.getName(), uri));
+        }
+        String packageName = onlyChars(removeExt(fileName.toLowerCase()));
+        if (packageName.isBlank()) {
+            throw new IllegalArgumentException(
+                    format("Empty package for file '%s'. A file name should contain at least one letter which is not part of the extension", fileName));
         }
         return new WorkflowOperationId(uri, actionResource.getOperation(), actionResource.getService(), fileName, packageName);
     }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/java/org/kie/kogito/serverless/workflow/operationid/FileNameWorkflowOperationIdTest.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/java/org/kie/kogito/serverless/workflow/operationid/FileNameWorkflowOperationIdTest.java
@@ -26,6 +26,7 @@ import io.serverlessworkflow.api.functions.FunctionDefinition;
 import io.serverlessworkflow.api.functions.FunctionDefinition.Type;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 class FileNameWorkflowOperationIdTest {
@@ -65,5 +66,13 @@ class FileNameWorkflowOperationIdTest {
         assertThat(id.getPackageName()).isEqualTo("pepe");
         assertThat(id.getUri()).hasToString("http://myserver.com/spec/PePE1.yaml");
         assertThat(id.getService()).isEqualTo("service");
+    }
+
+    @Test
+    void testEmptyFileName() {
+        definition.setType(Type.REST);
+        definition.setOperation("file://wrongUri.yaml#doSomething");
+        assertThatThrownBy(() -> WorkflowOperationIdFactoryType.FILE_NAME.factory().from(workflow, definition, Optional.empty())).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Empty file name");
     }
 }


### PR DESCRIPTION
Now the message when using file:// (which is not a valid file path) is 
`Empty file name for function named 'sayHello', please review uri 'file://greeting.proto' or consider using a different strategy defined in the kogito.sw.operationIdStrategy property `