### PR TITLE
#2745 spring configure consumer for SSL with Kafka

### DIFF
--- a/springboot/addons/messaging/implementation/src/main/java/org/kie/kogito/addon/cloudevents/spring/SpringKafkaConsumerConfig.java
+++ b/springboot/addons/messaging/implementation/src/main/java/org/kie/kogito/addon/cloudevents/spring/SpringKafkaConsumerConfig.java
@@ -15,7 +15,12 @@
  */
 package org.kie.kogito.addon.cloudevents.spring;
 
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.kafka.DefaultKafkaConsumerFactoryCustomizer;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafka;

--- a/springboot/addons/messaging/implementation/src/main/java/org/kie/kogito/addon/cloudevents/spring/SpringKafkaConsumerConfig.java
+++ b/springboot/addons/messaging/implementation/src/main/java/org/kie/kogito/addon/cloudevents/spring/SpringKafkaConsumerConfig.java
@@ -20,7 +20,6 @@ import java.util.Map;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
-import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -40,6 +39,16 @@ public class SpringKafkaConsumerConfig {
     String groupId;
     @Value(value = "${spring.kafka.consumer.auto-offset-reset}")
     String offset;
+    @Value(value = "${spring.kafka.security.protocol}")
+    String security_protocol;
+    @Value(value = "${spring.kafka.ssl.trust-store-location}")
+    String ts_location;
+    @Value(value = "${spring.kafka.ssl.trust-store-password}")
+    String ts_password;
+    @Value(value = "${spring.kafka.ssl.key-store-location}")
+    String ks_location;
+    @Value(value = "${spring.kafka.ssl.key-store-password}")
+    String ks_password;
 
     private static final Logger logger = LoggerFactory.getLogger(SpringKafkaConsumerConfig.class);
 
@@ -52,6 +61,12 @@ public class SpringKafkaConsumerConfig {
         props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, offset);
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+
+        props.put(AdminClientConfig.SECURITY_PROTOCOL_CONFIG, security_protocol);
+        props.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, ts_location);
+        props.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, ts_password);
+        props.put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, ks_location);
+        props.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, ks_password);
         return new DefaultKafkaConsumerFactory<>(props);
     }
 

--- a/springboot/addons/messaging/implementation/src/main/java/org/kie/kogito/addon/cloudevents/spring/SpringKafkaConsumerConfig.java
+++ b/springboot/addons/messaging/implementation/src/main/java/org/kie/kogito/addon/cloudevents/spring/SpringKafkaConsumerConfig.java
@@ -15,13 +15,7 @@
  */
 package org.kie.kogito.addon.cloudevents.spring;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.common.serialization.StringDeserializer;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafka;
@@ -33,46 +27,24 @@ import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 @Configuration
 public class SpringKafkaConsumerConfig {
 
-    @Value(value = "${spring.kafka.bootstrap-servers}")
-    String kafkaBootstrapAddress;
-    @Value(value = "${spring.kafka.consumer.group-id}")
-    String groupId;
-    @Value(value = "${spring.kafka.consumer.auto-offset-reset}")
-    String offset;
-    @Value(value = "${spring.kafka.security.protocol:#{null}}")
-    String security_protocol;
-    @Value(value = "${spring.kafka.ssl.trust-store-location:#{null}}")
-    String ts_location;
-    @Value(value = "${spring.kafka.ssl.trust-store-password:#{null}}")
-    String ts_password;
-    @Value(value = "${spring.kafka.ssl.key-store-location:#{null}}")
-    String ks_location;
-    @Value(value = "${spring.kafka.ssl.key-store-password:#{null}}")
-    String ks_password;
+    @Autowired
+    private ObjectProvider<DefaultKafkaConsumerFactoryCustomizer> customizers;
+
+    @Autowired
+    private KafkaProperties properties;
 
     private static final Logger logger = LoggerFactory.getLogger(SpringKafkaConsumerConfig.class);
 
     @Bean
     public ConsumerFactory<String, String> consumerFactory() {
-        logger.info("Creating consumer factory with bootstrap {} and groupid {}", kafkaBootstrapAddress, groupId);
-        Map<String, Object> props = new HashMap<>();
-        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaBootstrapAddress);
-        props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
-        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, offset);
-        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        logger.info("Creating Default Kafka Consumer Factory");
 
-        propsPut(props, AdminClientConfig.SECURITY_PROTOCOL_CONFIG, security_protocol);
-        propsPut(props, SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, ts_location);
-        propsPut(props, SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, ts_password);
-        propsPut(props, SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, ks_location);
-        propsPut(props, SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, ks_password);
-        return new DefaultKafkaConsumerFactory<>(props);
-    }
+        DefaultKafkaConsumerFactory<String, String> factory = new DefaultKafkaConsumerFactory<>(
+                this.properties.buildConsumerProperties());
 
-    private static void propsPut(Map<String, Object> props, String key, String val) {
-        if (val != null)
-            props.put(key, val);
+        customizers.orderedStream().forEach((customizer) -> customizer.customize(factory));
+
+        return factory;
     }
 
     @Bean

--- a/springboot/addons/messaging/implementation/src/main/java/org/kie/kogito/addon/cloudevents/spring/SpringKafkaConsumerConfig.java
+++ b/springboot/addons/messaging/implementation/src/main/java/org/kie/kogito/addon/cloudevents/spring/SpringKafkaConsumerConfig.java
@@ -39,15 +39,15 @@ public class SpringKafkaConsumerConfig {
     String groupId;
     @Value(value = "${spring.kafka.consumer.auto-offset-reset}")
     String offset;
-    @Value(value = "${spring.kafka.security.protocol}")
+    @Value(value = "${spring.kafka.security.protocol:#{null}}")
     String security_protocol;
-    @Value(value = "${spring.kafka.ssl.trust-store-location}")
+    @Value(value = "${spring.kafka.ssl.trust-store-location:#{null}}")
     String ts_location;
-    @Value(value = "${spring.kafka.ssl.trust-store-password}")
+    @Value(value = "${spring.kafka.ssl.trust-store-password:#{null}}")
     String ts_password;
-    @Value(value = "${spring.kafka.ssl.key-store-location}")
+    @Value(value = "${spring.kafka.ssl.key-store-location:#{null}}")
     String ks_location;
-    @Value(value = "${spring.kafka.ssl.key-store-password}")
+    @Value(value = "${spring.kafka.ssl.key-store-password:#{null}}")
     String ks_password;
 
     private static final Logger logger = LoggerFactory.getLogger(SpringKafkaConsumerConfig.class);
@@ -62,12 +62,17 @@ public class SpringKafkaConsumerConfig {
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
 
-        props.put(AdminClientConfig.SECURITY_PROTOCOL_CONFIG, security_protocol);
-        props.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, ts_location);
-        props.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, ts_password);
-        props.put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, ks_location);
-        props.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, ks_password);
+        propsPut(props, AdminClientConfig.SECURITY_PROTOCOL_CONFIG, security_protocol);
+        propsPut(props, SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, ts_location);
+        propsPut(props, SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, ts_password);
+        propsPut(props, SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, ks_location);
+        propsPut(props, SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, ks_password);
         return new DefaultKafkaConsumerFactory<>(props);
+    }
+
+    private static void propsPut(Map<String, Object> props, String key, String val) {
+        if (val != null)
+            props.put(key, val);
     }
 
     @Bean

--- a/springboot/addons/messaging/implementation/src/main/java/org/kie/kogito/addon/cloudevents/spring/SpringKafkaConsumerConfig.java
+++ b/springboot/addons/messaging/implementation/src/main/java/org/kie/kogito/addon/cloudevents/spring/SpringKafkaConsumerConfig.java
@@ -15,10 +15,7 @@
  */
 package org.kie.kogito.addon.cloudevents.spring;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.kafka.DefaultKafkaConsumerFactoryCustomizer;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.context.annotation.Bean;
@@ -32,30 +29,18 @@ import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 @Configuration
 public class SpringKafkaConsumerConfig {
 
-    @Autowired
-    private ObjectProvider<DefaultKafkaConsumerFactoryCustomizer> customizers;
-
-    @Autowired
-    private KafkaProperties properties;
-
-    private static final Logger logger = LoggerFactory.getLogger(SpringKafkaConsumerConfig.class);
-
     @Bean
-    public ConsumerFactory<String, String> consumerFactory() {
-        logger.info("Creating Default Kafka Consumer Factory");
-
+    public ConsumerFactory<String, String> consumerFactory(KafkaProperties properties, ObjectProvider<DefaultKafkaConsumerFactoryCustomizer> customizers) {
         DefaultKafkaConsumerFactory<String, String> factory = new DefaultKafkaConsumerFactory<>(
-                this.properties.buildConsumerProperties());
-
-        customizers.orderedStream().forEach((customizer) -> customizer.customize(factory));
-
+                properties.buildConsumerProperties());
+        customizers.orderedStream().forEach(customizer -> customizer.customize(factory));
         return factory;
     }
 
     @Bean
-    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory(ConsumerFactory<String, String> consumerFactory) {
         ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
-        factory.setConsumerFactory(consumerFactory());
+        factory.setConsumerFactory(consumerFactory);
         factory.setBatchListener(true);
         return factory;
     }


### PR DESCRIPTION
Changed SpringKafkaConsumerConfig to read the properties:
```ini
spring.kafka.security.protocol = ...
spring.kafka.ssl.trust-store-location = ...
spring.kafka.ssl.trust-store-password = ...
spring.kafka.ssl.key-store-location = ...
spring.kafka.ssl.key-store-password = ...
```