### PR TITLE
[KOGITO-7982] Changing splitType to XAND for exclusive

### DIFF
--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/CompositeContextNodeVisitor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/CompositeContextNodeVisitor.java
@@ -20,7 +20,6 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import org.jbpm.process.core.context.variable.VariableScope;
-import org.jbpm.process.core.timer.Timer;
 import org.jbpm.ruleflow.core.factory.CompositeContextNodeFactory;
 import org.jbpm.workflow.core.node.CompositeContextNode;
 import org.kie.api.definition.process.Node;
@@ -78,12 +77,9 @@ public class CompositeContextNodeVisitor<T extends CompositeContextNode> extends
 
         body.addStatement(getFactoryMethod(getNodeId(node), CompositeContextNodeFactory.METHOD_AUTO_COMPLETE, new BooleanLiteralExpr(node.isAutoComplete())));
 
-        if (node.getTimers() != null) {
-            for (Timer timer : node.getTimers().keySet()) {
-                if (timer.getTimeType() == Timer.TIME_DURATION) {
-                    body.addStatement(getFactoryMethod(getNodeId(node), "timeout", new StringLiteralExpr(timer.getDelay())));
-                }
-            }
+        String timeout = node.getTimeout();
+        if (timeout != null) {
+            body.addStatement(getFactoryMethod(getNodeId(node), "timeout", new StringLiteralExpr(timeout)));
         }
         addNodeMappings(node, body, getNodeId(node));
         visitNodes(getNodeId(node), node.getNodes(), body, scope, metadata);

--- a/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/CompositeContextNodeVisitor.java
+++ b/jbpm/jbpm-flow-builder/src/main/java/org/jbpm/compiler/canonical/CompositeContextNodeVisitor.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import org.jbpm.process.core.context.variable.VariableScope;
+import org.jbpm.process.core.timer.Timer;
 import org.jbpm.ruleflow.core.factory.CompositeContextNodeFactory;
 import org.jbpm.workflow.core.node.CompositeContextNode;
 import org.kie.api.definition.process.Node;
@@ -27,6 +28,7 @@ import org.kie.api.definition.process.Node;
 import com.github.javaparser.ast.expr.BooleanLiteralExpr;
 import com.github.javaparser.ast.expr.LongLiteralExpr;
 import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.StringLiteralExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
 
 public class CompositeContextNodeVisitor<T extends CompositeContextNode> extends AbstractCompositeNodeVisitor<T> {
@@ -75,6 +77,14 @@ public class CompositeContextNodeVisitor<T extends CompositeContextNode> extends
         visitCompensationScope(node, body);
 
         body.addStatement(getFactoryMethod(getNodeId(node), CompositeContextNodeFactory.METHOD_AUTO_COMPLETE, new BooleanLiteralExpr(node.isAutoComplete())));
+
+        if (node.getTimers() != null) {
+            for (Timer timer : node.getTimers().keySet()) {
+                if (timer.getTimeType() == Timer.TIME_DURATION) {
+                    body.addStatement(getFactoryMethod(getNodeId(node), "timeout", new StringLiteralExpr(timer.getDelay())));
+                }
+            }
+        }
         addNodeMappings(node, body, getNodeId(node));
         visitNodes(getNodeId(node), node.getNodes(), body, scope, metadata);
         visitConnections(getNodeId(node), node.getNodes(), body);

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/actions/AbstractNodeInstanceAction.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/actions/AbstractNodeInstanceAction.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.process.instance.impl.actions;
+
+import java.io.Serializable;
+import java.util.Collection;
+
+import org.jbpm.process.instance.impl.Action;
+import org.jbpm.workflow.instance.node.CompositeNodeInstance;
+import org.kie.api.runtime.process.NodeInstance;
+import org.kie.api.runtime.process.WorkflowProcessInstance;
+import org.kie.kogito.internal.process.runtime.KogitoProcessContext;
+
+public abstract class AbstractNodeInstanceAction implements Action, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private String attachedToNodeId;
+
+    protected AbstractNodeInstanceAction(String attachedToNodeId) {
+        this.attachedToNodeId = attachedToNodeId;
+    }
+
+    @Override
+    public void execute(KogitoProcessContext context) throws Exception {
+        WorkflowProcessInstance pi = context.getNodeInstance().getProcessInstance();
+        NodeInstance nodeInstance = findNodeByUniqueId(pi.getNodeInstances(), attachedToNodeId);
+        if (nodeInstance != null) {
+            execute(nodeInstance);
+        }
+    }
+
+    protected abstract void execute(NodeInstance nodeInstance);
+
+    private static NodeInstance findNodeByUniqueId(Collection<NodeInstance> nodeInstances, String uniqueId) {
+        if (nodeInstances != null && !nodeInstances.isEmpty()) {
+            for (NodeInstance nInstance : nodeInstances) {
+                String nodeUniqueId = (String) nInstance.getNode().getMetaData().get("UniqueId");
+                if (uniqueId.equals(nodeUniqueId)) {
+                    return nInstance;
+                }
+                if (nInstance instanceof CompositeNodeInstance) {
+                    NodeInstance nodeInstance = findNodeByUniqueId(((CompositeNodeInstance) nInstance).getNodeInstances(), uniqueId);
+                    if (nodeInstance != null) {
+                        return nodeInstance;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/actions/CompleteCompositeNodeInstanceAction.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/actions/CompleteCompositeNodeInstanceAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,18 +15,19 @@
  */
 package org.jbpm.process.instance.impl.actions;
 
+import org.jbpm.workflow.instance.node.CompositeNodeInstance;
 import org.kie.api.runtime.process.NodeInstance;
 
-public class CancelNodeInstanceAction extends AbstractNodeInstanceAction {
+public class CompleteCompositeNodeInstanceAction extends AbstractNodeInstanceAction {
 
     private static final long serialVersionUID = 1L;
 
-    public CancelNodeInstanceAction(String attachedToNodeId) {
+    public CompleteCompositeNodeInstanceAction(String attachedToNodeId) {
         super(attachedToNodeId);
     }
 
     @Override
     protected void execute(NodeInstance nodeInstance) {
-        ((org.jbpm.workflow.instance.NodeInstance) nodeInstance).cancel();
+        ((CompositeNodeInstance) nodeInstance).triggerCompleted();
     }
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/actions/CompleteStateBasedNodeInstanceAction.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/impl/actions/CompleteStateBasedNodeInstanceAction.java
@@ -15,19 +15,19 @@
  */
 package org.jbpm.process.instance.impl.actions;
 
-import org.jbpm.workflow.instance.node.CompositeNodeInstance;
+import org.jbpm.workflow.instance.node.StateBasedNodeInstance;
 import org.kie.api.runtime.process.NodeInstance;
 
-public class CompleteCompositeNodeInstanceAction extends AbstractNodeInstanceAction {
+public class CompleteStateBasedNodeInstanceAction extends AbstractNodeInstanceAction {
 
     private static final long serialVersionUID = 1L;
 
-    public CompleteCompositeNodeInstanceAction(String attachedToNodeId) {
+    public CompleteStateBasedNodeInstanceAction(String attachedToNodeId) {
         super(attachedToNodeId);
     }
 
     @Override
     protected void execute(NodeInstance nodeInstance) {
-        ((CompositeNodeInstance) nodeInstance).triggerCompleted();
+        ((StateBasedNodeInstance) nodeInstance).triggerCompleted();
     }
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/factory/AbstractCompositeNodeFactory.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/factory/AbstractCompositeNodeFactory.java
@@ -18,17 +18,10 @@ package org.jbpm.ruleflow.core.factory;
 import org.jbpm.process.core.context.variable.Variable;
 import org.jbpm.process.core.context.variable.VariableScope;
 import org.jbpm.process.core.datatype.DataType;
-import org.jbpm.process.core.timer.Timer;
-import org.jbpm.process.instance.impl.Action;
-import org.jbpm.process.instance.impl.actions.CompleteCompositeNodeInstanceAction;
-import org.jbpm.process.instance.impl.actions.SignalProcessInstanceAction;
 import org.jbpm.ruleflow.core.RuleFlowNodeContainerFactory;
 import org.jbpm.workflow.core.Node;
 import org.jbpm.workflow.core.NodeContainer;
-import org.jbpm.workflow.core.impl.DroolsConsequenceAction;
 import org.jbpm.workflow.core.node.CompositeContextNode;
-
-import static org.jbpm.ruleflow.core.Metadata.ACTION;
 
 @SuppressWarnings("unchecked")
 public abstract class AbstractCompositeNodeFactory<T extends RuleFlowNodeContainerFactory<T, P>, P extends RuleFlowNodeContainerFactory<P, ?>> extends RuleFlowNodeContainerFactory<T, P> {
@@ -45,18 +38,8 @@ public abstract class AbstractCompositeNodeFactory<T extends RuleFlowNodeContain
     }
 
     public T timeout(String timeout) {
-        CompositeContextNode node = getCompositeNode();
-        Timer timer = new Timer();
-        timer.setDelay(timeout);
-        node.addTimer(timer, createJavaAction(new SignalProcessInstanceAction("Timer-" + timeout + "-" + node.getId(),
-                kcontext -> kcontext.getNodeInstance().getStringId(), SignalProcessInstanceAction.PROCESS_INSTANCE_SCOPE)));
+        getCompositeNode().setTimeout(timeout);
         return (T) this;
-    }
-
-    private DroolsConsequenceAction createJavaAction(Action action) {
-        DroolsConsequenceAction cancelAction = new DroolsConsequenceAction("java", null);
-        cancelAction.setMetaData(ACTION, new CompleteCompositeNodeInstanceAction(getCompositeNode().getNodeUniqueId()));
-        return cancelAction;
     }
 
     @Override

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/impl/ExtendedNodeImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/impl/ExtendedNodeImpl.java
@@ -52,9 +52,4 @@ public class ExtendedNodeImpl extends NodeImpl {
     public String[] getActionTypes() {
         return EVENT_TYPES;
     }
-
-    @Override
-    public String getNodeUniqueId() {
-        throw new UnsupportedOperationException();
-    }
 }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/impl/NodeImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/impl/NodeImpl.java
@@ -397,7 +397,7 @@ public abstract class NodeImpl implements Node, ContextResolver, Mappable {
 
     @Override
     public String getNodeUniqueId() {
-        throw new UnsupportedOperationException();
+        return (String) getMetaData("UniqueId");
     }
 
     @Override

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/StateBasedNode.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/StateBasedNode.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.jbpm.process.core.timer.Timer;
-import org.jbpm.process.instance.impl.actions.CompleteCompositeNodeInstanceAction;
+import org.jbpm.process.instance.impl.actions.CompleteStateBasedNodeInstanceAction;
 import org.jbpm.workflow.core.DroolsAction;
 import org.jbpm.workflow.core.impl.DroolsConsequenceAction;
 import org.jbpm.workflow.core.impl.ExtendedNodeImpl;
@@ -47,7 +47,7 @@ public class StateBasedNode extends ExtendedNodeImpl {
         Timer timer = new Timer();
         timer.setDelay(duration);
         DroolsConsequenceAction timeoutAction = new DroolsConsequenceAction("java", null);
-        timeoutAction.setMetaData(ACTION, new CompleteCompositeNodeInstanceAction(getNodeUniqueId()));
+        timeoutAction.setMetaData(ACTION, new CompleteStateBasedNodeInstanceAction(getNodeUniqueId()));
         addTimer(timer, timeoutAction);
     }
 

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/StateBasedNode.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/StateBasedNode.java
@@ -21,8 +21,12 @@ import java.util.List;
 import java.util.Map;
 
 import org.jbpm.process.core.timer.Timer;
+import org.jbpm.process.instance.impl.actions.CompleteCompositeNodeInstanceAction;
 import org.jbpm.workflow.core.DroolsAction;
+import org.jbpm.workflow.core.impl.DroolsConsequenceAction;
 import org.jbpm.workflow.core.impl.ExtendedNodeImpl;
+
+import static org.jbpm.ruleflow.core.Metadata.ACTION;
 
 public class StateBasedNode extends ExtendedNodeImpl {
 
@@ -32,8 +36,23 @@ public class StateBasedNode extends ExtendedNodeImpl {
 
     private List<String> boundaryEvents;
 
+    private transient String duration;
+
     public Map<Timer, DroolsAction> getTimers() {
         return timers;
+    }
+
+    public void setTimeout(String duration) {
+        this.duration = duration;
+        Timer timer = new Timer();
+        timer.setDelay(duration);
+        DroolsConsequenceAction timeoutAction = new DroolsConsequenceAction("java", null);
+        timeoutAction.setMetaData(ACTION, new CompleteCompositeNodeInstanceAction(getNodeUniqueId()));
+        addTimer(timer, timeoutAction);
+    }
+
+    public String getTimeout() {
+        return duration;
     }
 
     public void addTimer(Timer timer, DroolsAction action) {

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/SplitInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/SplitInstance.java
@@ -195,8 +195,7 @@ public class SplitInstance extends NodeInstanceImpl {
                     }
                     Map<org.jbpm.workflow.instance.NodeInstance, String> nodeInstancesMap = new HashMap<>();
                     for (Connection connection : connections) {
-                        nodeInstancesMap.put(((org.jbpm.workflow.instance.NodeInstanceContainer) getNodeInstanceContainer())
-                                .getNodeInstance(connection.getTo()), connection.getToType());
+                        nodeInstancesMap.put(followConnection(connection), connection.getToType());
                     }
                     for (KogitoNodeInstance nodeInstance : nodeInstancesMap.keySet()) {
                         groupInstance.addNodeInstance(nodeInstance);

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/SplitInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/SplitInstance.java
@@ -195,7 +195,8 @@ public class SplitInstance extends NodeInstanceImpl {
                     }
                     Map<org.jbpm.workflow.instance.NodeInstance, String> nodeInstancesMap = new HashMap<>();
                     for (Connection connection : connections) {
-                        nodeInstancesMap.put(followConnection(connection), connection.getToType());
+                        nodeInstancesMap.put(((org.jbpm.workflow.instance.NodeInstanceContainer) getNodeInstanceContainer())
+                                .getNodeInstance(connection.getTo()), connection.getToType());
                     }
                     for (KogitoNodeInstance nodeInstance : nodeInstancesMap.keySet()) {
                         groupInstance.addNodeInstance(nodeInstance);

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/CallbackHandler.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/CallbackHandler.java
@@ -18,7 +18,6 @@ package org.kie.kogito.serverless.workflow.parser.handlers;
 import org.jbpm.ruleflow.core.RuleFlowNodeContainerFactory;
 import org.jbpm.ruleflow.core.factory.CompositeContextNodeFactory;
 import org.jbpm.ruleflow.core.factory.NodeFactory;
-import org.jbpm.workflow.core.node.Split;
 import org.kie.kogito.serverless.workflow.parser.ParserContext;
 
 import io.serverlessworkflow.api.Workflow;
@@ -43,7 +42,7 @@ public class CallbackHandler extends CompositeContextNodeHandler<CallbackState> 
             currentNode = connect(currentNode, getActionNode(embeddedSubProcess, state.getAction()));
         }
         currentNode = connect(currentNode, makeTimeoutNode(embeddedSubProcess,
-                filterAndMergeNode(embeddedSubProcess, state.getEventDataFilter(), (f, inputVar, outputVar) -> consumeEventNode(f, state.getEventRef(), inputVar, outputVar)), Split.TYPE_XAND));
+                filterAndMergeNode(embeddedSubProcess, state.getEventDataFilter(), (f, inputVar, outputVar) -> consumeEventNode(f, state.getEventRef(), inputVar, outputVar))));
         connect(currentNode, embeddedSubProcess.endNode(parserContext.newId()).name("EmbeddedEnd").terminate(true)).done();
         handleErrors(factory, embeddedSubProcess);
         return new MakeNodeResult(embeddedSubProcess);

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/EventHandler.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/EventHandler.java
@@ -67,8 +67,17 @@ public class EventHandler extends CompositeContextNodeHandler<EventState> {
             incomingNode = nodes.get(0).getIncomingNode();
             outgoingNode = nodes.get(0).getOutgoingNode();
         } else {
-            incomingNode = isStartState ? null : factory.splitNode(parserContext.newId()).name(state.getName() + "Split").type(Split.TYPE_AND);
-            outgoingNode = factory.joinNode(parserContext.newId()).name(state.getName() + "Join").type(state.isExclusive() ? Join.TYPE_XOR : Join.TYPE_AND);
+            final int splitType;
+            final int joinType;
+            if (state.isExclusive()) {
+                splitType = Split.TYPE_XAND;
+                joinType = Join.TYPE_XOR;
+            } else {
+                splitType = Split.TYPE_AND;
+                joinType = Join.TYPE_AND;
+            }
+            incomingNode = isStartState ? null : factory.splitNode(parserContext.newId()).name(state.getName() + "Split").type(splitType);
+            outgoingNode = factory.joinNode(parserContext.newId()).name(state.getName() + "Join").type(joinType);
             for (MakeNodeResult node : nodes) {
                 connectNode(node, incomingNode, outgoingNode);
             }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/EventHandler.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/EventHandler.java
@@ -16,11 +16,13 @@
 package org.kie.kogito.serverless.workflow.parser.handlers;
 
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.function.BiFunction;
 
 import org.jbpm.ruleflow.core.RuleFlowNodeContainerFactory;
 import org.jbpm.ruleflow.core.factory.CompositeContextNodeFactory;
+import org.jbpm.ruleflow.core.factory.JoinFactory;
 import org.jbpm.ruleflow.core.factory.NodeFactory;
+import org.jbpm.ruleflow.core.factory.SplitFactory;
 import org.jbpm.ruleflow.core.factory.StartNodeFactory;
 import org.jbpm.workflow.core.node.Join;
 import org.jbpm.workflow.core.node.Split;
@@ -46,26 +48,23 @@ public class EventHandler extends CompositeContextNodeHandler<EventState> {
 
     @Override
     public MakeNodeResult makeNode(RuleFlowNodeContainerFactory<?, ?> factory) {
-        MakeNodeResult currentBranch = joinNodes(factory, state.getOnEvents().stream().map(onEvent -> processOnEvent(factory, onEvent)).collect(Collectors.toList()));
+        MakeNodeResult currentBranch = joinNodes(factory, state.getOnEvents(), this::processOnEvent);
         // ignore timeout for start states
         return isStartState ? currentBranch : makeTimeoutNode(factory, currentBranch);
     }
 
     private MakeNodeResult processOnEvent(RuleFlowNodeContainerFactory<?, ?> factory, OnEvents onEvent) {
         MakeNodeResult result = joinNodes(factory,
-                onEvent.getEventRefs().stream().map(onEventRef -> filterAndMergeNode(factory, onEvent.getEventDataFilter(), isStartState ? ServerlessWorkflowParser.DEFAULT_WORKFLOW_VAR : getVarName(),
-                        (f, inputVar, outputVar) -> buildEventNode(f, onEventRef, inputVar, outputVar))).collect(Collectors.toList()));
+                onEvent.getEventRefs(), (fact, onEventRef) -> filterAndMergeNode(fact, onEvent.getEventDataFilter(), isStartState ? ServerlessWorkflowParser.DEFAULT_WORKFLOW_VAR : getVarName(),
+                        (f, inputVar, outputVar) -> buildEventNode(f, onEventRef, inputVar, outputVar)));
         CompositeContextNodeFactory<?> embeddedSubProcess = handleActions(makeCompositeNode(factory), onEvent.getActions());
         connect(result.getOutgoingNode(), embeddedSubProcess);
         return new MakeNodeResult(result.getIncomingNode(), embeddedSubProcess);
     }
 
-    private MakeNodeResult joinNodes(RuleFlowNodeContainerFactory<?, ?> factory, List<MakeNodeResult> nodes) {
-        NodeFactory<?, ?> incomingNode;
-        NodeFactory<?, ?> outgoingNode;
-        if (nodes.size() == 1) {
-            incomingNode = nodes.get(0).getIncomingNode();
-            outgoingNode = nodes.get(0).getOutgoingNode();
+    private <T> MakeNodeResult joinNodes(RuleFlowNodeContainerFactory<?, ?> factory, List<T> events, BiFunction<RuleFlowNodeContainerFactory<?, ?>, T, MakeNodeResult> function) {
+        if (events.size() == 1) {
+            return function.apply(factory, events.get(0));
         } else {
             final int splitType;
             final int joinType;
@@ -76,20 +75,30 @@ public class EventHandler extends CompositeContextNodeHandler<EventState> {
                 splitType = Split.TYPE_AND;
                 joinType = Join.TYPE_AND;
             }
-            incomingNode = isStartState ? null : factory.splitNode(parserContext.newId()).name(state.getName() + "Split").type(splitType);
-            outgoingNode = factory.joinNode(parserContext.newId()).name(state.getName() + "Join").type(joinType);
-            for (MakeNodeResult node : nodes) {
-                connectNode(node, incomingNode, outgoingNode);
+            if (isStartState) {
+                JoinFactory<?> joinFactory = joinFactory(factory, joinType);
+                for (T event : events) {
+                    connect(function.apply(factory, event).getOutgoingNode(), joinFactory);
+                }
+                return new MakeNodeResult(joinFactory);
+            } else {
+                CompositeContextNodeFactory<?> compositeNode = makeCompositeNode(factory);
+                SplitFactory<?> splitFactory = compositeNode.splitNode(parserContext.newId()).name(state.getName() + "Split").type(splitType);
+                connect(compositeNode.startNode(parserContext.newId()), splitFactory);
+                JoinFactory<?> joinFactory = joinFactory(compositeNode, joinType);
+                for (T event : events) {
+                    MakeNodeResult node = function.apply(compositeNode, event);
+                    connect(splitFactory, node.getIncomingNode());
+                    connect(node.getOutgoingNode(), joinFactory);
+                }
+                connect(joinFactory, compositeNode.endNode(parserContext.newId()));
+                return new MakeNodeResult(compositeNode);
             }
         }
-        return incomingNode != null ? new MakeNodeResult(incomingNode, outgoingNode) : new MakeNodeResult(outgoingNode);
     }
 
-    private void connectNode(MakeNodeResult node, NodeFactory<?, ?> incomingNode, NodeFactory<?, ?> outgoingNode) {
-        if (incomingNode != null) {
-            connect(incomingNode, node.getIncomingNode());
-        }
-        connect(node.getOutgoingNode(), outgoingNode);
+    private JoinFactory<?> joinFactory(RuleFlowNodeContainerFactory<?, ?> factory, int joinType) {
+        return factory.joinNode(parserContext.newId()).name(state.getName() + "Join").type(joinType);
     }
 
     private NodeFactory<?, ?> buildEventNode(RuleFlowNodeContainerFactory<?, ?> factory, String eventRef, String inputVar, String outputVar) {

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/EventHandler.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/EventHandler.java
@@ -48,7 +48,7 @@ public class EventHandler extends CompositeContextNodeHandler<EventState> {
     public MakeNodeResult makeNode(RuleFlowNodeContainerFactory<?, ?> factory) {
         MakeNodeResult currentBranch = joinNodes(factory, state.getOnEvents().stream().map(onEvent -> processOnEvent(factory, onEvent)).collect(Collectors.toList()));
         // ignore timeout for start states
-        return isStartState ? currentBranch : makeTimeoutNode(factory, currentBranch, Split.TYPE_AND);
+        return isStartState ? currentBranch : makeTimeoutNode(factory, currentBranch);
     }
 
     private MakeNodeResult processOnEvent(RuleFlowNodeContainerFactory<?, ?> factory, OnEvents onEvent) {

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/StateHandler.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/handlers/StateHandler.java
@@ -29,6 +29,7 @@ import org.jbpm.process.core.datatype.impl.type.ObjectDataType;
 import org.jbpm.ruleflow.core.Metadata;
 import org.jbpm.ruleflow.core.RuleFlowNodeContainerFactory;
 import org.jbpm.ruleflow.core.RuleFlowProcessFactory;
+import org.jbpm.ruleflow.core.factory.AbstractCompositeNodeFactory;
 import org.jbpm.ruleflow.core.factory.ActionNodeFactory;
 import org.jbpm.ruleflow.core.factory.BoundaryEventNodeFactory;
 import org.jbpm.ruleflow.core.factory.CompositeContextNodeFactory;
@@ -468,9 +469,9 @@ public abstract class StateHandler<S extends State> {
     protected final MakeNodeResult makeTimeoutNode(RuleFlowNodeContainerFactory<?, ?> factory, MakeNodeResult notTimerBranch) {
         String eventTimeout = resolveEventTimeout(state, workflow);
         if (eventTimeout != null) {
-            if (notTimerBranch.getIncomingNode() == notTimerBranch.getOutgoingNode() && notTimerBranch.getIncomingNode() instanceof CompositeContextNodeFactory) {
+            if (notTimerBranch.getIncomingNode() == notTimerBranch.getOutgoingNode() && notTimerBranch.getIncomingNode() instanceof AbstractCompositeNodeFactory) {
                 // reusing composite
-                ((CompositeContextNodeFactory) notTimerBranch.getIncomingNode()).timeout(eventTimeout);
+                ((AbstractCompositeNodeFactory<?, ?>) notTimerBranch.getIncomingNode()).timeout(eventTimeout);
                 return notTimerBranch;
             } else {
                 // creating a split-join branch for the timer

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/java/org/kie/kogito/serverless/workflow/ServerlessWorkflowParsingTest.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/test/java/org/kie/kogito/serverless/workflow/ServerlessWorkflowParsingTest.java
@@ -222,11 +222,11 @@ public class ServerlessWorkflowParsingTest extends AbstractServerlessWorkflowPar
         node = process.getNodes()[6];
         assertThat(node).isInstanceOf(CompositeContextNode.class);
         node = process.getNodes()[5];
-        assertThat(node).isInstanceOf(Join.class);
+        assertThat(node).isInstanceOf(ActionNode.class);
         node = process.getNodes()[1];
-        assertThat(node).isInstanceOf(StartNode.class);
+        assertThat(node).isInstanceOf(Join.class);
         node = process.getNodes()[3];
-        assertThat(node).isInstanceOf(StartNode.class);
+        assertThat(node).isInstanceOf(ActionNode.class);
 
         // now check the composite one to see what nodes it has
         CompositeContextNode compositeNode = (CompositeContextNode) process.getNodes()[6];
@@ -491,11 +491,11 @@ public class ServerlessWorkflowParsingTest extends AbstractServerlessWorkflowPar
         Node node = process.getNodes()[5];
         assertThat(node).isInstanceOf(CompositeContextNode.class);
         node = process.getNodes()[4];
-        assertThat(node).isInstanceOf(Join.class);
+        assertThat(node).isInstanceOf(ActionNode.class);
         node = process.getNodes()[0];
-        assertThat(node).isInstanceOf(StartNode.class);
+        assertThat(node).isInstanceOf(Join.class);
         node = process.getNodes()[2];
-        assertThat(node).isInstanceOf(StartNode.class);
+        assertThat(node).isInstanceOf(ActionNode.class);
         node = process.getNodes()[6];
         assertThat(node).isInstanceOf(Split.class);
         node = process.getNodes()[7];

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/eventMultiple.sw.json
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/eventMultiple.sw.json
@@ -86,9 +86,7 @@
         }
        ],
       "exclusive": false, 
-      "end": {
-        "terminate": "true"
-      }
+      "end": true
     }
   ]
 }

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/eventMultipleExclusive.sw.json
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/eventMultipleExclusive.sw.json
@@ -84,9 +84,7 @@
         }
        ],
       "exclusive": true, 
-      "end": {
-        "terminate": "true"
-      }
+      "end": true
     }
   ]
 }

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/eventMultipleTimeout.sw.json
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/eventMultipleTimeout.sw.json
@@ -87,9 +87,7 @@
       "timeouts": {
         "eventTimeout": "PT5S"
       }, 
-      "end": {
-        "terminate": "true"
-      }
+      "end": true
     }
   ]
 }

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/eventMultipleTimeoutExclusive.sw.json
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/eventMultipleTimeoutExclusive.sw.json
@@ -87,9 +87,7 @@
       "timeouts": {
         "eventTimeout": "PT5S"
       }, 
-      "end": {
-        "terminate": "true"
-      }
+      "end": true
     }
   ]
 }

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/EventFlowIT.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/EventFlowIT.java
@@ -73,7 +73,7 @@ class EventFlowIT {
     }
 
     @Test
-    void testNotStartingMultipleEventExclusive() throws IOException {
+    void testNotStartingMultipleEventExclusive1() throws IOException {
         doIt("nonStartMultipleEventExclusive", "event1Exclusive");
     }
 
@@ -82,6 +82,16 @@ class EventFlowIT {
         final String flowName = "nonStartMultipleEventWorkflowTimeout";
         String id = startProcess(flowName);
         waitForFinish(flowName, id, Duration.ofSeconds(5));
+    }
+
+    @Test
+    void testNotStartingMultipleEventExclusive2() throws IOException {
+        doIt("nonStartMultipleEventExclusive", "event2Exclusive");
+    }
+
+    @Test
+    void testNotStartingMultipleEventExclusive3() throws IOException {
+        doIt("nonStartMultipleEventExclusive", "event3Exclusive");
     }
 
     @Test


### PR DESCRIPTION
For exclusive rather than and-split and xor-join, we should have xand-split and xor-join.
Not exclusive remain the same, and-split and and-join. 
In order nested xand to work, split are embedded into composite nodes
For timers, there are two approaches. If the node is composite, a timer is added to it node (which internally use a DroolsAction, a slightly modification of existing CancelTimer). If the node is not a composite one (for example, in callback, when there is only one event node or in an event state with only one event type), then the former approach based on X_AND gateway is still used. 