### PR TITLE
[KOGITO-8489] Adding publishing test using the same channel

### DIFF
--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -27,7 +27,7 @@
     <version.net.thisptr.jackson-jq>1.0.0-preview.20220705</version.net.thisptr.jackson-jq>
     <version.io.quarkiverse.jackson-jq>1.1.0</version.io.quarkiverse.jackson-jq>
     <version.io.quarkiverse.openapi.generator>1.2.0</version.io.quarkiverse.openapi.generator>
-    <version.io.quarkiverse.asyncapi>0.0.2</version.io.quarkiverse.asyncapi>
+    <version.io.quarkiverse.asyncapi>0.0.3</version.io.quarkiverse.asyncapi>
     <version.io.quarkiverse.reactivemessaging.http>1.0.8</version.io.quarkiverse.reactivemessaging.http>
     <version.com.github.haifengl.smile>1.5.2</version.com.github.haifengl.smile>
     <version.com.github.javaparser>3.24.2</version.com.github.javaparser>

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/types/AsyncAPITypeHandler.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/src/main/java/org/kie/kogito/serverless/workflow/parser/types/AsyncAPITypeHandler.java
@@ -29,6 +29,8 @@ import org.kie.kogito.serverless.workflow.parser.VariableInfo;
 import org.kie.kogito.serverless.workflow.parser.handlers.NodeFactoryUtils;
 import org.kie.kogito.serverless.workflow.suppliers.ProduceEventActionSupplier;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 import io.serverlessworkflow.api.Workflow;
 import io.serverlessworkflow.api.functions.FunctionDefinition;
 import io.serverlessworkflow.api.functions.FunctionRef;
@@ -74,7 +76,8 @@ public class AsyncAPITypeHandler implements FunctionTypeHandler {
 
     private NodeFactory<?, ?> buildPublishNode(Workflow workflow, ParserContext context, RuleFlowNodeContainerFactory<?, ?> factory, FunctionDefinition functionDef, FunctionRef functionRef,
             VariableInfo varInfo, AsyncChannelInfo entry) {
-        return NodeFactoryUtils.sendEventNode(factory.actionNode(context.newId()).action(new ProduceEventActionSupplier(workflow, functionRef.getArguments().toString())), functionDef.getName(),
+        JsonNode args = functionRef.getArguments();
+        return NodeFactoryUtils.sendEventNode(factory.actionNode(context.newId()).action(new ProduceEventActionSupplier(workflow, args != null ? args.toString() : null)), functionDef.getName(),
                 entry.getName(), varInfo.getInputVar());
     }
 }

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/src/main/java/org/kie/kogito/quarkus/serverless/workflow/asyncapi/WorkflowAsyncApiSpecInputProvider.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/src/main/java/org/kie/kogito/quarkus/serverless/workflow/asyncapi/WorkflowAsyncApiSpecInputProvider.java
@@ -40,7 +40,7 @@ public class WorkflowAsyncApiSpecInputProvider implements AsyncApiSpecInputProvi
         }
         try (Stream<Path> workflowFiles = Files.walk(inputDir)) {
             return new AsyncAPISpecInput(WorkflowCodeGenUtils.operationResources(workflowFiles, f -> f.getType() == Type.ASYNCAPI, context)
-                    .collect(Collectors.toMap(resource -> resource.getOperationId().getFileName(), AsyncInputStreamSupplier::new)), KOGITO_PACKAGE_PREFIX);
+                    .collect(Collectors.toMap(resource -> resource.getOperationId().getFileName(), AsyncInputStreamSupplier::new, (key1, key2) -> key1)), KOGITO_PACKAGE_PREFIX);
         } catch (IOException io) {
             throw new IllegalStateException(io);
         }

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/asyncPublisher.sw.json
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/asyncPublisher.sw.json
@@ -1,0 +1,27 @@
+{
+  "id": "asyncEventPublisher",
+  "version": "1.0",
+  "name": "Workflow async consumer test",
+  "description": "An test that verifies an async api spec file with a publish channel is really publishing",
+  "start": "publishEvent",
+  "functions": [
+    {
+      "name": "publishEvent",
+      "type": "asyncapi",
+      "operation": "specs/asyncAPI.yaml#sendWait" 
+    }
+  ],
+  "states": [
+    {
+      "name": "publishEvent",
+      "type": "operation",
+      "actions": [
+          { 
+           "name": "publishEvent",
+           "functionRef": "publishEvent"
+          }
+       ], 
+      "end": true
+    }
+  ]
+}

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/specs/asyncAPI.yaml
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/specs/asyncAPI.yaml
@@ -21,6 +21,11 @@ channels:
       summary: Get messages
       message:
         $ref: '#/components/messages/message'
+    publish:
+      operationId: sendWait
+      summary: Send messages
+      message:
+        $ref: '#/components/messages/message'
 components:
   messages:
     message:


### PR DESCRIPTION
Adding the publish test, and fixing a couple of minor issues:

1.  Using no arguments caused a null pointer
2.  Cannot resuse the same spec file in multiple flows within the same project. 
3. Both flows (publising and consume) use the same channel for publish/sbuscribe intentionally

This requires async extension version 0.0.3 (being releases right now), because before same channel name was not supported