### PR TITLE
[BXMSPROD-728] set commit for check_run

### DIFF
--- a/.github/workflows/surefire.yml
+++ b/.github/workflows/surefire.yml
@@ -40,5 +40,7 @@ jobs:
         uses: kiegroup/kogito-pipelines/.ci/actions/surefire-report@main
         if: ${{ always() }}
         with:
+          check_name: ${{ github.event.workflow_run.name  }} test report
+          commit: ${{ github.event.workflow_run.head_sha }}
           report_paths: '**/surefire-reports/TEST-*.xml'
           skip_publishing: false

--- a/.github/workflows/surefire.yml
+++ b/.github/workflows/surefire.yml
@@ -13,7 +13,6 @@ jobs:
       checks: write
     name: Test analysis
     steps:
-      - uses: actions/checkout@v2
       - name: Download surefire reports
         uses: actions/github-script@v6
         with:


### PR DESCRIPTION
Looks like for the now the check run is being checked for main and not the PR. See - https://github.com/kiegroup/kogito-runtimes/actions/runs/4076623144/jobs/7024603659#step:5:19

Merge after:
* https://github.com/kiegroup/kogito-pipelines/pull/803