### PR TITLE
[KOGITO-8485]- Swagger is generated with example: null on 1.32

### DIFF
--- a/springboot/bom/pom.xml
+++ b/springboot/bom/pom.xml
@@ -15,8 +15,8 @@
   <packaging>pom</packaging>
 
   <properties>
-    <version.io.swagger.core.v3>2.1.7</version.io.swagger.core.v3>
-    <version.org.springdoc>1.5.9</version.org.springdoc>
+    <version.io.swagger.core.v3>2.2.7</version.io.swagger.core.v3>
+    <version.org.springdoc>1.6.14</version.org.springdoc>
     <!-- Groovy -->
     <!-- must be aligned with the Archetype plugin: https://maven.apache.org/archetype/maven-archetype-plugin/dependencies.html -->
     <version.org.codehaus.groovy>2.4.16</version.org.codehaus.groovy>


### PR DESCRIPTION
Jira - https://issues.redhat.com/browse/KOGITO-8485

Swagger is generated with example: null after upgrading jackson dependencies to 2.14.1 version in 1.31.1.Final version.

Upgraded swagger-annotations & springdoc-openapi-ui versions to be compatible with the 2.1.4.1 version of   jackson dependencies.