### PR TITLE
[KOGITO-8779] Restworkitemhandler query segment

### DIFF
--- a/kogito-workitems/kogito-rest-workitem/src/main/java/org/kogito/workitem/rest/pathresolvers/DefaultPathParamResolver.java
+++ b/kogito-workitems/kogito-rest-workitem/src/main/java/org/kogito/workitem/rest/pathresolvers/DefaultPathParamResolver.java
@@ -15,6 +15,8 @@
  */
 package org.kogito.workitem.rest.pathresolvers;
 
+import java.net.URLEncoder;
+import java.nio.charset.Charset;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -40,7 +42,7 @@ public class DefaultPathParamResolver implements PathParamResolver {
                 throw new IllegalArgumentException("missing parameter " + key);
             }
             toRemove.add(key);
-            sb.replace(start, end + 1, value.toString());
+            sb.replace(start, end + 1, URLEncoder.encode(value.toString(), Charset.defaultCharset()));
             start = sb.indexOf("{");
         }
         parameters.keySet().removeAll(toRemove);

--- a/kogito-workitems/kogito-rest-workitem/src/test/java/org/kogito/workitem/rest/RestWorkItemHandlerTest.java
+++ b/kogito-workitems/kogito-rest-workitem/src/test/java/org/kogito/workitem/rest/RestWorkItemHandlerTest.java
@@ -162,8 +162,8 @@ public class RestWorkItemHandlerTest {
     @Test
     public void testGetRestTaskHandler() {
         parameters.put("id", 26);
-        parameters.put("name", "pepe");
-        parameters.put(RestWorkItemHandler.URL, "http://localhost:8080/results/{id}/names/{name}");
+        parameters.put("name", "kogito is whitespace friendly");
+        parameters.put(RestWorkItemHandler.URL, "http://localhost:8080/results/{id}?name={name}");
         parameters.put(RestWorkItemHandler.METHOD, "GET");
         parameters.put(RestWorkItemHandler.CONTENT_DATA, workflowData);
 


### PR DESCRIPTION
As per JIRA description. 
More traces were added to be able to follow handler execution in failing cases (given the variabality of the possible inputs, this is desirable in this case) 
Merged with https://github.com/kiegroup/kogito-examples/pull/1595. I do not think the handler should support that case, that was a plain invalid URI, so I changed the example.  Code is properly encoding URI template parameters (both for path and query parameters), which might containe whitepaces, trails and so on. They are escaped properly, but a hardcoded URI with white spaces is a not valid one, so I do not think is kogito repsonsibility to transform it into a valid one, it is writer of the bpmn responsbilibty to encode the hardcoded URI (the important thing is the fact that it is hardcoded, not using templates)