### PR TITLE
[KOGITO-8840] Remove kie-internal as deprecated and not used anywhere

### DIFF
--- a/jbpm/jbpm-flow/pom.xml
+++ b/jbpm/jbpm-flow/pom.xml
@@ -70,10 +70,6 @@
           <groupId>org.drools</groupId>
           <artifactId>drools-compiler</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>org.kie</groupId>
-          <artifactId>kie-internal</artifactId>
-        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/kogito-build/kogito-kie-bom/pom.xml
+++ b/kogito-build/kogito-kie-bom/pom.xml
@@ -66,11 +66,6 @@
       </dependency>
       <dependency>
         <groupId>org.kie</groupId>
-        <artifactId>kie-internal</artifactId>
-        <version>${version.org.kie}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.kie</groupId>
         <artifactId>kie-test-util</artifactId>
         <version>${version.org.kie}</version>
       </dependency>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/KOGITO-8840

depends on https://github.com/kiegroup/drools/pull/5098