### PR TITLE
[DROOLS-7351] first implementation of reliable session

### DIFF
--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/LightProcessRuntime.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/LightProcessRuntime.java
@@ -490,7 +490,7 @@ public class LightProcessRuntime extends AbstractProcessRuntime {
         }
 
         @Override
-        public void execute(ReteEvaluator reteEvaluator) {
+        public void internalExecute(ReteEvaluator reteEvaluator) {
             signalEvent(type, event);
         }
     }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/ProcessRuntimeImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/ProcessRuntimeImpl.java
@@ -556,7 +556,7 @@ public class ProcessRuntimeImpl extends AbstractProcessRuntime {
         }
 
         @Override
-        public void execute(ReteEvaluator reteEvaluator) {
+        public void internalExecute(ReteEvaluator reteEvaluator) {
             signalEvent(type, event);
         }
     }

--- a/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/event/DefaultSignalManager.java
+++ b/jbpm/jbpm-flow/src/main/java/org/jbpm/process/instance/event/DefaultSignalManager.java
@@ -114,7 +114,7 @@ public class DefaultSignalManager implements SignalManager {
             }
         }
 
-        public void execute(ReteEvaluator reteEvaluator) {
+        public void internalExecute(ReteEvaluator reteEvaluator) {
             ProcessInstance processInstance = ((InternalKnowledgeRuntime) reteEvaluator).getProcessInstance(processInstanceId);
             if (processInstance != null) {
                 processInstance.signalEvent(type, event);
@@ -174,7 +174,7 @@ public class DefaultSignalManager implements SignalManager {
             }
         }
 
-        public void execute(ReteEvaluator reteEvaluator) {
+        public void internalExecute(ReteEvaluator reteEvaluator) {
             ((DefaultSignalManager) ((InternalProcessRuntime) ((InternalWorkingMemory) reteEvaluator).getProcessRuntime()).getSignalManager()).internalSignalEvent(type, event);
         }
 


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/DROOLS-7351

First implementation of a reliable session with a simplified strategy only using persisted object stores and reflushing all the objects contained in the stores when a new session is created out of an existing one.