### PR TITLE
Release: Fix setup data-index image tag

### DIFF
--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -95,6 +95,9 @@ pipeline {
                 script {
                     maven.mvnVersionsSet(getMavenCommand(), getProjectVersion(), !isRelease())
                     maven.mvnSetVersionProperty(getMavenCommand(), 'version.org.kie', getDroolsVersion())
+
+                    // Need artifacts available locally
+                    getMavenCommand().withProperty('quickly').run('clean install')
                     maven.mvnSetVersionProperty(getMavenCommand(getIntegrationTestHotReloadPath()), "data-index-ephemeral.image.test", "${getCurrentNightlyImage()}" )
                     maven.mvnSetVersionProperty(getMavenCommand(getWorkflowCommonDeploymentPath()), "data-index-ephemeral.image", "${getNextProdImage()}" )
                 }


### PR DESCRIPTION
```
14:32:05  + mvn -B -s /tmp/tmp.v1OJYZfQJb-settings.xml -fae -ntp -q help:evaluate -Dfull -Dexpression=data-index-ephemeral.image -DforceStdout
14:32:08  [ERROR] [ERROR] Some problems were encountered while processing the POMs:
14:32:08  [ERROR] Non-resolvable import POM: Could not find artifact org.kie.kogito:kogito-quarkus-bom:pom:1.36.0.Final in mirror-central (https://bxms-qe.rhev-ci-vms.eng.rdu2.redhat.com:8443/nexus/content/groups/kogito-runtimes-pr-artifacts-group/) @ org.kie.kogito:quarkus-extensions:1.36.0.Final, /home/jenkins/workspace/KIE/kogito/1.36.x/release/kogito-runtimes-deploy/kogito-runtimes/quarkus/extensions/pom.xml, line 20, column 19
14:32:08  [ERROR] Non-resolvable import POM: Could not find artifact org.kie.kogito:kogito-bom:pom:1.36.0.Final in mirror-central (https://bxms-qe.rhev-ci-vms.eng.rdu2.redhat.com:8443/nexus/content/groups/kogito-runtimes-pr-artifacts-group/) @ org.kie.kogito:kogito-build-parent:1.36.0.Final, /home/jenkins/workspace/KIE/kogito/1.36.x/release/kogito-runtimes-deploy/kogito-runtimes/kogito-build/kogito-build-parent/pom.xml, line 23, column 19
14:32:08  [ERROR] 'dependencies.dependency.version' for org.kie.kogito:kogito-quarkus-workflow-common:jar is missing. @ line 20, column 17
14:32:08  [ERROR] 'dependencies.dependency.version' for org.kie.kogito:kogito-quarkus-common-deployment:jar is missing. @ line 24, column 17
14:32:08  [ERROR] 'dependencies.dependency.version' for io.quarkus:quarkus-devservices-common:jar is missing. @ line 28, column 17
14:32:08  [ERROR] 'dependencies.dependency.version' for org.kie.kogito:kogito-quarkus-extension-spi:jar is missing. @ line 36, column 17
14:32:08  [ERROR] 'dependencies.dependency.version' for org.kie.kogito:kogito-codegen-processes:jar is missing. @ line 41, column 17
14:32:08  [ERROR] 'dependencies.dependency.version' for org.kie.kogito:kogito-codegen-processes:test-jar is missing. @ line 45, column 17
```