### PR TITLE
[KOGITO-9055] resteasy-reactive should not be together with resteasy-classic

### DIFF
--- a/quarkus/addons/process-svg/deployment/pom.xml
+++ b/quarkus/addons/process-svg/deployment/pom.xml
@@ -20,10 +20,6 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy-common-deployment</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-security-deployment</artifactId>
     </dependency>
   </dependencies>

--- a/quarkus/addons/process-svg/runtime/pom.xml
+++ b/quarkus/addons/process-svg/runtime/pom.xml
@@ -18,9 +18,10 @@
       <artifactId>kogito-addons-process-svg</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy-common</artifactId>
+      <groupId>org.jboss.spec.javax.ws.rs</groupId>
+      <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
     </dependency>
+
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-arc</artifactId>

--- a/quarkus/integration-tests/integration-tests-quarkus-source-files/pom.xml
+++ b/quarkus/integration-tests/integration-tests-quarkus-source-files/pom.xml
@@ -38,11 +38,11 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy-reactive</artifactId>
+      <artifactId>quarkus-resteasy</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+      <artifactId>quarkus-resteasy-jackson</artifactId>
     </dependency>
 
     <!-- Test -->


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-9055

SVG does not really need resteasy-common, but just the standard jaxrs annotations. 
Note that for quarkus3.x the dependency should be the jakarta one, not the jboss one

Added dependency change on source files integration tests