### PR TITLE
KOGITO-9072 Setup version after the patches are applied

### DIFF
--- a/.ci/environments/quarkus-3/after.sh
+++ b/.ci/environments/quarkus-3/after.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+
+script_dir_path=$(cd `dirname "${BASH_SOURCE[0]}"`; pwd -P)
+mvn_cmd="mvn ${BUILD_MVN_OPTS:-} ${BUILD_MVN_OPTS_QUARKUS_UPDATE:-}"
+project_version='quarkus-3-SNAPSHOT'
+
+# Change version
+${mvn_cmd} -e -N -Dfull -DnewVersion=${project_version} -DallowSnapshots=true -DgenerateBackupPoms=false versions:set

--- a/.ci/environments/quarkus-3/before.sh
+++ b/.ci/environments/quarkus-3/before.sh
@@ -7,7 +7,6 @@ ci="${CI:-false}"
 
 rewrite_plugin_version=4.43.0
 quarkus_version=${QUARKUS_VERSION:-3.0.0.CR1}
-project_version='quarkus-3-SNAPSHOT'
 
 quarkus_file="${script_dir_path}/quarkus3.yml"
 patch_file="${script_dir_path}"/patches/0001_before_sh.patch
@@ -31,12 +30,6 @@ if [ "${ci}" = "true" ]; then
     ${mvn_cmd} clean install -Dquickly
 fi
 
-# Change version
-${mvn_cmd} -e -N -Dfull -DnewVersion=${project_version} -DallowSnapshots=true -DgenerateBackupPoms=false versions:set
-
-# Make sure artifacts are updated locally
-${mvn_cmd} clean install -Dquickly
-
 # Regenerate quarkus3 recipe
 cd ${script_dir_path}
 curl -Ls https://sh.jbang.dev | bash -s - jbang/CreateQuarkusDroolsMigrationRecipe.java
@@ -50,7 +43,7 @@ fi
 ${mvn_cmd} org.openrewrite.maven:rewrite-maven-plugin:${rewrite_plugin_version}:run \
     -Drewrite.configLocation="${quarkus_file}" \
     -DactiveRecipes=io.quarkus.openrewrite.Quarkus \
-    -Drewrite.recipeArtifactCoordinates=org.kie:jpmml-migration-recipe:"${project_version}" \
+    -Drewrite.recipeArtifactCoordinates=org.kie:jpmml-migration-recipe:quarkus-3-SNAPSHOT \
     -Denforcer.skip \
     -fae \
     -Dexclusions=**/target \

--- a/.ci/environments/quarkus-3/patches/0001_before_sh.patch
+++ b/.ci/environments/quarkus-3/patches/0001_before_sh.patch
@@ -529,14 +529,14 @@ index aa06497e9f..84ea1c8314 100644
        </dependency>
        <dependency>
 diff --git a/kogito-build/kogito-kie-bom/pom.xml b/kogito-build/kogito-kie-bom/pom.xml
-index bfd8897310..31b7020647 100644
+index 8abcd45354..31b7020647 100644
 --- a/kogito-build/kogito-kie-bom/pom.xml
 +++ b/kogito-build/kogito-kie-bom/pom.xml
 @@ -18,7 +18,7 @@
    </description>
  
    <properties>
--    <version.org.kie>8.38.0-SNAPSHOT</version.org.kie>
+-    <version.org.kie>8.39.0-SNAPSHOT</version.org.kie>
 +    <version.org.kie>quarkus-3-SNAPSHOT</version.org.kie>
    </properties>
  

--- a/.ci/environments/quarkus-3/patches/0001_before_sh.patch
+++ b/.ci/environments/quarkus-3/patches/0001_before_sh.patch
@@ -1,133 +1,3 @@
-diff --git a/addons/common/events/decisions/pom.xml b/addons/common/events/decisions/pom.xml
-index 929e2d7cde..e7fdc14411 100644
---- a/addons/common/events/decisions/pom.xml
-+++ b/addons/common/events/decisions/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-events-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-addons-events-decisions</artifactId>
-diff --git a/addons/common/events/mongodb/pom.xml b/addons/common/events/mongodb/pom.xml
-index 9076b868fa..bb871029e0 100644
---- a/addons/common/events/mongodb/pom.xml
-+++ b/addons/common/events/mongodb/pom.xml
-@@ -7,7 +7,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-events-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-addons-events-mongodb</artifactId>
-diff --git a/addons/common/events/pom.xml b/addons/common/events/pom.xml
-index 49c9ca5280..5678a0237e 100644
---- a/addons/common/events/pom.xml
-+++ b/addons/common/events/pom.xml
-@@ -3,7 +3,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-common-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-events-parent</artifactId>
-   <packaging>pom</packaging>
-diff --git a/addons/common/events/predictions/pom.xml b/addons/common/events/predictions/pom.xml
-index 0273bec304..8f2afa77f9 100644
---- a/addons/common/events/predictions/pom.xml
-+++ b/addons/common/events/predictions/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-events-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-addons-events-predictions</artifactId>
-diff --git a/addons/common/events/rules/pom.xml b/addons/common/events/rules/pom.xml
-index d63fd05ee8..0e5e8f5e22 100644
---- a/addons/common/events/rules/pom.xml
-+++ b/addons/common/events/rules/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-events-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-addons-events-rules</artifactId>
-diff --git a/addons/common/explainability/pom.xml b/addons/common/explainability/pom.xml
-index f3ee948922..6acda7a06d 100644
---- a/addons/common/explainability/pom.xml
-+++ b/addons/common/explainability/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-common-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/addons/common/human-task-prediction/api/pom.xml b/addons/common/human-task-prediction/api/pom.xml
-index 8463a4a9c6..089b18f915 100644
---- a/addons/common/human-task-prediction/api/pom.xml
-+++ b/addons/common/human-task-prediction/api/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-human-task-prediction-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-human-task-prediction-api</artifactId>
-   <name>Kogito :: Add-Ons :: Predictions :: API</name>
-diff --git a/addons/common/human-task-prediction/pom.xml b/addons/common/human-task-prediction/pom.xml
-index 0dd443a3c6..0e4484ebbf 100644
---- a/addons/common/human-task-prediction/pom.xml
-+++ b/addons/common/human-task-prediction/pom.xml
-@@ -3,7 +3,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-common-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-human-task-prediction-parent</artifactId>
-   <packaging>pom</packaging>
-diff --git a/addons/common/human-task-prediction/smile/pom.xml b/addons/common/human-task-prediction/smile/pom.xml
-index c496d9727b..716bb949a2 100644
---- a/addons/common/human-task-prediction/smile/pom.xml
-+++ b/addons/common/human-task-prediction/smile/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-human-task-prediction-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-human-task-prediction-smile</artifactId>
-   <name>Kogito :: Add-Ons :: Predictions :: SMILE</name>
-diff --git a/addons/common/jobs/api/pom.xml b/addons/common/jobs/api/pom.xml
-index 06f6d79d7a..35a076a216 100644
---- a/addons/common/jobs/api/pom.xml
-+++ b/addons/common/jobs/api/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-jobs-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-jobs-api</artifactId>
-   <name>Kogito :: Add-Ons :: Jobs :: API</name>
 diff --git a/addons/common/jobs/api/src/main/java/org/kie/kogito/jobs/api/JobCallbackResourceDef.java b/addons/common/jobs/api/src/main/java/org/kie/kogito/jobs/api/JobCallbackResourceDef.java
 index 89006af2e6..e732a407c8 100644
 --- a/addons/common/jobs/api/src/main/java/org/kie/kogito/jobs/api/JobCallbackResourceDef.java
@@ -158,71 +28,6 @@ index 3c7708be2b..3b3c12b152 100644
  
  import org.junit.jupiter.api.Test;
  import org.kie.kogito.jobs.ExactExpirationTime;
-diff --git a/addons/common/jobs/management-common/pom.xml b/addons/common/jobs/management-common/pom.xml
-index 92048cf884..b03a317cf0 100644
---- a/addons/common/jobs/management-common/pom.xml
-+++ b/addons/common/jobs/management-common/pom.xml
-@@ -21,7 +21,7 @@
-   <parent>
-     <artifactId>kogito-addons-jobs-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/addons/common/jobs/pom.xml b/addons/common/jobs/pom.xml
-index 47bafea4b9..e872cd0190 100644
---- a/addons/common/jobs/pom.xml
-+++ b/addons/common/jobs/pom.xml
-@@ -3,7 +3,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-common-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-jobs-parent</artifactId>
-   <packaging>pom</packaging>
-diff --git a/addons/common/knative/eventing/pom.xml b/addons/common/knative/eventing/pom.xml
-index 1679a45dc8..069b6ef123 100644
---- a/addons/common/knative/eventing/pom.xml
-+++ b/addons/common/knative/eventing/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-knative-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/addons/common/knative/pom.xml b/addons/common/knative/pom.xml
-index 6e8a9e7589..3bf4576fcd 100644
---- a/addons/common/knative/pom.xml
-+++ b/addons/common/knative/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-common-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/addons/common/kubernetes/pom.xml b/addons/common/kubernetes/pom.xml
-index 7438fddef5..fb6b47fd8e 100644
---- a/addons/common/kubernetes/pom.xml
-+++ b/addons/common/kubernetes/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-common-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
 diff --git a/addons/common/kubernetes/src/main/java/org/kie/kogito/addons/k8s/workitems/AbstractDiscoveredEndpointCaller.java b/addons/common/kubernetes/src/main/java/org/kie/kogito/addons/k8s/workitems/AbstractDiscoveredEndpointCaller.java
 index 827d4f53c1..6698791988 100644
 --- a/addons/common/kubernetes/src/main/java/org/kie/kogito/addons/k8s/workitems/AbstractDiscoveredEndpointCaller.java
@@ -251,149 +56,10 @@ index 3ef249edfe..5b317809a4 100644
  
  import org.junit.jupiter.api.Test;
  import org.junit.jupiter.api.extension.ExtendWith;
-diff --git a/addons/common/mail/pom.xml b/addons/common/mail/pom.xml
-index e734a684ad..bbdf8e7c81 100644
---- a/addons/common/mail/pom.xml
-+++ b/addons/common/mail/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-common-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/addons/common/marshallers/avro/pom.xml b/addons/common/marshallers/avro/pom.xml
-index d455dc3ef6..b7a63433b1 100644
---- a/addons/common/marshallers/avro/pom.xml
-+++ b/addons/common/marshallers/avro/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-marshallers-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-addons-marshallers-avro</artifactId>
-diff --git a/addons/common/marshallers/pom.xml b/addons/common/marshallers/pom.xml
-index 7873789bae..59a2519dcf 100644
---- a/addons/common/marshallers/pom.xml
-+++ b/addons/common/marshallers/pom.xml
-@@ -3,7 +3,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-common-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-marshallers-parent</artifactId>
-   <packaging>pom</packaging>
-diff --git a/addons/common/messaging/pom.xml b/addons/common/messaging/pom.xml
-index cb437aca3c..79a519b478 100644
---- a/addons/common/messaging/pom.xml
-+++ b/addons/common/messaging/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-common-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-addons-messaging</artifactId>
-diff --git a/addons/common/monitoring/core/pom.xml b/addons/common/monitoring/core/pom.xml
-index 53375b5104..927f8b9b47 100644
---- a/addons/common/monitoring/core/pom.xml
-+++ b/addons/common/monitoring/core/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-monitoring-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
-   <name>Kogito :: Add-Ons :: Monitoring Core</name>
-diff --git a/addons/common/monitoring/elastic/pom.xml b/addons/common/monitoring/elastic/pom.xml
-index 8f5868b917..4e306ae428 100644
---- a/addons/common/monitoring/elastic/pom.xml
-+++ b/addons/common/monitoring/elastic/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-monitoring-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/addons/common/monitoring/pom.xml b/addons/common/monitoring/pom.xml
-index 2abd66e2d1..10d7d84f4b 100644
---- a/addons/common/monitoring/pom.xml
-+++ b/addons/common/monitoring/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-common-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-monitoring-parent</artifactId>
-   <name>Kogito :: Add-Ons :: Monitoring</name>
-diff --git a/addons/common/monitoring/prometheus/pom.xml b/addons/common/monitoring/prometheus/pom.xml
-index f1b5bdb12d..541bb214cf 100644
---- a/addons/common/monitoring/prometheus/pom.xml
-+++ b/addons/common/monitoring/prometheus/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-monitoring-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/addons/common/persistence/ddl/pom.xml b/addons/common/persistence/ddl/pom.xml
-index 9c541c5a30..9bfe475d1f 100644
---- a/addons/common/persistence/ddl/pom.xml
-+++ b/addons/common/persistence/ddl/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-persistence-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <modelVersion>4.0.0</modelVersion>
-diff --git a/addons/common/persistence/filesystem/pom.xml b/addons/common/persistence/filesystem/pom.xml
-index 20496b7ffa..9761a7b72e 100644
---- a/addons/common/persistence/filesystem/pom.xml
-+++ b/addons/common/persistence/filesystem/pom.xml
-@@ -3,7 +3,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-persistence-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-persistence-filesystem</artifactId>
-   <name>Kogito :: Add-Ons :: Persistence :: File System</name>
 diff --git a/addons/common/persistence/infinispan/pom.xml b/addons/common/persistence/infinispan/pom.xml
-index a7220d09ea..ac24f6cc5c 100644
+index a7220d09ea..9d64d395be 100644
 --- a/addons/common/persistence/infinispan/pom.xml
 +++ b/addons/common/persistence/infinispan/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-persistence-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-persistence-infinispan</artifactId>
-   <name>Kogito :: Add-Ons :: Persistence :: Infinispan</name>
 @@ -29,9 +29,9 @@
        <artifactId>process-serialization-protobuf</artifactId>
      </dependency>
@@ -406,370 +72,10 @@ index a7220d09ea..ac24f6cc5c 100644
      </dependency>
  
      <!-- test dependencies -->
-diff --git a/addons/common/persistence/jdbc/pom.xml b/addons/common/persistence/jdbc/pom.xml
-index 569322a7d8..60296c5ad0 100644
---- a/addons/common/persistence/jdbc/pom.xml
-+++ b/addons/common/persistence/jdbc/pom.xml
-@@ -3,7 +3,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-persistence-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-persistence-jdbc</artifactId>
-   <name>Kogito :: Add-Ons :: Persistence :: JDBC</name>
-diff --git a/addons/common/persistence/mongodb/pom.xml b/addons/common/persistence/mongodb/pom.xml
-index c31bf970c7..c57b9d83a5 100644
---- a/addons/common/persistence/mongodb/pom.xml
-+++ b/addons/common/persistence/mongodb/pom.xml
-@@ -21,7 +21,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-persistence-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/addons/common/persistence/pom.xml b/addons/common/persistence/pom.xml
-index e4d17a9a59..79bd795be7 100644
---- a/addons/common/persistence/pom.xml
-+++ b/addons/common/persistence/pom.xml
-@@ -4,7 +4,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-common-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-persistence-parent</artifactId>
-   <packaging>pom</packaging>
-diff --git a/addons/common/persistence/postgresql/pom.xml b/addons/common/persistence/postgresql/pom.xml
-index dda6dfe9ef..d93c0a143b 100644
---- a/addons/common/persistence/postgresql/pom.xml
-+++ b/addons/common/persistence/postgresql/pom.xml
-@@ -3,7 +3,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-persistence-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-persistence-postgresql</artifactId>
-   <name>Kogito :: Add-Ons :: Persistence :: PostgreSQL</name>
-diff --git a/addons/common/persistence/rocksdb/pom.xml b/addons/common/persistence/rocksdb/pom.xml
-index fac214bb2f..8b5db9fa06 100644
---- a/addons/common/persistence/rocksdb/pom.xml
-+++ b/addons/common/persistence/rocksdb/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-persistence-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-persistence-rocksdb</artifactId>
-   <name>Kogito :: Add-Ons :: Persistence :: RocksDB</name>
-diff --git a/addons/common/pom.xml b/addons/common/pom.xml
-index 5eaef5ab29..e5efa33f31 100644
---- a/addons/common/pom.xml
-+++ b/addons/common/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/addons/common/process-management/pom.xml b/addons/common/process-management/pom.xml
-index 99d190f7d4..7f74101f4f 100644
---- a/addons/common/process-management/pom.xml
-+++ b/addons/common/process-management/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-common-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/addons/common/process-svg/pom.xml b/addons/common/process-svg/pom.xml
-index 771dae5ba2..bd88927d1a 100644
---- a/addons/common/process-svg/pom.xml
-+++ b/addons/common/process-svg/pom.xml
-@@ -21,7 +21,7 @@
-   <parent>
-     <artifactId>kogito-addons-common-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/addons/common/rest-exception-handler/pom.xml b/addons/common/rest-exception-handler/pom.xml
-index db4f873ec8..823d34ae8c 100644
---- a/addons/common/rest-exception-handler/pom.xml
-+++ b/addons/common/rest-exception-handler/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-common-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/addons/common/source-files/pom.xml b/addons/common/source-files/pom.xml
-index 103890ecc3..d5922c7e06 100644
---- a/addons/common/source-files/pom.xml
-+++ b/addons/common/source-files/pom.xml
-@@ -5,7 +5,7 @@
-     <parent>
-         <artifactId>kogito-addons-common-parent</artifactId>
-         <groupId>org.kie.kogito</groupId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
-     <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/addons/common/task-management/pom.xml b/addons/common/task-management/pom.xml
-index 6c04e940de..88b2d6911f 100644
---- a/addons/common/task-management/pom.xml
-+++ b/addons/common/task-management/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-common-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/addons/common/tracing/decision-common/pom.xml b/addons/common/tracing/decision-common/pom.xml
-index 80426005c4..bcc1a9b3c0 100644
---- a/addons/common/tracing/decision-common/pom.xml
-+++ b/addons/common/tracing/decision-common/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-tracing-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/addons/common/tracing/pom.xml b/addons/common/tracing/pom.xml
-index e799b290c1..5b0a6887ec 100644
---- a/addons/common/tracing/pom.xml
-+++ b/addons/common/tracing/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-common-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/addons/common/tracing/tracing-api/pom.xml b/addons/common/tracing/tracing-api/pom.xml
-index 859e06f113..5f43e2ba48 100644
---- a/addons/common/tracing/tracing-api/pom.xml
-+++ b/addons/common/tracing/tracing-api/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-tracing-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/addons/common/tracing/typedvalue-api/pom.xml b/addons/common/tracing/typedvalue-api/pom.xml
-index 067f0f34cb..4070623621 100644
---- a/addons/common/tracing/typedvalue-api/pom.xml
-+++ b/addons/common/tracing/typedvalue-api/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-tracing-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/addons/pom.xml b/addons/pom.xml
-index 415d04771e..2950734647 100644
---- a/addons/pom.xml
-+++ b/addons/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-build-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-     <relativePath>../kogito-build/kogito-build-parent/pom.xml</relativePath>
-   </parent>
-   <artifactId>kogito-addons</artifactId>
-diff --git a/api/kogito-api-incubation-application/pom.xml b/api/kogito-api-incubation-application/pom.xml
-index 851bdc2cb0..a05f0a7036 100644
---- a/api/kogito-api-incubation-application/pom.xml
-+++ b/api/kogito-api-incubation-application/pom.xml
-@@ -22,7 +22,7 @@
-     <parent>
-         <groupId>org.kie.kogito</groupId>
-         <artifactId>kogito-api-parent</artifactId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
- 
-     <artifactId>kogito-api-incubation-application</artifactId>
-diff --git a/api/kogito-api-incubation-common-objectmapper/pom.xml b/api/kogito-api-incubation-common-objectmapper/pom.xml
-index cd71a203fa..95219f086d 100644
---- a/api/kogito-api-incubation-common-objectmapper/pom.xml
-+++ b/api/kogito-api-incubation-common-objectmapper/pom.xml
-@@ -22,7 +22,7 @@
-     <parent>
-         <groupId>org.kie.kogito</groupId>
-         <artifactId>kogito-api-parent</artifactId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
- 
-     <artifactId>kogito-api-incubation-common-objectmapper</artifactId>
-diff --git a/api/kogito-api-incubation-common/pom.xml b/api/kogito-api-incubation-common/pom.xml
-index 6e4e689e9a..fd338f48d7 100644
---- a/api/kogito-api-incubation-common/pom.xml
-+++ b/api/kogito-api-incubation-common/pom.xml
-@@ -22,7 +22,7 @@
-     <parent>
-         <groupId>org.kie.kogito</groupId>
-         <artifactId>kogito-api-parent</artifactId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
- 
-     <artifactId>kogito-api-incubation-common</artifactId>
-diff --git a/api/kogito-api-incubation-decisions-services/pom.xml b/api/kogito-api-incubation-decisions-services/pom.xml
-index 3abd3f6f2f..45e890ea79 100644
---- a/api/kogito-api-incubation-decisions-services/pom.xml
-+++ b/api/kogito-api-incubation-decisions-services/pom.xml
-@@ -22,7 +22,7 @@
-     <parent>
-         <groupId>org.kie.kogito</groupId>
-         <artifactId>kogito-api-parent</artifactId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
- 
-     <artifactId>kogito-api-incubation-decisions-services</artifactId>
-diff --git a/api/kogito-api-incubation-decisions/pom.xml b/api/kogito-api-incubation-decisions/pom.xml
-index cdff081e1d..c1ae179b1d 100644
---- a/api/kogito-api-incubation-decisions/pom.xml
-+++ b/api/kogito-api-incubation-decisions/pom.xml
-@@ -22,7 +22,7 @@
-     <parent>
-         <groupId>org.kie.kogito</groupId>
-         <artifactId>kogito-api-parent</artifactId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
- 
-     <artifactId>kogito-api-incubation-decisions</artifactId>
-diff --git a/api/kogito-api-incubation-predictions-services/pom.xml b/api/kogito-api-incubation-predictions-services/pom.xml
-index 8c7a7d35f7..753879b9d6 100644
---- a/api/kogito-api-incubation-predictions-services/pom.xml
-+++ b/api/kogito-api-incubation-predictions-services/pom.xml
-@@ -22,7 +22,7 @@
-     <parent>
-         <groupId>org.kie.kogito</groupId>
-         <artifactId>kogito-api-parent</artifactId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
- 
-     <artifactId>kogito-api-incubation-predictions-services</artifactId>
-diff --git a/api/kogito-api-incubation-predictions/pom.xml b/api/kogito-api-incubation-predictions/pom.xml
-index 275255ccb4..138a545810 100644
---- a/api/kogito-api-incubation-predictions/pom.xml
-+++ b/api/kogito-api-incubation-predictions/pom.xml
-@@ -22,7 +22,7 @@
-     <parent>
-         <groupId>org.kie.kogito</groupId>
-         <artifactId>kogito-api-parent</artifactId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
- 
-     <artifactId>kogito-api-incubation-predictions</artifactId>
-diff --git a/api/kogito-api-incubation-processes-services/pom.xml b/api/kogito-api-incubation-processes-services/pom.xml
-index 028c73645e..53c4c1718a 100644
---- a/api/kogito-api-incubation-processes-services/pom.xml
-+++ b/api/kogito-api-incubation-processes-services/pom.xml
-@@ -22,7 +22,7 @@
-     <parent>
-         <groupId>org.kie.kogito</groupId>
-         <artifactId>kogito-api-parent</artifactId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
- 
-     <artifactId>kogito-api-incubation-processes-services</artifactId>
-diff --git a/api/kogito-api-incubation-processes/pom.xml b/api/kogito-api-incubation-processes/pom.xml
-index b2407fc988..968f33b44a 100644
---- a/api/kogito-api-incubation-processes/pom.xml
-+++ b/api/kogito-api-incubation-processes/pom.xml
-@@ -22,7 +22,7 @@
-     <parent>
-         <groupId>org.kie.kogito</groupId>
-         <artifactId>kogito-api-parent</artifactId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
- 
-     <artifactId>kogito-api-incubation-processes</artifactId>
-diff --git a/api/kogito-api-incubation-rules-services/pom.xml b/api/kogito-api-incubation-rules-services/pom.xml
-index e1b8db37da..780f059a4e 100644
---- a/api/kogito-api-incubation-rules-services/pom.xml
-+++ b/api/kogito-api-incubation-rules-services/pom.xml
-@@ -22,7 +22,7 @@
-     <parent>
-         <groupId>org.kie.kogito</groupId>
-         <artifactId>kogito-api-parent</artifactId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
- 
-     <artifactId>kogito-api-incubation-rules-services</artifactId>
-diff --git a/api/kogito-api-incubation-rules/pom.xml b/api/kogito-api-incubation-rules/pom.xml
-index ac2c4a088c..80118ff0b9 100644
---- a/api/kogito-api-incubation-rules/pom.xml
-+++ b/api/kogito-api-incubation-rules/pom.xml
-@@ -22,7 +22,7 @@
-     <parent>
-         <groupId>org.kie.kogito</groupId>
-         <artifactId>kogito-api-parent</artifactId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
- 
-     <artifactId>kogito-api-incubation-rules</artifactId>
 diff --git a/api/kogito-api/pom.xml b/api/kogito-api/pom.xml
-index 85c613d88b..b6ba9e0d19 100755
+index 85c613d88b..c48d871ad5 100755
 --- a/api/kogito-api/pom.xml
 +++ b/api/kogito-api/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-api-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-api</artifactId>
 @@ -38,9 +38,10 @@
      </dependency>
  
@@ -783,227 +89,10 @@ index 85c613d88b..b6ba9e0d19 100755
      </dependency>
  
      <dependency>
-diff --git a/api/kogito-events-api/pom.xml b/api/kogito-events-api/pom.xml
-index f421e40a2c..69ecb9eaff 100644
---- a/api/kogito-events-api/pom.xml
-+++ b/api/kogito-events-api/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-api-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-events-api</artifactId>
-diff --git a/api/kogito-events-core/pom.xml b/api/kogito-events-core/pom.xml
-index eda94e5e2c..95f79bdd4a 100644
---- a/api/kogito-events-core/pom.xml
-+++ b/api/kogito-events-core/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-api-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-events-core</artifactId>
-diff --git a/api/kogito-jobs-service-api/pom.xml b/api/kogito-jobs-service-api/pom.xml
-index c7950704ce..4e1fcb47d2 100644
---- a/api/kogito-jobs-service-api/pom.xml
-+++ b/api/kogito-jobs-service-api/pom.xml
-@@ -21,7 +21,7 @@
-     <parent>
-         <artifactId>kogito-api-parent</artifactId>
-         <groupId>org.kie.kogito</groupId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
-     <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/api/kogito-services/pom.xml b/api/kogito-services/pom.xml
-index b83ab9c219..27772a6ae8 100644
---- a/api/kogito-services/pom.xml
-+++ b/api/kogito-services/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-api-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-services</artifactId>
-diff --git a/api/kogito-timer/pom.xml b/api/kogito-timer/pom.xml
-index f95979acd2..9f318b847c 100644
---- a/api/kogito-timer/pom.xml
-+++ b/api/kogito-timer/pom.xml
-@@ -20,7 +20,7 @@
-   <parent>
-     <artifactId>kogito-api-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/api/pom.xml b/api/pom.xml
-index d07be8a3a6..31234f20ae 100755
---- a/api/pom.xml
-+++ b/api/pom.xml
-@@ -6,7 +6,7 @@
-     <parent>
-         <groupId>org.kie.kogito</groupId>
-         <artifactId>kogito-build-parent</artifactId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-         <relativePath>../kogito-build/kogito-build-parent/pom.xml</relativePath>
-     </parent>
- 
-diff --git a/drools/kogito-dmn/pom.xml b/drools/kogito-dmn/pom.xml
-index 5f21b17679..844069a10f 100755
---- a/drools/kogito-dmn/pom.xml
-+++ b/drools/kogito-dmn/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>drools</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-dmn</artifactId>
-diff --git a/drools/kogito-drools/pom.xml b/drools/kogito-drools/pom.xml
-index 5bfe3421a0..2e85c5e99a 100644
---- a/drools/kogito-drools/pom.xml
-+++ b/drools/kogito-drools/pom.xml
-@@ -22,7 +22,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>drools</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-drools</artifactId>
-diff --git a/drools/kogito-efesto-drl/pom.xml b/drools/kogito-efesto-drl/pom.xml
-index 2f6e9cb688..7d54a2eca5 100644
---- a/drools/kogito-efesto-drl/pom.xml
-+++ b/drools/kogito-efesto-drl/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>drools</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
-   <packaging>pom</packaging>
-diff --git a/drools/kogito-pmml-api-dependencies/pom.xml b/drools/kogito-pmml-api-dependencies/pom.xml
-index 2f8a47e2f8..c32c2916ff 100644
---- a/drools/kogito-pmml-api-dependencies/pom.xml
-+++ b/drools/kogito-pmml-api-dependencies/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>drools</artifactId>
--     <version>2.0.0-SNAPSHOT</version>
-+     <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-pmml-api-dependencies</artifactId>
-diff --git a/drools/kogito-pmml-dependencies/pom.xml b/drools/kogito-pmml-dependencies/pom.xml
-index a5ca82be42..a3282a0a6f 100644
---- a/drools/kogito-pmml-dependencies/pom.xml
-+++ b/drools/kogito-pmml-dependencies/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>drools</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-pmml-dependencies</artifactId>
-diff --git a/drools/kogito-pmml-openapi/pom.xml b/drools/kogito-pmml-openapi/pom.xml
-index 01b906b075..5159c4b57e 100644
---- a/drools/kogito-pmml-openapi/pom.xml
-+++ b/drools/kogito-pmml-openapi/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>drools</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/drools/kogito-pmml/pom.xml b/drools/kogito-pmml/pom.xml
-index 40981db3c5..fe7ad02374 100644
---- a/drools/kogito-pmml/pom.xml
-+++ b/drools/kogito-pmml/pom.xml
-@@ -7,7 +7,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>drools</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-pmml</artifactId>
-diff --git a/drools/kogito-scenario-simulation/pom.xml b/drools/kogito-scenario-simulation/pom.xml
-index ea16548950..6bf99d59f5 100644
---- a/drools/kogito-scenario-simulation/pom.xml
-+++ b/drools/kogito-scenario-simulation/pom.xml
-@@ -6,7 +6,7 @@
-     <parent>
-         <groupId>org.kie.kogito</groupId>
-         <artifactId>drools</artifactId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
- 
-     <artifactId>kogito-scenario-simulation</artifactId>
-diff --git a/drools/pom.xml b/drools/pom.xml
-index 2f3f7b5fe5..3285b917df 100755
---- a/drools/pom.xml
-+++ b/drools/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-build-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-     <relativePath>../kogito-build/kogito-build-parent/pom.xml</relativePath>
-   </parent>
- 
-diff --git a/grafana-api/pom.xml b/grafana-api/pom.xml
-index bb2f2113ff..8a13a6eda4 100644
---- a/grafana-api/pom.xml
-+++ b/grafana-api/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-build-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-     <relativePath>../kogito-build/kogito-build-parent/pom.xml</relativePath>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
 diff --git a/jbpm/jbpm-bpmn2/pom.xml b/jbpm/jbpm-bpmn2/pom.xml
-index 92ba977bbd..b736a13838 100755
+index 92ba977bbd..92a1254696 100755
 --- a/jbpm/jbpm-bpmn2/pom.xml
 +++ b/jbpm/jbpm-bpmn2/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>jbpm</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>jbpm-bpmn2</artifactId>
 @@ -54,9 +54,10 @@
      </dependency>
  
@@ -1107,32 +196,10 @@ index e93c007f1e..d584c3f0c9 100755
  
  import org.jbpm.bpmn2.JbpmBpmn2TestCase;
  import org.jbpm.bpmn2.objects.Person;
-diff --git a/jbpm/jbpm-flow-builder/pom.xml b/jbpm/jbpm-flow-builder/pom.xml
-index 1fc3ec1346..fdd0a3c022 100755
---- a/jbpm/jbpm-flow-builder/pom.xml
-+++ b/jbpm/jbpm-flow-builder/pom.xml
-@@ -7,7 +7,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>jbpm</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>jbpm-flow-builder</artifactId>
 diff --git a/jbpm/jbpm-flow/pom.xml b/jbpm/jbpm-flow/pom.xml
-index da9b6da4da..4adab8ecfd 100755
+index da9b6da4da..3f182557c0 100755
 --- a/jbpm/jbpm-flow/pom.xml
 +++ b/jbpm/jbpm-flow/pom.xml
-@@ -7,7 +7,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>jbpm</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>jbpm-flow</artifactId>
 @@ -85,9 +85,10 @@
      </dependency>
  
@@ -1249,71 +316,10 @@ index 42d82935f9..157ad57d4b 100755
  
  import org.jbpm.process.instance.impl.ProcessInstanceImpl;
  import org.kie.api.command.ExecutableCommand;
-diff --git a/jbpm/pom.xml b/jbpm/pom.xml
-index 9b28d6c2c4..2c4df7603b 100755
---- a/jbpm/pom.xml
-+++ b/jbpm/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-build-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-     <relativePath>../kogito-build/kogito-build-parent/pom.xml</relativePath>
-   </parent>
- 
-diff --git a/jbpm/process-serialization-protobuf/pom.xml b/jbpm/process-serialization-protobuf/pom.xml
-index 163e6d8e4c..b96763e204 100644
---- a/jbpm/process-serialization-protobuf/pom.xml
-+++ b/jbpm/process-serialization-protobuf/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>jbpm</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
- 
-diff --git a/jbpm/process-workitems/pom.xml b/jbpm/process-workitems/pom.xml
-index 75ce0d3134..2d7405236b 100644
---- a/jbpm/process-workitems/pom.xml
-+++ b/jbpm/process-workitems/pom.xml
-@@ -7,7 +7,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>jbpm</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>process-workitems</artifactId>
-diff --git a/kogito-bom/pom.xml b/kogito-bom/pom.xml
-index 67927984ab..355a99330a 100755
---- a/kogito-bom/pom.xml
-+++ b/kogito-bom/pom.xml
-@@ -7,7 +7,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-runtimes</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-     <relativePath>../pom.xml</relativePath>
-   </parent>
- 
 diff --git a/kogito-build/kogito-build-no-bom-parent/pom.xml b/kogito-build/kogito-build-no-bom-parent/pom.xml
-index 97a45fea4d..c064a18e98 100644
+index 97a45fea4d..4ac46a1860 100644
 --- a/kogito-build/kogito-build-no-bom-parent/pom.xml
 +++ b/kogito-build/kogito-build-no-bom-parent/pom.xml
-@@ -8,7 +8,7 @@
-     <groupId>org.kie.kogito</groupId>
-     <!-- The Kogito Dependencies BOM is inherited here to reuse all the version properties defined there and used across our internal modules. -->
-     <artifactId>kogito-dependencies-bom</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-     <relativePath>../kogito-dependencies-bom/pom.xml</relativePath>
-   </parent>
- 
 @@ -618,7 +618,7 @@ limitations under the License.
          </plugin>
          <plugin>
@@ -1323,32 +329,10 @@ index 97a45fea4d..c064a18e98 100644
            <version>${version.io.quarkus}</version>
          </plugin>
          <plugin>
-diff --git a/kogito-build/kogito-build-parent/pom.xml b/kogito-build/kogito-build-parent/pom.xml
-index ef02cee368..9f108a7b9a 100644
---- a/kogito-build/kogito-build-parent/pom.xml
-+++ b/kogito-build/kogito-build-parent/pom.xml
-@@ -8,7 +8,7 @@
-     <groupId>org.kie.kogito</groupId>
-     <!-- The Kogito Dependencies BOM is transitively inherited here to reuse all the version properties defined there and used across our internal modules. -->
-     <artifactId>kogito-build-no-bom-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-     <relativePath>../kogito-build-no-bom-parent/pom.xml</relativePath>
-   </parent>
- 
 diff --git a/kogito-build/kogito-dependencies-bom/pom.xml b/kogito-build/kogito-dependencies-bom/pom.xml
-index aa06497e9f..43f4f41bfc 100644
+index aa06497e9f..84ea1c8314 100644
 --- a/kogito-build/kogito-dependencies-bom/pom.xml
 +++ b/kogito-build/kogito-dependencies-bom/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-build</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
 @@ -16,22 +16,22 @@
  
    <properties>
@@ -1544,32 +528,10 @@ index aa06497e9f..43f4f41bfc 100644
          <version>${version.org.infinispan}</version>
        </dependency>
        <dependency>
-diff --git a/kogito-build/kogito-ide-config/pom.xml b/kogito-build/kogito-ide-config/pom.xml
-index 101db9a286..d6a2e3d5c4 100644
---- a/kogito-build/kogito-ide-config/pom.xml
-+++ b/kogito-build/kogito-ide-config/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-runtimes</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-     <relativePath>../../pom.xml</relativePath>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
 diff --git a/kogito-build/kogito-kie-bom/pom.xml b/kogito-build/kogito-kie-bom/pom.xml
-index bfd8897310..384e2d354d 100644
+index bfd8897310..31b7020647 100644
 --- a/kogito-build/kogito-kie-bom/pom.xml
 +++ b/kogito-build/kogito-kie-bom/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-build</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-     <relativePath>../pom.xml</relativePath>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
 @@ -18,7 +18,7 @@
    </description>
  
@@ -1579,110 +541,10 @@ index bfd8897310..384e2d354d 100644
    </properties>
  
    <dependencyManagement>
-diff --git a/kogito-build/pom.xml b/kogito-build/pom.xml
-index 86a0556304..b4bd0ac94d 100644
---- a/kogito-build/pom.xml
-+++ b/kogito-build/pom.xml
-@@ -7,7 +7,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-runtimes</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-     <relativePath>../pom.xml</relativePath>
-   </parent>
- 
-diff --git a/kogito-codegen-modules/kogito-codegen-api/pom.xml b/kogito-codegen-modules/kogito-codegen-api/pom.xml
-index 435fd257b5..a82b788dad 100644
---- a/kogito-codegen-modules/kogito-codegen-api/pom.xml
-+++ b/kogito-codegen-modules/kogito-codegen-api/pom.xml
-@@ -5,7 +5,7 @@
-     <parent>
-         <groupId>org.kie.kogito</groupId>
-         <artifactId>kogito-codegen-modules</artifactId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
-     <modelVersion>4.0.0</modelVersion>
-     <artifactId>kogito-codegen-api</artifactId>
-diff --git a/kogito-codegen-modules/kogito-codegen-core/pom.xml b/kogito-codegen-modules/kogito-codegen-core/pom.xml
-index 55bf3b165a..8be4f4e4e4 100644
---- a/kogito-codegen-modules/kogito-codegen-core/pom.xml
-+++ b/kogito-codegen-modules/kogito-codegen-core/pom.xml
-@@ -5,7 +5,7 @@
-     <parent>
-         <groupId>org.kie.kogito</groupId>
-         <artifactId>kogito-codegen-modules</artifactId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
-     <modelVersion>4.0.0</modelVersion>
-     <artifactId>kogito-codegen-core</artifactId>
-diff --git a/kogito-codegen-modules/kogito-codegen-decisions/pom.xml b/kogito-codegen-modules/kogito-codegen-decisions/pom.xml
-index 217aafdd8a..958d66e845 100644
---- a/kogito-codegen-modules/kogito-codegen-decisions/pom.xml
-+++ b/kogito-codegen-modules/kogito-codegen-decisions/pom.xml
-@@ -5,7 +5,7 @@
-     <parent>
-         <groupId>org.kie.kogito</groupId>
-         <artifactId>kogito-codegen-modules</artifactId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
-     <modelVersion>4.0.0</modelVersion>
-     <artifactId>kogito-codegen-decisions</artifactId>
-diff --git a/kogito-codegen-modules/kogito-codegen-integration-tests/pom.xml b/kogito-codegen-modules/kogito-codegen-integration-tests/pom.xml
-index 230fc1d534..d316cb7b8f 100644
---- a/kogito-codegen-modules/kogito-codegen-integration-tests/pom.xml
-+++ b/kogito-codegen-modules/kogito-codegen-integration-tests/pom.xml
-@@ -5,7 +5,7 @@
-     <parent>
-         <groupId>org.kie.kogito</groupId>
-         <artifactId>kogito-codegen-modules</artifactId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
-     <modelVersion>4.0.0</modelVersion>
-     <artifactId>kogito-codegen-integration-tests</artifactId>
-diff --git a/kogito-codegen-modules/kogito-codegen-predictions/pom.xml b/kogito-codegen-modules/kogito-codegen-predictions/pom.xml
-index 543286280a..7338bf4202 100644
---- a/kogito-codegen-modules/kogito-codegen-predictions/pom.xml
-+++ b/kogito-codegen-modules/kogito-codegen-predictions/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-codegen-modules</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
-   <artifactId>kogito-codegen-predictions</artifactId>
-diff --git a/kogito-codegen-modules/kogito-codegen-processes-integration-tests/pom.xml b/kogito-codegen-modules/kogito-codegen-processes-integration-tests/pom.xml
-index c80f603c3a..6f33448607 100644
---- a/kogito-codegen-modules/kogito-codegen-processes-integration-tests/pom.xml
-+++ b/kogito-codegen-modules/kogito-codegen-processes-integration-tests/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-codegen-modules</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
-   <artifactId>kogito-codegen-processes-integration-tests</artifactId>
 diff --git a/kogito-codegen-modules/kogito-codegen-processes/pom.xml b/kogito-codegen-modules/kogito-codegen-processes/pom.xml
-index d7cf272966..19b61881a5 100644
+index d7cf272966..27e823f66d 100644
 --- a/kogito-codegen-modules/kogito-codegen-processes/pom.xml
 +++ b/kogito-codegen-modules/kogito-codegen-processes/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-codegen-modules</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
-   <artifactId>kogito-codegen-processes</artifactId>
 @@ -97,9 +97,10 @@
        <scope>test</scope>
      </dependency>
@@ -1727,461 +589,6 @@ index 37649b0a2c..275181529a 100644
      private String var1;
  
      public String getVar1() {
-diff --git a/kogito-codegen-modules/kogito-codegen-rules/pom.xml b/kogito-codegen-modules/kogito-codegen-rules/pom.xml
-index 2f75629713..9b02328627 100644
---- a/kogito-codegen-modules/kogito-codegen-rules/pom.xml
-+++ b/kogito-codegen-modules/kogito-codegen-rules/pom.xml
-@@ -5,7 +5,7 @@
-     <parent>
-         <groupId>org.kie.kogito</groupId>
-         <artifactId>kogito-codegen-modules</artifactId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
-     <modelVersion>4.0.0</modelVersion>
-     <artifactId>kogito-codegen-rules</artifactId>
-diff --git a/kogito-codegen-modules/kogito-codegen-sample/kogito-codegen-sample-generator/pom.xml b/kogito-codegen-modules/kogito-codegen-sample/kogito-codegen-sample-generator/pom.xml
-index 874b6dbbf9..ff43122489 100644
---- a/kogito-codegen-modules/kogito-codegen-sample/kogito-codegen-sample-generator/pom.xml
-+++ b/kogito-codegen-modules/kogito-codegen-sample/kogito-codegen-sample-generator/pom.xml
-@@ -5,7 +5,7 @@
-     <parent>
-         <groupId>org.kie.kogito</groupId>
-         <artifactId>kogito-codegen-sample</artifactId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
-     <modelVersion>4.0.0</modelVersion>
-     <artifactId>kogito-codegen-sample-generator</artifactId>
-diff --git a/kogito-codegen-modules/kogito-codegen-sample/kogito-codegen-sample-runtime/pom.xml b/kogito-codegen-modules/kogito-codegen-sample/kogito-codegen-sample-runtime/pom.xml
-index 70d1923c87..b9fe2f2ce7 100644
---- a/kogito-codegen-modules/kogito-codegen-sample/kogito-codegen-sample-runtime/pom.xml
-+++ b/kogito-codegen-modules/kogito-codegen-sample/kogito-codegen-sample-runtime/pom.xml
-@@ -5,7 +5,7 @@
-     <parent>
-         <groupId>org.kie.kogito</groupId>
-         <artifactId>kogito-codegen-sample</artifactId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
-     <modelVersion>4.0.0</modelVersion>
-     <artifactId>kogito-codegen-sample-runtime</artifactId>
-diff --git a/kogito-codegen-modules/kogito-codegen-sample/pom.xml b/kogito-codegen-modules/kogito-codegen-sample/pom.xml
-index 62257319d6..2c15c2d05d 100644
---- a/kogito-codegen-modules/kogito-codegen-sample/pom.xml
-+++ b/kogito-codegen-modules/kogito-codegen-sample/pom.xml
-@@ -6,7 +6,7 @@
-     <parent>
-         <groupId>org.kie.kogito</groupId>
-         <artifactId>kogito-codegen-modules</artifactId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
- 
-     <artifactId>kogito-codegen-sample</artifactId>
-diff --git a/kogito-codegen-modules/pom.xml b/kogito-codegen-modules/pom.xml
-index 598199a0be..ea07f7b97f 100644
---- a/kogito-codegen-modules/pom.xml
-+++ b/kogito-codegen-modules/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-build-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-     <relativePath>../kogito-build/kogito-build-parent/pom.xml</relativePath>
-   </parent>
- 
-diff --git a/kogito-maven-plugin/pom.xml b/kogito-maven-plugin/pom.xml
-index a6c171e121..59a1cd3f8a 100644
---- a/kogito-maven-plugin/pom.xml
-+++ b/kogito-maven-plugin/pom.xml
-@@ -7,7 +7,7 @@
-  <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-build-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-    <relativePath>../kogito-build/kogito-build-parent/pom.xml</relativePath>
-   </parent>
- 
-diff --git a/kogito-serverless-workflow/kogito-jq-expression/pom.xml b/kogito-serverless-workflow/kogito-jq-expression/pom.xml
-index 814fdfe987..037ea59eef 100644
---- a/kogito-serverless-workflow/kogito-jq-expression/pom.xml
-+++ b/kogito-serverless-workflow/kogito-jq-expression/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-serverless-workflow</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-jq-expression</artifactId>
-diff --git a/kogito-serverless-workflow/kogito-jsonpath-expression/pom.xml b/kogito-serverless-workflow/kogito-jsonpath-expression/pom.xml
-index 77cae5ae12..250289a9a6 100644
---- a/kogito-serverless-workflow/kogito-jsonpath-expression/pom.xml
-+++ b/kogito-serverless-workflow/kogito-jsonpath-expression/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-serverless-workflow</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-jsonpath-expression</artifactId>
-diff --git a/kogito-serverless-workflow/kogito-serverless-workflow-builder/pom.xml b/kogito-serverless-workflow/kogito-serverless-workflow-builder/pom.xml
-index 0ce1ee68fd..683927e755 100644
---- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/pom.xml
-+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-serverless-workflow</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-serverless-workflow-builder</artifactId>
-diff --git a/kogito-serverless-workflow/kogito-serverless-workflow-executor-core/pom.xml b/kogito-serverless-workflow/kogito-serverless-workflow-executor-core/pom.xml
-index ee111e741b..704c27ff9e 100644
---- a/kogito-serverless-workflow/kogito-serverless-workflow-executor-core/pom.xml
-+++ b/kogito-serverless-workflow/kogito-serverless-workflow-executor-core/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-serverless-workflow</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-serverless-workflow-executor-core</artifactId>
-diff --git a/kogito-serverless-workflow/kogito-serverless-workflow-executor-grpc/pom.xml b/kogito-serverless-workflow/kogito-serverless-workflow-executor-grpc/pom.xml
-index d0fb9e34d8..3c678e819b 100644
---- a/kogito-serverless-workflow/kogito-serverless-workflow-executor-grpc/pom.xml
-+++ b/kogito-serverless-workflow/kogito-serverless-workflow-executor-grpc/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-serverless-workflow</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-serverless-workflow-executor-grpc</artifactId>
-diff --git a/kogito-serverless-workflow/kogito-serverless-workflow-executor-rest/pom.xml b/kogito-serverless-workflow/kogito-serverless-workflow-executor-rest/pom.xml
-index 3803e503bb..7994961e51 100644
---- a/kogito-serverless-workflow/kogito-serverless-workflow-executor-rest/pom.xml
-+++ b/kogito-serverless-workflow/kogito-serverless-workflow-executor-rest/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-serverless-workflow</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-serverless-workflow-executor-rest</artifactId>
-diff --git a/kogito-serverless-workflow/kogito-serverless-workflow-executor-tests/pom.xml b/kogito-serverless-workflow/kogito-serverless-workflow-executor-tests/pom.xml
-index 565e0e71f0..0d43ac4149 100644
---- a/kogito-serverless-workflow/kogito-serverless-workflow-executor-tests/pom.xml
-+++ b/kogito-serverless-workflow/kogito-serverless-workflow-executor-tests/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-serverless-workflow</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-serverless-workflow-executor-tests</artifactId>
-diff --git a/kogito-serverless-workflow/kogito-serverless-workflow-executor/pom.xml b/kogito-serverless-workflow/kogito-serverless-workflow-executor/pom.xml
-index 26d482a093..66868c9c80 100644
---- a/kogito-serverless-workflow/kogito-serverless-workflow-executor/pom.xml
-+++ b/kogito-serverless-workflow/kogito-serverless-workflow-executor/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-serverless-workflow</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-serverless-workflow-executor</artifactId>
-diff --git a/kogito-serverless-workflow/kogito-serverless-workflow-fluent/pom.xml b/kogito-serverless-workflow/kogito-serverless-workflow-fluent/pom.xml
-index 74c49e72b1..4b32f3f85d 100644
---- a/kogito-serverless-workflow/kogito-serverless-workflow-fluent/pom.xml
-+++ b/kogito-serverless-workflow/kogito-serverless-workflow-fluent/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-serverless-workflow</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-serverless-workflow-fluent</artifactId>
-diff --git a/kogito-serverless-workflow/kogito-serverless-workflow-grpc-parser/pom.xml b/kogito-serverless-workflow/kogito-serverless-workflow-grpc-parser/pom.xml
-index 0942e3972e..e9e8cd353c 100644
---- a/kogito-serverless-workflow/kogito-serverless-workflow-grpc-parser/pom.xml
-+++ b/kogito-serverless-workflow/kogito-serverless-workflow-grpc-parser/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-serverless-workflow</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-serverless-workflow-grpc-parser</artifactId>
-diff --git a/kogito-serverless-workflow/kogito-serverless-workflow-grpc-runtime/pom.xml b/kogito-serverless-workflow/kogito-serverless-workflow-grpc-runtime/pom.xml
-index 87df913b4e..887029d9b7 100644
---- a/kogito-serverless-workflow/kogito-serverless-workflow-grpc-runtime/pom.xml
-+++ b/kogito-serverless-workflow/kogito-serverless-workflow-grpc-runtime/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-serverless-workflow</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-serverless-workflow-grpc-runtime</artifactId>
-diff --git a/kogito-serverless-workflow/kogito-serverless-workflow-openapi-common/pom.xml b/kogito-serverless-workflow/kogito-serverless-workflow-openapi-common/pom.xml
-index 1b7aa8b5ec..c652dd33c5 100644
---- a/kogito-serverless-workflow/kogito-serverless-workflow-openapi-common/pom.xml
-+++ b/kogito-serverless-workflow/kogito-serverless-workflow-openapi-common/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-serverless-workflow</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-serverless-workflow-openapi-common</artifactId>
-diff --git a/kogito-serverless-workflow/kogito-serverless-workflow-openapi-generated/pom.xml b/kogito-serverless-workflow/kogito-serverless-workflow-openapi-generated/pom.xml
-index 7c2e970d76..ff4fd5e0a9 100644
---- a/kogito-serverless-workflow/kogito-serverless-workflow-openapi-generated/pom.xml
-+++ b/kogito-serverless-workflow/kogito-serverless-workflow-openapi-generated/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-serverless-workflow</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-serverless-workflow-openapi-generated</artifactId>
-diff --git a/kogito-serverless-workflow/kogito-serverless-workflow-openapi-parser/pom.xml b/kogito-serverless-workflow/kogito-serverless-workflow-openapi-parser/pom.xml
-index eb7be4de4c..7fe32a2223 100644
---- a/kogito-serverless-workflow/kogito-serverless-workflow-openapi-parser/pom.xml
-+++ b/kogito-serverless-workflow/kogito-serverless-workflow-openapi-parser/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-serverless-workflow</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-serverless-workflow-openapi-parser</artifactId>
-diff --git a/kogito-serverless-workflow/kogito-serverless-workflow-rest-parser/pom.xml b/kogito-serverless-workflow/kogito-serverless-workflow-rest-parser/pom.xml
-index b6a08e2de5..74e04a933b 100644
---- a/kogito-serverless-workflow/kogito-serverless-workflow-rest-parser/pom.xml
-+++ b/kogito-serverless-workflow/kogito-serverless-workflow-rest-parser/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-serverless-workflow</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-serverless-workflow-rest-parser</artifactId>
-diff --git a/kogito-serverless-workflow/kogito-serverless-workflow-rest-runtime/pom.xml b/kogito-serverless-workflow/kogito-serverless-workflow-rest-runtime/pom.xml
-index 08b282f7a0..d1994676ef 100644
---- a/kogito-serverless-workflow/kogito-serverless-workflow-rest-runtime/pom.xml
-+++ b/kogito-serverless-workflow/kogito-serverless-workflow-rest-runtime/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-serverless-workflow</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-serverless-workflow-rest-runtime</artifactId>
-diff --git a/kogito-serverless-workflow/kogito-serverless-workflow-runtime/pom.xml b/kogito-serverless-workflow/kogito-serverless-workflow-runtime/pom.xml
-index 4aa240ccba..9757c74d0e 100644
---- a/kogito-serverless-workflow/kogito-serverless-workflow-runtime/pom.xml
-+++ b/kogito-serverless-workflow/kogito-serverless-workflow-runtime/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-serverless-workflow</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-serverless-workflow-runtime</artifactId>
-diff --git a/kogito-serverless-workflow/kogito-serverless-workflow-utils/pom.xml b/kogito-serverless-workflow/kogito-serverless-workflow-utils/pom.xml
-index 7aebf4f0d4..7325f363e5 100644
---- a/kogito-serverless-workflow/kogito-serverless-workflow-utils/pom.xml
-+++ b/kogito-serverless-workflow/kogito-serverless-workflow-utils/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-serverless-workflow</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-serverless-workflow-utils</artifactId>
-diff --git a/kogito-serverless-workflow/pom.xml b/kogito-serverless-workflow/pom.xml
-index 9160907939..50f3d52984 100644
---- a/kogito-serverless-workflow/pom.xml
-+++ b/kogito-serverless-workflow/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-build-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-     <relativePath>../kogito-build/kogito-build-parent/pom.xml</relativePath>
-   </parent>
- 
-diff --git a/kogito-test-utils/pom.xml b/kogito-test-utils/pom.xml
-index 762e4274de..5e08c99578 100644
---- a/kogito-test-utils/pom.xml
-+++ b/kogito-test-utils/pom.xml
-@@ -7,7 +7,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-build-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-     <relativePath>../kogito-build/kogito-build-parent/pom.xml</relativePath>
-   </parent>
- 
-diff --git a/kogito-workitems/kogito-jackson-utils/pom.xml b/kogito-workitems/kogito-jackson-utils/pom.xml
-index 017d58ec96..053b010943 100644
---- a/kogito-workitems/kogito-jackson-utils/pom.xml
-+++ b/kogito-workitems/kogito-jackson-utils/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-workitems</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-jackson-utils</artifactId>
-diff --git a/kogito-workitems/kogito-rest-utils/pom.xml b/kogito-workitems/kogito-rest-utils/pom.xml
-index f9b5146910..84102fc392 100644
---- a/kogito-workitems/kogito-rest-utils/pom.xml
-+++ b/kogito-workitems/kogito-rest-utils/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-workitems</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-rest-utils</artifactId>
-diff --git a/kogito-workitems/kogito-rest-workitem/pom.xml b/kogito-workitems/kogito-rest-workitem/pom.xml
-index 2ec2b3b175..b6da257831 100644
---- a/kogito-workitems/kogito-rest-workitem/pom.xml
-+++ b/kogito-workitems/kogito-rest-workitem/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-workitems</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-rest-workitem</artifactId>
-diff --git a/kogito-workitems/pom.xml b/kogito-workitems/pom.xml
-index 8bc2e6f396..1818694105 100644
---- a/kogito-workitems/pom.xml
-+++ b/kogito-workitems/pom.xml
-@@ -3,7 +3,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-build-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-     <relativePath>../kogito-build/kogito-build-parent/pom.xml</relativePath>
-   </parent>
-   <artifactId>kogito-workitems</artifactId>
-diff --git a/pom.xml b/pom.xml
-index 4f8a22ef85..305f3e0b55 100644
---- a/pom.xml
-+++ b/pom.xml
-@@ -12,7 +12,7 @@
-   <modelVersion>4.0.0</modelVersion>
-   <groupId>org.kie.kogito</groupId>
-   <artifactId>kogito-runtimes</artifactId>
--  <version>2.0.0-SNAPSHOT</version>
-+  <version>quarkus-3-SNAPSHOT</version>
-   <packaging>pom</packaging>
- 
-   <name>Kogito Runtimes</name>
-diff --git a/quarkus/addons/camel/deployment/pom.xml b/quarkus/addons/camel/deployment/pom.xml
-index 6a1b847cb6..80333650c9 100644
---- a/quarkus/addons/camel/deployment/pom.xml
-+++ b/quarkus/addons/camel/deployment/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-quarkus-camel-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/quarkus/addons/camel/integration-tests/pom.xml b/quarkus/addons/camel/integration-tests/pom.xml
-index b937d4b6e5..e16d912e6a 100644
---- a/quarkus/addons/camel/integration-tests/pom.xml
-+++ b/quarkus/addons/camel/integration-tests/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-quarkus-camel-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/quarkus/addons/camel/pom.xml b/quarkus/addons/camel/pom.xml
-index 45e4ebffd1..39eb5e6a63 100644
---- a/quarkus/addons/camel/pom.xml
-+++ b/quarkus/addons/camel/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-quarkus-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/quarkus/addons/camel/runtime/pom.xml b/quarkus/addons/camel/runtime/pom.xml
-index 258f632efe..7ab5a0e68a 100644
---- a/quarkus/addons/camel/runtime/pom.xml
-+++ b/quarkus/addons/camel/runtime/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-quarkus-camel-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
 diff --git a/quarkus/addons/camel/runtime/src/main/java/org/kie/kogito/addons/quarkus/camel/runtime/CamelCustomWorkItemHandler.java b/quarkus/addons/camel/runtime/src/main/java/org/kie/kogito/addons/quarkus/camel/runtime/CamelCustomWorkItemHandler.java
 index ba7c3c6366..e5051b4a5e 100644
 --- a/quarkus/addons/camel/runtime/src/main/java/org/kie/kogito/addons/quarkus/camel/runtime/CamelCustomWorkItemHandler.java
@@ -2220,71 +627,10 @@ index 2da06ff74e..b76f6aa336 100644
  import org.kie.kogito.process.impl.CachedWorkItemHandlerConfig;
  
  @ApplicationScoped
-diff --git a/quarkus/addons/common/deployment/pom.xml b/quarkus/addons/common/deployment/pom.xml
-index 4b157797ca..0fb9d7dbbc 100644
---- a/quarkus/addons/common/deployment/pom.xml
-+++ b/quarkus/addons/common/deployment/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-quarkus-common-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/quarkus/addons/common/pom.xml b/quarkus/addons/common/pom.xml
-index c86693faf5..a6d57d9d9d 100644
---- a/quarkus/addons/common/pom.xml
-+++ b/quarkus/addons/common/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-quarkus-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/quarkus/addons/events/decisions/deployment/pom.xml b/quarkus/addons/events/decisions/deployment/pom.xml
-index 3f3565f6cb..4f2a14093f 100644
---- a/quarkus/addons/events/decisions/deployment/pom.xml
-+++ b/quarkus/addons/events/decisions/deployment/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-events-decisions-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-events-decisions-deployment</artifactId>
-   <name>Kogito Add-On Events Decisions - Deployment</name>
-diff --git a/quarkus/addons/events/decisions/pom.xml b/quarkus/addons/events/decisions/pom.xml
-index e3706cf950..1dcbdbbe64 100644
---- a/quarkus/addons/events/decisions/pom.xml
-+++ b/quarkus/addons/events/decisions/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-events-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-addons-quarkus-events-decisions-parent</artifactId>
 diff --git a/quarkus/addons/events/decisions/runtime/pom.xml b/quarkus/addons/events/decisions/runtime/pom.xml
-index 8eb1c309cd..325219f203 100644
+index 8eb1c309cd..575ee45565 100644
 --- a/quarkus/addons/events/decisions/runtime/pom.xml
 +++ b/quarkus/addons/events/decisions/runtime/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-events-decisions-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-addons-quarkus-events-decisions</artifactId>
 @@ -31,7 +31,7 @@
      <plugins>
        <plugin>
@@ -2309,45 +655,10 @@ index 32da3571ba..e282deadbe 100644
  
  import org.kie.kogito.config.ConfigBean;
  import org.kie.kogito.decision.DecisionModels;
-diff --git a/quarkus/addons/events/mongodb/deployment/pom.xml b/quarkus/addons/events/mongodb/deployment/pom.xml
-index 621e3d7236..982b20fbb4 100644
---- a/quarkus/addons/events/mongodb/deployment/pom.xml
-+++ b/quarkus/addons/events/mongodb/deployment/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-events-mongodb-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-events-mongodb-deployment</artifactId>
-   <name>Kogito Add-On Events MongoDB - Deployment</name>
-diff --git a/quarkus/addons/events/mongodb/pom.xml b/quarkus/addons/events/mongodb/pom.xml
-index 1631e8b190..b24fbe81d2 100644
---- a/quarkus/addons/events/mongodb/pom.xml
-+++ b/quarkus/addons/events/mongodb/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-events-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-addons-quarkus-events-mongodb-parent</artifactId>
 diff --git a/quarkus/addons/events/mongodb/runtime/pom.xml b/quarkus/addons/events/mongodb/runtime/pom.xml
-index 5421d4a96e..8cec44a676 100644
+index 5421d4a96e..1594de9f17 100644
 --- a/quarkus/addons/events/mongodb/runtime/pom.xml
 +++ b/quarkus/addons/events/mongodb/runtime/pom.xml
-@@ -7,7 +7,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-events-mongodb-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-addons-quarkus-events-mongodb</artifactId>
 @@ -69,7 +69,7 @@
        </plugin>
        <plugin>
@@ -2414,58 +725,10 @@ index 2976a44a1e..a0ea0200a7 100644
  
  import org.junit.jupiter.api.Test;
  import org.kie.kogito.mongodb.transaction.AbstractTransactionManager;
-diff --git a/quarkus/addons/events/pom.xml b/quarkus/addons/events/pom.xml
-index b61b2476c3..d15f0eb8c1 100644
---- a/quarkus/addons/events/pom.xml
-+++ b/quarkus/addons/events/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-quarkus-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/quarkus/addons/events/predictions/deployment/pom.xml b/quarkus/addons/events/predictions/deployment/pom.xml
-index 35e8994b39..fdc320a748 100644
---- a/quarkus/addons/events/predictions/deployment/pom.xml
-+++ b/quarkus/addons/events/predictions/deployment/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-events-predictions-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-events-predictions-deployment</artifactId>
-   <name>Kogito Add-On Events Predictions - Deployment</name>
-diff --git a/quarkus/addons/events/predictions/pom.xml b/quarkus/addons/events/predictions/pom.xml
-index b219c28eac..d7d660b4e6 100644
---- a/quarkus/addons/events/predictions/pom.xml
-+++ b/quarkus/addons/events/predictions/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-events-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-addons-quarkus-events-predictions-parent</artifactId>
 diff --git a/quarkus/addons/events/predictions/runtime/pom.xml b/quarkus/addons/events/predictions/runtime/pom.xml
-index caffff49de..e3b7e7879b 100644
+index caffff49de..4da6d6518d 100644
 --- a/quarkus/addons/events/predictions/runtime/pom.xml
 +++ b/quarkus/addons/events/predictions/runtime/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-events-predictions-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-addons-quarkus-events-predictions</artifactId>
 @@ -31,7 +31,7 @@
      <plugins>
        <plugin>
@@ -2490,45 +753,10 @@ index 1d0a6ec2a6..b5714777f2 100644
  
  import org.kie.kogito.config.ConfigBean;
  import org.kie.kogito.event.EventEmitter;
-diff --git a/quarkus/addons/events/process/deployment/pom.xml b/quarkus/addons/events/process/deployment/pom.xml
-index c086c56791..961528af82 100644
---- a/quarkus/addons/events/process/deployment/pom.xml
-+++ b/quarkus/addons/events/process/deployment/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-events-process-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-events-process-deployment</artifactId>
-   <name>Kogito Add-On Events Process - Deployment</name>
-diff --git a/quarkus/addons/events/process/pom.xml b/quarkus/addons/events/process/pom.xml
-index 4a41eda5ce..29b01cbffd 100644
---- a/quarkus/addons/events/process/pom.xml
-+++ b/quarkus/addons/events/process/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-events-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-addons-quarkus-events-process-parent</artifactId>
 diff --git a/quarkus/addons/events/process/runtime/pom.xml b/quarkus/addons/events/process/runtime/pom.xml
-index 99ac64a6af..775494e30b 100644
+index 99ac64a6af..e6918f15e5 100644
 --- a/quarkus/addons/events/process/runtime/pom.xml
 +++ b/quarkus/addons/events/process/runtime/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-events-process-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-events-process</artifactId>
-   <name>Kogito Add-On Events Process</name>
 @@ -64,7 +64,7 @@
        </plugin>
        <plugin>
@@ -2553,45 +781,10 @@ index 00874a436d..ecc02ada63 100644
  
  import org.eclipse.microprofile.config.inject.ConfigProperty;
  import org.eclipse.microprofile.reactive.messaging.Channel;
-diff --git a/quarkus/addons/events/rules/deployment/pom.xml b/quarkus/addons/events/rules/deployment/pom.xml
-index f9b894fac4..d3fe1ba7b3 100644
---- a/quarkus/addons/events/rules/deployment/pom.xml
-+++ b/quarkus/addons/events/rules/deployment/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-events-rules-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-events-rules-deployment</artifactId>
-   <name>Kogito Add-On Events Rules - Deployment</name>
-diff --git a/quarkus/addons/events/rules/pom.xml b/quarkus/addons/events/rules/pom.xml
-index c1a23bdffb..12d8ea330d 100644
---- a/quarkus/addons/events/rules/pom.xml
-+++ b/quarkus/addons/events/rules/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-events-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-addons-quarkus-events-rules-parent</artifactId>
 diff --git a/quarkus/addons/events/rules/runtime/pom.xml b/quarkus/addons/events/rules/runtime/pom.xml
-index 99b5870071..eaf16410b4 100644
+index 99b5870071..c74f928495 100644
 --- a/quarkus/addons/events/rules/runtime/pom.xml
 +++ b/quarkus/addons/events/rules/runtime/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-events-rules-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-addons-quarkus-events-rules</artifactId>
 @@ -31,7 +31,7 @@
      <plugins>
        <plugin>
@@ -2616,32 +809,6 @@ index 777439455a..3337ba231d 100644
  
  import org.kie.kogito.config.ConfigBean;
  import org.kie.kogito.event.EventEmitter;
-diff --git a/quarkus/addons/explainability/deployment/pom.xml b/quarkus/addons/explainability/deployment/pom.xml
-index a77bef3124..e0db15b4ab 100644
---- a/quarkus/addons/explainability/deployment/pom.xml
-+++ b/quarkus/addons/explainability/deployment/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-explainability-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-explainability-deployment</artifactId>
-   <name>Kogito Add-On Explainability - Deployment</name>
-diff --git a/quarkus/addons/explainability/integration-tests/pom.xml b/quarkus/addons/explainability/integration-tests/pom.xml
-index 90cc98b27b..566c00611a 100644
---- a/quarkus/addons/explainability/integration-tests/pom.xml
-+++ b/quarkus/addons/explainability/integration-tests/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-explainability-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-explainability-it</artifactId>
-   <name>Kogito Add-On Explainability - Integration tests</name>
 diff --git a/quarkus/addons/explainability/integration-tests/src/test/java/org/kie/kogito/explainability/QuarkusExplainableResourceIT.java b/quarkus/addons/explainability/integration-tests/src/test/java/org/kie/kogito/explainability/QuarkusExplainableResourceIT.java
 index 6fbf975d41..9b3599f562 100644
 --- a/quarkus/addons/explainability/integration-tests/src/test/java/org/kie/kogito/explainability/QuarkusExplainableResourceIT.java
@@ -2657,32 +824,10 @@ index 6fbf975d41..9b3599f562 100644
  
  import org.hamcrest.Matchers;
  import org.junit.jupiter.api.Test;
-diff --git a/quarkus/addons/explainability/pom.xml b/quarkus/addons/explainability/pom.xml
-index 622718a780..b4f490ed2f 100644
---- a/quarkus/addons/explainability/pom.xml
-+++ b/quarkus/addons/explainability/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-addons-quarkus-explainability-parent</artifactId>
 diff --git a/quarkus/addons/explainability/runtime/pom.xml b/quarkus/addons/explainability/runtime/pom.xml
-index 8fd4cfcc9e..a05bf5e47c 100644
+index 8fd4cfcc9e..ab80329157 100644
 --- a/quarkus/addons/explainability/runtime/pom.xml
 +++ b/quarkus/addons/explainability/runtime/pom.xml
-@@ -5,7 +5,7 @@
-     <parent>
-         <artifactId>kogito-addons-quarkus-explainability-parent</artifactId>
-         <groupId>org.kie.kogito</groupId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
-     <modelVersion>4.0.0</modelVersion>
- 
 @@ -65,7 +65,7 @@
          <plugins>
              <plugin>
@@ -2717,45 +862,6 @@ index fac920d739..cdbc8756bc 100644
  
  import org.kie.kogito.Application;
  import org.kie.kogito.explainability.model.PredictInput;
-diff --git a/quarkus/addons/jobs/common/messaging/pom.xml b/quarkus/addons/jobs/common/messaging/pom.xml
-index a99da61323..bcb457e911 100644
---- a/quarkus/addons/jobs/common/messaging/pom.xml
-+++ b/quarkus/addons/jobs/common/messaging/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-jobs-common-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-addons-quarkus-jobs-common-messaging</artifactId>
-diff --git a/quarkus/addons/jobs/common/pom.xml b/quarkus/addons/jobs/common/pom.xml
-index 3b8040cf0a..7d9b80badd 100644
---- a/quarkus/addons/jobs/common/pom.xml
-+++ b/quarkus/addons/jobs/common/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-jobs-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-addons-quarkus-jobs-common-parent</artifactId>
-diff --git a/quarkus/addons/jobs/common/rest-callback/pom.xml b/quarkus/addons/jobs/common/rest-callback/pom.xml
-index b9283679f3..b156062341 100644
---- a/quarkus/addons/jobs/common/rest-callback/pom.xml
-+++ b/quarkus/addons/jobs/common/rest-callback/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-jobs-common-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-addons-quarkus-rest-callback</artifactId>
 diff --git a/quarkus/addons/jobs/common/rest-callback/src/main/java/org/kie/kogito/jobs/quarkus/common/CallbackJobsServiceResource.java b/quarkus/addons/jobs/common/rest-callback/src/main/java/org/kie/kogito/jobs/quarkus/common/CallbackJobsServiceResource.java
 index 270cb5fa8a..58f1702b6e 100644
 --- a/quarkus/addons/jobs/common/rest-callback/src/main/java/org/kie/kogito/jobs/quarkus/common/CallbackJobsServiceResource.java
@@ -2817,45 +923,10 @@ index 5fcd29c913..cc568d7493 100644
  import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
  import static org.mockito.ArgumentMatchers.any;
  import static org.mockito.Mockito.doReturn;
-diff --git a/quarkus/addons/jobs/knative-eventing/deployment/pom.xml b/quarkus/addons/jobs/knative-eventing/deployment/pom.xml
-index fce1b7c0fc..ad27536430 100644
---- a/quarkus/addons/jobs/knative-eventing/deployment/pom.xml
-+++ b/quarkus/addons/jobs/knative-eventing/deployment/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-jobs-knative-eventing-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-jobs-knative-eventing-deployment</artifactId>
-   <name>Kogito Add-Ons Quarkus Jobs Knative Eventing - Deployment</name>
-diff --git a/quarkus/addons/jobs/knative-eventing/pom.xml b/quarkus/addons/jobs/knative-eventing/pom.xml
-index 07665272a7..2462f69508 100644
---- a/quarkus/addons/jobs/knative-eventing/pom.xml
-+++ b/quarkus/addons/jobs/knative-eventing/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-jobs-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-addons-quarkus-jobs-knative-eventing-parent</artifactId>
 diff --git a/quarkus/addons/jobs/knative-eventing/runtime/pom.xml b/quarkus/addons/jobs/knative-eventing/runtime/pom.xml
-index ad641090c9..01ecfd788d 100644
+index ad641090c9..2972fb53c9 100644
 --- a/quarkus/addons/jobs/knative-eventing/runtime/pom.xml
 +++ b/quarkus/addons/jobs/knative-eventing/runtime/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-jobs-knative-eventing-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-jobs-knative-eventing</artifactId>
-   <name>Kogito Add-Ons Quarkus Jobs - Knative Eventing</name>
 @@ -82,7 +82,7 @@
      <plugins>
        <plugin>
@@ -2893,45 +964,10 @@ index c4da02e7fa..a1d9e27e8a 100644
  
  import org.eclipse.microprofile.reactive.messaging.Emitter;
  import org.eclipse.microprofile.reactive.messaging.Message;
-diff --git a/quarkus/addons/jobs/management/deployment/pom.xml b/quarkus/addons/jobs/management/deployment/pom.xml
-index 492826d606..d2e60d28dd 100644
---- a/quarkus/addons/jobs/management/deployment/pom.xml
-+++ b/quarkus/addons/jobs/management/deployment/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-jobs-management-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-jobs-management-deployment</artifactId>
-   <name>Kogito Add-Ons Quarkus Jobs Management - Deployment</name>
-diff --git a/quarkus/addons/jobs/management/pom.xml b/quarkus/addons/jobs/management/pom.xml
-index ea155107ae..f49b3823d6 100644
---- a/quarkus/addons/jobs/management/pom.xml
-+++ b/quarkus/addons/jobs/management/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-jobs-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-addons-quarkus-jobs-management-parent</artifactId>
 diff --git a/quarkus/addons/jobs/management/runtime/pom.xml b/quarkus/addons/jobs/management/runtime/pom.xml
-index a0f478bb08..7206b5d822 100644
+index a0f478bb08..59d24ff4db 100644
 --- a/quarkus/addons/jobs/management/runtime/pom.xml
 +++ b/quarkus/addons/jobs/management/runtime/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-jobs-management-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-jobs-management</artifactId>
-   <name>Kogito Add-Ons Quarkus Jobs - Management</name>
 @@ -90,7 +90,7 @@
      <plugins>
        <plugin>
@@ -2987,45 +1023,10 @@ index 6f994f007e..a01b931f2a 100644
  
  import org.junit.jupiter.api.Test;
  import org.junit.jupiter.api.extension.ExtendWith;
-diff --git a/quarkus/addons/jobs/messaging/deployment/pom.xml b/quarkus/addons/jobs/messaging/deployment/pom.xml
-index d00bfd7e02..09c599c64b 100644
---- a/quarkus/addons/jobs/messaging/deployment/pom.xml
-+++ b/quarkus/addons/jobs/messaging/deployment/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-jobs-messaging-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-jobs-messaging-deployment</artifactId>
-   <name>Kogito Add-Ons Quarkus Jobs Messaging - Deployment</name>
-diff --git a/quarkus/addons/jobs/messaging/pom.xml b/quarkus/addons/jobs/messaging/pom.xml
-index 532af342ad..b353dd74d9 100644
---- a/quarkus/addons/jobs/messaging/pom.xml
-+++ b/quarkus/addons/jobs/messaging/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-jobs-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-addons-quarkus-jobs-messaging-parent</artifactId>
 diff --git a/quarkus/addons/jobs/messaging/runtime/pom.xml b/quarkus/addons/jobs/messaging/runtime/pom.xml
-index 0e91be1cfc..2e4b2584b3 100644
+index 0e91be1cfc..56c0cea7ed 100644
 --- a/quarkus/addons/jobs/messaging/runtime/pom.xml
 +++ b/quarkus/addons/jobs/messaging/runtime/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-jobs-messaging-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-jobs-messaging</artifactId>
-   <name>Kogito Add-Ons Quarkus Jobs - Messaging</name>
 @@ -87,7 +87,7 @@
      <plugins>
        <plugin>
@@ -3050,58 +1051,10 @@ index 9894ced190..7052f46fe3 100644
  
  import org.eclipse.microprofile.config.inject.ConfigProperty;
  import org.eclipse.microprofile.reactive.messaging.Channel;
-diff --git a/quarkus/addons/jobs/pom.xml b/quarkus/addons/jobs/pom.xml
-index 6e6a06c90a..34440aafaf 100644
---- a/quarkus/addons/jobs/pom.xml
-+++ b/quarkus/addons/jobs/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-addons-quarkus-jobs-parent</artifactId>
-diff --git a/quarkus/addons/knative/eventing/deployment/pom.xml b/quarkus/addons/knative/eventing/deployment/pom.xml
-index 2971323f2f..e3fa3b4d51 100644
---- a/quarkus/addons/knative/eventing/deployment/pom.xml
-+++ b/quarkus/addons/knative/eventing/deployment/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-knative-eventing-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-knative-eventing-deployment</artifactId>
-   <name>Kogito Add-On Knative Eventing - Deployment</name>
-diff --git a/quarkus/addons/knative/eventing/pom.xml b/quarkus/addons/knative/eventing/pom.xml
-index 4c8d470e57..0091b3f6b0 100644
---- a/quarkus/addons/knative/eventing/pom.xml
-+++ b/quarkus/addons/knative/eventing/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-knative-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-addons-quarkus-knative-eventing-parent</artifactId>
 diff --git a/quarkus/addons/knative/eventing/runtime/pom.xml b/quarkus/addons/knative/eventing/runtime/pom.xml
-index c0f137fc5a..f8a201f87b 100644
+index c0f137fc5a..4a2d16a435 100644
 --- a/quarkus/addons/knative/eventing/runtime/pom.xml
 +++ b/quarkus/addons/knative/eventing/runtime/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-quarkus-knative-eventing-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
 @@ -38,7 +38,7 @@
      <plugins>
        <plugin>
@@ -3124,58 +1077,10 @@ index 92771a52f3..1a2dfbd2cf 100644
  
  import org.eclipse.microprofile.health.HealthCheck;
  import org.eclipse.microprofile.health.HealthCheckResponse;
-diff --git a/quarkus/addons/knative/pom.xml b/quarkus/addons/knative/pom.xml
-index 80db20caf7..f3649ba2fc 100644
---- a/quarkus/addons/knative/pom.xml
-+++ b/quarkus/addons/knative/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-quarkus-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/quarkus/addons/knative/serving/deployment/pom.xml b/quarkus/addons/knative/serving/deployment/pom.xml
-index ce5d66cc00..f40d3538a3 100644
---- a/quarkus/addons/knative/serving/deployment/pom.xml
-+++ b/quarkus/addons/knative/serving/deployment/pom.xml
-@@ -6,7 +6,7 @@
-     <parent>
-         <groupId>org.kie.kogito</groupId>
-         <artifactId>kogito-addons-quarkus-knative-serving-parent</artifactId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
- 
-     <artifactId>kogito-addons-quarkus-knative-serving-deployment</artifactId>
-diff --git a/quarkus/addons/knative/serving/pom.xml b/quarkus/addons/knative/serving/pom.xml
-index ea7cd0d019..0e1e9d4f6f 100644
---- a/quarkus/addons/knative/serving/pom.xml
-+++ b/quarkus/addons/knative/serving/pom.xml
-@@ -6,7 +6,7 @@
-     <parent>
-         <groupId>org.kie.kogito</groupId>
-         <artifactId>kogito-addons-quarkus-knative-parent</artifactId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
- 
-     <artifactId>kogito-addons-quarkus-knative-serving-parent</artifactId>
 diff --git a/quarkus/addons/knative/serving/runtime/pom.xml b/quarkus/addons/knative/serving/runtime/pom.xml
-index 75a9ffdb38..ef1a838958 100644
+index 75a9ffdb38..38a5c63ae8 100644
 --- a/quarkus/addons/knative/serving/runtime/pom.xml
 +++ b/quarkus/addons/knative/serving/runtime/pom.xml
-@@ -5,7 +5,7 @@
-     <parent>
-         <groupId>org.kie.kogito</groupId>
-         <artifactId>kogito-addons-quarkus-knative-serving-parent</artifactId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
-     <modelVersion>4.0.0</modelVersion>
- 
 @@ -76,7 +76,7 @@
          <plugins>
              <plugin>
@@ -3312,19 +1217,6 @@ index 15cf23aefc..8e277efd86 100644
  
  import org.eclipse.microprofile.config.inject.ConfigProperty;
  import org.junit.jupiter.api.AfterAll;
-diff --git a/quarkus/addons/kubernetes/deployment/pom.xml b/quarkus/addons/kubernetes/deployment/pom.xml
-index c265505adf..240d6cdfec 100644
---- a/quarkus/addons/kubernetes/deployment/pom.xml
-+++ b/quarkus/addons/kubernetes/deployment/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-kubernetes-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-kubernetes-deployment</artifactId>
-   <name>Kogito Add-On Kubernetes - Deployment</name>
 diff --git a/quarkus/addons/kubernetes/deployment/src/test/java/org/kie/kogito/addons/quarkus/kubernetes/KubernetesAddOnTest.java b/quarkus/addons/kubernetes/deployment/src/test/java/org/kie/kogito/addons/quarkus/kubernetes/KubernetesAddOnTest.java
 index e1549df41b..77a4491cbd 100644
 --- a/quarkus/addons/kubernetes/deployment/src/test/java/org/kie/kogito/addons/quarkus/kubernetes/KubernetesAddOnTest.java
@@ -3338,32 +1230,10 @@ index e1549df41b..77a4491cbd 100644
  
  import org.jboss.shrinkwrap.api.ShrinkWrap;
  import org.jboss.shrinkwrap.api.spec.JavaArchive;
-diff --git a/quarkus/addons/kubernetes/pom.xml b/quarkus/addons/kubernetes/pom.xml
-index e0450efd4f..534cb53fab 100644
---- a/quarkus/addons/kubernetes/pom.xml
-+++ b/quarkus/addons/kubernetes/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-quarkus-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
 diff --git a/quarkus/addons/kubernetes/runtime/pom.xml b/quarkus/addons/kubernetes/runtime/pom.xml
-index 8c2951cf09..0ff739f21b 100644
+index 8c2951cf09..3888092318 100644
 --- a/quarkus/addons/kubernetes/runtime/pom.xml
 +++ b/quarkus/addons/kubernetes/runtime/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-kubernetes-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-kubernetes</artifactId>
-   <name>Kogito Add-On Kubernetes</name>
 @@ -71,7 +71,7 @@
      <plugins>
        <plugin>
@@ -3611,58 +1481,10 @@ index e559e1f2d9..10b356868b 100644
  
  import org.junit.jupiter.api.BeforeEach;
  import org.junit.jupiter.api.Test;
-diff --git a/quarkus/addons/kubernetes/test-utils/pom.xml b/quarkus/addons/kubernetes/test-utils/pom.xml
-index 7b2c01d10e..7d31a32ec9 100644
---- a/quarkus/addons/kubernetes/test-utils/pom.xml
-+++ b/quarkus/addons/kubernetes/test-utils/pom.xml
-@@ -6,7 +6,7 @@
-     <parent>
-         <groupId>org.kie.kogito</groupId>
-         <artifactId>kogito-addons-quarkus-kubernetes-parent</artifactId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
-     <artifactId>kogito-addons-quarkus-kubernetes-test-utils</artifactId>
-     <name>Kogito Add-On Kubernetes Tests Utils</name>
-diff --git a/quarkus/addons/mail/deployment/pom.xml b/quarkus/addons/mail/deployment/pom.xml
-index 95ec85e465..a0587c1c23 100644
---- a/quarkus/addons/mail/deployment/pom.xml
-+++ b/quarkus/addons/mail/deployment/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-mail-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-mail-deployment</artifactId>
-   <name>Kogito Add-On Mail - Deployment</name>
-diff --git a/quarkus/addons/mail/pom.xml b/quarkus/addons/mail/pom.xml
-index 77b36e61cc..7935b7b7c2 100644
---- a/quarkus/addons/mail/pom.xml
-+++ b/quarkus/addons/mail/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-addons-quarkus-mail-parent</artifactId>
 diff --git a/quarkus/addons/mail/runtime/pom.xml b/quarkus/addons/mail/runtime/pom.xml
-index af87d750fe..19a848deae 100644
+index af87d750fe..d967d932c6 100644
 --- a/quarkus/addons/mail/runtime/pom.xml
 +++ b/quarkus/addons/mail/runtime/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-mail-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-mail</artifactId>
-   <name>Kogito Add-On Mail</name>
 @@ -41,7 +41,7 @@
      <plugins>
        <plugin>
@@ -3700,45 +1522,10 @@ index bf5c0438ea..4e4cb5d4e3 100644
  
  import org.junit.jupiter.api.BeforeEach;
  import org.junit.jupiter.api.Test;
-diff --git a/quarkus/addons/marshallers/avro/deployment/pom.xml b/quarkus/addons/marshallers/avro/deployment/pom.xml
-index 8b5871d221..17a812b128 100644
---- a/quarkus/addons/marshallers/avro/deployment/pom.xml
-+++ b/quarkus/addons/marshallers/avro/deployment/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-marshallers-avro-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-addons-quarkus-marshallers-avro-deployment</artifactId>
-diff --git a/quarkus/addons/marshallers/avro/pom.xml b/quarkus/addons/marshallers/avro/pom.xml
-index d7afb0be86..1de19595d8 100644
---- a/quarkus/addons/marshallers/avro/pom.xml
-+++ b/quarkus/addons/marshallers/avro/pom.xml
-@@ -3,7 +3,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-marshallers-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-marshallers-avro-parent</artifactId>
-   <packaging>pom</packaging>
 diff --git a/quarkus/addons/marshallers/avro/runtime/pom.xml b/quarkus/addons/marshallers/avro/runtime/pom.xml
-index 608b072048..c34a0a31f6 100644
+index 608b072048..26b16c3d65 100644
 --- a/quarkus/addons/marshallers/avro/runtime/pom.xml
 +++ b/quarkus/addons/marshallers/avro/runtime/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-marshallers-avro-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-addons-quarkus-marshallers-avro</artifactId>
 @@ -27,7 +27,7 @@
      <plugins>
         <plugin>
@@ -3748,32 +1535,6 @@ index 608b072048..c34a0a31f6 100644
          <version>${version.io.quarkus}</version>
          <executions>
            <execution>
-diff --git a/quarkus/addons/marshallers/pom.xml b/quarkus/addons/marshallers/pom.xml
-index 4b99a1e9fd..0457f0e3f3 100644
---- a/quarkus/addons/marshallers/pom.xml
-+++ b/quarkus/addons/marshallers/pom.xml
-@@ -3,7 +3,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-marshallers-parent</artifactId>
-   <packaging>pom</packaging>
-diff --git a/quarkus/addons/messaging/common/pom.xml b/quarkus/addons/messaging/common/pom.xml
-index 6f5dd4363d..1576d3c6be 100644
---- a/quarkus/addons/messaging/common/pom.xml
-+++ b/quarkus/addons/messaging/common/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-messaging-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-messaging-common</artifactId>
-   <name>Kogito Add-On Messaging - Common</name>
 diff --git a/quarkus/addons/messaging/common/src/main/java/org/kie/kogito/addon/quarkus/messaging/common/AbstractQuarkusCloudEventEmitter.java b/quarkus/addons/messaging/common/src/main/java/org/kie/kogito/addon/quarkus/messaging/common/AbstractQuarkusCloudEventEmitter.java
 index e1d5202e5b..49c8b27d0d 100644
 --- a/quarkus/addons/messaging/common/src/main/java/org/kie/kogito/addon/quarkus/messaging/common/AbstractQuarkusCloudEventEmitter.java
@@ -4018,19 +1779,6 @@ index dbf71649a4..f3e727574f 100644
  
  import org.eclipse.microprofile.reactive.messaging.Message;
  import org.junit.jupiter.api.Test;
-diff --git a/quarkus/addons/messaging/deployment/pom.xml b/quarkus/addons/messaging/deployment/pom.xml
-index e2f9527fb4..18f46103c8 100644
---- a/quarkus/addons/messaging/deployment/pom.xml
-+++ b/quarkus/addons/messaging/deployment/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-messaging-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-messaging-deployment</artifactId>
-   <name>Kogito Add-On Messaging - Deployment</name>
 diff --git a/quarkus/addons/messaging/deployment/src/main/resources/class-templates/ChannelQualifierQuarkusTemplate.java b/quarkus/addons/messaging/deployment/src/main/resources/class-templates/ChannelQualifierQuarkusTemplate.java
 index 41974d80c5..c0758ca7d7 100644
 --- a/quarkus/addons/messaging/deployment/src/main/resources/class-templates/ChannelQualifierQuarkusTemplate.java
@@ -4079,32 +1827,10 @@ index 8a23525327..acbd1c48ca 100644
  
  
  import io.quarkus.runtime.Startup;
-diff --git a/quarkus/addons/messaging/pom.xml b/quarkus/addons/messaging/pom.xml
-index 38f0cfe451..0143e84a2c 100644
---- a/quarkus/addons/messaging/pom.xml
-+++ b/quarkus/addons/messaging/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-messaging-parent</artifactId>
-   <packaging>pom</packaging>
 diff --git a/quarkus/addons/messaging/runtime/pom.xml b/quarkus/addons/messaging/runtime/pom.xml
-index d5a81c2cef..4279dc66a4 100644
+index d5a81c2cef..b80ef76384 100644
 --- a/quarkus/addons/messaging/runtime/pom.xml
 +++ b/quarkus/addons/messaging/runtime/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-quarkus-messaging-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
 @@ -52,7 +52,7 @@
        </plugin>
        <plugin>
@@ -4131,19 +1857,6 @@ index d6618e0ffd..1e820b4df2 100644
  
  import org.kie.kogito.addon.quarkus.messaging.common.AbstractQuarkusCloudEventReceiver;
  import org.kie.kogito.config.ConfigBean;
-diff --git a/quarkus/addons/monitoring/core/pom.xml b/quarkus/addons/monitoring/core/pom.xml
-index 64502e78f8..9c2c2d6140 100644
---- a/quarkus/addons/monitoring/core/pom.xml
-+++ b/quarkus/addons/monitoring/core/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-quarkus-monitoring-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
-   <artifactId>kogito-addons-quarkus-monitoring-core</artifactId>
 diff --git a/quarkus/addons/monitoring/core/src/main/java/org/kie/kogito/monitoring/core/quarkus/QuarkusEventListenerFactory.java b/quarkus/addons/monitoring/core/src/main/java/org/kie/kogito/monitoring/core/quarkus/QuarkusEventListenerFactory.java
 index c0dc15fd1d..478cd757c5 100644
 --- a/quarkus/addons/monitoring/core/src/main/java/org/kie/kogito/monitoring/core/quarkus/QuarkusEventListenerFactory.java
@@ -4253,45 +1966,10 @@ index ecd08becd3..14989d4d53 100644
  
  import org.junit.jupiter.api.Test;
  import org.kie.kogito.monitoring.core.common.system.interceptor.MetricsInterceptor;
-diff --git a/quarkus/addons/monitoring/elastic/deployment/pom.xml b/quarkus/addons/monitoring/elastic/deployment/pom.xml
-index 0ce27bc05b..a2026551c6 100644
---- a/quarkus/addons/monitoring/elastic/deployment/pom.xml
-+++ b/quarkus/addons/monitoring/elastic/deployment/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-monitoring-elastic-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-monitoring-elastic-deployment</artifactId>
-   <name>Kogito Add-On Monitoring Elastic - Deployment</name>
-diff --git a/quarkus/addons/monitoring/elastic/pom.xml b/quarkus/addons/monitoring/elastic/pom.xml
-index 6165d2f198..2c975a8a78 100644
---- a/quarkus/addons/monitoring/elastic/pom.xml
-+++ b/quarkus/addons/monitoring/elastic/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-monitoring-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-monitoring-elastic-parent</artifactId>
-   <packaging>pom</packaging>
 diff --git a/quarkus/addons/monitoring/elastic/runtime/pom.xml b/quarkus/addons/monitoring/elastic/runtime/pom.xml
-index 4487866fb2..2884eb1a17 100644
+index 4487866fb2..393d1f3e8a 100644
 --- a/quarkus/addons/monitoring/elastic/runtime/pom.xml
 +++ b/quarkus/addons/monitoring/elastic/runtime/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-quarkus-monitoring-elastic-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
 @@ -32,7 +32,7 @@
      <plugins>
        <plugin>
@@ -4316,58 +1994,10 @@ index 08dd6c8568..2097ed9d8a 100644
  
  import org.eclipse.microprofile.config.inject.ConfigProperty;
  import org.kie.kogito.monitoring.elastic.common.ElasticConfigFactory;
-diff --git a/quarkus/addons/monitoring/pom.xml b/quarkus/addons/monitoring/pom.xml
-index c1438df0f2..6c54df52cc 100644
---- a/quarkus/addons/monitoring/pom.xml
-+++ b/quarkus/addons/monitoring/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-quarkus-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/quarkus/addons/monitoring/prometheus/deployment/pom.xml b/quarkus/addons/monitoring/prometheus/deployment/pom.xml
-index eb126516af..54e17c33a5 100644
---- a/quarkus/addons/monitoring/prometheus/deployment/pom.xml
-+++ b/quarkus/addons/monitoring/prometheus/deployment/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-monitoring-prometheus-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-monitoring-prometheus-deployment</artifactId>
-   <name>Kogito Add-On Monitoring Prometheus - Deployment</name>
-diff --git a/quarkus/addons/monitoring/prometheus/pom.xml b/quarkus/addons/monitoring/prometheus/pom.xml
-index 5b213f6417..cae730d15b 100644
---- a/quarkus/addons/monitoring/prometheus/pom.xml
-+++ b/quarkus/addons/monitoring/prometheus/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-monitoring-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-monitoring-prometheus-parent</artifactId>
-   <packaging>pom</packaging>
 diff --git a/quarkus/addons/monitoring/prometheus/runtime/pom.xml b/quarkus/addons/monitoring/prometheus/runtime/pom.xml
-index c3ac08f49e..52b8e1f7a3 100644
+index c3ac08f49e..6b53bd08a0 100644
 --- a/quarkus/addons/monitoring/prometheus/runtime/pom.xml
 +++ b/quarkus/addons/monitoring/prometheus/runtime/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-quarkus-monitoring-prometheus-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
 @@ -53,7 +53,7 @@
      <plugins>
        <plugin>
@@ -4377,45 +2007,10 @@ index c3ac08f49e..52b8e1f7a3 100644
          <version>${version.io.quarkus}</version>
          <executions>
            <execution>
-diff --git a/quarkus/addons/persistence/filesystem/deployment/pom.xml b/quarkus/addons/persistence/filesystem/deployment/pom.xml
-index a69e6bbec8..b8e20d352f 100644
---- a/quarkus/addons/persistence/filesystem/deployment/pom.xml
-+++ b/quarkus/addons/persistence/filesystem/deployment/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-persistence-filesystem-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-persistence-filesystem-deployment</artifactId>
-   <name>Kogito Add-On Persistence FileSystem - Deployment</name>
-diff --git a/quarkus/addons/persistence/filesystem/pom.xml b/quarkus/addons/persistence/filesystem/pom.xml
-index f2fb6cf961..e70881f352 100644
---- a/quarkus/addons/persistence/filesystem/pom.xml
-+++ b/quarkus/addons/persistence/filesystem/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-persistence-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-persistence-filesystem-parent</artifactId>
-   <packaging>pom</packaging>
 diff --git a/quarkus/addons/persistence/filesystem/runtime/pom.xml b/quarkus/addons/persistence/filesystem/runtime/pom.xml
-index b1f0446419..23f2600ec9 100644
+index b1f0446419..5e93af241f 100644
 --- a/quarkus/addons/persistence/filesystem/runtime/pom.xml
 +++ b/quarkus/addons/persistence/filesystem/runtime/pom.xml
-@@ -21,7 +21,7 @@
-   <parent>
-     <artifactId>kogito-addons-quarkus-persistence-filesystem-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
 @@ -58,7 +58,7 @@
        </plugin>
        <plugin>
@@ -4440,32 +2035,6 @@ index 0fd6369208..f5bb74e762 100644
  
  import org.eclipse.microprofile.config.inject.ConfigProperty;
  import org.kie.kogito.persistence.filesystem.AbstractProcessInstancesFactory;
-diff --git a/quarkus/addons/persistence/infinispan/deployment/pom.xml b/quarkus/addons/persistence/infinispan/deployment/pom.xml
-index bf178fbbf5..c23798caa3 100644
---- a/quarkus/addons/persistence/infinispan/deployment/pom.xml
-+++ b/quarkus/addons/persistence/infinispan/deployment/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-persistence-infinispan-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-persistence-infinispan-deployment</artifactId>
-   <name>Kogito Add-On Persistence Infinispan - Deployment</name>
-diff --git a/quarkus/addons/persistence/infinispan/health/pom.xml b/quarkus/addons/persistence/infinispan/health/pom.xml
-index 13c878cdd6..f279bce6c7 100644
---- a/quarkus/addons/persistence/infinispan/health/pom.xml
-+++ b/quarkus/addons/persistence/infinispan/health/pom.xml
-@@ -21,7 +21,7 @@
-   <parent>
-     <artifactId>kogito-addons-quarkus-persistence-infinispan-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
 diff --git a/quarkus/addons/persistence/infinispan/health/src/main/java/org/kie/kogito/infinispan/health/InfinispanHealthCheck.java b/quarkus/addons/persistence/infinispan/health/src/main/java/org/kie/kogito/infinispan/health/InfinispanHealthCheck.java
 index 92245898e4..2b7b0e20e2 100644
 --- a/quarkus/addons/persistence/infinispan/health/src/main/java/org/kie/kogito/infinispan/health/InfinispanHealthCheck.java
@@ -4497,32 +2066,10 @@ index 2107932098..ee1c2a50f2 100644
  import org.eclipse.microprofile.health.HealthCheckResponse;
  import org.infinispan.client.hotrod.RemoteCacheManager;
  import org.junit.jupiter.api.Test;
-diff --git a/quarkus/addons/persistence/infinispan/pom.xml b/quarkus/addons/persistence/infinispan/pom.xml
-index 15a7974073..37b3985865 100644
---- a/quarkus/addons/persistence/infinispan/pom.xml
-+++ b/quarkus/addons/persistence/infinispan/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-persistence-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-persistence-infinispan-parent</artifactId>
-   <packaging>pom</packaging>
 diff --git a/quarkus/addons/persistence/infinispan/runtime/pom.xml b/quarkus/addons/persistence/infinispan/runtime/pom.xml
-index 8482d8911c..907d9c04c0 100644
+index 8482d8911c..739dab2a7b 100644
 --- a/quarkus/addons/persistence/infinispan/runtime/pom.xml
 +++ b/quarkus/addons/persistence/infinispan/runtime/pom.xml
-@@ -21,7 +21,7 @@
-   <parent>
-     <artifactId>kogito-addons-quarkus-persistence-infinispan-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
 @@ -58,7 +58,7 @@
        </plugin>
        <plugin>
@@ -4547,45 +2094,10 @@ index 96d2192088..9e34b69376 100644
  
  import org.eclipse.microprofile.config.inject.ConfigProperty;
  import org.infinispan.client.hotrod.RemoteCacheManager;
-diff --git a/quarkus/addons/persistence/jdbc/deployment/pom.xml b/quarkus/addons/persistence/jdbc/deployment/pom.xml
-index 37b8a87e15..1b01a34254 100644
---- a/quarkus/addons/persistence/jdbc/deployment/pom.xml
-+++ b/quarkus/addons/persistence/jdbc/deployment/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-persistence-jdbc-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-persistence-jdbc-deployment</artifactId>
-   <name>Kogito Add-On Persistence JDBC - Deployment</name>
-diff --git a/quarkus/addons/persistence/jdbc/pom.xml b/quarkus/addons/persistence/jdbc/pom.xml
-index 776ed4adb8..94aadecbb1 100644
---- a/quarkus/addons/persistence/jdbc/pom.xml
-+++ b/quarkus/addons/persistence/jdbc/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-persistence-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-persistence-jdbc-parent</artifactId>
-   <packaging>pom</packaging>
 diff --git a/quarkus/addons/persistence/jdbc/runtime/pom.xml b/quarkus/addons/persistence/jdbc/runtime/pom.xml
-index 3b5bf94b2e..93eb0f00c7 100644
+index 3b5bf94b2e..eab5ac273e 100644
 --- a/quarkus/addons/persistence/jdbc/runtime/pom.xml
 +++ b/quarkus/addons/persistence/jdbc/runtime/pom.xml
-@@ -21,7 +21,7 @@
-   <parent>
-     <artifactId>kogito-addons-quarkus-persistence-jdbc-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
 @@ -72,7 +72,7 @@
        </plugin>
        <plugin>
@@ -4623,45 +2135,10 @@ index 45d6fe1144..33a13bba2c 100644
  import javax.sql.DataSource;
  
  import org.kie.kogito.correlation.CorrelationService;
-diff --git a/quarkus/addons/persistence/kafka/deployment/pom.xml b/quarkus/addons/persistence/kafka/deployment/pom.xml
-index c8e3ad3c42..0b4ce96f40 100644
---- a/quarkus/addons/persistence/kafka/deployment/pom.xml
-+++ b/quarkus/addons/persistence/kafka/deployment/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-persistence-kafka-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-persistence-kafka-deployment</artifactId>
-   <name>Kogito Add-On Persistence Kafka Streams - Deployment</name>
-diff --git a/quarkus/addons/persistence/kafka/pom.xml b/quarkus/addons/persistence/kafka/pom.xml
-index e18c60d294..da521d1d0f 100644
---- a/quarkus/addons/persistence/kafka/pom.xml
-+++ b/quarkus/addons/persistence/kafka/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-persistence-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-persistence-kafka-parent</artifactId>
-   <packaging>pom</packaging>
 diff --git a/quarkus/addons/persistence/kafka/runtime/pom.xml b/quarkus/addons/persistence/kafka/runtime/pom.xml
-index 4180a4c9b7..97757b9d88 100644
+index 4180a4c9b7..6c7c92cd5e 100644
 --- a/quarkus/addons/persistence/kafka/runtime/pom.xml
 +++ b/quarkus/addons/persistence/kafka/runtime/pom.xml
-@@ -21,7 +21,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-persistence-kafka-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
 @@ -117,7 +117,7 @@
        </plugin>
        <plugin>
@@ -4722,45 +2199,10 @@ index 641b7e691a..c3ec471b68 100644
  
  import org.apache.kafka.streams.Topology;
  
-diff --git a/quarkus/addons/persistence/mongodb/deployment/pom.xml b/quarkus/addons/persistence/mongodb/deployment/pom.xml
-index 2116170cae..13f90f23c9 100644
---- a/quarkus/addons/persistence/mongodb/deployment/pom.xml
-+++ b/quarkus/addons/persistence/mongodb/deployment/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-persistence-mongodb-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-persistence-mongodb-deployment</artifactId>
-   <name>Kogito Add-On Persistence MongoDB - Deployment</name>
-diff --git a/quarkus/addons/persistence/mongodb/pom.xml b/quarkus/addons/persistence/mongodb/pom.xml
-index 87954ca857..a47097409f 100644
---- a/quarkus/addons/persistence/mongodb/pom.xml
-+++ b/quarkus/addons/persistence/mongodb/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-persistence-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-persistence-mongodb-parent</artifactId>
-   <packaging>pom</packaging>
 diff --git a/quarkus/addons/persistence/mongodb/runtime/pom.xml b/quarkus/addons/persistence/mongodb/runtime/pom.xml
-index dff5d8ac92..dca11aa7d5 100644
+index dff5d8ac92..3f58530ef0 100644
 --- a/quarkus/addons/persistence/mongodb/runtime/pom.xml
 +++ b/quarkus/addons/persistence/mongodb/runtime/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-quarkus-persistence-mongodb-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
 @@ -46,7 +46,7 @@
        </plugin>
        <plugin>
@@ -4800,58 +2242,10 @@ index b216cb27bf..f921041a20 100644
  
  import org.eclipse.microprofile.config.inject.ConfigProperty;
  import org.kie.kogito.mongodb.transaction.AbstractTransactionManager;
-diff --git a/quarkus/addons/persistence/pom.xml b/quarkus/addons/persistence/pom.xml
-index ef4914c150..0d426b7c6f 100644
---- a/quarkus/addons/persistence/pom.xml
-+++ b/quarkus/addons/persistence/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-quarkus-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/quarkus/addons/persistence/postgresql/deployment/pom.xml b/quarkus/addons/persistence/postgresql/deployment/pom.xml
-index c060803b7f..252a137467 100644
---- a/quarkus/addons/persistence/postgresql/deployment/pom.xml
-+++ b/quarkus/addons/persistence/postgresql/deployment/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-persistence-postgresql-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-persistence-postgresql-deployment</artifactId>
-   <name>Kogito Add-On Persistence PostgreSQL - Deployment</name>
-diff --git a/quarkus/addons/persistence/postgresql/pom.xml b/quarkus/addons/persistence/postgresql/pom.xml
-index 7b5043c0d8..074a2f1eb2 100644
---- a/quarkus/addons/persistence/postgresql/pom.xml
-+++ b/quarkus/addons/persistence/postgresql/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-persistence-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-persistence-postgresql-parent</artifactId>
-   <packaging>pom</packaging>
 diff --git a/quarkus/addons/persistence/postgresql/runtime/pom.xml b/quarkus/addons/persistence/postgresql/runtime/pom.xml
-index 313e265e12..9fe3724f8d 100644
+index 313e265e12..0eec3b0607 100644
 --- a/quarkus/addons/persistence/postgresql/runtime/pom.xml
 +++ b/quarkus/addons/persistence/postgresql/runtime/pom.xml
-@@ -21,7 +21,7 @@
-   <parent>
-     <artifactId>kogito-addons-quarkus-persistence-postgresql-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
 @@ -71,7 +71,7 @@
        </plugin>
        <plugin>
@@ -4876,45 +2270,10 @@ index 613dc845ed..60d4d45251 100644
  
  import org.eclipse.microprofile.config.inject.ConfigProperty;
  import org.kie.kogito.persistence.postgresql.AbstractProcessInstancesFactory;
-diff --git a/quarkus/addons/persistence/rocksdb/deployment/pom.xml b/quarkus/addons/persistence/rocksdb/deployment/pom.xml
-index 337591b483..f1c888b908 100644
---- a/quarkus/addons/persistence/rocksdb/deployment/pom.xml
-+++ b/quarkus/addons/persistence/rocksdb/deployment/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-persistence-rocksdb-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-persistence-rocksdb-deployment</artifactId>
-   <name>Kogito Add-On Persistence Rocksdb - Deployment</name>
-diff --git a/quarkus/addons/persistence/rocksdb/pom.xml b/quarkus/addons/persistence/rocksdb/pom.xml
-index 6de5c52ee2..011f54ae33 100644
---- a/quarkus/addons/persistence/rocksdb/pom.xml
-+++ b/quarkus/addons/persistence/rocksdb/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-persistence-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-persistence-rocksdb-parent</artifactId>
-   <packaging>pom</packaging>
 diff --git a/quarkus/addons/persistence/rocksdb/runtime/pom.xml b/quarkus/addons/persistence/rocksdb/runtime/pom.xml
-index 63f8fecb62..0d61f45067 100644
+index 63f8fecb62..977fccae63 100644
 --- a/quarkus/addons/persistence/rocksdb/runtime/pom.xml
 +++ b/quarkus/addons/persistence/rocksdb/runtime/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-quarkus-persistence-rocksdb-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
 @@ -41,7 +41,7 @@
        </plugin>
        <plugin>
@@ -4946,58 +2305,10 @@ index 83e7d81c55..8daa52c6e1 100644
  import org.kie.kogito.persistence.rocksdb.RocksDBProcessInstancesFactory;
  import org.kie.kogito.process.ProcessInstancesFactory;
  import org.rocksdb.Options;
-diff --git a/quarkus/addons/pom.xml b/quarkus/addons/pom.xml
-index 6c77056956..4d19133602 100644
---- a/quarkus/addons/pom.xml
-+++ b/quarkus/addons/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-quarkus-bom</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-     <relativePath>../bom/pom.xml</relativePath>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
-diff --git a/quarkus/addons/process-management/deployment/pom.xml b/quarkus/addons/process-management/deployment/pom.xml
-index a145b634c1..70068dc95d 100644
---- a/quarkus/addons/process-management/deployment/pom.xml
-+++ b/quarkus/addons/process-management/deployment/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-process-management-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-process-management-deployment</artifactId>
-   <name>Kogito Add-On Process Management - Deployment</name>
-diff --git a/quarkus/addons/process-management/pom.xml b/quarkus/addons/process-management/pom.xml
-index 120a2fcf44..4f1b4d082d 100644
---- a/quarkus/addons/process-management/pom.xml
-+++ b/quarkus/addons/process-management/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-quarkus-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
 diff --git a/quarkus/addons/process-management/runtime/pom.xml b/quarkus/addons/process-management/runtime/pom.xml
-index ce0eedf6cd..2e7569ba25 100644
+index ce0eedf6cd..eea0ab21f5 100644
 --- a/quarkus/addons/process-management/runtime/pom.xml
 +++ b/quarkus/addons/process-management/runtime/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-process-management-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-process-management</artifactId>
-   <name>Kogito Add-On Process Management</name>
 @@ -60,9 +60,10 @@
        <scope>test</scope>
      </dependency>
@@ -5072,45 +2383,10 @@ index cb57bd172c..0722824b67 100644
  
  import org.junit.jupiter.api.BeforeAll;
  import org.junit.jupiter.api.BeforeEach;
-diff --git a/quarkus/addons/process-svg/deployment/pom.xml b/quarkus/addons/process-svg/deployment/pom.xml
-index 0674a4eb18..1cf2bc9303 100644
---- a/quarkus/addons/process-svg/deployment/pom.xml
-+++ b/quarkus/addons/process-svg/deployment/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-process-svg-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-process-svg-deployment</artifactId>
-   <name>Kogito Add-On Process SVG - Deployment</name>
-diff --git a/quarkus/addons/process-svg/pom.xml b/quarkus/addons/process-svg/pom.xml
-index 5fa2ebc8cd..5b83956ff6 100644
---- a/quarkus/addons/process-svg/pom.xml
-+++ b/quarkus/addons/process-svg/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-quarkus-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
 diff --git a/quarkus/addons/process-svg/runtime/pom.xml b/quarkus/addons/process-svg/runtime/pom.xml
-index bce5c23278..471fecc7d2 100644
+index bce5c23278..75c510b8c4 100644
 --- a/quarkus/addons/process-svg/runtime/pom.xml
 +++ b/quarkus/addons/process-svg/runtime/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-process-svg-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-process-svg</artifactId>
-   <name>Kogito Add-On Process SVG</name>
 @@ -18,8 +18,8 @@
        <artifactId>kogito-addons-process-svg</artifactId>
      </dependency>
@@ -5194,18 +2470,9 @@ index 295de81ef7..e85b0f8c09 100644
  import org.eclipse.microprofile.config.inject.ConfigProperty;
  import org.kie.kogito.svg.AbstractProcessSvgService;
 diff --git a/quarkus/addons/rest-exception-handler/pom.xml b/quarkus/addons/rest-exception-handler/pom.xml
-index d0ffa42730..89d62e655b 100644
+index d0ffa42730..abbc56828f 100644
 --- a/quarkus/addons/rest-exception-handler/pom.xml
 +++ b/quarkus/addons/rest-exception-handler/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-rest-exception-handler</artifactId>
-   <name>Kogito :: Rest Exception Handler :: Quarkus</name>
 @@ -47,9 +47,10 @@
        <scope>test</scope>
      </dependency>
@@ -5436,45 +2703,10 @@ index d23e927288..800ab5c9b6 100644
  
  import org.junit.jupiter.api.BeforeEach;
  import org.junit.jupiter.api.Test;
-diff --git a/quarkus/addons/source-files/deployment/pom.xml b/quarkus/addons/source-files/deployment/pom.xml
-index a0c59c05ab..ad67a0933b 100644
---- a/quarkus/addons/source-files/deployment/pom.xml
-+++ b/quarkus/addons/source-files/deployment/pom.xml
-@@ -6,7 +6,7 @@
-     <parent>
-         <artifactId>kogito-addons-quarkus-source-files-parent</artifactId>
-         <groupId>org.kie.kogito</groupId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
-     <artifactId>kogito-addons-quarkus-source-files-deployment</artifactId>
-     <name>Kogito Add-On Source Files - Deployment</name>
-diff --git a/quarkus/addons/source-files/pom.xml b/quarkus/addons/source-files/pom.xml
-index d8255b9a23..6f930b0ad7 100644
---- a/quarkus/addons/source-files/pom.xml
-+++ b/quarkus/addons/source-files/pom.xml
-@@ -10,7 +10,7 @@
-     <parent>
-         <artifactId>kogito-addons-quarkus-parent</artifactId>
-         <groupId>org.kie.kogito</groupId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
-     <artifactId>kogito-addons-quarkus-source-files-parent</artifactId>
-     <packaging>pom</packaging>
 diff --git a/quarkus/addons/source-files/runtime/pom.xml b/quarkus/addons/source-files/runtime/pom.xml
-index 06f3532bfd..b0e97f0293 100644
+index 06f3532bfd..871eaaab54 100644
 --- a/quarkus/addons/source-files/runtime/pom.xml
 +++ b/quarkus/addons/source-files/runtime/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <artifactId>kogito-addons-quarkus-source-files-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-addons-quarkus-source-files</artifactId>
 @@ -103,7 +103,7 @@
          <plugins>
              <plugin>
@@ -5556,45 +2788,10 @@ index c2ad3e8355..49a0d884af 100644
  
  import org.junit.jupiter.api.BeforeEach;
  import org.junit.jupiter.api.Test;
-diff --git a/quarkus/addons/task-management/deployment/pom.xml b/quarkus/addons/task-management/deployment/pom.xml
-index b52153e73c..5f6ac6deb4 100644
---- a/quarkus/addons/task-management/deployment/pom.xml
-+++ b/quarkus/addons/task-management/deployment/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-task-management-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-task-management-deployment</artifactId>
-   <name>Kogito Add-On Task Management - Deployment</name>
-diff --git a/quarkus/addons/task-management/pom.xml b/quarkus/addons/task-management/pom.xml
-index 51ee637298..2c2a64607b 100644
---- a/quarkus/addons/task-management/pom.xml
-+++ b/quarkus/addons/task-management/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-quarkus-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
 diff --git a/quarkus/addons/task-management/runtime/pom.xml b/quarkus/addons/task-management/runtime/pom.xml
-index 02ffb5bd84..5d3aaa2554 100644
+index 02ffb5bd84..ede13669a9 100644
 --- a/quarkus/addons/task-management/runtime/pom.xml
 +++ b/quarkus/addons/task-management/runtime/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-task-management-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-task-management</artifactId>
-   <name>Kogito Add-On Task Management</name>
 @@ -61,7 +61,7 @@
      <plugins>
        <plugin>
@@ -5641,45 +2838,10 @@ index 24a604c875..764baaf1b7 100644
  
  import org.kie.kogito.process.ProcessConfig;
  import org.kie.kogito.process.Processes;
-diff --git a/quarkus/addons/task-notification/deployment/pom.xml b/quarkus/addons/task-notification/deployment/pom.xml
-index b87d5172c3..8795070479 100644
---- a/quarkus/addons/task-notification/deployment/pom.xml
-+++ b/quarkus/addons/task-notification/deployment/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-task-notification-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-task-notification-deployment</artifactId>
-   <name>Kogito Add-On Task Notification - Deployment</name>
-diff --git a/quarkus/addons/task-notification/pom.xml b/quarkus/addons/task-notification/pom.xml
-index e7158b4ae0..c17d86dd50 100644
---- a/quarkus/addons/task-notification/pom.xml
-+++ b/quarkus/addons/task-notification/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-quarkus-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
 diff --git a/quarkus/addons/task-notification/runtime/pom.xml b/quarkus/addons/task-notification/runtime/pom.xml
-index c4079745a5..e5b5bcf545 100644
+index c4079745a5..587a908f17 100644
 --- a/quarkus/addons/task-notification/runtime/pom.xml
 +++ b/quarkus/addons/task-notification/runtime/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-task-notification-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-task-notification</artifactId>
-   <name>Kogito Add-On Task Notification</name>
 @@ -63,7 +63,7 @@
      <plugins>
        <plugin>
@@ -5704,58 +2866,10 @@ index 4d8d26c4a1..7a10464d29 100644
  
  import org.eclipse.microprofile.reactive.messaging.Channel;
  import org.eclipse.microprofile.reactive.messaging.Emitter;
-diff --git a/quarkus/addons/tracing-decision/deployment/pom.xml b/quarkus/addons/tracing-decision/deployment/pom.xml
-index bcb0dbbd43..62c3ecaa99 100644
---- a/quarkus/addons/tracing-decision/deployment/pom.xml
-+++ b/quarkus/addons/tracing-decision/deployment/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-tracing-decision-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-tracing-decision-deployment</artifactId>
-   <name>Kogito Add-On Tracing Decision - Deployment</name>
-diff --git a/quarkus/addons/tracing-decision/integration-tests/pom.xml b/quarkus/addons/tracing-decision/integration-tests/pom.xml
-index 0d652a2725..1dae623869 100644
---- a/quarkus/addons/tracing-decision/integration-tests/pom.xml
-+++ b/quarkus/addons/tracing-decision/integration-tests/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-quarkus-tracing-decision-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-quarkus-tracing-decision-it</artifactId>
-   <name>Kogito Add-On Tracing Decision - Integration tests</name>
-diff --git a/quarkus/addons/tracing-decision/pom.xml b/quarkus/addons/tracing-decision/pom.xml
-index 3c1f67ad0a..059cd86056 100644
---- a/quarkus/addons/tracing-decision/pom.xml
-+++ b/quarkus/addons/tracing-decision/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-quarkus-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
 diff --git a/quarkus/addons/tracing-decision/runtime/pom.xml b/quarkus/addons/tracing-decision/runtime/pom.xml
-index df07561419..7aa9d1e76c 100644
+index df07561419..e7e7a0404d 100644
 --- a/quarkus/addons/tracing-decision/runtime/pom.xml
 +++ b/quarkus/addons/tracing-decision/runtime/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-quarkus-tracing-decision-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
 @@ -84,7 +84,7 @@
      <plugins>
        <plugin>
@@ -5840,58 +2954,6 @@ index 999d129ceb..a887b5519b 100644
  
  import org.eclipse.microprofile.reactive.messaging.Outgoing;
  import org.kie.kogito.tracing.EventEmitter;
-diff --git a/quarkus/bom/pom.xml b/quarkus/bom/pom.xml
-index 788f799cbf..2ef639bec0 100755
---- a/quarkus/bom/pom.xml
-+++ b/quarkus/bom/pom.xml
-@@ -7,7 +7,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>quarkus</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-quarkus-bom</artifactId>
-diff --git a/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-deployment/pom.xml b/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-deployment/pom.xml
-index f7b0c32227..439d7a7986 100644
---- a/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-deployment/pom.xml
-+++ b/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-deployment/pom.xml
-@@ -5,7 +5,7 @@
-     <parent>
-         <artifactId>kogito-quarkus-decisions-extension</artifactId>
-         <groupId>org.kie.kogito</groupId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
-     <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test-hot-reload/pom.xml b/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test-hot-reload/pom.xml
-index ad2ab0456d..7bd470e8be 100644
---- a/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test-hot-reload/pom.xml
-+++ b/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test-hot-reload/pom.xml
-@@ -5,7 +5,7 @@
-     <parent>
-         <artifactId>kogito-quarkus-decisions-extension</artifactId>
-         <groupId>org.kie.kogito</groupId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
-     <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test/pom.xml b/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test/pom.xml
-index 0e50b278ba..a00db5c35d 100644
---- a/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test/pom.xml
-+++ b/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test/pom.xml
-@@ -5,7 +5,7 @@
-     <parent>
-         <artifactId>kogito-quarkus-decisions-extension</artifactId>
-         <groupId>org.kie.kogito</groupId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
-     <modelVersion>4.0.0</modelVersion>
- 
 diff --git a/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test/src/main/java/org/kie/kogito/quarkus/dmn/CustomEndpoint.java b/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test/src/main/java/org/kie/kogito/quarkus/dmn/CustomEndpoint.java
 index 9a0df50ab9..af28d1a5a1 100644
 --- a/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test/src/main/java/org/kie/kogito/quarkus/dmn/CustomEndpoint.java
@@ -5916,18 +2978,9 @@ index 9a0df50ab9..af28d1a5a1 100644
  import org.kie.kogito.incubation.application.AppRoot;
  import org.kie.kogito.incubation.common.DataContext;
 diff --git a/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions/pom.xml b/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions/pom.xml
-index f3d9cb7a38..e4d4046f27 100644
+index f3d9cb7a38..34729dc886 100644
 --- a/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions/pom.xml
 +++ b/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions/pom.xml
-@@ -3,7 +3,7 @@
-     <parent>
-         <artifactId>kogito-quarkus-decisions-extension</artifactId>
-         <groupId>org.kie.kogito</groupId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
-     <modelVersion>4.0.0</modelVersion>
- 
 @@ -66,7 +66,7 @@
              </plugin>
              <plugin>
@@ -5970,32 +3023,6 @@ index 3c7cf9db4b..39d6329064 100644
  import org.kie.kogito.decision.DecisionModels;
  import org.kie.kogito.incubation.common.DataContext;
  import org.kie.kogito.incubation.common.ExtendedDataContext;
-diff --git a/quarkus/extensions/kogito-quarkus-decisions-extension/pom.xml b/quarkus/extensions/kogito-quarkus-decisions-extension/pom.xml
-index 5dce797e75..bdac3cc788 100644
---- a/quarkus/extensions/kogito-quarkus-decisions-extension/pom.xml
-+++ b/quarkus/extensions/kogito-quarkus-decisions-extension/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>quarkus-extensions</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/pom.xml b/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/pom.xml
-index 8857eaf412..9f25023c3e 100644
---- a/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/pom.xml
-+++ b/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-quarkus-extension-common</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
 diff --git a/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoAssetsProcessor.java b/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoAssetsProcessor.java
 index 579ca04ddb..fcdc3f09ad 100644
 --- a/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoAssetsProcessor.java
@@ -6012,18 +3039,9 @@ index 579ca04ddb..fcdc3f09ad 100644
  import org.drools.codegen.common.DroolsModelBuildContext;
  import org.drools.codegen.common.GeneratedFile;
 diff --git a/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common/pom.xml b/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common/pom.xml
-index ea70600f2e..3276b362e4 100644
+index ea70600f2e..878cca24d4 100644
 --- a/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common/pom.xml
 +++ b/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common/pom.xml
-@@ -5,7 +5,7 @@
-     <parent>
-         <artifactId>kogito-quarkus-extension-common</artifactId>
-         <groupId>org.kie.kogito</groupId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
-     <modelVersion>4.0.0</modelVersion>
- 
 @@ -87,7 +87,7 @@
          <plugins>
              <plugin>
@@ -6080,58 +3098,6 @@ index e0af805b1f..2147548e66 100644
  
  import org.kie.kogito.KogitoGAV;
  import org.kie.kogito.config.StaticConfigBean;
-diff --git a/quarkus/extensions/kogito-quarkus-extension-common/pom.xml b/quarkus/extensions/kogito-quarkus-extension-common/pom.xml
-index e5273ab858..2a41a9429e 100644
---- a/quarkus/extensions/kogito-quarkus-extension-common/pom.xml
-+++ b/quarkus/extensions/kogito-quarkus-extension-common/pom.xml
-@@ -5,7 +5,7 @@
-     <parent>
-         <artifactId>quarkus-extensions</artifactId>
-         <groupId>org.kie.kogito</groupId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
-     <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/quarkus/extensions/kogito-quarkus-extension-spi/pom.xml b/quarkus/extensions/kogito-quarkus-extension-spi/pom.xml
-index a5d85b08e5..898bbf98c1 100644
---- a/quarkus/extensions/kogito-quarkus-extension-spi/pom.xml
-+++ b/quarkus/extensions/kogito-quarkus-extension-spi/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>quarkus-extensions</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-deployment/pom.xml b/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-deployment/pom.xml
-index 194d6aff08..503fdf40af 100644
---- a/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-deployment/pom.xml
-+++ b/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-deployment/pom.xml
-@@ -7,7 +7,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-quarkus-extension</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-quarkus-deployment</artifactId>
-diff --git a/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-integration-test-maven-devmode/pom.xml b/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-integration-test-maven-devmode/pom.xml
-index 89399627ce..a8d2367898 100644
---- a/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-integration-test-maven-devmode/pom.xml
-+++ b/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-integration-test-maven-devmode/pom.xml
-@@ -7,7 +7,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-quarkus-extension</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-quarkus-integration-test-maven-devmode</artifactId>
 diff --git a/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-integration-test-maven-devmode/src/test/resources/projects/classic-inst/src/main/java/control/RestControl.java b/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-integration-test-maven-devmode/src/test/resources/projects/classic-inst/src/main/java/control/RestControl.java
 index a54f09d2e0..b7e7f82682 100644
 --- a/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-integration-test-maven-devmode/src/test/resources/projects/classic-inst/src/main/java/control/RestControl.java
@@ -6174,19 +3140,6 @@ index a54f09d2e0..b7e7f82682 100644
  import java.util.UUID;
  
  @Path("/control")
-diff --git a/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-integration-test/pom.xml b/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-integration-test/pom.xml
-index bdedf5ebd0..3ee0649638 100644
---- a/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-integration-test/pom.xml
-+++ b/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-integration-test/pom.xml
-@@ -7,7 +7,7 @@
-     <parent>
-         <groupId>org.kie.kogito</groupId>
-         <artifactId>kogito-quarkus-extension</artifactId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
- 
-     <artifactId>kogito-quarkus-integration-test</artifactId>
 diff --git a/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-integration-test/src/main/java/io/quarkus/it/kogito/jbpm/CalculationService.java b/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-integration-test/src/main/java/io/quarkus/it/kogito/jbpm/CalculationService.java
 index fa64bd910a..4aac344b05 100644
 --- a/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-integration-test/src/main/java/io/quarkus/it/kogito/jbpm/CalculationService.java
@@ -6216,18 +3169,9 @@ index e19a919615..1419d03903 100644
  import org.junit.jupiter.api.Test;
  import org.kie.kogito.Model;
 diff --git a/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus/pom.xml b/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus/pom.xml
-index f41f347b1a..8be46e5f67 100644
+index f41f347b1a..6e6c5d59c8 100644
 --- a/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus/pom.xml
 +++ b/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus/pom.xml
-@@ -7,7 +7,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-quarkus-extension</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-quarkus</artifactId>
 @@ -50,7 +50,7 @@
      <plugins>
        <plugin>
@@ -6237,45 +3181,6 @@ index f41f347b1a..8be46e5f67 100644
          <version>${version.io.quarkus}</version>
          <executions>
            <execution>
-diff --git a/quarkus/extensions/kogito-quarkus-extension/pom.xml b/quarkus/extensions/kogito-quarkus-extension/pom.xml
-index c560b214c2..6725f414ff 100644
---- a/quarkus/extensions/kogito-quarkus-extension/pom.xml
-+++ b/quarkus/extensions/kogito-quarkus-extension/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>quarkus-extensions</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions-deployment/pom.xml b/quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions-deployment/pom.xml
-index f65ec3074b..4cc099f03c 100644
---- a/quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions-deployment/pom.xml
-+++ b/quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions-deployment/pom.xml
-@@ -5,7 +5,7 @@
-     <parent>
-         <artifactId>kogito-quarkus-predictions-extension</artifactId>
-         <groupId>org.kie.kogito</groupId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
-     <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions-integration-test/pom.xml b/quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions-integration-test/pom.xml
-index 3d0802bd20..415e273596 100644
---- a/quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions-integration-test/pom.xml
-+++ b/quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions-integration-test/pom.xml
-@@ -5,7 +5,7 @@
-     <parent>
-         <artifactId>kogito-quarkus-predictions-extension</artifactId>
-         <groupId>org.kie.kogito</groupId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
-     <modelVersion>4.0.0</modelVersion>
- 
 diff --git a/quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions-integration-test/src/main/java/org/kie/kogito/quarkus/pmml/CustomEndpoint.java b/quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions-integration-test/src/main/java/org/kie/kogito/quarkus/pmml/CustomEndpoint.java
 index b4d754eb99..d1a28b41e2 100644
 --- a/quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions-integration-test/src/main/java/org/kie/kogito/quarkus/pmml/CustomEndpoint.java
@@ -6300,18 +3205,9 @@ index b4d754eb99..d1a28b41e2 100644
  import org.kie.kogito.incubation.application.AppRoot;
  import org.kie.kogito.incubation.common.DataContext;
 diff --git a/quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions/pom.xml b/quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions/pom.xml
-index 63409a8999..d8cfd51b84 100644
+index 63409a8999..7c16750413 100644
 --- a/quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions/pom.xml
 +++ b/quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions/pom.xml
-@@ -5,7 +5,7 @@
-     <parent>
-         <artifactId>kogito-quarkus-predictions-extension</artifactId>
-         <groupId>org.kie.kogito</groupId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
-     <modelVersion>4.0.0</modelVersion>
- 
 @@ -38,7 +38,7 @@
          <plugins>
              <plugin>
@@ -6353,45 +3249,6 @@ index c168a06b34..3b6391cbc9 100644
  
  import org.kie.kogito.incubation.common.DataContext;
  import org.kie.kogito.incubation.common.ExtendedDataContext;
-diff --git a/quarkus/extensions/kogito-quarkus-predictions-extension/pom.xml b/quarkus/extensions/kogito-quarkus-predictions-extension/pom.xml
-index bfb0752074..443d88df94 100644
---- a/quarkus/extensions/kogito-quarkus-predictions-extension/pom.xml
-+++ b/quarkus/extensions/kogito-quarkus-predictions-extension/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>quarkus-extensions</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-deployment/pom.xml b/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-deployment/pom.xml
-index cd81b3d9e9..ff2bf97090 100644
---- a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-deployment/pom.xml
-+++ b/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-deployment/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-quarkus-processes-extension</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-integration-test-hot-reload/pom.xml b/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-integration-test-hot-reload/pom.xml
-index 8f455fb15b..8d50c9fe83 100644
---- a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-integration-test-hot-reload/pom.xml
-+++ b/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-integration-test-hot-reload/pom.xml
-@@ -7,7 +7,7 @@
-     <parent>
-         <groupId>org.kie.kogito</groupId>
-         <artifactId>kogito-quarkus-processes-extension</artifactId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
- 
-     <artifactId>kogito-quarkus-processes-integration-test-hot-reload</artifactId>
 diff --git a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-integration-test-hot-reload/src/main/java/io/quarkus/it/kogito/process/CalculationService.java b/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-integration-test-hot-reload/src/main/java/io/quarkus/it/kogito/process/CalculationService.java
 index 03de815b57..a5d09dfa94 100644
 --- a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-integration-test-hot-reload/src/main/java/io/quarkus/it/kogito/process/CalculationService.java
@@ -6418,19 +3275,6 @@ index afa85f97fa..48d597db45 100644
  
  /**
   * HotReloadTestHelper
-diff --git a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-integration-test/pom.xml b/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-integration-test/pom.xml
-index 8fa2c347c3..cc59c9311e 100644
---- a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-integration-test/pom.xml
-+++ b/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-integration-test/pom.xml
-@@ -7,7 +7,7 @@
-     <parent>
-         <groupId>org.kie.kogito</groupId>
-         <artifactId>kogito-quarkus-processes-extension</artifactId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
- 
-     <artifactId>kogito-quarkus-processes-integration-test</artifactId>
 diff --git a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-integration-test/src/main/java/org/acme/GreetingResource.java b/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-integration-test/src/main/java/org/acme/GreetingResource.java
 index 17b400d4a5..a677c45868 100644
 --- a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-integration-test/src/main/java/org/acme/GreetingResource.java
@@ -6474,18 +3318,9 @@ index e98e388939..0903d20f57 100644
  import org.junit.jupiter.api.Test;
  import org.kie.kogito.incubation.application.AppRoot;
 diff --git a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes/pom.xml b/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes/pom.xml
-index 9027a12a2a..e200a5e7c7 100644
+index 9027a12a2a..305be55bb5 100644
 --- a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes/pom.xml
 +++ b/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-quarkus-processes-extension</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
 @@ -36,7 +36,7 @@
      <plugins>
        <plugin>
@@ -6568,58 +3403,6 @@ index 1f66512e9f..807d060370 100644
  import org.kie.kogito.incubation.common.DataContext;
  import org.kie.kogito.incubation.common.Id;
  import org.kie.kogito.incubation.processes.services.StraightThroughProcessService;
-diff --git a/quarkus/extensions/kogito-quarkus-processes-extension/pom.xml b/quarkus/extensions/kogito-quarkus-processes-extension/pom.xml
-index 02a4bd68df..e3c988cfdc 100644
---- a/quarkus/extensions/kogito-quarkus-processes-extension/pom.xml
-+++ b/quarkus/extensions/kogito-quarkus-processes-extension/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>quarkus-extensions</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-deployment/pom.xml b/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-deployment/pom.xml
-index 538988f425..6e49e64f22 100644
---- a/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-deployment/pom.xml
-+++ b/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-deployment/pom.xml
-@@ -5,7 +5,7 @@
-     <parent>
-         <artifactId>kogito-quarkus-rules-extension</artifactId>
-         <groupId>org.kie.kogito</groupId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
-     <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test-hot-reload/pom.xml b/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test-hot-reload/pom.xml
-index 389f5c62f4..f0730f55f3 100644
---- a/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test-hot-reload/pom.xml
-+++ b/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test-hot-reload/pom.xml
-@@ -5,7 +5,7 @@
-     <parent>
-         <artifactId>kogito-quarkus-rules-extension</artifactId>
-         <groupId>org.kie.kogito</groupId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
-     <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test/pom.xml b/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test/pom.xml
-index 6da32e41e4..3abcdc83d8 100644
---- a/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test/pom.xml
-+++ b/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test/pom.xml
-@@ -5,7 +5,7 @@
-     <parent>
-         <artifactId>kogito-quarkus-rules-extension</artifactId>
-         <groupId>org.kie.kogito</groupId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
-     <modelVersion>4.0.0</modelVersion>
- 
 diff --git a/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test/src/main/java/org/kie/kogito/quarkus/drools/AnotherService.java b/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test/src/main/java/org/kie/kogito/quarkus/drools/AnotherService.java
 index 93979d672b..5aa0d04570 100644
 --- a/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test/src/main/java/org/kie/kogito/quarkus/drools/AnotherService.java
@@ -6685,18 +3468,9 @@ index f748c5d240..eae5b1a543 100644
  import org.drools.ruleunits.api.DataSource;
  import org.junit.jupiter.api.Test;
 diff --git a/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules/pom.xml b/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules/pom.xml
-index fa1b6a36b1..d8189a12c7 100644
+index fa1b6a36b1..333ab9809a 100644
 --- a/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules/pom.xml
 +++ b/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules/pom.xml
-@@ -5,7 +5,7 @@
-     <parent>
-         <artifactId>kogito-quarkus-rules-extension</artifactId>
-         <groupId>org.kie.kogito</groupId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
-     <modelVersion>4.0.0</modelVersion>
- 
 @@ -41,7 +41,7 @@
          <plugins>
              <plugin>
@@ -6807,32 +3581,6 @@ index 6c3bc7471b..6d23aa87de 100644
  
  import com.fasterxml.jackson.databind.ObjectMapper;
  
-diff --git a/quarkus/extensions/kogito-quarkus-rules-extension/pom.xml b/quarkus/extensions/kogito-quarkus-rules-extension/pom.xml
-index 514551702a..cf436dca6c 100644
---- a/quarkus/extensions/kogito-quarkus-rules-extension/pom.xml
-+++ b/quarkus/extensions/kogito-quarkus-rules-extension/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>quarkus-extensions</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/pom.xml b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/pom.xml
-index f6d76c7b70..e9eb81ed8a 100644
---- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/pom.xml
-+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-quarkus-serverless-workflow-extension</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
 diff --git a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/src/main/java/org/kie/kogito/quarkus/serverless/workflow/openapi/WorkflowOpenApiHandlerGenerator.java b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/src/main/java/org/kie/kogito/quarkus/serverless/workflow/openapi/WorkflowOpenApiHandlerGenerator.java
 index efb1b1bd62..c926eb8941 100644
 --- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/src/main/java/org/kie/kogito/quarkus/serverless/workflow/openapi/WorkflowOpenApiHandlerGenerator.java
@@ -6861,32 +3609,6 @@ index f3669957d8..cb8ac2d291 100644
  
  import org.eclipse.microprofile.config.inject.ConfigProperty;
  import org.jboss.jandex.IndexView;
-diff --git a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-image-integration-test/pom.xml b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-image-integration-test/pom.xml
-index 60bf95e779..be70df5f49 100644
---- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-image-integration-test/pom.xml
-+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-image-integration-test/pom.xml
-@@ -5,7 +5,7 @@
-     <parent>
-         <artifactId>kogito-quarkus-serverless-workflow-extension</artifactId>
-         <groupId>org.kie.kogito</groupId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
-     <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/pom.xml b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/pom.xml
-index 4560393e2e..de912ea678 100644
---- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/pom.xml
-+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-quarkus-serverless-workflow-extension</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
 diff --git a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/java/org/kie/kogito/workflows/services/AgePersonService.java b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/java/org/kie/kogito/workflows/services/AgePersonService.java
 index 509b193727..2b0fa6b37f 100644
 --- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/java/org/kie/kogito/workflows/services/AgePersonService.java
@@ -7109,18 +3831,9 @@ index 2f155e5d3b..52c71870de 100644
  import org.assertj.core.api.Assertions;
  import org.junit.jupiter.api.Test;
 diff --git a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/pom.xml b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/pom.xml
-index 0db41ce855..64572e2d25 100644
+index 0db41ce855..69afd01c0f 100644
 --- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/pom.xml
 +++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-quarkus-serverless-workflow-extension</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
 @@ -148,7 +148,7 @@
        </plugin>
        <plugin>
@@ -7232,58 +3945,6 @@ index dcbc67d4a7..56149fd8a8 100644
  
  import org.kie.kogito.event.cloudevents.extension.ProcessMeta;
  import org.kie.kogito.internal.process.runtime.KogitoWorkItem;
-diff --git a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/pom.xml b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/pom.xml
-index f0c943041a..c74dd6f337 100644
---- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/pom.xml
-+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>quarkus-extensions</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/quarkus/extensions/kogito-quarkus-test-list/pom.xml b/quarkus/extensions/kogito-quarkus-test-list/pom.xml
-index 256be139b0..3f49f1713d 100644
---- a/quarkus/extensions/kogito-quarkus-test-list/pom.xml
-+++ b/quarkus/extensions/kogito-quarkus-test-list/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>quarkus-extensions</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/quarkus/extensions/kogito-quarkus-workflow-extension-common/kogito-quarkus-workflow-common-deployment/pom.xml b/quarkus/extensions/kogito-quarkus-workflow-extension-common/kogito-quarkus-workflow-common-deployment/pom.xml
-index 76ff7b7389..3a9cba09f4 100644
---- a/quarkus/extensions/kogito-quarkus-workflow-extension-common/kogito-quarkus-workflow-common-deployment/pom.xml
-+++ b/quarkus/extensions/kogito-quarkus-workflow-extension-common/kogito-quarkus-workflow-common-deployment/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-quarkus-workflow-extension-common</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-quarkus-workflow-common-deployment</artifactId>
-diff --git a/quarkus/extensions/kogito-quarkus-workflow-extension-common/kogito-quarkus-workflow-common/pom.xml b/quarkus/extensions/kogito-quarkus-workflow-extension-common/kogito-quarkus-workflow-common/pom.xml
-index faae89aa4d..cbb9548390 100644
---- a/quarkus/extensions/kogito-quarkus-workflow-extension-common/kogito-quarkus-workflow-common/pom.xml
-+++ b/quarkus/extensions/kogito-quarkus-workflow-extension-common/kogito-quarkus-workflow-common/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-quarkus-workflow-extension-common</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-quarkus-workflow-common</artifactId>
 diff --git a/quarkus/extensions/kogito-quarkus-workflow-extension-common/kogito-quarkus-workflow-common/src/main/java/org/kie/kogito/quarkus/workflow/KogitoBeanProducer.java b/quarkus/extensions/kogito-quarkus-workflow-extension-common/kogito-quarkus-workflow-common/src/main/java/org/kie/kogito/quarkus/workflow/KogitoBeanProducer.java
 index 0cc10085f7..37550b4871 100644
 --- a/quarkus/extensions/kogito-quarkus-workflow-extension-common/kogito-quarkus-workflow-common/src/main/java/org/kie/kogito/quarkus/workflow/KogitoBeanProducer.java
@@ -7315,45 +3976,6 @@ index d4216b1cc3..41a44c6592 100644
  import org.eclipse.microprofile.config.inject.ConfigProperty;
  import org.kie.kogito.event.DataEvent;
  import org.kie.kogito.event.EventPublisher;
-diff --git a/quarkus/extensions/kogito-quarkus-workflow-extension-common/pom.xml b/quarkus/extensions/kogito-quarkus-workflow-extension-common/pom.xml
-index ffa1c32599..f7539c0134 100644
---- a/quarkus/extensions/kogito-quarkus-workflow-extension-common/pom.xml
-+++ b/quarkus/extensions/kogito-quarkus-workflow-extension-common/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>quarkus-extensions</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/quarkus/extensions/pom.xml b/quarkus/extensions/pom.xml
-index e48b8d84fc..16d6ff7046 100644
---- a/quarkus/extensions/pom.xml
-+++ b/quarkus/extensions/pom.xml
-@@ -7,7 +7,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>quarkus</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>quarkus-extensions</artifactId>
-diff --git a/quarkus/integration-tests/integration-tests-kogito-plugin/pom.xml b/quarkus/integration-tests/integration-tests-kogito-plugin/pom.xml
-index b47dee335c..60fa1ce27c 100644
---- a/quarkus/integration-tests/integration-tests-kogito-plugin/pom.xml
-+++ b/quarkus/integration-tests/integration-tests-kogito-plugin/pom.xml
-@@ -3,7 +3,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-quarkus-integration-tests</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>integration-tests-kogito-plugin</artifactId>
-   <name>Kogito :: Integration Tests :: Maven Plugin</name>
 diff --git a/quarkus/integration-tests/integration-tests-kogito-plugin/src/it/integration-tests-kogito-plugin-it/src/test/java/org/acme/travels/PersonProcessTest.java b/quarkus/integration-tests/integration-tests-kogito-plugin/src/it/integration-tests-kogito-plugin-it/src/test/java/org/acme/travels/PersonProcessTest.java
 index 9a8f24e3b8..2bfa200841 100644
 --- a/quarkus/integration-tests/integration-tests-kogito-plugin/src/it/integration-tests-kogito-plugin-it/src/test/java/org/acme/travels/PersonProcessTest.java
@@ -7369,19 +3991,6 @@ index 9a8f24e3b8..2bfa200841 100644
  
  import org.junit.jupiter.api.Test;
  import org.kie.kogito.Model;
-diff --git a/quarkus/integration-tests/integration-tests-quarkus-decisions/pom.xml b/quarkus/integration-tests/integration-tests-quarkus-decisions/pom.xml
-index bb5b789e42..017baeedd0 100644
---- a/quarkus/integration-tests/integration-tests-quarkus-decisions/pom.xml
-+++ b/quarkus/integration-tests/integration-tests-quarkus-decisions/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-quarkus-integration-tests</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>integration-tests-quarkus-decisions</artifactId>
-   <name>Kogito :: Integration Tests :: Quarkus :: Decisions</name>
 diff --git a/quarkus/integration-tests/integration-tests-quarkus-decisions/src/main/java/org/kie/kogito/integrationtests/InjectDecisionModels.java b/quarkus/integration-tests/integration-tests-quarkus-decisions/src/main/java/org/kie/kogito/integrationtests/InjectDecisionModels.java
 index 1b82df7f43..f7595d1337 100644
 --- a/quarkus/integration-tests/integration-tests-quarkus-decisions/src/main/java/org/kie/kogito/integrationtests/InjectDecisionModels.java
@@ -7395,32 +4004,6 @@ index 1b82df7f43..f7595d1337 100644
  
  import org.kie.kogito.Application;
  import org.kie.kogito.decision.DecisionConfig;
-diff --git a/quarkus/integration-tests/integration-tests-quarkus-gradle/pom.xml b/quarkus/integration-tests/integration-tests-quarkus-gradle/pom.xml
-index 410bcbce64..3f0a26b11d 100644
---- a/quarkus/integration-tests/integration-tests-quarkus-gradle/pom.xml
-+++ b/quarkus/integration-tests/integration-tests-quarkus-gradle/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-quarkus-integration-tests</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>integration-tests-quarkus-gradle</artifactId>
-   <name>Kogito :: Integration Tests :: Quarkus :: Gradle</name>
-diff --git a/quarkus/integration-tests/integration-tests-quarkus-norest/pom.xml b/quarkus/integration-tests/integration-tests-quarkus-norest/pom.xml
-index aabd4450c3..ba8193fe80 100644
---- a/quarkus/integration-tests/integration-tests-quarkus-norest/pom.xml
-+++ b/quarkus/integration-tests/integration-tests-quarkus-norest/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-quarkus-integration-tests</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>integration-tests-quarkus-norest</artifactId>
-   <name>Kogito :: Integration Tests :: Quarkus :: Without REST</name>
 diff --git a/quarkus/integration-tests/integration-tests-quarkus-norest/src/test/java/org/kie/kogito/quarkus/dmn/TrafficViolationTest.java b/quarkus/integration-tests/integration-tests-quarkus-norest/src/test/java/org/kie/kogito/quarkus/dmn/TrafficViolationTest.java
 index 3c7c37692c..e8bc6621b7 100644
 --- a/quarkus/integration-tests/integration-tests-quarkus-norest/src/test/java/org/kie/kogito/quarkus/dmn/TrafficViolationTest.java
@@ -7475,32 +4058,6 @@ index c98969bc15..a39f4dab3a 100644
  
  import org.assertj.core.data.Offset;
  import org.junit.jupiter.api.Test;
-diff --git a/quarkus/integration-tests/integration-tests-quarkus-openapi-client/pom.xml b/quarkus/integration-tests/integration-tests-quarkus-openapi-client/pom.xml
-index bc40deba63..11c51bebbf 100644
---- a/quarkus/integration-tests/integration-tests-quarkus-openapi-client/pom.xml
-+++ b/quarkus/integration-tests/integration-tests-quarkus-openapi-client/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-quarkus-integration-tests</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <name>Kogito :: Integration Tests :: Quarkus :: OpenAPI Client Codegen</name>
-   <artifactId>integration-tests-quarkus-openapi-client</artifactId>
-diff --git a/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-processes-persistence-common/pom.xml b/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-processes-persistence-common/pom.xml
-index 0a84773238..c250d50e16 100644
---- a/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-processes-persistence-common/pom.xml
-+++ b/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-processes-persistence-common/pom.xml
-@@ -4,7 +4,7 @@
-   <parent>
-     <artifactId>integration-tests-quarkus-processes-persistence</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-     <relativePath>../pom.xml</relativePath>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
 diff --git a/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-processes-persistence-common/src/main/java/org/kie/kogito/HelloService.java b/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-processes-persistence-common/src/main/java/org/kie/kogito/HelloService.java
 index 99b30ac17f..5b6fa14e9e 100644
 --- a/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-processes-persistence-common/src/main/java/org/kie/kogito/HelloService.java
@@ -7540,123 +4097,6 @@ index 950134a0d3..4d09e25ca5 100644
  
  import org.kie.kogito.process.impl.DefaultWorkItemHandlerConfig;
  
-diff --git a/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-filesystem/pom.xml b/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-filesystem/pom.xml
-index b5abe30d47..d6a0c5cb93 100644
---- a/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-filesystem/pom.xml
-+++ b/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-filesystem/pom.xml
-@@ -4,7 +4,7 @@
-   <parent>
-     <artifactId>integration-tests-quarkus-processes-persistence</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-     <relativePath>../pom.xml</relativePath>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
-diff --git a/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-infinispan/pom.xml b/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-infinispan/pom.xml
-index d92a623221..7ef2beb9c3 100644
---- a/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-infinispan/pom.xml
-+++ b/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-infinispan/pom.xml
-@@ -4,7 +4,7 @@
-   <parent>
-     <artifactId>integration-tests-quarkus-processes-persistence</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-     <relativePath>../pom.xml</relativePath>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
-diff --git a/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-jdbc/pom.xml b/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-jdbc/pom.xml
-index c499550f0e..35451ed0d1 100644
---- a/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-jdbc/pom.xml
-+++ b/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-jdbc/pom.xml
-@@ -4,7 +4,7 @@
-   <parent>
-     <artifactId>integration-tests-quarkus-processes-persistence</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-     <relativePath>../pom.xml</relativePath>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
-diff --git a/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-kafka-persistence/pom.xml b/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-kafka-persistence/pom.xml
-index 8113d3477f..d7d70d7e49 100644
---- a/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-kafka-persistence/pom.xml
-+++ b/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-kafka-persistence/pom.xml
-@@ -4,7 +4,7 @@
-   <parent>
-     <artifactId>integration-tests-quarkus-processes-persistence</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-     <relativePath>../pom.xml</relativePath>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
-diff --git a/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-mongodb/pom.xml b/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-mongodb/pom.xml
-index 0426dfaec8..c3420a46ff 100644
---- a/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-mongodb/pom.xml
-+++ b/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-mongodb/pom.xml
-@@ -4,7 +4,7 @@
-   <parent>
-     <artifactId>integration-tests-quarkus-processes-persistence</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-     <relativePath>../pom.xml</relativePath>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
-diff --git a/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-postgresql/pom.xml b/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-postgresql/pom.xml
-index 8712d1bdcd..835a6c064a 100644
---- a/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-postgresql/pom.xml
-+++ b/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-postgresql/pom.xml
-@@ -4,7 +4,7 @@
-   <parent>
-     <artifactId>integration-tests-quarkus-processes-persistence</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-     <relativePath>../pom.xml</relativePath>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
-diff --git a/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/pom.xml b/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/pom.xml
-index 19b4f1ee14..5849ffffd9 100644
---- a/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/pom.xml
-+++ b/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/pom.xml
-@@ -2,7 +2,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-quarkus-integration-tests</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
-   <packaging>pom</packaging>
-diff --git a/quarkus/integration-tests/integration-tests-quarkus-processes-reactive/pom.xml b/quarkus/integration-tests/integration-tests-quarkus-processes-reactive/pom.xml
-index 322c4194a2..a41cb4bf0c 100644
---- a/quarkus/integration-tests/integration-tests-quarkus-processes-reactive/pom.xml
-+++ b/quarkus/integration-tests/integration-tests-quarkus-processes-reactive/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-quarkus-integration-tests</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>integration-tests-quarkus-processes-reactive</artifactId>
-   <name>Kogito :: Integration Tests :: Quarkus :: Processes :: Reactive</name>
-diff --git a/quarkus/integration-tests/integration-tests-quarkus-processes/pom.xml b/quarkus/integration-tests/integration-tests-quarkus-processes/pom.xml
-index 95e2c7f1a6..8db89f1bd9 100644
---- a/quarkus/integration-tests/integration-tests-quarkus-processes/pom.xml
-+++ b/quarkus/integration-tests/integration-tests-quarkus-processes/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-quarkus-integration-tests</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>integration-tests-quarkus-processes</artifactId>
-   <name>Kogito :: Integration Tests :: Quarkus :: Processes</name>
 diff --git a/quarkus/integration-tests/integration-tests-quarkus-processes/src/main/java/org/acme/WIHRegister.java b/quarkus/integration-tests/integration-tests-quarkus-processes/src/main/java/org/acme/WIHRegister.java
 index b46eefab97..3ff04416a9 100644
 --- a/quarkus/integration-tests/integration-tests-quarkus-processes/src/main/java/org/acme/WIHRegister.java
@@ -7785,45 +4225,6 @@ index 59f6147d63..e564a0d7c2 100644
  
  import org.acme.travels.Traveller;
  import org.junit.jupiter.api.Test;
-diff --git a/quarkus/integration-tests/integration-tests-quarkus-resteasy-classic/pom.xml b/quarkus/integration-tests/integration-tests-quarkus-resteasy-classic/pom.xml
-index e12efaa150..00b5464b86 100644
---- a/quarkus/integration-tests/integration-tests-quarkus-resteasy-classic/pom.xml
-+++ b/quarkus/integration-tests/integration-tests-quarkus-resteasy-classic/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-quarkus-integration-tests</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>integration-tests-quarkus-resteasy-classic</artifactId>
-   <name>Kogito :: Integration Tests :: Quarkus :: RESTEasy Classic</name>
-diff --git a/quarkus/integration-tests/integration-tests-quarkus-resteasy-reactive/pom.xml b/quarkus/integration-tests/integration-tests-quarkus-resteasy-reactive/pom.xml
-index 4df8474427..52a5e9f50e 100644
---- a/quarkus/integration-tests/integration-tests-quarkus-resteasy-reactive/pom.xml
-+++ b/quarkus/integration-tests/integration-tests-quarkus-resteasy-reactive/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-quarkus-integration-tests</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>integration-tests-quarkus-resteasy-reactive</artifactId>
-   <name>Kogito :: Integration Tests :: Quarkus :: RESTEasy Reactive</name>
-diff --git a/quarkus/integration-tests/integration-tests-quarkus-rules/pom.xml b/quarkus/integration-tests/integration-tests-quarkus-rules/pom.xml
-index c570e1035a..4321411002 100644
---- a/quarkus/integration-tests/integration-tests-quarkus-rules/pom.xml
-+++ b/quarkus/integration-tests/integration-tests-quarkus-rules/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-quarkus-integration-tests</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>integration-tests-quarkus-rules</artifactId>
-   <name>Kogito :: Integration Tests :: Quarkus :: Rules</name>
 diff --git a/quarkus/integration-tests/integration-tests-quarkus-rules/src/main/java/org/kie/kogito/integrationtests/InjectRuleUnits.java b/quarkus/integration-tests/integration-tests-quarkus-rules/src/main/java/org/kie/kogito/integrationtests/InjectRuleUnits.java
 index a1aa6749ff..7a969aed5e 100644
 --- a/quarkus/integration-tests/integration-tests-quarkus-rules/src/main/java/org/kie/kogito/integrationtests/InjectRuleUnits.java
@@ -7837,19 +4238,6 @@ index a1aa6749ff..7a969aed5e 100644
  
  import org.kie.kogito.Application;
  import org.kie.kogito.rules.RuleConfig;
-diff --git a/quarkus/integration-tests/integration-tests-quarkus-source-files/pom.xml b/quarkus/integration-tests/integration-tests-quarkus-source-files/pom.xml
-index ee19c9b892..38844c5c0c 100644
---- a/quarkus/integration-tests/integration-tests-quarkus-source-files/pom.xml
-+++ b/quarkus/integration-tests/integration-tests-quarkus-source-files/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-quarkus-integration-tests</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>integration-tests-quarkus-source-files</artifactId>
-   <name>Kogito :: Integration Tests :: Quarkus :: Processes :: Source Files</name>
 diff --git a/quarkus/integration-tests/integration-tests-quarkus-source-files/src/main/java/org/kie/kogito/examples/CalculationService.java b/quarkus/integration-tests/integration-tests-quarkus-source-files/src/main/java/org/kie/kogito/examples/CalculationService.java
 index 2d2627a412..51acce14b8 100644
 --- a/quarkus/integration-tests/integration-tests-quarkus-source-files/src/main/java/org/kie/kogito/examples/CalculationService.java
@@ -7863,45 +4251,6 @@ index 2d2627a412..51acce14b8 100644
  
  import org.kie.kogito.examples.demo.Order;
  
-diff --git a/quarkus/integration-tests/pom.xml b/quarkus/integration-tests/pom.xml
-index 2e54511651..7e457ef078 100644
---- a/quarkus/integration-tests/pom.xml
-+++ b/quarkus/integration-tests/pom.xml
-@@ -4,7 +4,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>quarkus</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-quarkus-integration-tests</artifactId>
-   <name>Kogito :: Integration Tests :: Quarkus</name>
-diff --git a/quarkus/pom.xml b/quarkus/pom.xml
-index f7cf9b4ebb..030fdf3045 100644
---- a/quarkus/pom.xml
-+++ b/quarkus/pom.xml
-@@ -7,7 +7,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-build-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-     <relativePath>../kogito-build/kogito-build-parent/pom.xml</relativePath>
-   </parent>
- 
-diff --git a/quarkus/test/pom.xml b/quarkus/test/pom.xml
-index 8e555ade19..d369517ac1 100644
---- a/quarkus/test/pom.xml
-+++ b/quarkus/test/pom.xml
-@@ -7,7 +7,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>quarkus</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-quarkus-test-utils</artifactId>
 diff --git a/quarkus/test/src/main/java/org/kie/kogito/test/quarkus/QuarkusTestProperty.java b/quarkus/test/src/main/java/org/kie/kogito/test/quarkus/QuarkusTestProperty.java
 index 0e56b7f4c1..1f6d444cc9 100644
 --- a/quarkus/test/src/main/java/org/kie/kogito/test/quarkus/QuarkusTestProperty.java
@@ -7943,19 +4292,6 @@ index bacb17a6be..ebcc399a59 100644
  import org.junit.jupiter.api.BeforeEach;
  import org.junit.jupiter.api.Test;
  import org.junit.jupiter.api.extension.ExtendWith;
-diff --git a/springboot/addons/events/decisions/pom.xml b/springboot/addons/events/decisions/pom.xml
-index 231b4034fe..ac316cf0a7 100644
---- a/springboot/addons/events/decisions/pom.xml
-+++ b/springboot/addons/events/decisions/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-springboot-events-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-addons-springboot-events-decisions</artifactId>
 diff --git a/springboot/addons/events/decisions/src/main/java/org/kie/kogito/eventdriven/decision/SpringBootEventDrivenDecisionController.java b/springboot/addons/events/decisions/src/main/java/org/kie/kogito/eventdriven/decision/SpringBootEventDrivenDecisionController.java
 index 8188a297f6..1486a4b523 100644
 --- a/springboot/addons/events/decisions/src/main/java/org/kie/kogito/eventdriven/decision/SpringBootEventDrivenDecisionController.java
@@ -7970,32 +4306,6 @@ index 8188a297f6..1486a4b523 100644
  import org.kie.kogito.config.ConfigBean;
  import org.kie.kogito.decision.DecisionModels;
  import org.kie.kogito.event.EventEmitter;
-diff --git a/springboot/addons/events/kafka/pom.xml b/springboot/addons/events/kafka/pom.xml
-index b36f4b3364..2f0f79dc06 100644
---- a/springboot/addons/events/kafka/pom.xml
-+++ b/springboot/addons/events/kafka/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-springboot-events-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-springboot-events-process-kafka</artifactId>
-   <name>Kogito :: Add-Ons :: Events :: SprintBoot :: Process :: Kafka</name>
-diff --git a/springboot/addons/events/mongodb/pom.xml b/springboot/addons/events/mongodb/pom.xml
-index 3f065c3712..9cb1def473 100644
---- a/springboot/addons/events/mongodb/pom.xml
-+++ b/springboot/addons/events/mongodb/pom.xml
-@@ -6,7 +6,7 @@
-     <parent>
-         <groupId>org.kie.kogito</groupId>
-         <artifactId>kogito-addons-springboot-events-parent</artifactId>
--        <version>2.0.0-SNAPSHOT</version>
-+        <version>quarkus-3-SNAPSHOT</version>
-     </parent>
-     <modelVersion>4.0.0</modelVersion>
- 
 diff --git a/springboot/addons/events/mongodb/src/main/java/org/kie/kogito/events/mongodb/SpringbootMongoDBEventPublisher.java b/springboot/addons/events/mongodb/src/main/java/org/kie/kogito/events/mongodb/SpringbootMongoDBEventPublisher.java
 index e9280cdeda..6c15897b1a 100644
 --- a/springboot/addons/events/mongodb/src/main/java/org/kie/kogito/events/mongodb/SpringbootMongoDBEventPublisher.java
@@ -8010,32 +4320,6 @@ index e9280cdeda..6c15897b1a 100644
  import org.kie.kogito.mongodb.transaction.AbstractTransactionManager;
  import org.springframework.beans.factory.annotation.Autowired;
  import org.springframework.beans.factory.annotation.Value;
-diff --git a/springboot/addons/events/pom.xml b/springboot/addons/events/pom.xml
-index e3ad5934ee..96b04b4724 100644
---- a/springboot/addons/events/pom.xml
-+++ b/springboot/addons/events/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-springboot-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/springboot/addons/events/predictions/pom.xml b/springboot/addons/events/predictions/pom.xml
-index 89bc219a4c..62d5802a6b 100644
---- a/springboot/addons/events/predictions/pom.xml
-+++ b/springboot/addons/events/predictions/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-springboot-events-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-addons-springboot-events-predictions</artifactId>
 diff --git a/springboot/addons/events/predictions/src/main/java/org/kie/kogito/eventdriven/predictions/SpringBootEventDrivenPredictionsController.java b/springboot/addons/events/predictions/src/main/java/org/kie/kogito/eventdriven/predictions/SpringBootEventDrivenPredictionsController.java
 index 4cbb0cd60b..0fd5c48b70 100644
 --- a/springboot/addons/events/predictions/src/main/java/org/kie/kogito/eventdriven/predictions/SpringBootEventDrivenPredictionsController.java
@@ -8050,45 +4334,10 @@ index 4cbb0cd60b..0fd5c48b70 100644
  import org.kie.kogito.config.ConfigBean;
  import org.kie.kogito.event.EventEmitter;
  import org.kie.kogito.event.EventReceiver;
-diff --git a/springboot/addons/events/rules/pom.xml b/springboot/addons/events/rules/pom.xml
-index ced2af7fd0..18327d4947 100644
---- a/springboot/addons/events/rules/pom.xml
-+++ b/springboot/addons/events/rules/pom.xml
-@@ -6,7 +6,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-springboot-events-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-addons-springboot-events-rules</artifactId>
-diff --git a/springboot/addons/explainability/pom.xml b/springboot/addons/explainability/pom.xml
-index 18d0e99eb5..33b3edd595 100644
---- a/springboot/addons/explainability/pom.xml
-+++ b/springboot/addons/explainability/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-springboot-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
 diff --git a/springboot/addons/jobs/pom.xml b/springboot/addons/jobs/pom.xml
-index ec8e361691..b0d286dd7c 100644
+index ec8e361691..0abe916c34 100644
 --- a/springboot/addons/jobs/pom.xml
 +++ b/springboot/addons/jobs/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-springboot-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-springboot-jobs-management</artifactId>
-   <name>Kogito :: Add-Ons :: Jobs :: Management SprintBoot Addon</name>
 @@ -33,8 +33,8 @@
        <artifactId>kogito-spring-boot-starter</artifactId>
      </dependency>
@@ -8114,45 +4363,6 @@ index 58c9dec473..40f39725ab 100644
  import org.kie.kogito.jobs.ProcessInstanceJobDescription;
  import org.kie.kogito.jobs.ProcessJobDescription;
  import org.kie.kogito.jobs.management.RestJobsService;
-diff --git a/springboot/addons/kubernetes/pom.xml b/springboot/addons/kubernetes/pom.xml
-index f145a06825..ef45976e78 100644
---- a/springboot/addons/kubernetes/pom.xml
-+++ b/springboot/addons/kubernetes/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-springboot-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/springboot/addons/mail/pom.xml b/springboot/addons/mail/pom.xml
-index dfcbcd5a00..ac13752bee 100644
---- a/springboot/addons/mail/pom.xml
-+++ b/springboot/addons/mail/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-springboot-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/springboot/addons/messaging/implementation/pom.xml b/springboot/addons/messaging/implementation/pom.xml
-index 5951d3a7e3..86150b5a77 100644
---- a/springboot/addons/messaging/implementation/pom.xml
-+++ b/springboot/addons/messaging/implementation/pom.xml
-@@ -22,7 +22,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-springboot-messaging-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-springboot-messaging</artifactId>
-   <name>Kogito :: Add-Ons :: Messaging :: Spring Boot</name>
 diff --git a/springboot/addons/messaging/implementation/src/main/java/org/kie/kogito/addon/cloudevents/spring/SpringBootKogitoExtensionInitializer.java b/springboot/addons/messaging/implementation/src/main/java/org/kie/kogito/addon/cloudevents/spring/SpringBootKogitoExtensionInitializer.java
 index 97b9d51aac..1d51253270 100644
 --- a/springboot/addons/messaging/implementation/src/main/java/org/kie/kogito/addon/cloudevents/spring/SpringBootKogitoExtensionInitializer.java
@@ -8181,45 +4391,6 @@ index 496db7192a..67b4087b5a 100644
  import org.kie.kogito.addon.cloudevents.Subscription;
  import org.kie.kogito.config.ConfigBean;
  import org.kie.kogito.event.CloudEventUnmarshallerFactory;
-diff --git a/springboot/addons/messaging/integration-tests/pom.xml b/springboot/addons/messaging/integration-tests/pom.xml
-index a0c4830f05..7861c1c9fe 100644
---- a/springboot/addons/messaging/integration-tests/pom.xml
-+++ b/springboot/addons/messaging/integration-tests/pom.xml
-@@ -8,7 +8,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-springboot-messaging-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-springboot-messaging-it</artifactId>
-   <name>Kogito :: Add-Ons :: Messaging :: Spring Boot (ITs)</name>
-diff --git a/springboot/addons/messaging/pom.xml b/springboot/addons/messaging/pom.xml
-index a445b460ef..ffde62caa3 100644
---- a/springboot/addons/messaging/pom.xml
-+++ b/springboot/addons/messaging/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-springboot-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/springboot/addons/monitoring/core/pom.xml b/springboot/addons/monitoring/core/pom.xml
-index db16aa8da5..e013287ba8 100644
---- a/springboot/addons/monitoring/core/pom.xml
-+++ b/springboot/addons/monitoring/core/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-springboot-monitoring-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
-   <name>Kogito :: Add-Ons :: Monitoring Core Springboot</name>
 diff --git a/springboot/addons/monitoring/core/src/main/java/org/kie/kogito/monitoring/core/springboot/SpringbootMetricsInterceptor.java b/springboot/addons/monitoring/core/src/main/java/org/kie/kogito/monitoring/core/springboot/SpringbootMetricsInterceptor.java
 index 30ae90d94c..ec2410eacd 100644
 --- a/springboot/addons/monitoring/core/src/main/java/org/kie/kogito/monitoring/core/springboot/SpringbootMetricsInterceptor.java
@@ -8264,19 +4435,6 @@ index 4cacb54001..996815f8a7 100644
  
  import org.junit.jupiter.api.Test;
  import org.kie.kogito.monitoring.core.common.system.interceptor.MetricsInterceptor;
-diff --git a/springboot/addons/monitoring/elastic/pom.xml b/springboot/addons/monitoring/elastic/pom.xml
-index d1d32f77e4..90647bf86e 100644
---- a/springboot/addons/monitoring/elastic/pom.xml
-+++ b/springboot/addons/monitoring/elastic/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-springboot-monitoring-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
 diff --git a/springboot/addons/monitoring/elastic/src/main/java/org/kie/kogito/monitoring/elastic/springboot/SpringbootElasticRegistryProvider.java b/springboot/addons/monitoring/elastic/src/main/java/org/kie/kogito/monitoring/elastic/springboot/SpringbootElasticRegistryProvider.java
 index bf643296a0..ec8ad4e9c2 100644
 --- a/springboot/addons/monitoring/elastic/src/main/java/org/kie/kogito/monitoring/elastic/springboot/SpringbootElasticRegistryProvider.java
@@ -8291,149 +4449,10 @@ index bf643296a0..ec8ad4e9c2 100644
  import org.kie.kogito.monitoring.elastic.common.ElasticConfigFactory;
  import org.kie.kogito.monitoring.elastic.common.ElasticRegistry;
  import org.kie.kogito.monitoring.elastic.common.KogitoElasticConfig;
-diff --git a/springboot/addons/monitoring/pom.xml b/springboot/addons/monitoring/pom.xml
-index 6050bcaca4..60b836830a 100644
---- a/springboot/addons/monitoring/pom.xml
-+++ b/springboot/addons/monitoring/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-springboot-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/springboot/addons/monitoring/prometheus/pom.xml b/springboot/addons/monitoring/prometheus/pom.xml
-index 2024837475..490060e7ab 100644
---- a/springboot/addons/monitoring/prometheus/pom.xml
-+++ b/springboot/addons/monitoring/prometheus/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-springboot-monitoring-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
-   <name>Kogito :: Add-Ons :: Monitoring Prometheus Springboot</name>
-diff --git a/springboot/addons/persistence/filesystem/pom.xml b/springboot/addons/persistence/filesystem/pom.xml
-index 89edbad65d..7d83e7b218 100644
---- a/springboot/addons/persistence/filesystem/pom.xml
-+++ b/springboot/addons/persistence/filesystem/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-springboot-persistence-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
-   <name>Kogito :: Add-Ons :: Persistence File System :: Springboot</name>
-diff --git a/springboot/addons/persistence/infinispan/pom.xml b/springboot/addons/persistence/infinispan/pom.xml
-index 06f0e218f9..302dd8ba6c 100644
---- a/springboot/addons/persistence/infinispan/pom.xml
-+++ b/springboot/addons/persistence/infinispan/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-springboot-persistence-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
-   <name>Kogito :: Add-Ons :: Persistence Infinispan :: Springboot</name>
-diff --git a/springboot/addons/persistence/jdbc/pom.xml b/springboot/addons/persistence/jdbc/pom.xml
-index 0be5319d90..c91fa4b66b 100644
---- a/springboot/addons/persistence/jdbc/pom.xml
-+++ b/springboot/addons/persistence/jdbc/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-springboot-persistence-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
-   <name>Kogito :: Add-Ons :: Persistence JDBC :: Springboot</name>
-diff --git a/springboot/addons/persistence/mongodb/pom.xml b/springboot/addons/persistence/mongodb/pom.xml
-index 3c90314af3..72d9d197d7 100644
---- a/springboot/addons/persistence/mongodb/pom.xml
-+++ b/springboot/addons/persistence/mongodb/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-springboot-persistence-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
-   <name>Kogito :: Add-Ons :: Persistence MongoDB :: Springboot</name>
-diff --git a/springboot/addons/persistence/pom.xml b/springboot/addons/persistence/pom.xml
-index 5cc4e57ed6..28438fbd40 100644
---- a/springboot/addons/persistence/pom.xml
-+++ b/springboot/addons/persistence/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-springboot-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/springboot/addons/persistence/postgresql/pom.xml b/springboot/addons/persistence/postgresql/pom.xml
-index 8187456aa5..32f066d7f4 100644
---- a/springboot/addons/persistence/postgresql/pom.xml
-+++ b/springboot/addons/persistence/postgresql/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-springboot-persistence-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
-   <name>Kogito :: Add-Ons :: Persistence PostgreSQL :: Springboot</name>
-diff --git a/springboot/addons/pom.xml b/springboot/addons/pom.xml
-index 29302f5f64..7e1ec0aa12 100644
---- a/springboot/addons/pom.xml
-+++ b/springboot/addons/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>springboot</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/springboot/addons/process-management/pom.xml b/springboot/addons/process-management/pom.xml
-index 03de1dce5d..8606eb62a5 100644
---- a/springboot/addons/process-management/pom.xml
-+++ b/springboot/addons/process-management/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-springboot-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
 diff --git a/springboot/addons/process-svg/pom.xml b/springboot/addons/process-svg/pom.xml
-index 3f6c25309c..08c83807fb 100644
+index 3f6c25309c..18986e6356 100644
 --- a/springboot/addons/process-svg/pom.xml
 +++ b/springboot/addons/process-svg/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-springboot-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-addons-springboot-process-svg</artifactId>
-   <name>Kogito :: Add-Ons :: Process SVG :: Spring Boot Addon</name>
 @@ -47,8 +47,8 @@
        <scope>provided</scope>
      </dependency>
@@ -8459,58 +4478,10 @@ index a0919f003a..fd9c31ee5f 100644
  import org.keycloak.KeycloakPrincipal;
  import org.kie.kogito.svg.ProcessSVGException;
  import org.slf4j.Logger;
-diff --git a/springboot/addons/rest-exception-handler/pom.xml b/springboot/addons/rest-exception-handler/pom.xml
-index 87fe7fcdfc..85a451ff6c 100644
---- a/springboot/addons/rest-exception-handler/pom.xml
-+++ b/springboot/addons/rest-exception-handler/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-addons-springboot-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/springboot/addons/task-management/pom.xml b/springboot/addons/task-management/pom.xml
-index efb8388c27..a2482de96e 100644
---- a/springboot/addons/task-management/pom.xml
-+++ b/springboot/addons/task-management/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-springboot-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/springboot/addons/task-notification/pom.xml b/springboot/addons/task-notification/pom.xml
-index a81c55fc61..f22a207cba 100644
---- a/springboot/addons/task-notification/pom.xml
-+++ b/springboot/addons/task-notification/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-springboot-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
 diff --git a/springboot/addons/tracing-decision/pom.xml b/springboot/addons/tracing-decision/pom.xml
-index 1896563401..5962ae8dc9 100644
+index 1896563401..e13646549a 100644
 --- a/springboot/addons/tracing-decision/pom.xml
 +++ b/springboot/addons/tracing-decision/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>kogito-addons-springboot-parent</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
 @@ -29,8 +29,8 @@
      </dependency>
  
@@ -8536,32 +4507,10 @@ index 5b7f0e8a75..712d3d1e17 100644
  import org.kie.kogito.decision.DecisionModelResourcesProvider;
  import org.springframework.beans.factory.annotation.Autowired;
  import org.springframework.beans.factory.annotation.Value;
-diff --git a/springboot/archetype/pom.xml b/springboot/archetype/pom.xml
-index 7ecac37610..2dfed2698e 100644
---- a/springboot/archetype/pom.xml
-+++ b/springboot/archetype/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>springboot</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-spring-boot-archetype</artifactId>
-   <packaging>maven-archetype</packaging>
 diff --git a/springboot/bom/pom.xml b/springboot/bom/pom.xml
-index 7651661c3d..7df3bbc303 100644
+index 7651661c3d..10b6eff566 100644
 --- a/springboot/bom/pom.xml
 +++ b/springboot/bom/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>springboot</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
 @@ -22,10 +22,9 @@
      <version.org.codehaus.groovy>2.4.16</version.org.codehaus.groovy>
      <version.org.spockframework>1.3-groovy-2.4</version.org.spockframework>
@@ -8586,110 +4535,10 @@ index 7651661c3d..7df3bbc303 100644
      </dependencies>
    </dependencyManagement>
    <build>
-diff --git a/springboot/integration-tests/pom.xml b/springboot/integration-tests/pom.xml
-index eb8dab1759..85115dea09 100644
---- a/springboot/integration-tests/pom.xml
-+++ b/springboot/integration-tests/pom.xml
-@@ -4,7 +4,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>springboot</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <artifactId>kogito-spring-boot-integration-tests</artifactId>
-   <name>Kogito :: Integration Tests :: Spring Boot</name>
-diff --git a/springboot/pom.xml b/springboot/pom.xml
-index 194a3ea981..203dc256d1 100644
---- a/springboot/pom.xml
-+++ b/springboot/pom.xml
-@@ -22,7 +22,7 @@
-   <parent>
-     <groupId>org.kie.kogito</groupId>
-     <artifactId>kogito-build-parent</artifactId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-     <relativePath>../kogito-build/kogito-build-parent/pom.xml</relativePath>
-   </parent>
- 
-diff --git a/springboot/starters/kogito-decisions-spring-boot-starter/pom.xml b/springboot/starters/kogito-decisions-spring-boot-starter/pom.xml
-index 82c72c21e6..1666a6fb8e 100644
---- a/springboot/starters/kogito-decisions-spring-boot-starter/pom.xml
-+++ b/springboot/starters/kogito-decisions-spring-boot-starter/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>spring-boot-starters</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/springboot/starters/kogito-predictions-spring-boot-starter/pom.xml b/springboot/starters/kogito-predictions-spring-boot-starter/pom.xml
-index c7ebe2b442..6514dd3484 100644
---- a/springboot/starters/kogito-predictions-spring-boot-starter/pom.xml
-+++ b/springboot/starters/kogito-predictions-spring-boot-starter/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>spring-boot-starters</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/springboot/starters/kogito-processes-spring-boot-starter/pom.xml b/springboot/starters/kogito-processes-spring-boot-starter/pom.xml
-index 97ce24b06e..a4ac86e1a7 100644
---- a/springboot/starters/kogito-processes-spring-boot-starter/pom.xml
-+++ b/springboot/starters/kogito-processes-spring-boot-starter/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>spring-boot-starters</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/springboot/starters/kogito-rules-spring-boot-starter/pom.xml b/springboot/starters/kogito-rules-spring-boot-starter/pom.xml
-index b35a1f97ff..2f414fbb46 100644
---- a/springboot/starters/kogito-rules-spring-boot-starter/pom.xml
-+++ b/springboot/starters/kogito-rules-spring-boot-starter/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>spring-boot-starters</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
-diff --git a/springboot/starters/kogito-spring-boot-starter/pom.xml b/springboot/starters/kogito-spring-boot-starter/pom.xml
-index d013bf76a5..948e10f05b 100644
---- a/springboot/starters/kogito-spring-boot-starter/pom.xml
-+++ b/springboot/starters/kogito-spring-boot-starter/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>spring-boot-starters</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
 diff --git a/springboot/starters/pom.xml b/springboot/starters/pom.xml
-index 97d40cc694..1cd38fbd83 100644
+index 97d40cc694..657f222c75 100644
 --- a/springboot/starters/pom.xml
 +++ b/springboot/starters/pom.xml
-@@ -5,7 +5,7 @@
-   <parent>
-     <artifactId>springboot</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
-   <modelVersion>4.0.0</modelVersion>
- 
 @@ -44,12 +44,12 @@
        <artifactId>kogito-api</artifactId>
      </dependency>
@@ -8707,19 +4556,6 @@ index 97d40cc694..1cd38fbd83 100644
      </dependency>
      <dependency>
        <groupId>io.swagger.core.v3</groupId>
-diff --git a/springboot/test/pom.xml b/springboot/test/pom.xml
-index 6b7f429740..d52a456726 100644
---- a/springboot/test/pom.xml
-+++ b/springboot/test/pom.xml
-@@ -23,7 +23,7 @@
-   <parent>
-     <artifactId>springboot</artifactId>
-     <groupId>org.kie.kogito</groupId>
--    <version>2.0.0-SNAPSHOT</version>
-+    <version>quarkus-3-SNAPSHOT</version>
-   </parent>
- 
-   <artifactId>kogito-spring-boot-test-utils</artifactId>
 diff --git a/springboot/test/src/main/java/org/kie/kogito/test/springboot/kafka/KafkaTestClient.java b/springboot/test/src/main/java/org/kie/kogito/test/springboot/kafka/KafkaTestClient.java
 index 7b04631699..62fc719e1b 100644
 --- a/springboot/test/src/main/java/org/kie/kogito/test/springboot/kafka/KafkaTestClient.java

--- a/.ci/environments/quarkus-3/quarkus3.yml
+++ b/.ci/environments/quarkus-3/quarkus3.yml
@@ -143,10 +143,9 @@ recipeList:
     newArtifactId: infinispan-client-hotrod-jakarta
   }
 ---
-displayName: Update Managed Dependencies
-name: org.kie.ManagedDependencies
 description: Update all managed dependencies based on dependency updates from Quarkus.
-type: specs.openrewrite.org/v1beta/recipe
+name: org.kie.ManagedDependencies
+displayName: Update Managed Dependencies
 recipeList:
 - org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId: {
     oldGroupId: javax.activation,
@@ -531,6 +530,7 @@ recipeList:
     newGroupId: org.keycloak,
     newArtifactId: keycloak-admin-client-jakarta
   }
+type: specs.openrewrite.org/v1beta/recipe
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: io.quarkus.updates.core.quarkus30.UpgradeQuarkiverse


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-9072

With this PR the `0001_before_sh` patch will be much smaller and won't contain the version change.
The version is set after all patches are applied, in the `after.sh` script
Here are the pros:
- Better reading of the patch if needed. and only the migration part will be displayed when reviewing
- Adding new module if needed without those being much impacted by the Q3
- `versions:set` is taking ~20s and we remove one quick install which is taking minutes

**Related:**
- https://github.com/kiegroup/drools/pull/5202
- https://github.com/kiegroup/kogito-runtimes/pull/2954