### PR TITLE
KOGITO-8848 Added flexibility for users to send a custom CloudEvent ID in Knative custom functions

### DIFF
--- a/api/kogito-events-core/pom.xml
+++ b/api/kogito-events-core/pom.xml
@@ -46,6 +46,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/api/kogito-events-core/src/main/java/org/kie/kogito/event/cloudevents/utils/BaseCloudEventValidator.java
+++ b/api/kogito-events-core/src/main/java/org/kie/kogito/event/cloudevents/utils/BaseCloudEventValidator.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.event.cloudevents.utils;
+
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import io.cloudevents.SpecVersion;
+
+import static io.cloudevents.core.v1.CloudEventV1.DATACONTENTTYPE;
+import static io.cloudevents.core.v1.CloudEventV1.TIME;
+
+abstract class BaseCloudEventValidator {
+
+    private final String specVersionAttributeName;
+
+    private final SpecVersion supportedSpecVersion;
+
+    BaseCloudEventValidator(String specVersionAttributeName, SpecVersion supportedSpecVersion) {
+        this.specVersionAttributeName = specVersionAttributeName;
+        this.supportedSpecVersion = supportedSpecVersion;
+    }
+
+    final void validateCloudEvent(Map<String, Object> cloudEvent) throws InvalidCloudEventException {
+        Object specVersion = cloudEvent.get(specVersionAttributeName);
+
+        if (specVersion == null) {
+            throw new InvalidCloudEventException(List.of("Missing mandatory attribute: " + specVersionAttributeName));
+        }
+
+        if (specVersion.toString().equals(supportedSpecVersion.toString())) {
+            List<String> errors = new ArrayList<>();
+
+            CloudEventUtils.getMissingAttributes(cloudEvent)
+                    .forEach(missingAttribute -> errors.add("Missing mandatory attribute: " + missingAttribute));
+
+            errors.addAll(validateNonEmptyAttributes(cloudEvent));
+
+            errors.addAll(validateRfc2046Attributes(cloudEvent));
+
+            errors.addAll(validateRfc3339Attributes(cloudEvent));
+
+            if (!errors.isEmpty()) {
+                throw new InvalidCloudEventException(errors);
+            }
+        } else {
+            throw new UnsupportedOperationException(
+                    "Invalid CloudEvents specification version: " + specVersion + ". "
+                            + CloudEventValidatorV03.class.getName() + " supports only CloudEvents " + supportedSpecVersion);
+        }
+    }
+
+    /**
+     * Validates attributes that must adhere to the format specified in <a href="https://datatracker.ietf.org/doc/html/rfc3339">RFC 3339</a>.
+     *
+     * @param cloudEvent the CloudEvent
+     * @return a {@link List} of errors
+     */
+    private static List<String> validateRfc3339Attributes(Map<String, Object> cloudEvent) {
+        return Stream.of(TIME)
+                .filter(attribute -> {
+                    Object value = cloudEvent.get(attribute);
+                    return value != null && !isRfc3339Value(value);
+                }).map(attribute -> attribute + " MUST adhere to the format specified in RFC 3339 (https://datatracker.ietf.org/doc/html/rfc3339).")
+                .collect(Collectors.toList());
+    }
+
+    private static boolean isRfc3339Value(Object value) {
+        if (value instanceof String) {
+            try {
+                DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse((String) value);
+                return true;
+            } catch (DateTimeParseException e) {
+                return false;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Validates attributes that must adhere to the format specified in <a href="https://datatracker.ietf.org/doc/html/rfc2046">RFC 2046</a>.
+     *
+     * @param cloudEvent the CloudEvent
+     * @return a {@link List} of errors
+     */
+    private List<String> validateRfc2046Attributes(Map<String, Object> cloudEvent) {
+        return Stream.of(DATACONTENTTYPE)
+                .filter(attribute -> {
+                    Object value = cloudEvent.get(attribute);
+                    return value != null && !isRfc2046Value(value);
+                }).map(attribute -> attribute + " MUST adhere to the format specified in RFC 2046 (https://datatracker.ietf.org/doc/html/rfc2046).")
+                .collect(Collectors.toList());
+    }
+
+    private static boolean isRfc2046Value(Object value) {
+        if (value instanceof String) {
+            Pattern pattern = Pattern.compile("^[a-zA-Z]+/[a-zA-Z]+(?:[+\\-.][a-zA-Z0-9]+){0,10}$");
+            Matcher matcher = pattern.matcher((String) value);
+            return matcher.matches();
+        }
+        return false;
+    }
+
+    private List<String> validateNonEmptyAttributes(Map<String, Object> cloudEvent) {
+        return getNonEmptyAttributes().stream()
+                .filter(attribute -> "".equals(cloudEvent.get(attribute)))
+                .map(attribute -> attribute + " must be a non-empty String.")
+                .collect(Collectors.toList());
+    }
+
+    protected abstract List<String> getNonEmptyAttributes();
+}

--- a/api/kogito-events-core/src/main/java/org/kie/kogito/event/cloudevents/utils/BaseCloudEventValidator.java
+++ b/api/kogito-events-core/src/main/java/org/kie/kogito/event/cloudevents/utils/BaseCloudEventValidator.java
@@ -101,11 +101,7 @@ abstract class BaseCloudEventValidator {
     }
 
     private static boolean isRfc2046Value(String value) {
-        if (value != null) {
-            Matcher matcher = RFCC2046.matcher(value);
-            return matcher.matches();
-        }
-        return false;
+       return RFCC2046.matches(value).matches();
     }
 
     private void validateNonEmptyAttributes(Map<String, Object> cloudEvent, List<String> errors) {

--- a/api/kogito-events-core/src/main/java/org/kie/kogito/event/cloudevents/utils/CloudEventUtils.java
+++ b/api/kogito-events-core/src/main/java/org/kie/kogito/event/cloudevents/utils/CloudEventUtils.java
@@ -269,7 +269,7 @@ public final class CloudEventUtils {
     }
 
     public static void validateCloudEvent(Map<String, Object> cloudEvent) throws InvalidCloudEventException {
-        SpecVersion specVersion = SpecVersion.parse(cloudEvent.getOrDefault(CloudEventV1.SPECVERSION, "1.0").toString());
+        SpecVersion specVersion = SpecVersion.parse(String.valueOf(cloudEvent.get(CloudEventV1.SPECVERSION)));
         switch (specVersion) {
             case V1:
                 CloudEventValidatorV1.getInstance().validateCloudEvent(cloudEvent);

--- a/api/kogito-events-core/src/main/java/org/kie/kogito/event/cloudevents/utils/CloudEventUtils.java
+++ b/api/kogito-events-core/src/main/java/org/kie/kogito/event/cloudevents/utils/CloudEventUtils.java
@@ -268,6 +268,20 @@ public final class CloudEventUtils {
         return bool != null && bool.booleanValue();
     }
 
+    public static void validateCloudEvent(Map<String, Object> cloudEvent) throws InvalidCloudEventException {
+        SpecVersion specVersion = SpecVersion.parse(cloudEvent.getOrDefault(CloudEventV1.SPECVERSION, "1.0").toString());
+        switch (specVersion) {
+            case V1:
+                CloudEventValidatorV1.getInstance().validateCloudEvent(cloudEvent);
+                break;
+            case V03:
+                CloudEventValidatorV03.getInstance().validateCloudEvent(cloudEvent);
+                break;
+            default:
+                throw new UnsupportedOperationException("Unsupported CloudEvents version: " + specVersion);
+        }
+    }
+
     public static List<String> getMissingAttributes(Map<String, Object> cloudEventInfo) {
         String specVersion = cloudEventInfo.getOrDefault(CloudEventV1.SPECVERSION, "1.0").toString();
 

--- a/api/kogito-events-core/src/main/java/org/kie/kogito/event/cloudevents/utils/CloudEventUtils.java
+++ b/api/kogito-events-core/src/main/java/org/kie/kogito/event/cloudevents/utils/CloudEventUtils.java
@@ -270,16 +270,8 @@ public final class CloudEventUtils {
 
     public static void validateCloudEvent(Map<String, Object> cloudEvent) throws InvalidCloudEventException {
         SpecVersion specVersion = SpecVersion.parse(String.valueOf(cloudEvent.get(CloudEventV1.SPECVERSION)));
-        switch (specVersion) {
-            case V1:
-                CloudEventValidatorV1.getInstance().validateCloudEvent(cloudEvent);
-                break;
-            case V03:
-                CloudEventValidatorV03.getInstance().validateCloudEvent(cloudEvent);
-                break;
-            default:
-                throw new UnsupportedOperationException("Unsupported CloudEvents version: " + specVersion);
-        }
+        BaseCloudEventValidator validator = specVersion == SpecVersion.V1 ? CloudEventValidatorV1.getInstance() : CloudEventValidatorV03.getInstance();
+        validator.validateCloudEvent(cloudEvent);
     }
 
     public static List<String> getMissingAttributes(Map<String, Object> cloudEventInfo) {

--- a/api/kogito-events-core/src/main/java/org/kie/kogito/event/cloudevents/utils/CloudEventValidatorV03.java
+++ b/api/kogito-events-core/src/main/java/org/kie/kogito/event/cloudevents/utils/CloudEventValidatorV03.java
@@ -17,14 +17,11 @@ package org.kie.kogito.event.cloudevents.utils;
 
 import java.util.List;
 
-import io.cloudevents.SpecVersion;
-
 import static io.cloudevents.core.v03.CloudEventV03.DATACONTENTENCODING;
 import static io.cloudevents.core.v03.CloudEventV03.DATACONTENTTYPE;
 import static io.cloudevents.core.v03.CloudEventV03.ID;
-import static io.cloudevents.core.v03.CloudEventV03.SOURCE;
-import static io.cloudevents.core.v03.CloudEventV03.SPECVERSION;
 import static io.cloudevents.core.v03.CloudEventV03.SUBJECT;
+import static io.cloudevents.core.v03.CloudEventV03.TIME;
 import static io.cloudevents.core.v03.CloudEventV03.TYPE;
 
 final class CloudEventValidatorV03 extends BaseCloudEventValidator {
@@ -32,12 +29,22 @@ final class CloudEventValidatorV03 extends BaseCloudEventValidator {
     private static final CloudEventValidatorV03 instance = new CloudEventValidatorV03();
 
     private CloudEventValidatorV03() {
-        super(SPECVERSION, SpecVersion.V03);
+        super();
+    }
+
+    @Override
+    protected String getRfc3339Attribute() {
+        return TIME;
+    }
+
+    @Override
+    protected String getRfc2046Attribute() {
+        return DATACONTENTTYPE;
     }
 
     @Override
     protected List<String> getNonEmptyAttributes() {
-        return List.of(ID, SOURCE, TYPE, DATACONTENTTYPE, DATACONTENTENCODING, SUBJECT);
+        return List.of(ID, TYPE, DATACONTENTTYPE, DATACONTENTENCODING, SUBJECT);
     }
 
     static CloudEventValidatorV03 getInstance() {

--- a/api/kogito-events-core/src/main/java/org/kie/kogito/event/cloudevents/utils/CloudEventValidatorV03.java
+++ b/api/kogito-events-core/src/main/java/org/kie/kogito/event/cloudevents/utils/CloudEventValidatorV03.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.event.cloudevents.utils;
+
+import java.util.List;
+
+import io.cloudevents.SpecVersion;
+
+import static io.cloudevents.core.v03.CloudEventV03.DATACONTENTENCODING;
+import static io.cloudevents.core.v03.CloudEventV03.DATACONTENTTYPE;
+import static io.cloudevents.core.v03.CloudEventV03.ID;
+import static io.cloudevents.core.v03.CloudEventV03.SOURCE;
+import static io.cloudevents.core.v03.CloudEventV03.SPECVERSION;
+import static io.cloudevents.core.v03.CloudEventV03.SUBJECT;
+import static io.cloudevents.core.v03.CloudEventV03.TYPE;
+
+final class CloudEventValidatorV03 extends BaseCloudEventValidator {
+
+    private static final CloudEventValidatorV03 instance = new CloudEventValidatorV03();
+
+    private CloudEventValidatorV03() {
+        super(SPECVERSION, SpecVersion.V03);
+    }
+
+    @Override
+    protected List<String> getNonEmptyAttributes() {
+        return List.of(ID, SOURCE, TYPE, DATACONTENTTYPE, DATACONTENTENCODING, SUBJECT);
+    }
+
+    static CloudEventValidatorV03 getInstance() {
+        return instance;
+    }
+}

--- a/api/kogito-events-core/src/main/java/org/kie/kogito/event/cloudevents/utils/CloudEventValidatorV1.java
+++ b/api/kogito-events-core/src/main/java/org/kie/kogito/event/cloudevents/utils/CloudEventValidatorV1.java
@@ -17,14 +17,12 @@ package org.kie.kogito.event.cloudevents.utils;
 
 import java.util.List;
 
-import io.cloudevents.SpecVersion;
-
 import static io.cloudevents.core.v1.CloudEventV1.DATACONTENTTYPE;
 import static io.cloudevents.core.v1.CloudEventV1.DATASCHEMA;
 import static io.cloudevents.core.v1.CloudEventV1.ID;
 import static io.cloudevents.core.v1.CloudEventV1.SOURCE;
-import static io.cloudevents.core.v1.CloudEventV1.SPECVERSION;
 import static io.cloudevents.core.v1.CloudEventV1.SUBJECT;
+import static io.cloudevents.core.v1.CloudEventV1.TIME;
 import static io.cloudevents.core.v1.CloudEventV1.TYPE;
 
 final class CloudEventValidatorV1 extends BaseCloudEventValidator {
@@ -32,12 +30,22 @@ final class CloudEventValidatorV1 extends BaseCloudEventValidator {
     private static final CloudEventValidatorV1 instance = new CloudEventValidatorV1();
 
     private CloudEventValidatorV1() {
-        super(SPECVERSION, SpecVersion.V1);
+        super();
     }
 
     @Override
     protected List<String> getNonEmptyAttributes() {
         return List.of(ID, SOURCE, TYPE, DATACONTENTTYPE, DATASCHEMA, SUBJECT);
+    }
+
+    @Override
+    protected String getRfc3339Attribute() {
+        return TIME;
+    }
+
+    @Override
+    protected String getRfc2046Attribute() {
+        return DATACONTENTTYPE;
     }
 
     static CloudEventValidatorV1 getInstance() {

--- a/api/kogito-events-core/src/main/java/org/kie/kogito/event/cloudevents/utils/CloudEventValidatorV1.java
+++ b/api/kogito-events-core/src/main/java/org/kie/kogito/event/cloudevents/utils/CloudEventValidatorV1.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.event.cloudevents.utils;
+
+import java.util.List;
+
+import io.cloudevents.SpecVersion;
+
+import static io.cloudevents.core.v1.CloudEventV1.DATACONTENTTYPE;
+import static io.cloudevents.core.v1.CloudEventV1.DATASCHEMA;
+import static io.cloudevents.core.v1.CloudEventV1.ID;
+import static io.cloudevents.core.v1.CloudEventV1.SOURCE;
+import static io.cloudevents.core.v1.CloudEventV1.SPECVERSION;
+import static io.cloudevents.core.v1.CloudEventV1.SUBJECT;
+import static io.cloudevents.core.v1.CloudEventV1.TYPE;
+
+final class CloudEventValidatorV1 extends BaseCloudEventValidator {
+
+    private static final CloudEventValidatorV1 instance = new CloudEventValidatorV1();
+
+    private CloudEventValidatorV1() {
+        super(SPECVERSION, SpecVersion.V1);
+    }
+
+    @Override
+    protected List<String> getNonEmptyAttributes() {
+        return List.of(ID, SOURCE, TYPE, DATACONTENTTYPE, DATASCHEMA, SUBJECT);
+    }
+
+    static CloudEventValidatorV1 getInstance() {
+        return instance;
+    }
+}

--- a/api/kogito-events-core/src/main/java/org/kie/kogito/event/cloudevents/utils/InvalidCloudEventException.java
+++ b/api/kogito-events-core/src/main/java/org/kie/kogito/event/cloudevents/utils/InvalidCloudEventException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.event.cloudevents.utils;
+
+import java.util.Collections;
+import java.util.List;
+
+public final class InvalidCloudEventException extends RuntimeException {
+
+    private final List<String> errors;
+
+    public InvalidCloudEventException(List<String> errors) {
+        this.errors = Collections.unmodifiableList(errors);
+    }
+
+    public List<String> getErrors() {
+        return errors;
+    }
+
+    @Override
+    public String getMessage() {
+        return "Invalid CloudEvent: " + System.lineSeparator() + String.join(System.lineSeparator(), errors);
+    }
+}

--- a/api/kogito-events-core/src/test/java/org/kie/kogito/event/cloudevents/utils/BaseCloudEventValidatorTest.java
+++ b/api/kogito-events-core/src/test/java/org/kie/kogito/event/cloudevents/utils/BaseCloudEventValidatorTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.event.cloudevents.utils;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.cloudevents.SpecVersion;
+
+import static java.util.function.Predicate.not;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+abstract class BaseCloudEventValidatorTest<T extends BaseCloudEventValidator> {
+
+    private final SpecVersion supportedVersion;
+
+    private final String specVersionAttributeName;
+
+    private final T cloudEventValidator;
+
+    BaseCloudEventValidatorTest(T cloudEventValidator, SpecVersion supportedVersion, String specVersionAttributeName) {
+        this.cloudEventValidator = cloudEventValidator;
+        this.supportedVersion = supportedVersion;
+        this.specVersionAttributeName = specVersionAttributeName;
+    }
+
+    protected abstract Map<String, Object> createValidCloudEvent();
+
+    protected abstract String getRfc3339Attribute();
+
+    protected abstract String getRfc2046Attribute();
+
+    private Map<String, Object> cloudEventMissing(String attribute) {
+        Map<String, Object> cloudEvent = createValidCloudEvent();
+        cloudEvent.remove(attribute);
+        return cloudEvent;
+    }
+
+    private Map<String, Object> cloudEventWithEmptyAttribute(String attribute) {
+        Map<String, Object> cloudEvent = createValidCloudEvent();
+        cloudEvent.put(attribute, "");
+        return cloudEvent;
+    }
+
+    public static Stream<Arguments> testInvalidRfcXXXXAttributeSource() {
+        return Stream.of(
+                Arguments.of("invalid"),
+                Arguments.of(new Object()));
+    }
+
+    @Test
+    void testValidCloudEvent() {
+        assertThatCode(() -> cloudEventValidator.validateCloudEvent(createValidCloudEvent()))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void testUnsupportedVersion() {
+        Map<String, Object> cloudEvent = createValidCloudEvent();
+
+        SpecVersion unsupportedVersion = Arrays.stream(SpecVersion.values())
+                .filter(not(supportedVersion::equals))
+                .findAny()
+                .orElseThrow();
+
+        cloudEvent.put(specVersionAttributeName, unsupportedVersion.toString());
+
+        assertThatExceptionOfType(UnsupportedOperationException.class)
+                .isThrownBy(() -> cloudEventValidator.validateCloudEvent(cloudEvent));
+    }
+
+    @Test
+    void testMissingMandatoryAttribute() {
+        supportedVersion.getMandatoryAttributes().forEach(mandatoryAttribute -> {
+            Map<String, Object> cloudEvent = cloudEventMissing(mandatoryAttribute);
+
+            InvalidCloudEventException ex = Assertions.assertThrows(InvalidCloudEventException.class,
+                    () -> cloudEventValidator.validateCloudEvent(cloudEvent));
+
+            assertThat(ex.getErrors())
+                    .hasSize(1)
+                    .contains("Missing mandatory attribute: " + mandatoryAttribute);
+        });
+    }
+
+    @ParameterizedTest
+    @MethodSource("testInvalidRfcXXXXAttributeSource")
+    void testInvalidRfc3339Attribute(Object value) {
+        Map<String, Object> cloudEvent = createValidCloudEvent();
+        cloudEvent.put(getRfc3339Attribute(), value);
+
+        InvalidCloudEventException ex = Assertions.assertThrows(InvalidCloudEventException.class,
+                () -> cloudEventValidator.validateCloudEvent(cloudEvent));
+
+        assertThat(ex.getErrors())
+                .containsOnly(getRfc3339Attribute() + " MUST adhere to the format specified in RFC 3339 (https://datatracker.ietf.org/doc/html/rfc3339).");
+    }
+
+    @ParameterizedTest
+    @MethodSource("testInvalidRfcXXXXAttributeSource")
+    void testInvalidRfc2046Attribute(Object value) {
+        Map<String, Object> cloudEvent = createValidCloudEvent();
+        cloudEvent.put(getRfc2046Attribute(), value);
+
+        InvalidCloudEventException ex = Assertions.assertThrows(InvalidCloudEventException.class,
+                () -> cloudEventValidator.validateCloudEvent(cloudEvent));
+
+        assertThat(ex.getErrors())
+                .containsOnly(getRfc2046Attribute() + " MUST adhere to the format specified in RFC 2046 (https://datatracker.ietf.org/doc/html/rfc2046).");
+    }
+
+    @Test
+    void testNonEmptyAttribute() {
+        cloudEventValidator.getNonEmptyAttributes().forEach(nonEmptyAttribute -> {
+            Map<String, Object> cloudEvent = cloudEventWithEmptyAttribute(nonEmptyAttribute);
+
+            InvalidCloudEventException ex = Assertions.assertThrows(InvalidCloudEventException.class,
+                    () -> cloudEventValidator.validateCloudEvent(cloudEvent));
+
+            assertThat(ex.getErrors())
+                    .contains(nonEmptyAttribute + " must be a non-empty String.");
+        });
+    }
+}

--- a/api/kogito-events-core/src/test/java/org/kie/kogito/event/cloudevents/utils/CloudEventValidatorV03Test.java
+++ b/api/kogito-events-core/src/test/java/org/kie/kogito/event/cloudevents/utils/CloudEventValidatorV03Test.java
@@ -18,6 +18,8 @@ package org.kie.kogito.event.cloudevents.utils;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.jupiter.api.Test;
+
 import io.cloudevents.SpecVersion;
 
 import static io.cloudevents.core.v03.CloudEventV03.DATACONTENTTYPE;
@@ -26,12 +28,15 @@ import static io.cloudevents.core.v03.CloudEventV03.SOURCE;
 import static io.cloudevents.core.v03.CloudEventV03.SPECVERSION;
 import static io.cloudevents.core.v03.CloudEventV03.TIME;
 import static io.cloudevents.core.v03.CloudEventV03.TYPE;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 import static org.kie.kogito.event.cloudevents.utils.CloudEventUtils.DATA;
 
 class CloudEventValidatorV03Test extends BaseCloudEventValidatorTest<CloudEventValidatorV03> {
 
+    private static final CloudEventValidatorV03 CLOUD_EVENT_VALIDATOR = CloudEventValidatorV03.getInstance();
+
     CloudEventValidatorV03Test() {
-        super(CloudEventValidatorV03.getInstance(), SpecVersion.V03, SPECVERSION);
+        super(CLOUD_EVENT_VALIDATOR, SpecVersion.V03);
     }
 
     @Override
@@ -47,13 +52,12 @@ class CloudEventValidatorV03Test extends BaseCloudEventValidatorTest<CloudEventV
         return cloudEvent;
     }
 
-    @Override
-    protected String getRfc3339Attribute() {
-        return TIME;
-    }
+    @Test
+    void emptySourceShouldBeValid() {
+        Map<String, Object> cloudEvent = createValidCloudEvent();
+        cloudEvent.put(SOURCE, "");
 
-    @Override
-    protected String getRfc2046Attribute() {
-        return DATACONTENTTYPE;
+        assertThatCode(() -> CLOUD_EVENT_VALIDATOR.validateCloudEvent(createValidCloudEvent()))
+                .doesNotThrowAnyException();
     }
 }

--- a/api/kogito-events-core/src/test/java/org/kie/kogito/event/cloudevents/utils/CloudEventValidatorV03Test.java
+++ b/api/kogito-events-core/src/test/java/org/kie/kogito/event/cloudevents/utils/CloudEventValidatorV03Test.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.event.cloudevents.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.cloudevents.SpecVersion;
+
+import static io.cloudevents.core.v03.CloudEventV03.DATACONTENTTYPE;
+import static io.cloudevents.core.v03.CloudEventV03.ID;
+import static io.cloudevents.core.v03.CloudEventV03.SOURCE;
+import static io.cloudevents.core.v03.CloudEventV03.SPECVERSION;
+import static io.cloudevents.core.v03.CloudEventV03.TIME;
+import static io.cloudevents.core.v03.CloudEventV03.TYPE;
+import static org.kie.kogito.event.cloudevents.utils.CloudEventUtils.DATA;
+
+class CloudEventValidatorV03Test extends BaseCloudEventValidatorTest<CloudEventValidatorV03> {
+
+    CloudEventValidatorV03Test() {
+        super(CloudEventValidatorV03.getInstance(), SpecVersion.V03, SPECVERSION);
+    }
+
+    @Override
+    protected Map<String, Object> createValidCloudEvent() {
+        Map<String, Object> cloudEvent = new HashMap<>();
+        cloudEvent.put(SPECVERSION, SpecVersion.V03.toString());
+        cloudEvent.put(ID, "abc-123");
+        cloudEvent.put(SOURCE, "/myapp");
+        cloudEvent.put(TYPE, "com.example.someevent");
+        cloudEvent.put(DATACONTENTTYPE, "application/json");
+        cloudEvent.put(TIME, "2023-05-03T12:34:56Z");
+        cloudEvent.put(DATA, "{\"foo\":\"bar\"}");
+        return cloudEvent;
+    }
+
+    @Override
+    protected String getRfc3339Attribute() {
+        return TIME;
+    }
+
+    @Override
+    protected String getRfc2046Attribute() {
+        return DATACONTENTTYPE;
+    }
+}

--- a/api/kogito-events-core/src/test/java/org/kie/kogito/event/cloudevents/utils/CloudEventValidatorV1Test.java
+++ b/api/kogito-events-core/src/test/java/org/kie/kogito/event/cloudevents/utils/CloudEventValidatorV1Test.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.event.cloudevents.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.cloudevents.SpecVersion;
+
+import static io.cloudevents.core.v1.CloudEventV1.DATACONTENTTYPE;
+import static io.cloudevents.core.v1.CloudEventV1.ID;
+import static io.cloudevents.core.v1.CloudEventV1.SOURCE;
+import static io.cloudevents.core.v1.CloudEventV1.SPECVERSION;
+import static io.cloudevents.core.v1.CloudEventV1.TIME;
+import static io.cloudevents.core.v1.CloudEventV1.TYPE;
+import static org.kie.kogito.event.cloudevents.utils.CloudEventUtils.DATA;
+
+class CloudEventValidatorV1Test extends BaseCloudEventValidatorTest<CloudEventValidatorV1> {
+
+    CloudEventValidatorV1Test() {
+        super(CloudEventValidatorV1.getInstance(), SpecVersion.V1, SPECVERSION);
+    }
+
+    @Override
+    protected Map<String, Object> createValidCloudEvent() {
+        Map<String, Object> cloudEvent = new HashMap<>();
+        cloudEvent.put(SPECVERSION, SpecVersion.V1.toString());
+        cloudEvent.put(ID, "abc-123");
+        cloudEvent.put(SOURCE, "/myapp");
+        cloudEvent.put(TYPE, "com.example.someevent");
+        cloudEvent.put(DATACONTENTTYPE, "application/json");
+        cloudEvent.put(TIME, "2023-05-03T12:34:56Z");
+        cloudEvent.put(DATA, "{\"foo\":\"bar\"}");
+        return cloudEvent;
+    }
+
+    @Override
+    protected String getRfc3339Attribute() {
+        return TIME;
+    }
+
+    @Override
+    protected String getRfc2046Attribute() {
+        return DATACONTENTTYPE;
+    }
+}

--- a/api/kogito-events-core/src/test/java/org/kie/kogito/event/cloudevents/utils/CloudEventValidatorV1Test.java
+++ b/api/kogito-events-core/src/test/java/org/kie/kogito/event/cloudevents/utils/CloudEventValidatorV1Test.java
@@ -31,7 +31,7 @@ import static org.kie.kogito.event.cloudevents.utils.CloudEventUtils.DATA;
 class CloudEventValidatorV1Test extends BaseCloudEventValidatorTest<CloudEventValidatorV1> {
 
     CloudEventValidatorV1Test() {
-        super(CloudEventValidatorV1.getInstance(), SpecVersion.V1, SPECVERSION);
+        super(CloudEventValidatorV1.getInstance(), SpecVersion.V1);
     }
 
     @Override
@@ -45,15 +45,5 @@ class CloudEventValidatorV1Test extends BaseCloudEventValidatorTest<CloudEventVa
         cloudEvent.put(TIME, "2023-05-03T12:34:56Z");
         cloudEvent.put(DATA, "{\"foo\":\"bar\"}");
         return cloudEvent;
-    }
-
-    @Override
-    protected String getRfc3339Attribute() {
-        return TIME;
-    }
-
-    @Override
-    protected String getRfc2046Attribute() {
-        return DATACONTENTTYPE;
     }
 }

--- a/quarkus/addons/knative/serving/runtime/src/main/java/org/kie/kogito/addons/quarkus/knative/serving/customfunctions/CloudEventKnativeServiceRequestClient.java
+++ b/quarkus/addons/knative/serving/runtime/src/main/java/org/kie/kogito/addons/quarkus/knative/serving/customfunctions/CloudEventKnativeServiceRequestClient.java
@@ -18,7 +18,6 @@ package org.kie.kogito.addons.quarkus.knative.serving.customfunctions;
 import java.net.URI;
 import java.time.Duration;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -45,6 +44,8 @@ class CloudEventKnativeServiceRequestClient extends KnativeServiceRequestClient 
 
     private static final Logger logger = LoggerFactory.getLogger(CloudEventKnativeServiceRequestClient.class);
 
+    private static final String ID = "id";
+
     private final WebClient webClient;
 
     private final Duration requestTimeout;
@@ -58,8 +59,6 @@ class CloudEventKnativeServiceRequestClient extends KnativeServiceRequestClient 
 
     @Override
     protected JsonNode sendRequest(String processInstanceId, URI serviceAddress, String path, Map<String, Object> cloudEvent) {
-        validateCloudEvent(cloudEvent);
-
         HttpRequest<Buffer> request;
         if (serviceAddress.getPort() >= 0) {
             request = webClient.post(serviceAddress.getPort(), serviceAddress.getHost(), path);
@@ -69,13 +68,13 @@ class CloudEventKnativeServiceRequestClient extends KnativeServiceRequestClient 
         request.putHeader("Content-Type", APPLICATION_CLOUDEVENTS_JSON_CHARSET_UTF_8)
                 .ssl("https".equals(serviceAddress.getScheme()));
 
-        JsonObject body;
-
-        if (cloudEvent.get("id") == null) {
-            body = new JsonObject(createCloudEventWithGeneratedId(cloudEvent, processInstanceId));
-        } else {
-            body = new JsonObject(new HashMap<>(cloudEvent));
+        if (cloudEvent.get(ID) == null) {
+            cloudEvent = createCloudEventWithGeneratedId(cloudEvent, processInstanceId);
         }
+
+        CloudEventUtils.validateCloudEvent(cloudEvent);
+
+        JsonObject body = new JsonObject(cloudEvent);
 
         logger.debug("Sending request with CloudEvent - host: {}, port: {}, path: {}, CloudEvent: {}",
                 serviceAddress.getHost(), serviceAddress.getPort(), path, body);
@@ -87,22 +86,19 @@ class CloudEventKnativeServiceRequestClient extends KnativeServiceRequestClient 
 
     private static Map<String, Object> createCloudEventWithGeneratedId(Map<String, Object> cloudEvent, String processInstanceId) {
         Map<String, Object> modifiableCloudEvent = new HashMap<>(cloudEvent);
-        modifiableCloudEvent.put("id", generateCloudEventId(processInstanceId, cloudEvent.get("source").toString()));
+        Object source = cloudEvent.get("source");
+        if (source == null) {
+            CloudEventUtils.validateCloudEvent(cloudEvent);
+
+            // CloudEventUtils#validateCloudEvent will throw exception. This line will never be reached.
+            throw new IllegalArgumentException("Invalid CloudEvent: Attribute source is mandatory.");
+        }
+        modifiableCloudEvent.put(ID, generateCloudEventId(processInstanceId, source.toString()));
         return modifiableCloudEvent;
     }
 
     static String generateCloudEventId(String processInstanceId, String source) {
         return source + '_' + processInstanceId;
-    }
-
-    private void validateCloudEvent(Map<String, Object> cloudEvent) {
-        List<String> missingAttributes = CloudEventUtils.getMissingAttributes(cloudEvent);
-        missingAttributes.remove("id");
-
-        if (!missingAttributes.isEmpty()) {
-            throw new IllegalArgumentException("Invalid CloudEvent. The following mandatory attributes are missing: "
-                    + String.join(", ", missingAttributes));
-        }
     }
 
     @PreDestroy

--- a/quarkus/addons/knative/serving/runtime/src/main/java/org/kie/kogito/addons/quarkus/knative/serving/customfunctions/CloudEventKnativeServiceRequestClient.java
+++ b/quarkus/addons/knative/serving/runtime/src/main/java/org/kie/kogito/addons/quarkus/knative/serving/customfunctions/CloudEventKnativeServiceRequestClient.java
@@ -88,9 +88,6 @@ class CloudEventKnativeServiceRequestClient extends KnativeServiceRequestClient 
         Map<String, Object> modifiableCloudEvent = new HashMap<>(cloudEvent);
         Object source = cloudEvent.get("source");
         if (source == null) {
-            CloudEventUtils.validateCloudEvent(cloudEvent);
-
-            // CloudEventUtils#validateCloudEvent will throw exception. This line will never be reached.
             throw new IllegalArgumentException("Invalid CloudEvent: Attribute source is mandatory.");
         }
         modifiableCloudEvent.put(ID, generateCloudEventId(processInstanceId, source.toString()));

--- a/quarkus/addons/knative/serving/runtime/src/main/java/org/kie/kogito/addons/quarkus/knative/serving/customfunctions/CloudEventKnativeServiceRequestClient.java
+++ b/quarkus/addons/knative/serving/runtime/src/main/java/org/kie/kogito/addons/quarkus/knative/serving/customfunctions/CloudEventKnativeServiceRequestClient.java
@@ -85,17 +85,17 @@ class CloudEventKnativeServiceRequestClient extends KnativeServiceRequestClient 
     }
 
     private static Map<String, Object> createCloudEventWithGeneratedId(Map<String, Object> cloudEvent, String processInstanceId) {
-        Map<String, Object> modifiableCloudEvent = new HashMap<>(cloudEvent);
-        Object source = cloudEvent.get("source");
-        if (source == null) {
-            throw new IllegalArgumentException("Invalid CloudEvent: Attribute source is mandatory.");
-        }
-        modifiableCloudEvent.put(ID, generateCloudEventId(processInstanceId, source.toString()));
+        Map<String, Object> modifiableCloudEvent = ensureModifiable(cloudEvent);
+        modifiableCloudEvent.put(ID, generateCloudEventId(processInstanceId, cloudEvent));
         return modifiableCloudEvent;
     }
 
-    static String generateCloudEventId(String processInstanceId, String source) {
-        return source + '_' + processInstanceId;
+    private static Map<String, Object> ensureModifiable(Map<String, Object> map) {
+        return map instanceof HashMap ? map : new HashMap<>(map);
+    }
+
+    static String generateCloudEventId(String processInstanceId, Map<String, Object> cloudEvent) {
+        return processInstanceId + "_" + cloudEvent.hashCode();
     }
 
     @PreDestroy

--- a/quarkus/addons/knative/serving/runtime/src/test/java/org/kie/kogito/addons/quarkus/knative/serving/customfunctions/CloudEventKnativeServiceRequestClientTest.java
+++ b/quarkus/addons/knative/serving/runtime/src/test/java/org/kie/kogito/addons/quarkus/knative/serving/customfunctions/CloudEventKnativeServiceRequestClientTest.java
@@ -74,7 +74,7 @@ class CloudEventKnativeServiceRequestClientTest {
 
         client.sendRequest(processInstanceId, URI.create(wireMockServer.baseUrl()), "/cloud-event", cloudEvent);
 
-        String expectedCloudEventId = CloudEventKnativeServiceRequestClient.generateCloudEventId(processInstanceId, source);
+        String expectedCloudEventId = CloudEventKnativeServiceRequestClient.generateCloudEventId(processInstanceId, cloudEvent);
 
         wireMockServer.verify(postRequestedFor(urlEqualTo("/cloud-event"))
                 .withRequestBody(matchingJsonPath("$.id", equalTo(expectedCloudEventId)))

--- a/quarkus/addons/knative/serving/runtime/src/test/java/org/kie/kogito/addons/quarkus/knative/serving/customfunctions/CloudEventKnativeServiceRequestClientTest.java
+++ b/quarkus/addons/knative/serving/runtime/src/test/java/org/kie/kogito/addons/quarkus/knative/serving/customfunctions/CloudEventKnativeServiceRequestClientTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.addons.quarkus.knative.serving.customfunctions;
+
+import java.net.URI;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+
+import io.cloudevents.core.v1.CloudEventV1;
+import io.quarkus.test.junit.QuarkusTest;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.kie.kogito.addons.quarkus.knative.serving.customfunctions.KnativeServiceRequestClient.APPLICATION_CLOUDEVENTS_JSON_CHARSET_UTF_8;
+
+@QuarkusTest
+class CloudEventKnativeServiceRequestClientTest {
+
+    private static WireMockServer wireMockServer;
+
+    @Inject
+    CloudEventKnativeServiceRequestClient client;
+
+    @Test
+    void cloudEventWithoutIdMustHaveGeneratedId() {
+        mockServer();
+
+        String processInstanceId = "process1";
+        String source = "https://localhost:8080";
+        Map<String, Object> cloudEvent = Map.of(
+                CloudEventV1.SPECVERSION, 1.0,
+                "source", source,
+                "type", "org.kie.kogito.test",
+                "data", Map.of(
+                        "org", "Acme",
+                        "project", "Kogito"));
+
+        client.sendRequest(processInstanceId, URI.create(wireMockServer.baseUrl()), "/cloud-event", cloudEvent);
+
+        String expectedCloudEventId = CloudEventKnativeServiceRequestClient.generateCloudEventId(processInstanceId, source);
+
+        wireMockServer.verify(postRequestedFor(urlEqualTo("/cloud-event"))
+                .withRequestBody(matchingJsonPath("$.id", equalTo(expectedCloudEventId)))
+                .withHeader("Content-Type", equalTo(APPLICATION_CLOUDEVENTS_JSON_CHARSET_UTF_8)));
+    }
+
+    @Test
+    void cloudEventWithIdMustBeSentAsIs() {
+        mockServer();
+
+        String processInstanceId = "process1";
+        Map<String, Object> cloudEvent = Map.of(
+                CloudEventV1.SPECVERSION, 1.0,
+                "id", 42,
+                "source", "https://localhost:8080",
+                "type", "org.kie.kogito.test",
+                "data", Map.of(
+                        "org", "Acme",
+                        "project", "Kogito"));
+
+        client.sendRequest(processInstanceId, URI.create(wireMockServer.baseUrl()), "/cloud-event", cloudEvent);
+
+        wireMockServer.verify(postRequestedFor(urlEqualTo("/cloud-event"))
+                .withRequestBody(matchingJsonPath("$.id", equalTo("42")))
+                .withHeader("Content-Type", equalTo(APPLICATION_CLOUDEVENTS_JSON_CHARSET_UTF_8)));
+    }
+
+    private static void mockServer() {
+        wireMockServer.stubFor(post(urlEqualTo("/cloud-event"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", APPLICATION_CLOUDEVENTS_JSON_CHARSET_UTF_8)
+                        .withJsonBody(JsonNodeFactory.instance.objectNode()
+                                .put("message", "CloudEvents are awesome!")
+                                .set("object", JsonNodeFactory.instance.objectNode()
+                                        .put("long", 42L)
+                                        .put("String", "Knowledge is everything")))));
+    }
+
+    private static void createWiremockServer() {
+        wireMockServer = new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
+        wireMockServer.start();
+    }
+
+    @BeforeAll
+    static void beforeAll() {
+        createWiremockServer();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        if (wireMockServer != null) {
+            wireMockServer.stop();
+        }
+    }
+}

--- a/quarkus/addons/knative/serving/runtime/src/test/java/org/kie/kogito/addons/quarkus/knative/serving/customfunctions/CloudEventKnativeServiceRequestClientTest.java
+++ b/quarkus/addons/knative/serving/runtime/src/test/java/org/kie/kogito/addons/quarkus/knative/serving/customfunctions/CloudEventKnativeServiceRequestClientTest.java
@@ -16,18 +16,22 @@
 package org.kie.kogito.addons.quarkus.knative.serving.customfunctions;
 
 import java.net.URI;
+import java.util.HashMap;
 import java.util.Map;
 
 import javax.inject.Inject;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.kie.kogito.event.cloudevents.utils.InvalidCloudEventException;
 
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 
+import io.cloudevents.SpecVersion;
 import io.cloudevents.core.v1.CloudEventV1;
 import io.quarkus.test.junit.QuarkusTest;
 
@@ -37,7 +41,14 @@ import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static io.cloudevents.core.v1.CloudEventV1.DATACONTENTTYPE;
+import static io.cloudevents.core.v1.CloudEventV1.ID;
+import static io.cloudevents.core.v1.CloudEventV1.SOURCE;
+import static io.cloudevents.core.v1.CloudEventV1.SPECVERSION;
+import static io.cloudevents.core.v1.CloudEventV1.TIME;
+import static io.cloudevents.core.v1.CloudEventV1.TYPE;
 import static org.kie.kogito.addons.quarkus.knative.serving.customfunctions.KnativeServiceRequestClient.APPLICATION_CLOUDEVENTS_JSON_CHARSET_UTF_8;
+import static org.kie.kogito.event.cloudevents.utils.CloudEventUtils.DATA;
 
 @QuarkusTest
 class CloudEventKnativeServiceRequestClientTest {
@@ -89,6 +100,25 @@ class CloudEventKnativeServiceRequestClientTest {
         wireMockServer.verify(postRequestedFor(urlEqualTo("/cloud-event"))
                 .withRequestBody(matchingJsonPath("$.id", equalTo("42")))
                 .withHeader("Content-Type", equalTo(APPLICATION_CLOUDEVENTS_JSON_CHARSET_UTF_8)));
+    }
+
+    @Test
+    void invalidCloudEventMustThrowException() {
+        String processInstanceId = "process1";
+
+        Map<String, Object> cloudEvent = new HashMap<>();
+        cloudEvent.put(SPECVERSION, SpecVersion.V1.toString());
+        cloudEvent.put(ID, "abc-123");
+        cloudEvent.put(SOURCE, "/myapp");
+        cloudEvent.put(TYPE, "com.example.someevent");
+        cloudEvent.put(DATACONTENTTYPE, "application/json");
+        cloudEvent.put(TIME, "invalid");
+        cloudEvent.put(DATA, "{\"foo\":\"bar\"}");
+
+        URI uri = URI.create(wireMockServer.baseUrl());
+
+        Assertions.assertThatExceptionOfType(InvalidCloudEventException.class)
+                .isThrownBy(() -> client.sendRequest(processInstanceId, uri, "/cloud-event", cloudEvent));
     }
 
     private static void mockServer() {

--- a/quarkus/addons/knative/serving/runtime/src/test/java/org/kie/kogito/addons/quarkus/knative/serving/customfunctions/KnativeServerlessWorkflowCustomFunctionTest.java
+++ b/quarkus/addons/knative/serving/runtime/src/test/java/org/kie/kogito/addons/quarkus/knative/serving/customfunctions/KnativeServerlessWorkflowCustomFunctionTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.kie.kogito.event.cloudevents.utils.InvalidCloudEventException;
 import org.kie.kogito.process.workitem.WorkItemExecutionException;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/quarkus/addons/knative/serving/runtime/src/test/java/org/kie/kogito/addons/quarkus/knative/serving/customfunctions/KnativeServerlessWorkflowCustomFunctionTest.java
+++ b/quarkus/addons/knative/serving/runtime/src/test/java/org/kie/kogito/addons/quarkus/knative/serving/customfunctions/KnativeServerlessWorkflowCustomFunctionTest.java
@@ -330,7 +330,7 @@ class KnativeServerlessWorkflowCustomFunctionTest {
     void executeWithInvalidCloudEvent() {
         Map<String, Object> cloudEvent = Map.of(
                 CloudEventV1.SPECVERSION, SpecVersion.V1.toString(),
-                "type", "org.kie.kogito.test",
+                "source", "https://localhost:8080",
                 "data", Map.of(
                         "org", "Acme",
                         "project", "Kogito"));

--- a/quarkus/addons/knative/serving/runtime/src/test/java/org/kie/kogito/addons/quarkus/knative/serving/customfunctions/KnativeServerlessWorkflowCustomFunctionTest.java
+++ b/quarkus/addons/knative/serving/runtime/src/test/java/org/kie/kogito/addons/quarkus/knative/serving/customfunctions/KnativeServerlessWorkflowCustomFunctionTest.java
@@ -302,7 +302,7 @@ class KnativeServerlessWorkflowCustomFunctionTest {
         assertThat(output).hasToString(expected.toString());
 
         wireMockServer.verify(postRequestedFor(urlEqualTo(CLOUD_EVENT_PATH))
-                .withRequestBody(matchingJsonPath("$.id", equalTo(source + "_" + processInstanceId)))
+                .withRequestBody(matchingJsonPath("$.id", equalTo("42")))
                 .withHeader("Content-Type", equalTo(APPLICATION_CLOUDEVENTS_JSON_CHARSET_UTF_8)));
     }
 
@@ -337,9 +337,8 @@ class KnativeServerlessWorkflowCustomFunctionTest {
 
         String operation = SERVICENAME + "?asCloudEvent=true&path=" + CLOUD_EVENT_PATH;
 
-        assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> knativeServerlessWorkflowCustomFunction.execute(UNUSED, operation, cloudEvent))
-                .withMessage("Invalid CloudEvent. The following mandatory attributes are missing: source");
+        assertThatExceptionOfType(InvalidCloudEventException.class)
+                .isThrownBy(() -> knativeServerlessWorkflowCustomFunction.execute(UNUSED, operation, cloudEvent));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/KOGITO-8848

PR to update docs:

- https://github.com/kiegroup/kogito-docs/pull/337

-----------

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] native-lts</b>
 
- <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>

<details>
<summary>
Quarkus-3 PR check is failing ... what to do ?
</summary>
The Quarkus 3 check is applying patches from the `.ci/environments/quarkus-3/patches`.

The first patch, called `0001_before_sh.patch`, is generated from Openrewrite `.ci/environments/quarkus-3/quarkus3.yml` recipe. The patch is created to speed up the check. But it may be that some changes in the PR broke this patch.  
No panic, there is an easy way to regenerate it. You just need to comment on the PR:
```
jenkins rewrite quarkus-3
```
and it should, after some minutes (~20/30min) apply a commit on the PR with the patch regenerated.

Other patches were generated manually. If any of it fails, you will need to manually update it... and push your changes.
</details>
