### PR TITLE
[KOGITO-9217] Set property name to "kogito.codegen.process.failOnError"

### DIFF
--- a/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/ProcessCodegen.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/main/java/org/kie/kogito/codegen/process/ProcessCodegen.java
@@ -168,7 +168,7 @@ public class ProcessCodegen extends AbstractGenerator {
             ValidationLogDecorator decorator = new ValidationLogDecorator(processesErrors);
             decorator.decorate();
             //rethrow exception to break the flow after decoration unless property is set to false
-            if (context.getApplicationProperty("kogito.process.build.failOnError", Boolean.class).orElse(true)) {
+            if (context.getApplicationProperty("kogito.codegen.process.failOnError", Boolean.class).orElse(true)) {
                 throw new ProcessCodegenException("Processes with errors are " + decorator.toString());
             }
         }

--- a/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common/src/main/java/org/kie/kogito/quarkus/config/KogitoBuildTimeConfig.java
+++ b/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common/src/main/java/org/kie/kogito/quarkus/config/KogitoBuildTimeConfig.java
@@ -58,4 +58,11 @@ public class KogitoBuildTimeConfig {
     @ConfigItem(name = "codegen.ignoreHiddenFiles", defaultValue = "true")
     public Boolean ignoreHiddenFiles;
 
+    /**
+     * Whether to fail when there are parsing/validation errors of process assets
+     * <p>
+     * If not defined, true will be used.
+     */
+    @ConfigItem(name = "codegen.process.failOnError", defaultValue = "true")
+    public Boolean failOnError;
 }


### PR DESCRIPTION
To be consistent with alrady existing naming convention. Also adding the property to KogitoBuildTimeConfig bean to avoid quarkus warning
