### PR TITLE
[KOGITO-9281] Setting CE attributes as process instance headers

### DIFF
--- a/api/kogito-api/src/main/java/org/kie/kogito/process/ProcessInstance.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/process/ProcessInstance.java
@@ -62,6 +62,15 @@ public interface ProcessInstance<T> {
     void start(String trigger, String referenceId);
 
     /**
+     * Starts process instance with trigger
+     *
+     * @param trigger name of the trigger that will indicate what start node to trigger
+     * @param referenceId optional reference id that points to a another component triggering this instance
+     * @param headers process headers
+     */
+    void start(String trigger, String referenceId, Map<String, List<String>> headers);
+
+    /**
      * Starts process instance with trigger and headers
      *
      * @param trigger name of the trigger that will indicate what start node to trigger
@@ -91,6 +100,15 @@ public interface ProcessInstance<T> {
      * @param referenceId optional reference id that points to a another component triggering this instance
      */
     void startFrom(String nodeId, String referenceId);
+
+    /**
+     * Starts process instance from given node
+     *
+     * @param nodeId node id that should be used as the first node
+     * @param referenceId optional reference id that points to a another component triggering this instance
+     * @param headers process headers
+     */
+    void startFrom(String nodeId, String referenceId, Map<String, List<String>> headers);
 
     /**
      * Sends given signal into this process instance

--- a/api/kogito-api/src/main/java/org/kie/kogito/process/ProcessService.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/process/ProcessService.java
@@ -43,7 +43,16 @@ public interface ProcessService {
             T model, Map<String, List<String>> headers,
             String startFromNodeId);
 
+    default <T extends Model> ProcessInstance<T> createProcessInstance(Process<T> process, String businessKey, T model,
+            String startFromNodeId,
+            String trigger,
+            String kogitoReferenceId,
+            CompositeCorrelation correlation) {
+        return createProcessInstance(process, businessKey, model, Collections.emptyMap(), startFromNodeId, trigger, kogitoReferenceId, correlation);
+    }
+
     <T extends Model> ProcessInstance<T> createProcessInstance(Process<T> process, String businessKey, T model,
+            Map<String, List<String>> headers,
             String startFromNodeId,
             String trigger,
             String kogitoReferenceId,

--- a/api/kogito-events-core/src/main/java/org/kie/kogito/event/AbstractDataEvent.java
+++ b/api/kogito-events-core/src/main/java/org/kie/kogito/event/AbstractDataEvent.java
@@ -19,6 +19,7 @@ import java.net.URI;
 import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -317,7 +318,7 @@ public abstract class AbstractDataEvent<T> implements DataEvent<T> {
     @JsonIgnore
     @Override
     public Set<String> getAttributeNames() {
-        return DataEvent.super.getAttributeNames();
+        return specVersion == null ? Collections.emptySet() : DataEvent.super.getAttributeNames();
     }
 
     @JsonIgnore

--- a/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcessInstance.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/AbstractProcessInstance.java
@@ -264,7 +264,8 @@ public abstract class AbstractProcessInstance<T extends Model> implements Proces
         start(trigger, referenceId, Collections.emptyMap());
     }
 
-    private void start(String trigger, String referenceId, Map<String, List<String>> headers) {
+    @Override
+    public void start(String trigger, String referenceId, Map<String, List<String>> headers) {
         if (this.status != KogitoProcessInstance.STATE_PENDING) {
             throw new IllegalStateException("Impossible to start process instance that already has started");
         }
@@ -409,7 +410,8 @@ public abstract class AbstractProcessInstance<T extends Model> implements Proces
         startFrom(nodeId, referenceId, Collections.emptyMap());
     }
 
-    private void startFrom(String nodeId, String referenceId, Map<String, List<String>> headers) {
+    @Override
+    public void startFrom(String nodeId, String referenceId, Map<String, List<String>> headers) {
         processInstance.setStartDate(new Date());
         processInstance.setState(STATE_ACTIVE);
         getProcessRuntime().getProcessInstanceManager().addProcessInstance(this.processInstance);

--- a/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/ProcessServiceImpl.java
+++ b/jbpm/jbpm-flow/src/main/java/org/kie/kogito/process/impl/ProcessServiceImpl.java
@@ -78,17 +78,17 @@ public class ProcessServiceImpl implements ProcessService {
     @Override
     public <T extends Model> ProcessInstance<T> createProcessInstance(Process<T> process, String businessKey,
             T model,
+            Map<String, List<String>> headers,
             String startFromNodeId,
             String trigger,
             String kogitoReferenceId,
             CompositeCorrelation correlation) {
-
         return UnitOfWorkExecutor.executeInUnitOfWork(application.unitOfWorkManager(), () -> {
             ProcessInstance<T> pi = process.createInstance(businessKey, correlation, model);
             if (startFromNodeId != null) {
-                pi.startFrom(startFromNodeId, kogitoReferenceId);
+                pi.startFrom(startFromNodeId, kogitoReferenceId, headers);
             } else {
-                pi.start(trigger, kogitoReferenceId);
+                pi.start(trigger, kogitoReferenceId, headers);
             }
             return pi;
         });
@@ -397,5 +397,4 @@ public class ProcessServiceImpl implements ProcessService {
                 new Policy<?>[] { policy },
                 JsonSchemaUtil.load(Thread.currentThread().getContextClassLoader(), process.id(), taskName));
     }
-
 }


### PR DESCRIPTION
As requested on comunity, this add CE attributes/extensions as headers available in KogitoProcessContext. 
I reused the exist Map<String,List<String>> interface. 
