### PR TITLE
[KOGITO-9501] Changing Everit to json-schema-validator

### DIFF
--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -22,6 +22,7 @@
     <version.org.apache.kafka>3.4.0</version.org.apache.kafka>
 
     <!-- dependencies versions -->
+    <version.com.networknt>1.0.86</version.com.networknt>
     <version.com.fasterxml.jackson>2.14.2</version.com.fasterxml.jackson>
     <version.com.fasterxml.jackson.databind>2.14.2</version.com.fasterxml.jackson.databind>
     <version.com.jayway.jsonpath>2.8.0</version.com.jayway.jsonpath>
@@ -34,7 +35,6 @@
     <version.io.quarkiverse.embedded.postgresql>0.0.8</version.io.quarkiverse.embedded.postgresql>
     <version.com.github.haifengl.smile>1.5.2</version.com.github.haifengl.smile>
     <version.com.github.javaparser>3.24.2</version.com.github.javaparser>
-    <version.com.github.java-json-tools>2.2.14</version.com.github.java-json-tools>
     <version.com.fasterxml.jackson.datatype>2.14.2</version.com.fasterxml.jackson.datatype>
     <version.com.github.victools>4.18.0</version.com.github.victools>
     <version.com.github.tomakehurst.wiremock>2.33.2</version.com.github.tomakehurst.wiremock>
@@ -703,9 +703,15 @@
         <version>${version.com.github.victools}</version>
       </dependency>
       <dependency>
-        <groupId>com.github.java-json-tools</groupId>
+        <groupId>com.networknt</groupId>
         <artifactId>json-schema-validator</artifactId>
-        <version>${version.com.github.java-json-tools}</version>
+        <version>${version.com.networknt}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+          </exclusion>
+         </exclusions>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -36,7 +36,6 @@
     <version.com.github.javaparser>3.24.2</version.com.github.javaparser>
     <version.com.github.java-json-tools>2.2.14</version.com.github.java-json-tools>
     <version.com.fasterxml.jackson.datatype>2.14.2</version.com.fasterxml.jackson.datatype>
-    <version.com.github.erosb>1.14.2</version.com.github.erosb>
     <version.com.github.victools>4.18.0</version.com.github.victools>
     <version.com.github.tomakehurst.wiremock>2.33.2</version.com.github.tomakehurst.wiremock>
     <version.com.google.protobuf>3.22.0</version.com.google.protobuf>
@@ -707,19 +706,12 @@
         <groupId>com.github.java-json-tools</groupId>
         <artifactId>json-schema-validator</artifactId>
         <version>${version.com.github.java-json-tools}</version>
-        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-json-org</artifactId>
         <version>${version.com.fasterxml.jackson.datatype}</version>
       </dependency>
-      <dependency>
-        <groupId>com.github.erosb</groupId>
-        <artifactId>everit-json-schema</artifactId>
-        <version>${version.com.github.erosb}</version>
-      </dependency>
-
       <!-- Serverless Workflow -->
       <dependency>
         <groupId>io.serverlessworkflow</groupId>

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/pom.xml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/pom.xml
@@ -23,10 +23,6 @@
       <artifactId>kogito-serverless-workflow-runtime</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.github.erosb</groupId>
-      <artifactId>everit-json-schema</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-codegen-api</artifactId>
     </dependency>

--- a/kogito-serverless-workflow/kogito-serverless-workflow-runtime/pom.xml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-runtime/pom.xml
@@ -26,10 +26,10 @@
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-rest-utils</artifactId>
     </dependency>
-    <dependency>
-      <groupId>com.github.java-json-tools</groupId>
-      <artifactId>json-schema-validator</artifactId>
-    </dependency>
+   <dependency>
+     <groupId>com.networknt</groupId>
+     <artifactId>json-schema-validator</artifactId>
+   </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-json-org</artifactId>

--- a/kogito-serverless-workflow/kogito-serverless-workflow-runtime/pom.xml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-runtime/pom.xml
@@ -27,8 +27,8 @@
       <artifactId>kogito-rest-utils</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.github.erosb</groupId>
-      <artifactId>everit-json-schema</artifactId>
+      <groupId>com.github.java-json-tools</groupId>
+      <artifactId>json-schema-validator</artifactId>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/kogito-serverless-workflow/kogito-serverless-workflow-runtime/src/main/java/org/kie/kogito/serverless/workflow/actions/JsonSchemaValidator.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-runtime/src/main/java/org/kie/kogito/serverless/workflow/actions/JsonSchemaValidator.java
@@ -54,7 +54,9 @@ public class JsonSchemaValidator implements WorkflowModelValidator {
         try {
             ProcessingReport report = JsonSchemaFactory.byDefault().getJsonSchema(schemaData()).validate((JsonNode) model.getOrDefault(SWFConstants.DEFAULT_WORKFLOW_VAR, NullNode.instance));
             if (!report.isSuccess()) {
-                final String validationMessage = String.format("Validation errors %s", report.toString());
+                StringBuilder sb = new StringBuilder("There are JsonSchema validation errors:");
+                report.forEach(m -> sb.append(System.lineSeparator()).append(m.getMessage()));
+                final String validationMessage = sb.toString();
                 logger.warn(validationMessage);
                 if (failOnValidationErrors) {
                     throw new IllegalArgumentException(validationMessage);

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/src/main/java/org/kie/kogito/serverless/workflow/parser/schema/OpenApiModelSchemaGenerator.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/src/main/java/org/kie/kogito/serverless/workflow/parser/schema/OpenApiModelSchemaGenerator.java
@@ -115,7 +115,7 @@ public final class OpenApiModelSchemaGenerator {
 
     private static Schema getSchema(JsonSchemaValidator validator) {
         try {
-            return ObjectMapperFactory.get().readValue(validator.load().toString(), JsonSchemaImpl.class);
+            return ObjectMapperFactory.get().convertValue(validator.schemaData(), JsonSchemaImpl.class);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/ExpressionRestIT.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/ExpressionRestIT.java
@@ -67,7 +67,7 @@ class ExpressionRestIT {
                 .post("/invalidOutputExpression")
                 .then()
                 .statusCode(is(400))
-                .body("message", containsString("required key [message] not found"))
+                .body("message", containsString("message"))
                 .body("id", notNullValue());
     }
 }

--- a/quarkus/integration-tests/integration-tests-quarkus-processes/pom.xml
+++ b/quarkus/integration-tests/integration-tests-quarkus-processes/pom.xml
@@ -83,12 +83,6 @@
       <artifactId>rest-assured</artifactId>
       <scope>test</scope>
     </dependency>
-
-    <dependency>
-      <groupId>com.github.java-json-tools</groupId>
-      <artifactId>json-schema-validator</artifactId>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>json-schema-validator</artifactId>


### PR DESCRIPTION
Using jackson validator rather than gson one. 
In order gson one to dissapear completely, we need PR to remove it from [Java SDK.](https://github.com/serverlessworkflow/sdk-java/blob/main/pom.xml#L130-L140) 
There is also another subttle change in behaviour (for good). This jackson API allows us to distinghish between a validation failure of the schema against the data (that might or not be ignored as per spec) and a failure parsing the schema itself (which in my opinion should be propagated always because there is a fatal configuration error that requires user intervention, for example, a bad formatted schema file or an unavailable one) . 