### PR TITLE
[KOGITO-9568] Declaring dmn as optional

### DIFF
--- a/addons/common/source-files/pom.xml
+++ b/addons/common/source-files/pom.xml
@@ -15,7 +15,7 @@
     <dependencies>
         <dependency>
             <groupId>org.kie.kogito</groupId>
-            <artifactId>kogito-codegen-processes</artifactId>
+            <artifactId>kogito-api</artifactId>
         </dependency>
         <!-- Test -->
 

--- a/addons/common/source-files/src/main/java/org/kie/kogito/addon/source/files/SourceFilesProviderImpl.java
+++ b/addons/common/source-files/src/main/java/org/kie/kogito/addon/source/files/SourceFilesProviderImpl.java
@@ -23,7 +23,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
-import org.kie.kogito.codegen.process.ProcessCodegen;
+import org.kie.kogito.internal.SupportedExtensions;
 
 public final class SourceFilesProviderImpl implements SourceFilesProvider {
 
@@ -54,9 +54,7 @@ public final class SourceFilesProviderImpl implements SourceFilesProvider {
     }
 
     private boolean isValidDefinitionSource(SourceFile sourceFile) {
-        if (ProcessCodegen.SUPPORTED_BPMN_EXTENSIONS.stream().noneMatch(sourceFile.getUri()::endsWith)) {
-            return ProcessCodegen.SUPPORTED_SW_EXTENSIONS.keySet().stream().anyMatch(sourceFile.getUri()::endsWith);
-        }
-        return true;
+        return SupportedExtensions.getBPMNExtensions().stream().anyMatch(sourceFile.getUri()::endsWith) ||
+                SupportedExtensions.getSWFExtensions().stream().anyMatch(sourceFile.getUri()::endsWith);
     }
 }

--- a/addons/common/source-files/src/main/java/org/kie/kogito/addon/source/files/SourceFilesProviderImpl.java
+++ b/addons/common/source-files/src/main/java/org/kie/kogito/addon/source/files/SourceFilesProviderImpl.java
@@ -54,7 +54,6 @@ public final class SourceFilesProviderImpl implements SourceFilesProvider {
     }
 
     private boolean isValidDefinitionSource(SourceFile sourceFile) {
-        return SupportedExtensions.getBPMNExtensions().stream().anyMatch(sourceFile.getUri()::endsWith) ||
-                SupportedExtensions.getSWFExtensions().stream().anyMatch(sourceFile.getUri()::endsWith);
+        return SupportedExtensions.isSourceFile(sourceFile.getUri());
     }
 }

--- a/api/kogito-api/src/main/java/org/kie/kogito/internal/SupportedExtensions.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/internal/SupportedExtensions.java
@@ -13,21 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.kie.kogito.serverless.workflow.utils;
+package org.kie.kogito.internal;
 
-import java.nio.file.Path;
+import java.util.Set;
 
-public enum WorkflowFormat {
-    JSON,
-    YAML;
+public class SupportedExtensions {
 
-    private static final String JSON_EXTENSION = ".json";
+    private static final Set<String> BPMN_EXTENSIONS = Set.of(".bpmn", ".bpmn2");
+    private static final Set<String> SWF_EXTENSIONS = Set.of(".sw.yml", ".sw.yaml", ".sw.json");
 
-    public static WorkflowFormat fromFileName(String fileName) {
-        return fileName.endsWith(JSON_EXTENSION) ? JSON : YAML;
+    public static Set<String> getBPMNExtensions() {
+        return BPMN_EXTENSIONS;
     }
 
-    public static WorkflowFormat fromFileName(Path fileName) {
-        return fromFileName(fileName.toString());
+    public static Set<String> getSWFExtensions() {
+        return SWF_EXTENSIONS;
+    }
+
+    private SupportedExtensions() {
     }
 }

--- a/api/kogito-api/src/main/java/org/kie/kogito/internal/SupportedExtensions.java
+++ b/api/kogito-api/src/main/java/org/kie/kogito/internal/SupportedExtensions.java
@@ -15,12 +15,22 @@
  */
 package org.kie.kogito.internal;
 
+import java.nio.file.Path;
 import java.util.Set;
 
 public class SupportedExtensions {
 
     private static final Set<String> BPMN_EXTENSIONS = Set.of(".bpmn", ".bpmn2");
     private static final Set<String> SWF_EXTENSIONS = Set.of(".sw.yml", ".sw.yaml", ".sw.json");
+
+    public static boolean isSourceFile(Path file) {
+        return isSourceFile(file.toString());
+    }
+
+    public static boolean isSourceFile(String file) {
+        return BPMN_EXTENSIONS.stream().anyMatch(file::endsWith)
+                || SWF_EXTENSIONS.stream().anyMatch(file::endsWith);
+    }
 
     public static Set<String> getBPMNExtensions() {
         return BPMN_EXTENSIONS;

--- a/jbpm/jbpm-flow-builder/pom.xml
+++ b/jbpm/jbpm-flow-builder/pom.xml
@@ -38,6 +38,11 @@
       <artifactId>jbpm-flow</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-dmn</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-compiler</artifactId>
     </dependency>

--- a/jbpm/jbpm-flow/pom.xml
+++ b/jbpm/jbpm-flow/pom.xml
@@ -40,6 +40,7 @@
     <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-dmn</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.kie.kogito</groupId>

--- a/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/java/org/kie/kogito/codegen/process/ProcessGenerationIT.java
+++ b/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/java/org/kie/kogito/codegen/process/ProcessGenerationIT.java
@@ -113,8 +113,7 @@ public class ProcessGenerationIT extends AbstractCodegenIT {
         Set<String> ignoredFiles = Files.lines(BASE_PATH.resolve("org/kie/kogito/codegen/process/process-generation-test.skip.txt"))
                 .collect(Collectors.toSet());
         return Files.find(BASE_PATH, 10, ((path, basicFileAttributes) -> basicFileAttributes.isRegularFile()
-                && (SupportedExtensions.getBPMNExtensions().stream().anyMatch(ext -> path.getFileName().toString().endsWith(ext))
-                        || SupportedExtensions.getSWFExtensions().stream().anyMatch(ext -> path.getFileName().toString().endsWith(ext)))))
+                && SupportedExtensions.isSourceFile(path)))
                 .map(BASE_PATH::relativize)
                 .map(Path::toString)
                 .filter(p -> ignoredFiles.stream().noneMatch(ignored -> p.contains(ignored)));

--- a/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/java/org/kie/kogito/codegen/process/ProcessGenerationIT.java
+++ b/kogito-codegen-modules/kogito-codegen-processes-integration-tests/src/test/java/org/kie/kogito/codegen/process/ProcessGenerationIT.java
@@ -69,6 +69,7 @@ import org.kie.kogito.Application;
 import org.kie.kogito.Model;
 import org.kie.kogito.codegen.AbstractCodegenIT;
 import org.kie.kogito.codegen.api.io.CollectedResource;
+import org.kie.kogito.internal.SupportedExtensions;
 import org.kie.kogito.process.Processes;
 import org.kie.kogito.process.impl.AbstractProcess;
 
@@ -112,8 +113,8 @@ public class ProcessGenerationIT extends AbstractCodegenIT {
         Set<String> ignoredFiles = Files.lines(BASE_PATH.resolve("org/kie/kogito/codegen/process/process-generation-test.skip.txt"))
                 .collect(Collectors.toSet());
         return Files.find(BASE_PATH, 10, ((path, basicFileAttributes) -> basicFileAttributes.isRegularFile()
-                && (ProcessCodegen.SUPPORTED_BPMN_EXTENSIONS.stream().anyMatch(ext -> path.getFileName().toString().endsWith(ext))
-                        || ProcessCodegen.SUPPORTED_SW_EXTENSIONS.keySet().stream().anyMatch(ext -> path.getFileName().toString().endsWith(ext)))))
+                && (SupportedExtensions.getBPMNExtensions().stream().anyMatch(ext -> path.getFileName().toString().endsWith(ext))
+                        || SupportedExtensions.getSWFExtensions().stream().anyMatch(ext -> path.getFileName().toString().endsWith(ext)))))
                 .map(BASE_PATH::relativize)
                 .map(Path::toString)
                 .filter(p -> ignoredFiles.stream().noneMatch(ignored -> p.contains(ignored)));

--- a/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/process/ProcessGenerationUtils.java
+++ b/kogito-codegen-modules/kogito-codegen-processes/src/test/java/org/kie/kogito/codegen/process/ProcessGenerationUtils.java
@@ -26,7 +26,9 @@ import org.drools.io.FileSystemResource;
 import org.jbpm.compiler.canonical.ProcessToExecModelGenerator;
 import org.kie.api.definition.process.Process;
 import org.kie.kogito.codegen.api.context.impl.JavaKogitoBuildContext;
+import org.kie.kogito.internal.SupportedExtensions;
 import org.kie.kogito.internal.process.runtime.KogitoWorkflowProcess;
+import org.kie.kogito.serverless.workflow.utils.WorkflowFormat;
 
 /**
  * Utilities for unit Process generation tests
@@ -57,13 +59,10 @@ public class ProcessGenerationUtils {
         for (File processSourceFile : processFiles) {
             try {
                 FileSystemResource r = new FileSystemResource(processSourceFile);
-                if (ProcessCodegen.SUPPORTED_BPMN_EXTENSIONS.stream().anyMatch(processSourceFile.getPath()::endsWith)) {
+                if (SupportedExtensions.getBPMNExtensions().stream().anyMatch(processSourceFile.getPath()::endsWith)) {
                     processes.addAll(ProcessCodegen.parseProcessFile(r));
-                } else {
-                    ProcessCodegen.SUPPORTED_SW_EXTENSIONS.entrySet()
-                            .stream()
-                            .filter(e -> processSourceFile.getPath().endsWith(e.getKey()))
-                            .forEach(e -> processes.add(ProcessCodegen.parseWorkflowFile(r, e.getValue(), JavaKogitoBuildContext.builder().build()).info()));
+                } else if (SupportedExtensions.getSWFExtensions().stream().anyMatch(processSourceFile.getPath()::endsWith)) {
+                    processes.add(ProcessCodegen.parseWorkflowFile(r, WorkflowFormat.fromFileName(processSourceFile.getPath()), JavaKogitoBuildContext.builder().build()).info());
                 }
                 if (processes.isEmpty()) {
                     throw new IllegalArgumentException("Unable to process file with unsupported extension: " + processSourceFile);

--- a/quarkus/addons/source-files/deployment/src/main/java/org/kie/kogito/addon/source/files/deployment/KogitoAddOnSourceFilesProcessor.java
+++ b/quarkus/addons/source-files/deployment/src/main/java/org/kie/kogito/addon/source/files/deployment/KogitoAddOnSourceFilesProcessor.java
@@ -26,6 +26,7 @@ import java.util.stream.Stream;
 import org.kie.kogito.addon.source.files.SourceFilesProviderProducer;
 import org.kie.kogito.addon.source.files.SourceFilesRecorder;
 import org.kie.kogito.codegen.api.context.KogitoBuildContext;
+import org.kie.kogito.internal.SupportedExtensions;
 import org.kie.kogito.quarkus.addons.common.deployment.KogitoCapability;
 import org.kie.kogito.quarkus.addons.common.deployment.OneOfCapabilityKogitoAddOnProcessor;
 import org.kie.kogito.quarkus.common.deployment.KogitoBuildContextBuildItem;
@@ -36,9 +37,6 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
-
-import static org.kie.kogito.codegen.process.ProcessCodegen.SUPPORTED_BPMN_EXTENSIONS;
-import static org.kie.kogito.codegen.process.ProcessCodegen.SUPPORTED_SW_EXTENSIONS;
 
 class KogitoAddOnSourceFilesProcessor extends OneOfCapabilityKogitoAddOnProcessor {
 
@@ -98,7 +96,7 @@ class KogitoAddOnSourceFilesProcessor extends OneOfCapabilityKogitoAddOnProcesso
     }
 
     private boolean isSourceFile(Path file) {
-        return SUPPORTED_BPMN_EXTENSIONS.stream().anyMatch(extension -> file.toString().endsWith(extension))
-                || SUPPORTED_SW_EXTENSIONS.keySet().stream().anyMatch(extension -> file.toString().endsWith(extension));
+        return SupportedExtensions.getBPMNExtensions().stream().anyMatch(extension -> file.toString().endsWith(extension))
+                || SupportedExtensions.getSWFExtensions().stream().anyMatch(extension -> file.toString().endsWith(extension));
     }
 }

--- a/quarkus/addons/source-files/deployment/src/main/java/org/kie/kogito/addon/source/files/deployment/KogitoAddOnSourceFilesProcessor.java
+++ b/quarkus/addons/source-files/deployment/src/main/java/org/kie/kogito/addon/source/files/deployment/KogitoAddOnSourceFilesProcessor.java
@@ -96,7 +96,6 @@ class KogitoAddOnSourceFilesProcessor extends OneOfCapabilityKogitoAddOnProcesso
     }
 
     private boolean isSourceFile(Path file) {
-        return SupportedExtensions.getBPMNExtensions().stream().anyMatch(extension -> file.toString().endsWith(extension))
-                || SupportedExtensions.getSWFExtensions().stream().anyMatch(extension -> file.toString().endsWith(extension));
+        return SupportedExtensions.isSourceFile(file);
     }
 }

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/src/main/java/org/kie/kogito/quarkus/serverless/workflow/WorkflowCodeGenUtils.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/src/main/java/org/kie/kogito/quarkus/serverless/workflow/WorkflowCodeGenUtils.java
@@ -30,12 +30,13 @@ import org.drools.codegen.common.GeneratedFile;
 import org.drools.codegen.common.GeneratedFileType;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.kie.kogito.codegen.api.context.KogitoBuildContext;
-import org.kie.kogito.codegen.process.ProcessCodegen;
+import org.kie.kogito.internal.SupportedExtensions;
 import org.kie.kogito.serverless.workflow.io.URIContentLoaderFactory;
 import org.kie.kogito.serverless.workflow.operationid.WorkflowOperationId;
 import org.kie.kogito.serverless.workflow.operationid.WorkflowOperationIdFactory;
 import org.kie.kogito.serverless.workflow.operationid.WorkflowOperationIdFactoryProvider;
 import org.kie.kogito.serverless.workflow.utils.ServerlessWorkflowUtils;
+import org.kie.kogito.serverless.workflow.utils.WorkflowFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -95,12 +96,12 @@ public class WorkflowCodeGenUtils {
     }
 
     private static Optional<Workflow> getWorkflow(Path path) {
-        return workflowCache.computeIfAbsent(path, p -> ProcessCodegen.SUPPORTED_SW_EXTENSIONS.entrySet()
+        return workflowCache.computeIfAbsent(path, p -> SupportedExtensions.getSWFExtensions()
                 .stream()
-                .filter(e -> p.getFileName().toString().endsWith(e.getKey()))
+                .filter(e -> p.getFileName().toString().endsWith(e))
                 .map(e -> {
                     try (Reader r = Files.newBufferedReader(p)) {
-                        return Optional.of(ServerlessWorkflowUtils.getWorkflow(r, e.getValue()));
+                        return Optional.of(ServerlessWorkflowUtils.getWorkflow(r, WorkflowFormat.fromFileName(p.getFileName())));
                     } catch (IOException ex) {
                         if (ConfigProvider.getConfig().getOptionalValue(FAIL_ON_ERROR_PROPERTY, Boolean.class).orElse(true)) {
                             throw new UncheckedIOException(ex);

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/src/main/java/org/kie/kogito/quarkus/serverless/workflow/deployment/ServerlessWorkflowCompilationProvider.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/src/main/java/org/kie/kogito/quarkus/serverless/workflow/deployment/ServerlessWorkflowCompilationProvider.java
@@ -17,13 +17,13 @@ package org.kie.kogito.quarkus.serverless.workflow.deployment;
 
 import java.util.Set;
 
-import org.kie.kogito.codegen.process.ProcessCodegen;
+import org.kie.kogito.internal.SupportedExtensions;
 import org.kie.kogito.quarkus.common.deployment.KogitoCompilationProvider;
 
 public class ServerlessWorkflowCompilationProvider extends KogitoCompilationProvider {
 
     @Override
     public Set<String> handledExtensions() {
-        return ProcessCodegen.SUPPORTED_SW_EXTENSIONS.keySet();
+        return SupportedExtensions.getSWFExtensions();
     }
 }


### PR DESCRIPTION
Besides declaring DMN as optional in jbpm-flow and jbpm-flow-builder, this refactors the extension identification code to avoid an undesired dependency between source addon and codegen, which carry forward dmn (because codegen correctly depends on bpmn2, which needs dmn)

To be merged with https://github.com/kiegroup/kogito-apps/pull/1808
