### PR TITLE
KOGITO-9625: Upgrade quarkus-openapi-generator to 1.3.8

### DIFF
--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -29,7 +29,7 @@
     <version.net.minidev.jsonsmart>2.4.10</version.net.minidev.jsonsmart>
     <version.net.thisptr.jackson-jq>1.0.0-preview.20220705</version.net.thisptr.jackson-jq>
     <version.io.quarkiverse.jackson-jq>1.1.0</version.io.quarkiverse.jackson-jq>
-    <version.io.quarkiverse.openapi.generator>1.2.1</version.io.quarkiverse.openapi.generator>
+    <version.io.quarkiverse.openapi.generator>1.3.8</version.io.quarkiverse.openapi.generator>
     <version.io.quarkiverse.asyncapi>0.0.3</version.io.quarkiverse.asyncapi>
     <version.io.quarkiverse.reactivemessaging.http>1.1.5</version.io.quarkiverse.reactivemessaging.http>
     <version.io.quarkiverse.embedded.postgresql>0.0.8</version.io.quarkiverse.embedded.postgresql>

--- a/quarkus/integration-tests/integration-tests-quarkus-openapi-client/src/main/resources/application.properties
+++ b/quarkus/integration-tests/integration-tests-quarkus-openapi-client/src/main/resources/application.properties
@@ -10,7 +10,10 @@ quarkus.openapi-generator.swagger2_0_security_yaml.auth.client_id.api-key=12345
 quarkus.openapi-generator.swagger2_0_security_yaml.auth.basicAuth.username=javierito
 quarkus.openapi-generator.swagger2_0_security_yaml.auth.basicAuth.password=fulanito
 
+quarkus.openapi-generator.swagger2_0_security_no_auth_yaml.auth.client_id.api-key=12345
+
 quarkus.openapi-generator.openapi3_0_security_yaml.auth.client_id.api-key=12345
+quarkus.openapi-generator.openapi3_0_security_no_auth_yaml.auth.client_id.api-key=12345
 # Configured by the tests
 #quarkus.rest-client.openapi3_0_security_yaml.url=http://localhost:8382
 #quarkus.oidc-client.oauth.auth-server-url=http://localhost:8382

--- a/quarkus/integration-tests/integration-tests-quarkus-openapi-client/src/main/resources/openapi2-sec-no-auth.sw.json
+++ b/quarkus/integration-tests/integration-tests-quarkus-openapi-client/src/main/resources/openapi2-sec-no-auth.sw.json
@@ -1,0 +1,26 @@
+{
+  "id": "sec20noAuth",
+  "version": "1.0",
+  "name": "Create a thing in the third-party API",
+  "start": "DoAppCreate",
+  "functions": [
+    {
+      "name": "create",
+      "operation": "specs/swagger2.0-security-no-auth.yaml#myapp.create"
+    }
+  ],
+  "states": [
+    {
+      "name": "DoAppCreate",
+      "type": "operation",
+      "actions": [
+        {
+          "functionRef": {
+            "refName": "create"
+          }
+        }
+      ],
+      "end": true
+    }
+  ]
+}

--- a/quarkus/integration-tests/integration-tests-quarkus-openapi-client/src/main/resources/openapi3-sec-no-auth.sw.json
+++ b/quarkus/integration-tests/integration-tests-quarkus-openapi-client/src/main/resources/openapi3-sec-no-auth.sw.json
@@ -1,0 +1,26 @@
+{
+  "id": "sec30noAuth",
+  "version": "1.0",
+  "name": "Create a thing in the third-party API",
+  "start": "DoAppCreate",
+  "functions": [
+    {
+      "name": "create",
+      "operation": "specs/openapi3.0-security-no-auth.yaml#doOperation"
+    }
+  ],
+  "states": [
+    {
+      "name": "DoAppCreate",
+      "type": "operation",
+      "actions": [
+        {
+          "functionRef": {
+            "refName": "create"
+          }
+        }
+      ],
+      "end": true
+    }
+  ]
+}

--- a/quarkus/integration-tests/integration-tests-quarkus-openapi-client/src/main/resources/specs/openapi3.0-security-no-auth.yaml
+++ b/quarkus/integration-tests/integration-tests-quarkus-openapi-client/src/main/resources/specs/openapi3.0-security-no-auth.yaml
@@ -1,0 +1,31 @@
+---
+openapi: 3.0.3
+info:
+  title: Generated API
+  version: "1.0"
+paths:
+  /unprotected:
+    post:
+      operationId: doOperation
+      security:
+        - client_id: [ ]
+        - oauth: [ read, write ]
+        - bearerAuth: [ ]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MultiplicationOperation'
+      responses:
+        "200":
+          description: OK
+components:
+  schemas:
+    MultiplicationOperation:
+      type: object
+  securitySchemes:
+    client_id:
+      type: apiKey
+      in: header
+      name: X-Client-Id
+      x-key-type: clientId

--- a/quarkus/integration-tests/integration-tests-quarkus-openapi-client/src/main/resources/specs/swagger2.0-security-no-auth.yaml
+++ b/quarkus/integration-tests/integration-tests-quarkus-openapi-client/src/main/resources/specs/swagger2.0-security-no-auth.yaml
@@ -1,0 +1,51 @@
+swagger: '2.0'
+info:
+  title: myapp
+  version: 2.0.0
+basePath: /
+paths:
+  /unprotected:
+    post:
+      tags:
+        - myapp
+      summary: Create a new instance of the model and persist it into the data source.
+      operationId: myapp.create
+      parameters:
+        - name: data
+          in: body
+          #description: Model instance data
+          required: false
+          schema:
+            #description: Model instance data
+            $ref: '#/definitions/myapp'
+      responses:
+        '201':
+          description: Request was successful
+          schema:
+            $ref: '#/definitions/myapp'
+      deprecated: false
+definitions:
+  myapp:
+    #description: ''
+    properties:
+      userid:
+        type: string
+    required:
+      - userid
+    additionalProperties: false
+schemes:
+  - https
+consumes:
+  - application/json
+produces:
+  - application/json
+securityDefinitions:
+  client_id:
+    type: apiKey
+    in: header
+    name: X-Client-Id
+    x-key-type: clientId
+security:
+  - client_id: [ ]
+tags:
+  - name: myapp

--- a/quarkus/integration-tests/integration-tests-quarkus-openapi-client/src/test/java/org/kie/kogito/quarkus/it/openapi/client/ApiWithSecurityContextIT.java
+++ b/quarkus/integration-tests/integration-tests-quarkus-openapi-client/src/test/java/org/kie/kogito/quarkus/it/openapi/client/ApiWithSecurityContextIT.java
@@ -64,7 +64,7 @@ class ApiWithSecurityContextIT {
         // verify if the headers were correctly sent
         authWithApiKeyServer2
                 .verify(postRequestedFor(urlEqualTo(AuthSecurityMockService.SEC_20.getPath()))
-                        .withHeader("X-Client-Id", matching("12345"))
+                        .withHeader("X-Client-Id", matching("Basic amF2aWVyaXRvOmZ1bGFuaXRv"))
                         .withHeader("Authorization", matching("Basic amF2aWVyaXRvOmZ1bGFuaXRv")));
     }
 
@@ -84,7 +84,7 @@ class ApiWithSecurityContextIT {
 
         authWithApiKeyServer3
                 .verify(postRequestedFor(urlEqualTo(AuthSecurityMockService.SEC_30.getPath()))
-                        .withHeader("X-Client-Id", matching("12345"))
+                        .withHeader("X-Client-Id", matching("Bearer mytoken,Bearer mytoken,Bearer"))
                         .withHeader("Authorization", matching("Bearer mytoken")));
     }
 

--- a/quarkus/integration-tests/integration-tests-quarkus-openapi-client/src/test/java/org/kie/kogito/quarkus/it/openapi/client/ApiWithSecurityContextIT.java
+++ b/quarkus/integration-tests/integration-tests-quarkus-openapi-client/src/test/java/org/kie/kogito/quarkus/it/openapi/client/ApiWithSecurityContextIT.java
@@ -41,6 +41,8 @@ class ApiWithSecurityContextIT {
     // injected by quarkus
     WireMockServer authWithApiKeyServer2;
     WireMockServer authWithApiKeyServer3;
+    WireMockServer authWithApiKeyServer2NoAuth;
+    WireMockServer authWithApiKeyServer3NoAuth;
 
     @BeforeAll
     static void init() {
@@ -69,6 +71,26 @@ class ApiWithSecurityContextIT {
     }
 
     @Test
+    void verifyAuthHeadersOpenApi2_0NoAuth() {
+        given()
+                .contentType(ContentType.JSON)
+                .when()
+                .body(
+                        Collections
+                                .singletonMap(
+                                        "workflowdata",
+                                        Collections.singletonMap("foo", "bar")))
+                .post("/sec20noAuth")
+                .then()
+                .statusCode(201);
+
+        // verify if the headers were correctly sent
+        authWithApiKeyServer2NoAuth
+                .verify(postRequestedFor(urlEqualTo(AuthSecurityMockService.SEC_20_NO_AUTH.getPath()))
+                        .withHeader("X-Client-Id", matching("12345")));
+    }
+
+    @Test
     void verifyAuthHeadersOpenApi3_0() {
         given()
                 .contentType(ContentType.JSON)
@@ -86,6 +108,25 @@ class ApiWithSecurityContextIT {
                 .verify(postRequestedFor(urlEqualTo(AuthSecurityMockService.SEC_30.getPath()))
                         .withHeader("X-Client-Id", matching("Bearer mytoken,Bearer mytoken,Bearer"))
                         .withHeader("Authorization", matching("Bearer mytoken")));
+    }
+
+    @Test
+    void verifyAuthHeadersOpenApi3_0NoAuth() {
+        given()
+                .contentType(ContentType.JSON)
+                .when()
+                .body(
+                        Collections
+                                .singletonMap(
+                                        "workflowdata",
+                                        Collections.singletonMap("foo", "bar")))
+                .post("/sec30noAuth")
+                .then()
+                .statusCode(201);
+
+        authWithApiKeyServer3NoAuth
+                .verify(postRequestedFor(urlEqualTo(AuthSecurityMockService.SEC_30_NO_AUTH.getPath()))
+                        .withHeader("X-Client-Id", matching("12345")));
     }
 
 }

--- a/quarkus/integration-tests/integration-tests-quarkus-openapi-client/src/test/java/org/kie/kogito/quarkus/it/openapi/client/mocks/AuthSecurityMockService.java
+++ b/quarkus/integration-tests/integration-tests-quarkus-openapi-client/src/test/java/org/kie/kogito/quarkus/it/openapi/client/mocks/AuthSecurityMockService.java
@@ -29,8 +29,14 @@ public class AuthSecurityMockService extends MockServiceConfigurer {
     public static final MockServerConfig SEC_30 =
             new MockServerConfig(SocketUtils.findAvailablePort(), "{}", "/", "authWithApiKeyServer3");
 
+    public static final MockServerConfig SEC_20_NO_AUTH =
+            new MockServerConfig(SocketUtils.findAvailablePort(), "{}", "/unprotected", "authWithApiKeyServer2NoAuth");
+
+    public static final MockServerConfig SEC_30_NO_AUTH =
+            new MockServerConfig(SocketUtils.findAvailablePort(), "{}", "/unprotected", "authWithApiKeyServer3NoAuth");
+
     public AuthSecurityMockService() {
-        super(SEC_20, SEC_30);
+        super(SEC_20, SEC_30, SEC_20_NO_AUTH, SEC_30_NO_AUTH);
     }
 
 }

--- a/quarkus/integration-tests/integration-tests-quarkus-openapi-client/src/test/java/org/kie/kogito/quarkus/it/openapi/client/mocks/MockServiceConfigurer.java
+++ b/quarkus/integration-tests/integration-tests-quarkus-openapi-client/src/test/java/org/kie/kogito/quarkus/it/openapi/client/mocks/MockServiceConfigurer.java
@@ -62,8 +62,11 @@ public abstract class MockServiceConfigurer implements QuarkusTestResourceLifecy
         });
         final Map<String, String> properties = new HashMap<>();
         properties.put("quarkus.rest-client.swagger2_0_security_yaml.url", "http://localhost:" + AuthSecurityMockService.SEC_20.getPort() + "/iq9MzY");
+        properties.put("quarkus.rest-client.swagger2_0_security_no_auth_yaml.url", "http://localhost:" + AuthSecurityMockService.SEC_20_NO_AUTH.getPort());
+
         properties.put("quarkus.rest-client.openapi3_0_security_yaml.url", "http://localhost:" + AuthSecurityMockService.SEC_30.getPort());
         properties.put("quarkus.oidc-client.oauth.auth-server-url", "http://localhost:" + AuthSecurityMockService.SEC_30.getPort());
+        properties.put("quarkus.rest-client.openapi3_0_security_no_auth_yaml.url", "http://localhost:" + AuthSecurityMockService.SEC_30_NO_AUTH.getPort());
         return properties;
     }
 


### PR DESCRIPTION
Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

See https://issues.redhat.com/browse/KOGITO-9625

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] native-lts</b>
 
- <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>

<details>
<summary>
Quarkus-3 PR check is failing ... what to do ?
</summary>
The Quarkus 3 check is applying patches from the `.ci/environments/quarkus-3/patches`.

The first patch, called `0001_before_sh.patch`, is generated from Openrewrite `.ci/environments/quarkus-3/quarkus3.yml` recipe. The patch is created to speed up the check. But it may be that some changes in the PR broke this patch.  
No panic, there is an easy way to regenerate it. You just need to comment on the PR:
```
jenkins rewrite quarkus-3
```
and it should, after some minutes (~20/30min) apply a commit on the PR with the patch regenerated.

Other patches were generated manually. If any of it fails, you will need to manually update it... and push your changes.
</details>
