### PR TITLE
KOGITO-9605 Created abstract test class that implementations of `KubernetesServiceCatalog` must cover

### DIFF
--- a/addons/common/kubernetes-service-catalog/pom.xml
+++ b/addons/common/kubernetes-service-catalog/pom.xml
@@ -12,4 +12,17 @@
     <artifactId>kogito-addons-kubernetes-service-catalog</artifactId>
     <name>Kogito :: Add-Ons :: Kubernetes Service Catalog</name>
     <description>Common Library for Kubernetes Service Discovery implementations</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/addons/common/kubernetes-service-catalog/src/test/java/org/kie/kogito/addons/k8s/resource/catalog/KubernetesServiceCatalogTest.java
+++ b/addons/common/kubernetes-service-catalog/src/test/java/org/kie/kogito/addons/k8s/resource/catalog/KubernetesServiceCatalogTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.addons.k8s.resource.catalog;
+
+import java.net.URI;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.kie.kogito.addons.k8s.resource.catalog.KubernetesProtocol.KNATIVE;
+import static org.kie.kogito.addons.k8s.resource.catalog.KubernetesProtocol.KUBERNETES;
+import static org.kie.kogito.addons.k8s.resource.catalog.KubernetesProtocol.OPENSHIFT;
+
+/**
+ * Test classes for implementations of {@link KubernetesServiceCatalog} must extend this class.
+ * It tests all use cases an implementation of {@link KubernetesServiceCatalog} must cover.
+ */
+public abstract class KubernetesServiceCatalogTest {
+
+    private static final String EXPECTED_KNATIVE_URI = "http://serverless-workflow-greeting-quarkus.test.10.99.154.147.sslip.io";
+
+    private static final String EXPECTED_KUBERNETES_URI = "http://serverless-workflow-greeting-quarkus-kubernetes.test.10.99.154.147.sslip.io";
+
+    private static final String EXPECTED_OPENSHIFT_URI = "http://serverless-workflow-greeting-quarkus-openshift.test.10.99.154.147.sslip.io";
+
+    private static final String NAMESPACE = "test";
+
+    private static final String KNATIVE_SERVICENAME = "serverless-workflow-greeting-quarkus";
+
+    private static final String KUBERNETES_SERVICENAME = "serverless-workflow-greeting-quarkus-kubernetes";
+
+    private static final String OPENSHIFT_SERVICENAME = "serverless-workflow-greeting-quarkus-openshift";
+
+    private static final String NAMESPACE_KNATIVE_SERVICENAME = NAMESPACE + '/' + KNATIVE_SERVICENAME;
+
+    private static final String NAMESPACE_KUBERNETES_SERVICENAME = NAMESPACE + '/' + KUBERNETES_SERVICENAME;
+
+    private static final String NAMESPACE_OPENSHIFT_SERVICENAME = NAMESPACE + '/' + OPENSHIFT_SERVICENAME;
+
+    private static final String GVK = "services.v1.serving.knative.dev";
+
+    private static final String GVK_KNATIVE_SERVICENAME = GVK + '/' + KNATIVE_SERVICENAME;
+
+    private static final String GVK_NAMESPACE_SERVICENAME = GVK + '/' + NAMESPACE_KNATIVE_SERVICENAME;
+
+    private static final String GVK_KUBERNETES_SERVICENAME = GVK + '/' + KUBERNETES_SERVICENAME;
+
+    private static final String GVK_NAMESPACE_KUBERNETES_SERVICENAME = GVK + '/' + NAMESPACE_KUBERNETES_SERVICENAME;
+
+    private static final String GVK_OPENSHIFT_SERVICENAME = GVK + '/' + OPENSHIFT_SERVICENAME;
+
+    private static final String GVK_NAMESPACE_OPENSHIFT_SERVICENAME = GVK + '/' + NAMESPACE_OPENSHIFT_SERVICENAME;
+
+    private final KubernetesServiceCatalog kubernetesServiceCatalog;
+
+    protected KubernetesServiceCatalogTest(KubernetesServiceCatalog kubernetesServiceCatalog) {
+        this.kubernetesServiceCatalog = kubernetesServiceCatalog;
+    }
+
+    protected final String getNamespace() {
+        return NAMESPACE;
+    }
+
+    protected final String getKnativeServiceName() {
+        return KNATIVE_SERVICENAME;
+    }
+
+    protected final String getKubernetesServiceName() {
+        return KUBERNETES_SERVICENAME;
+    }
+
+    protected final String getOpenshiftServicename() {
+        return OPENSHIFT_SERVICENAME;
+    }
+
+    @ParameterizedTest
+    @MethodSource("possibleUriFormats")
+    void getServiceAddress(KubernetesProtocol kubernetesProtocol, String coordinates, String expectedUri) {
+        KubernetesServiceCatalogKey key = new KubernetesServiceCatalogKey(kubernetesProtocol, coordinates);
+        assertThat(kubernetesServiceCatalog.getServiceAddress(key))
+                .map(URI::toString)
+                .hasValue(expectedUri);
+    }
+
+    protected static Stream<Arguments> possibleUriFormats() {
+        return Stream.of(
+                Arguments.of(KNATIVE, KNATIVE_SERVICENAME, EXPECTED_KNATIVE_URI),
+                Arguments.of(KNATIVE, NAMESPACE_KNATIVE_SERVICENAME, EXPECTED_KNATIVE_URI),
+                Arguments.of(KNATIVE, GVK_KNATIVE_SERVICENAME, EXPECTED_KNATIVE_URI),
+                Arguments.of(KNATIVE, GVK_NAMESPACE_SERVICENAME, EXPECTED_KNATIVE_URI),
+
+                Arguments.of(KUBERNETES, GVK_KUBERNETES_SERVICENAME, EXPECTED_KUBERNETES_URI),
+                Arguments.of(KUBERNETES, GVK_NAMESPACE_KUBERNETES_SERVICENAME, EXPECTED_KUBERNETES_URI),
+
+                Arguments.of(OPENSHIFT, GVK_OPENSHIFT_SERVICENAME, EXPECTED_OPENSHIFT_URI),
+                Arguments.of(OPENSHIFT, GVK_NAMESPACE_OPENSHIFT_SERVICENAME, EXPECTED_OPENSHIFT_URI));
+    }
+}

--- a/quarkus/addons/fabric8-kubernetes-service-catalog/runtime/pom.xml
+++ b/quarkus/addons/fabric8-kubernetes-service-catalog/runtime/pom.xml
@@ -35,6 +35,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.kie.kogito</groupId>
+            <artifactId>kogito-addons-kubernetes-service-catalog</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-test-kubernetes-client</artifactId>
             <scope>test</scope>

--- a/quarkus/addons/fabric8-kubernetes-service-catalog/runtime/src/test/java/org/kie/kogito/addons/quarkus/fabric8/k8s/service/catalog/Fabric8KubernetesServiceCatalogTest.java
+++ b/quarkus/addons/fabric8-kubernetes-service-catalog/runtime/src/test/java/org/kie/kogito/addons/quarkus/fabric8/k8s/service/catalog/Fabric8KubernetesServiceCatalogTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.addons.quarkus.fabric8.k8s.service.catalog;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.kie.kogito.addons.k8s.resource.catalog.KubernetesServiceCatalogTest;
+
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.kubernetes.client.KubernetesTestServer;
+import io.quarkus.test.kubernetes.client.WithKubernetesTestServer;
+
+import static org.kie.kogito.addons.quarkus.k8s.test.utils.KnativeResourceDiscoveryTestUtil.createServiceIfNotExists;
+
+@QuarkusTest
+@WithKubernetesTestServer
+class Fabric8KubernetesServiceCatalogTest extends KubernetesServiceCatalogTest {
+
+    @KubernetesTestServer
+    KubernetesServer mockServer;
+
+    @BeforeEach
+    void beforeEach() {
+        createServiceIfNotExists(mockServer, "knative/quarkus-greeting.yaml", getNamespace(), getKnativeServiceName());
+        createServiceIfNotExists(mockServer, "knative/quarkus-greeting-kubernetes.yaml", getNamespace(), getKubernetesServiceName());
+        createServiceIfNotExists(mockServer, "knative/quarkus-greeting-openshift.yaml", getNamespace(), getOpenshiftServicename());
+    }
+
+    @Inject
+    Fabric8KubernetesServiceCatalogTest(Fabric8KubernetesServiceCatalog fabric8KubernetesServiceCatalog) {
+        super(fabric8KubernetesServiceCatalog);
+    }
+}

--- a/quarkus/addons/fabric8-kubernetes-service-catalog/runtime/src/test/java/org/kie/kogito/addons/quarkus/fabric8/k8s/service/catalog/KnativeServiceDiscoveryTest.java
+++ b/quarkus/addons/fabric8-kubernetes-service-catalog/runtime/src/test/java/org/kie/kogito/addons/quarkus/fabric8/k8s/service/catalog/KnativeServiceDiscoveryTest.java
@@ -45,7 +45,7 @@ class KnativeServiceDiscoveryTest {
     @Test
     void queryService() {
         String remoteServiceUrl = "http://" + REMOTE_SERVICE_HOST;
-        KnativeResourceDiscoveryTestUtil.createServiceIfNotExists(mockServer, remoteServiceUrl, "knative/quarkus-greeting.yaml", "test", "serverless-workflow-greeting-quarkus");
+        KnativeResourceDiscoveryTestUtil.createServiceIfNotExists(mockServer, "knative/quarkus-greeting.yaml", "test", "serverless-workflow-greeting-quarkus", remoteServiceUrl);
 
         Optional<URI> uri = knativeServiceDiscovery.query(new KnativeServiceUri("test", "serverless-workflow-greeting-quarkus"));
 
@@ -62,7 +62,7 @@ class KnativeServiceDiscoveryTest {
     @Test
     void https() {
         String remoteServiceUrl = "https://" + REMOTE_SERVICE_HOST;
-        KnativeResourceDiscoveryTestUtil.createServiceIfNotExists(mockServer, remoteServiceUrl, "knative/quarkus-greeting-https.yaml", "test", "serverless-workflow-greeting-quarkus-https");
+        KnativeResourceDiscoveryTestUtil.createServiceIfNotExists(mockServer, "knative/quarkus-greeting-https.yaml", "test", "serverless-workflow-greeting-quarkus-https", remoteServiceUrl);
 
         Optional<URI> url = knativeServiceDiscovery.query(new KnativeServiceUri("test", "serverless-workflow-greeting-quarkus-https"));
 

--- a/quarkus/addons/fabric8-kubernetes-service-catalog/runtime/src/test/resources/knative/quarkus-greeting-kubernetes.yaml
+++ b/quarkus/addons/fabric8-kubernetes-service-catalog/runtime/src/test/resources/knative/quarkus-greeting-kubernetes.yaml
@@ -1,0 +1,54 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  annotations:
+    serving.knative.dev/creator: minikube-user
+    serving.knative.dev/lastModifier: minikube-user
+  creationTimestamp: '2022-08-17T13:58:53Z'
+  generation: 1
+  name: serverless-workflow-greeting-quarkus-kubernetes
+  resourceVersion: '43817'
+  uid: 98530cb6-3274-4d0c-b654-a82645cda058
+spec:
+  template:
+    metadata:
+      annotations:
+        client.knative.dev/updateTimestamp: '2022-08-17T13:58:53Z'
+        client.knative.dev/user-image: kiegroup/serverless-workflow-greeting-quarkus:1.0
+      creationTimestamp:
+    spec:
+      containerConcurrency: 0
+      containers:
+        - image: kiegroup/serverless-workflow-greeting-quarkus:1.0
+          name: user-container
+          readinessProbe:
+            successThreshold: 1
+            tcpSocket:
+              port: 0
+          resources: { }
+      enableServiceLinks: false
+      timeoutSeconds: 300
+  traffic:
+    - latestRevision: true
+      percent: 100
+status:
+  address:
+    url: http://serverless-workflow-greeting-quarkus.test.svc.cluster.local
+  conditions:
+    - lastTransitionTime: '2022-08-17T13:59:00Z'
+      status: 'True'
+      type: ConfigurationsReady
+    - lastTransitionTime: '2022-08-17T13:59:00Z'
+      status: 'True'
+      type: Ready
+    - lastTransitionTime: '2022-08-17T13:59:00Z'
+      status: 'True'
+      type: RoutesReady
+  latestCreatedRevisionName: serverless-workflow-greeting-quarkus-00001
+  latestReadyRevisionName: serverless-workflow-greeting-quarkus-00001
+  observedGeneration: 1
+  traffic:
+    - latestRevision: true
+      percent: 100
+      revisionName: serverless-workflow-greeting-quarkus-00001
+  url: http://serverless-workflow-greeting-quarkus-kubernetes.test.10.99.154.147.sslip.io

--- a/quarkus/addons/fabric8-kubernetes-service-catalog/runtime/src/test/resources/knative/quarkus-greeting-openshift.yaml
+++ b/quarkus/addons/fabric8-kubernetes-service-catalog/runtime/src/test/resources/knative/quarkus-greeting-openshift.yaml
@@ -1,0 +1,54 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  annotations:
+    serving.knative.dev/creator: minikube-user
+    serving.knative.dev/lastModifier: minikube-user
+  creationTimestamp: '2022-08-17T13:58:53Z'
+  generation: 1
+  name: serverless-workflow-greeting-quarkus-openshift
+  resourceVersion: '43817'
+  uid: 98530cb6-3274-4d0c-b654-a82645cda058
+spec:
+  template:
+    metadata:
+      annotations:
+        client.knative.dev/updateTimestamp: '2022-08-17T13:58:53Z'
+        client.knative.dev/user-image: kiegroup/serverless-workflow-greeting-quarkus:1.0
+      creationTimestamp:
+    spec:
+      containerConcurrency: 0
+      containers:
+        - image: kiegroup/serverless-workflow-greeting-quarkus:1.0
+          name: user-container
+          readinessProbe:
+            successThreshold: 1
+            tcpSocket:
+              port: 0
+          resources: { }
+      enableServiceLinks: false
+      timeoutSeconds: 300
+  traffic:
+    - latestRevision: true
+      percent: 100
+status:
+  address:
+    url: http://serverless-workflow-greeting-quarkus.test.svc.cluster.local
+  conditions:
+    - lastTransitionTime: '2022-08-17T13:59:00Z'
+      status: 'True'
+      type: ConfigurationsReady
+    - lastTransitionTime: '2022-08-17T13:59:00Z'
+      status: 'True'
+      type: Ready
+    - lastTransitionTime: '2022-08-17T13:59:00Z'
+      status: 'True'
+      type: RoutesReady
+  latestCreatedRevisionName: serverless-workflow-greeting-quarkus-00001
+  latestReadyRevisionName: serverless-workflow-greeting-quarkus-00001
+  observedGeneration: 1
+  traffic:
+    - latestRevision: true
+      percent: 100
+      revisionName: serverless-workflow-greeting-quarkus-00001
+  url: http://serverless-workflow-greeting-quarkus-openshift.test.10.99.154.147.sslip.io

--- a/quarkus/addons/fabric8-kubernetes-service-catalog/test-utils/src/main/java/org/kie/kogito/addons/quarkus/k8s/test/utils/KnativeResourceDiscoveryTestUtil.java
+++ b/quarkus/addons/fabric8-kubernetes-service-catalog/test-utils/src/main/java/org/kie/kogito/addons/quarkus/k8s/test/utils/KnativeResourceDiscoveryTestUtil.java
@@ -26,8 +26,12 @@ public final class KnativeResourceDiscoveryTestUtil {
     private KnativeResourceDiscoveryTestUtil() {
     }
 
+    public static void createServiceIfNotExists(KubernetesServer k8sServer, String knativeYaml, String namespace, String serviceName) {
+        createServiceIfNotExists(k8sServer, knativeYaml, namespace, serviceName, null);
+    }
+
     @SuppressWarnings("deprecation") // Quarkus LTS 2.13 compatibility
-    public static void createServiceIfNotExists(KubernetesServer k8sServer, String remoteServiceUrl, String knativeYaml, String namespace, String serviceName) {
+    public static void createServiceIfNotExists(KubernetesServer k8sServer, String knativeYaml, String namespace, String serviceName, String remoteServiceUrl) {
         if (k8sServer.getClient().services().inNamespace("test").withName(serviceName).get() == null) {
             KnativeClient knativeClient = k8sServer.getClient().adapt(KnativeClient.class);
 
@@ -36,7 +40,9 @@ public final class KnativeResourceDiscoveryTestUtil {
                     .load(getResourceAsStream(knativeYaml))
                     .get();
 
-            service.getStatus().setUrl(remoteServiceUrl);
+            if (remoteServiceUrl != null) {
+                service.getStatus().setUrl(remoteServiceUrl);
+            }
 
             // ItemWritableOperation#create is deprecated. However, we can't use the new method while Quarkus LTS is not greater than 2.16.
             knativeClient.services().inNamespace(namespace).create(service);

--- a/quarkus/addons/kubernetes/runtime/src/test/java/org/kie/kogito/addons/quarkus/k8s/config/KubeDiscoveryConfigCacheUpdaterTest.java
+++ b/quarkus/addons/kubernetes/runtime/src/test/java/org/kie/kogito/addons/quarkus/k8s/config/KubeDiscoveryConfigCacheUpdaterTest.java
@@ -47,7 +47,7 @@ class KubeDiscoveryConfigCacheUpdaterTest {
 
     @BeforeEach
     void beforeEach() {
-        createServiceIfNotExists(mockServer, remoteServiceUrl, "knative/quarkus-greeting.yaml", "test", "serverless-workflow-greeting-quarkus");
+        createServiceIfNotExists(mockServer, "knative/quarkus-greeting.yaml", "test", "serverless-workflow-greeting-quarkus", remoteServiceUrl);
         kubeDiscoveryConfigCacheUpdater = new KubeDiscoveryConfigCacheUpdater(kubernetesServiceCatalog);
     }
 


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/KOGITO-9605

This PR refactors tests related to `KubernetesServiceCatalog` so they can be reused by the implementation created in https://issues.redhat.com/browse/KOGITO-9145

--------

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] native</b>

- for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] native-lts</b>
 
- <b>Full Kogito testing</b> (with cloud images and operator BDD testing)  
  Please add comment: <b>Jenkins run BDD</b>  
  <b>This check should be used only if a big change is done as it takes time to run, need resources and one full BDD tests check can be done at a time ...</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>

<details>
<summary>
Quarkus-3 PR check is failing ... what to do ?
</summary>
The Quarkus 3 check is applying patches from the `.ci/environments/quarkus-3/patches`.

The first patch, called `0001_before_sh.patch`, is generated from Openrewrite `.ci/environments/quarkus-3/quarkus3.yml` recipe. The patch is created to speed up the check. But it may be that some changes in the PR broke this patch.  
No panic, there is an easy way to regenerate it. You just need to comment on the PR:
```
jenkins rewrite quarkus-3
```
and it should, after some minutes (~20/30min) apply a commit on the PR with the patch regenerated.

Other patches were generated manually. If any of it fails, you will need to manually update it... and push your changes.
</details>
