### PR TITLE
[KOGITO-9613] Adding persistence support to executor

### DIFF
--- a/kogito-serverless-workflow/kogito-serverless-workflow-executor-core/src/main/java/org/kie/kogito/serverless/workflow/executor/StaticWorkflowApplication.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-executor-core/src/main/java/org/kie/kogito/serverless/workflow/executor/StaticWorkflowApplication.java
@@ -46,6 +46,7 @@ import org.kie.kogito.internal.process.event.DefaultKogitoProcessEventListener;
 import org.kie.kogito.internal.process.runtime.KogitoWorkItemHandler;
 import org.kie.kogito.process.Process;
 import org.kie.kogito.process.ProcessInstance;
+import org.kie.kogito.process.ProcessInstancesFactory;
 import org.kie.kogito.process.Processes;
 import org.kie.kogito.process.impl.CachedWorkItemHandlerConfig;
 import org.kie.kogito.process.impl.DefaultProcessEventListenerConfig;
@@ -90,6 +91,7 @@ public class StaticWorkflowApplication extends StaticApplication implements Auto
     private Iterable<StaticProcessRegister> processRegisters;
     private final Collection<AutoCloseable> closeables = new ArrayList<>();
     private final Map<String, SynchronousQueue<JsonNodeModel>> queues;
+    private ProcessInstancesFactory processInstancesFactory;
 
     private static class StaticCompletionEventListener extends DefaultKogitoProcessEventListener {
 
@@ -169,6 +171,11 @@ public class StaticWorkflowApplication extends StaticApplication implements Auto
      */
     public JsonNodeModel execute(Workflow workflow, JsonNode data) {
         return execute(findOrCreate(workflow), data);
+    }
+
+    public StaticWorkflowApplication withProcessInstances(ProcessInstancesFactory processInstanceFactory) {
+        this.processInstancesFactory = processInstanceFactory;
+        return this;
     }
 
     private Process<JsonNodeModel> findOrCreate(Workflow workflow) {
@@ -264,7 +271,7 @@ public class StaticWorkflowApplication extends StaticApplication implements Auto
 
     private Process<JsonNodeModel> createProcess(Workflow workflow) {
         workflowRegisters.forEach(r -> r.register(this, workflow));
-        StaticWorkflowProcess process = new StaticWorkflowProcess(this, handlers, ServerlessWorkflowParser
+        StaticWorkflowProcess process = new StaticWorkflowProcess(this, handlers, processInstancesFactory, ServerlessWorkflowParser
                 .of(workflow, JavaKogitoBuildContext.builder().withApplicationProperties(System.getProperties()).build()).getProcessInfo().info());
         processRegisters.forEach(r -> r.register(this, workflow, process));
         WorkflowProcessImpl workflowProcess = (WorkflowProcessImpl) process.get();

--- a/kogito-serverless-workflow/kogito-serverless-workflow-executor-core/src/main/java/org/kie/kogito/serverless/workflow/executor/StaticWorkflowApplication.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-executor-core/src/main/java/org/kie/kogito/serverless/workflow/executor/StaticWorkflowApplication.java
@@ -107,7 +107,9 @@ public class StaticWorkflowApplication extends StaticApplication implements Auto
             SynchronousQueue<JsonNodeModel> queue = queues.remove(instance.getId());
             if (queue != null) {
                 try {
-                    queue.offer(new JsonNodeModel(instance.getId(), instance.getVariables().get(SWFConstants.DEFAULT_WORKFLOW_VAR)), 1L, TimeUnit.SECONDS);
+                    if (queue.offer(new JsonNodeModel(instance.getId(), instance.getVariables().get(SWFConstants.DEFAULT_WORKFLOW_VAR)), 1L, TimeUnit.SECONDS)) {
+                        logger.debug("waiting process instance {} has been notified about its completion", instance.getId());
+                    }
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                 }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-executor-core/src/main/java/org/kie/kogito/serverless/workflow/executor/StaticWorkflowApplication.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-executor-core/src/main/java/org/kie/kogito/serverless/workflow/executor/StaticWorkflowApplication.java
@@ -107,7 +107,7 @@ public class StaticWorkflowApplication extends StaticApplication implements Auto
             SynchronousQueue<JsonNodeModel> queue = queues.remove(instance.getId());
             if (queue != null) {
                 try {
-                    queue.offer(new JsonNodeModel(instance.getId(), instance.getVariables().get(SWFConstants.DEFAULT_WORKFLOW_VAR)), 1000L, TimeUnit.SECONDS);
+                    queue.offer(new JsonNodeModel(instance.getId(), instance.getVariables().get(SWFConstants.DEFAULT_WORKFLOW_VAR)), 1L, TimeUnit.SECONDS);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                 }
@@ -173,7 +173,7 @@ public class StaticWorkflowApplication extends StaticApplication implements Auto
         return execute(findOrCreate(workflow), data);
     }
 
-    public StaticWorkflowApplication withProcessInstances(ProcessInstancesFactory processInstanceFactory) {
+    public StaticWorkflowApplication processInstancesFactory(ProcessInstancesFactory processInstanceFactory) {
         this.processInstancesFactory = processInstanceFactory;
         return this;
     }

--- a/kogito-serverless-workflow/kogito-serverless-workflow-executor-core/src/main/java/org/kie/kogito/serverless/workflow/executor/StaticWorkflowProcess.java
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-executor-core/src/main/java/org/kie/kogito/serverless/workflow/executor/StaticWorkflowProcess.java
@@ -25,6 +25,7 @@ import org.kie.kogito.correlation.CompositeCorrelation;
 import org.kie.kogito.internal.process.runtime.KogitoWorkItemHandler;
 import org.kie.kogito.internal.process.runtime.KogitoWorkflowProcess;
 import org.kie.kogito.process.ProcessInstance;
+import org.kie.kogito.process.ProcessInstancesFactory;
 import org.kie.kogito.process.impl.AbstractProcess;
 import org.kie.kogito.serverless.workflow.models.JsonNodeModel;
 
@@ -32,9 +33,10 @@ class StaticWorkflowProcess extends AbstractProcess<JsonNodeModel> {
 
     private final KogitoWorkflowProcess process;
 
-    public StaticWorkflowProcess(Application app, Collection<KogitoWorkItemHandler> handlers, KogitoWorkflowProcess process) {
-        super(app, handlers, null);
+    public StaticWorkflowProcess(Application app, Collection<KogitoWorkItemHandler> handlers, ProcessInstancesFactory processInstanceFactory, KogitoWorkflowProcess process) {
+        super(app, handlers, null, processInstanceFactory);
         this.process = process;
+        activate();
     }
 
     @Override
@@ -51,6 +53,11 @@ class StaticWorkflowProcess extends AbstractProcess<JsonNodeModel> {
     @Override
     public ProcessInstance<? extends Model> createInstance(Model m) {
         return createInstance((JsonNodeModel) m);
+    }
+
+    @Override
+    public JsonNodeModel createModel() {
+        return new JsonNodeModel();
     }
 
     @Override

--- a/kogito-serverless-workflow/kogito-serverless-workflow-executor-kafka/pom.xml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-executor-kafka/pom.xml
@@ -37,6 +37,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>

--- a/kogito-serverless-workflow/kogito-serverless-workflow-executor-kafka/pom.xml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-executor-kafka/pom.xml
@@ -27,6 +27,11 @@
       <artifactId>cloudevents-kafka</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-addons-persistence-rocksdb</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>

--- a/quarkus/addons/process-definitions/runtime/pom.xml
+++ b/quarkus/addons/process-definitions/runtime/pom.xml
@@ -37,7 +37,7 @@
     </dependency>
     <dependency>
       <groupId>org.kie.kogito</groupId>
-      <artifactId>kogito-addons-quarkus-persistence-rocksdb</artifactId>
+      <artifactId>kogito-addons-quarkus-persistence-rocksdb-deployment</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/quarkus/addons/process-definitions/runtime/pom.xml
+++ b/quarkus/addons/process-definitions/runtime/pom.xml
@@ -36,6 +36,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-addons-quarkus-persistence-rocksdb</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
       <scope>test</scope>

--- a/quarkus/addons/process-definitions/runtime/src/main/java/org/kie/kogito/process/definitions/ProcessDefinitionsResource.java
+++ b/quarkus/addons/process-definitions/runtime/src/main/java/org/kie/kogito/process/definitions/ProcessDefinitionsResource.java
@@ -20,6 +20,8 @@ import java.io.StringReader;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -28,6 +30,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import org.kie.kogito.process.ProcessInstancesFactory;
 import org.kie.kogito.serverless.workflow.executor.StaticWorkflowApplication;
 import org.kie.kogito.serverless.workflow.models.JsonNodeModel;
 import org.kie.kogito.serverless.workflow.models.JsonNodeModelInput;
@@ -41,9 +44,13 @@ public class ProcessDefinitionsResource {
 
     private StaticWorkflowApplication application;
 
+    @Inject
+    Instance<ProcessInstancesFactory> factories;
+
     @PostConstruct
     void init() {
         application = StaticWorkflowApplication.create();
+        factories.stream().findFirst().ifPresent(application::processInstancesFactory);
     }
 
     @PreDestroy


### PR DESCRIPTION
New method added to StaticWorkfApplication. This method accepts the ProcessInstancesFactory object of the persistence addon
Usage example  
```
  try (StaticWorkflowApplication application =
                StaticWorkflowApplication.create().processInstancesFactory(new RocksDBProcessInstancesFactory(new Options().setCreateIfMissing(true), tempDir.toString())))
```

Also added persistence addon support to definitions addon