### PR TITLE
[KOGITO-9763] Restoring nodeDefinitionId

### DIFF
--- a/addons/common/process-management/src/main/java/org/kie/kogito/process/management/BaseProcessInstanceManagementResource.java
+++ b/addons/common/process-management/src/main/java/org/kie/kogito/process/management/BaseProcessInstanceManagementResource.java
@@ -92,6 +92,7 @@ public abstract class BaseProcessInstanceManagementResource<T> implements Proces
                 Map<String, Object> data = new HashMap<>();
                 data.put("id", n.getId());
                 data.put("uniqueId", ((Node) n).getUniqueId());
+                data.put("nodeDefinitionId", n.getMetaData().get(Metadata.UNIQUE_ID));
                 data.put("metadata", n.getMetaData());
                 data.put("type", n.getClass().getSimpleName());
                 data.put("name", n.getName());

--- a/quarkus/integration-tests/integration-tests-quarkus-processes/src/test/java/org/kie/kogito/integrationtests/quarkus/ManagementAddOnIT.java
+++ b/quarkus/integration-tests/integration-tests-quarkus-processes/src/test/java/org/kie/kogito/integrationtests/quarkus/ManagementAddOnIT.java
@@ -92,10 +92,12 @@ class ManagementAddOnIT {
                 .body("[0].name", is("End"))
                 .body("[0].type", is("EndNode"))
                 .body("[0].uniqueId", is("1"))
+                .body("[0].nodeDefinitionId", not(emptyOrNullString()))
                 .body("[9].id", is(10))
                 .body("[9].name", is("BoundaryEvent"))
                 .body("[9].type", is("BoundaryEventNode"))
-                .body("[9].uniqueId", is("10"));
+                .body("[9].uniqueId", is("10"))
+                .body("[9].nodeDefinitionId", not(emptyOrNullString()));
     }
 
     @Test

--- a/springboot/integration-tests/src/it/integration-tests-springboot-processes-it/src/test/java/org/kie/kogito/integrationtests/springboot/ManagementAddOnTest.java
+++ b/springboot/integration-tests/src/it/integration-tests-springboot-processes-it/src/test/java/org/kie/kogito/integrationtests/springboot/ManagementAddOnTest.java
@@ -93,10 +93,12 @@ class ManagementAddOnTest extends BaseRestTest {
                 .body("[0].name", is("End"))
                 .body("[0].type", is("EndNode"))
                 .body("[0].uniqueId", is("1"))
+                .body("[0].nodeDefinitionId", not(emptyOrNullString()))
                 .body("[9].id", is(10))
                 .body("[9].name", is("BoundaryEvent"))
                 .body("[9].type", is("BoundaryEventNode"))
-                .body("[9].uniqueId", is("10"));
+                .body("[9].uniqueId", is("10"))
+                .body("[9].nodeDefinitionId", not(emptyOrNullString()));
     }
 
     @Test


### PR DESCRIPTION
NodeDefinitionId is used by runtime tools