### PR TITLE
snake-yaml to 2.0 

### DIFF
--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -21,7 +21,7 @@
     <version.org.springframework.boot>2.5.12</version.org.springframework.boot>
 
     <!-- dependencies versions -->
-    <version.com.fasterxml.jackson>2.14.2</version.com.fasterxml.jackson>
+    <version.com.fasterxml.jackson>2.15.0</version.com.fasterxml.jackson>
     <version.com.jayway.jsonpath>2.6.0</version.com.jayway.jsonpath>
     <version.io.quarkiverse.reactivemessaging.http>1.0.0</version.io.quarkiverse.reactivemessaging.http>
     <version.com.github.haifengl.smile>1.5.2</version.com.github.haifengl.smile>
@@ -103,7 +103,7 @@
 
     <!-- CVE-2022-25857: Upgrading snakeyaml until we upgrade to Spring Boot 3.x -->
     <!-- See: https://github.com/spring-projects/spring-boot/issues/32221 -->
-    <snakeyaml.version>1.33</snakeyaml.version>
+    <snakeyaml.version>2.0</snakeyaml.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Backport: https://github.com/kiegroup/kogito-runtimes/pull/9

https://issues.redhat.com/browse/RHPAM-4700

No org.yaml:snakeyaml:jar:1.33.0 traces on optaweb* or kogito-examples projects after related PRs

Related PRs:

https://github.com/kiegroup/optaplanner/pull/25
https://github.com/kiegroup/optaweb-vehicle-routing/pull/871
