### PR TITLE
SRVLOGIC-202: Schedule apache-main sync from upstream

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -29,7 +29,7 @@ jobs:
           git remote add upstream $UPSTREAM_REMOTE
 
       - name: Fetch all
-        run: git fetch --all
+        run: git fetch --all --tags
 
       - name: Checkout main-apache branch
         run: git checkout --track origin/main-apache
@@ -43,3 +43,5 @@ jobs:
       - name: Push changes
         run: git push
 
+      - name: Push last tag
+        run: git push origin $(git tag --sort=creatordate | tail -n 1)


### PR DESCRIPTION
**Jira:** https://issues.redhat.com/browse/SRVLOGIC-202

**Description:**
Set up a GitHub Action to sync our midstream main-apache branch with the upstream main branch every day.

**Repository used for tests:**
https://github.com/fantonangeli/kogito-runtimes-fantonangeli-test
Sync CI: https://github.com/fantonangeli/kogito-runtimes-fantonangeli-test/actions/workflows/upstream-sync.yml