### PR TITLE
[9.101.x-prod] Bump version.io.quarkiverse.embedded.postgresql to 0.2.3 (#3666)

### DIFF
--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -53,7 +53,7 @@
     <version.io.quarkiverse.openapi.generator>2.4.1</version.io.quarkiverse.openapi.generator>
     <version.io.quarkiverse.asyncapi>0.3.0</version.io.quarkiverse.asyncapi>
     <version.io.quarkiverse.reactivemessaging.http>2.2.0</version.io.quarkiverse.reactivemessaging.http>
-    <version.io.quarkiverse.embedded.postgresql>0.2.2</version.io.quarkiverse.embedded.postgresql> <!-- TODO: no matching release yet -->
+    <version.io.quarkiverse.embedded.postgresql>0.2.3</version.io.quarkiverse.embedded.postgresql>
     <version.com.github.haifengl.smile>1.5.2</version.com.github.haifengl.smile>
     <version.com.github.javaparser>3.25.8</version.com.github.javaparser>
     <version.com.fasterxml.jackson.datatype>2.17.2</version.com.fasterxml.jackson.datatype>


### PR DESCRIPTION
Backported from https://github.com/apache/incubator-kie-kogito-runtimes/pull/3666

