### PR TITLE
[9.104.x-prod] Issue-1899 Add JWT token parsing support for SonataFlow workflows (#4…

### DIFF
--- a/quarkus/addons/jwt-parser/deployment/pom.xml
+++ b/quarkus/addons/jwt-parser/deployment/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>sonataflow-addons-quarkus-jwt-parser-parent</artifactId>
+    <groupId>org.apache.kie.sonataflow</groupId>
+    <version>9.104.0</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <properties>
+     <java.module.name>org.kie.kogito.addons.quarkus.jwt.deployment</java.module.name>
+  </properties>
+
+  <name>SonataFlow :: Add-Ons :: Quarkus :: JWT Parser :: Deployment</name>
+  <description>SonataFlow Quarkus JWT Token Parser for Serverless Workflow</description>
+  <artifactId>sonataflow-addons-quarkus-jwt-parser-deployment</artifactId>
+  <dependencies>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-arc-deployment</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kie.sonataflow</groupId>
+      <artifactId>sonataflow-addons-quarkus-jwt-parser</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5-internal</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>io.quarkus</groupId>
+              <artifactId>quarkus-extension-processor</artifactId>
+              <version>${version.io.quarkus}</version>
+            </path>
+          </annotationProcessorPaths>
+          <compilerArgs>
+            <arg>-AlegacyConfigRoot=true</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/quarkus/addons/jwt-parser/deployment/src/main/java/org/kie/kogito/addons/jwt/deployment/JwtParserProcessor.java
+++ b/quarkus/addons/jwt-parser/deployment/src/main/java/org/kie/kogito/addons/jwt/deployment/JwtParserProcessor.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.addons.jwt.deployment;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+
+/**
+ * Quarkus deployment processor for JWT parser functionality
+ * The JWT parser work item handlers are discovered via ServiceLoader and don't require CDI bean registration
+ */
+public class JwtParserProcessor {
+
+    private static final String FEATURE = "sonataflow-addons-jwt-parser";
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(FEATURE);
+    }
+}

--- a/quarkus/addons/jwt-parser/integration-tests/pom.xml
+++ b/quarkus/addons/jwt-parser/integration-tests/pom.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>sonataflow-addons-quarkus-jwt-parser-parent</artifactId>
+    <groupId>org.apache.kie.sonataflow</groupId>
+    <version>9.104.0</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>sonataflow-addons-quarkus-jwt-parser-integration-tests</artifactId>
+  <name>SonataFlow :: Add-Ons :: Quarkus :: JWT Parser :: Integration Tests</name>
+  
+  <properties>
+     <java.module.name>org.kie.kogito.addons.quarkus.jwt.integration.tests</java.module.name>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.kie.sonataflow</groupId>
+      <artifactId>sonataflow-quarkus</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kie.sonataflow</groupId>
+      <artifactId>sonataflow-addons-quarkus-jwt-parser</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-rest</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-rest-jackson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-test-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>build</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/quarkus/addons/jwt-parser/integration-tests/src/main/resources/application.properties
+++ b/quarkus/addons/jwt-parser/integration-tests/src/main/resources/application.properties
@@ -1,0 +1,7 @@
+# JWT Parser Integration Test Configuration
+quarkus.log.level=INFO
+quarkus.log.category."org.kie.kogito.addons.jwt".level=DEBUG
+quarkus.http.test-port=0
+
+# SonataFlow configuration
+kogito.sw.functions.timeout.default=PT30S

--- a/quarkus/addons/jwt-parser/integration-tests/src/main/resources/jwt-example.sw.json
+++ b/quarkus/addons/jwt-parser/integration-tests/src/main/resources/jwt-example.sw.json
@@ -1,0 +1,43 @@
+{
+  "id": "jwt_example",
+  "version": "1.0",
+  "name": "JWT Token Processing Example",
+  "description": "Demonstrates JWT token parsing functionality as requested in Issue apache/incubator-kie-issues#1899",
+  "start": "extractUser",
+  "functions": [
+    {
+      "name": "extractUser",
+      "type": "custom",
+      "operation": "jwt-parser:extractUser"
+    }
+  ],
+  "states": [
+    {
+      "name": "extractUser",
+      "type": "operation",
+      "actions": [
+        {
+          "name": "extractUserAction",
+          "functionRef": {
+            "refName": "extractUser",
+            "arguments": {
+              "token": "${ $WORKFLOW.headers.\"X-Authorization-acme_financial_auth\" }"
+            }
+          }
+        }
+      ],
+      "transition": "approveLoan"
+    },
+    {
+      "name": "approveLoan",
+      "type": "inject",
+      "data": {
+        "loanApproved": true
+      },
+      "stateDataFilter": {
+        "output": "${ { preferred_username, sub, email, iat, loanApproved, message: (\"Congrats \" + .preferred_username + \"! Your loan has been approved!\") } }"
+      },
+      "end": true
+    }
+  ]
+}

--- a/quarkus/addons/jwt-parser/integration-tests/src/test/java/org/kie/kogito/addons/jwt/it/JwtParserIT.java
+++ b/quarkus/addons/jwt-parser/integration-tests/src/test/java/org/kie/kogito/addons/jwt/it/JwtParserIT.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.addons.jwt.it;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.restassured.path.json.JsonPath;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.kie.kogito.test.utils.ProcessInstancesRESTTestUtils.assertProcessInstanceNotExists;
+import static org.kie.kogito.test.utils.ProcessInstancesRESTTestUtils.newProcessInstance;
+
+/**
+ * Integration tests for JWT Parser functionality
+ * Tests the complete workflow with JWT token parsing as requested in Issue #1899
+ */
+@QuarkusIntegrationTest
+class JwtParserIT {
+
+    // Valid JWT token for testing (contains: {"sub":"1234567890","preferred_username":"johndoe","email":"johndoe@example.com","iat":1516239022})
+    private static final String VALID_JWT_TOKEN =
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiam9obmRvZSIsImVtYWlsIjoiam9obmRvZUBleGFtcGxlLmNvbSIsImlhdCI6MTUxNjIzOTAyMn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+
+    /**
+     * End-to-end test that verifies the JWT parser works within a complete SonataFlow workflow.
+     * This test demonstrates the feature working as requested in Issue #1899.
+     * 
+     * The workflow is one-shot (executes without intermediate stops), so results are immediately
+     * available in the initial response. After completion, the process instance is removed from storage.
+     */
+    @Test
+    void testJwtParserWorkflowEndToEnd() {
+        // Prepare workflow input
+        String processInput = "{}";
+
+        // Set up headers with JWT token
+        Map<String, String> headers = new HashMap<>();
+        headers.put("X-Authorization-acme_financial_auth", VALID_JWT_TOKEN);
+
+        // Start the workflow - for one-shot workflows, results are immediately available
+        JsonPath jsonPath = newProcessInstance("/jwt_example", processInput, headers);
+        String processInstanceId = jsonPath.getString("id");
+        assertThat(processInstanceId).isNotBlank();
+
+        // Verify that the JWT was parsed and user information was extracted
+        // The workflow data is available in the initial response for one-shot workflows
+        String username = jsonPath.getString("workflowdata.preferred_username");
+        assertThat(username).isEqualTo("johndoe"); // The preferred_username from the JWT
+
+        String message = jsonPath.getString("workflowdata.message");
+        assertThat(message).isEqualTo("Congrats johndoe! Your loan has been approved!");
+
+        Boolean loanApproved = jsonPath.getBoolean("workflowdata.loanApproved");
+        assertThat(loanApproved).isTrue();
+
+        // Verify the process completed and was removed from storage (following TokenExchangeIT pattern)
+        assertProcessInstanceNotExists("/jwt_example/{id}", processInstanceId);
+    }
+
+    /**
+     * Test workflow with Bearer prefix in JWT token
+     */
+    @Test
+    void testJwtParserWithBearerPrefix() {
+        String processInput = "{}";
+        Map<String, String> headers = new HashMap<>();
+        headers.put("X-Authorization-acme_financial_auth", "Bearer " + VALID_JWT_TOKEN);
+
+        JsonPath jsonPath = newProcessInstance("/jwt_example", processInput, headers);
+        String processInstanceId = jsonPath.getString("id");
+        assertThat(processInstanceId).isNotBlank();
+
+        // Verify the JWT was parsed correctly despite the Bearer prefix
+        String username = jsonPath.getString("workflowdata.preferred_username");
+        assertThat(username).isEqualTo("johndoe");
+
+        String message = jsonPath.getString("workflowdata.message");
+        assertThat(message).contains("johndoe");
+
+        // Verify process was cleaned up
+        assertProcessInstanceNotExists("/jwt_example/{id}", processInstanceId);
+    }
+}

--- a/quarkus/addons/jwt-parser/pom.xml
+++ b/quarkus/addons/jwt-parser/pom.xml
@@ -19,58 +19,26 @@
     under the License.
 
 -->
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
-    <artifactId>kogito-quarkus-bom</artifactId>
-    <groupId>org.kie.kogito</groupId>
+    <artifactId>kogito-addons-quarkus-parent</artifactId>
+    <groupId>org.kie</groupId>
     <version>9.104.0</version>
-    <relativePath>../bom/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.kie</groupId>
-  <artifactId>kogito-addons-quarkus-parent</artifactId>
-  <name>Kogito :: Add-Ons :: Quarkus</name>
-  <description>Parent Module for Kogito Quarkus Add-Ons. All add-ons are Quarkus Extensions.</description>
-  <packaging>pom</packaging>
-
+  <groupId>org.apache.kie.sonataflow</groupId>
+  <artifactId>sonataflow-addons-quarkus-jwt-parser-parent</artifactId>
+  <name>SonataFlow :: Add-Ons :: Quarkus :: JWT Parser :: Parent</name>
+  <description>SonataFlow Quarkus JWT Token Parser for Serverless Workflow</description>
   <modules>
-    <module>messaging</module>
-    <module>common</module>
-    <module>rest-exception-handler</module>
-    <module>flyway</module>
-    <module>persistence</module>
-    <module>process-management</module>
-    <module>source-files</module>
-    <module>knative</module>
-    <module>kubernetes</module>
-    <module>events</module>
-    <module>camel</module>
-    <module>fabric8-kubernetes-service-catalog</module>
-    <module>microprofile-config-service-catalog</module>
-    <module>jobs</module>
-    <module>monitoring</module>
-    <module>dynamic</module>
-    <module>jwt-parser</module>
-    <module>token-exchange</module>
+    <module>deployment</module>
+    <module>runtime</module>
+    <module>integration-tests</module>
   </modules>
-
-  <profiles>
-    <profile>
-      <id>full</id>
-      <activation>
-        <property>
-          <name>full</name>
-        </property>
-      </activation>
-      <modules>
-        <module>python</module>
-       </modules>
-     </profile>
-  </profiles>
-
+  <packaging>pom</packaging>
   <build>
     <pluginManagement>
       <plugins>
@@ -81,7 +49,6 @@
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>${version.surefire.plugin}</version>
           <configuration>
             <systemPropertyVariables>
               <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
@@ -92,7 +59,6 @@
         </plugin>
         <plugin>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>${version.maven-surefire}</version>
           <configuration>
             <systemPropertyVariables>
               <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
@@ -104,6 +70,11 @@
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${version.compiler.plugin}</version>
+          <configuration>
+            <compilerArgs>
+              <arg>-parameters</arg>
+            </compilerArgs>
+          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/quarkus/addons/jwt-parser/runtime/pom.xml
+++ b/quarkus/addons/jwt-parser/runtime/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>sonataflow-addons-quarkus-jwt-parser-parent</artifactId>
+    <groupId>org.apache.kie.sonataflow</groupId>
+    <version>9.104.0</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <name>SonataFlow :: Add-Ons :: Quarkus :: JWT Parser :: Runtime</name>
+  <description>SonataFlow Quarkus JWT Token Parser for Serverless Workflow</description>
+  <artifactId>sonataflow-addons-quarkus-jwt-parser</artifactId>
+
+  <properties>
+     <java.module.name>org.kie.kogito.addons.quarkus.jwt.runtime</java.module.name>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-serverless-workflow-builder</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-jackson-utils</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-arc</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-extension-maven-plugin</artifactId>
+        <version>${version.io.quarkus}</version>
+        <executions>
+          <execution>
+            <phase>compile</phase>
+            <goals>
+              <goal>extension-descriptor</goal>
+            </goals>
+            <configuration>
+              <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}</deployment>
+              <capabilities>
+                <provides>org.apache.kie.sonataflow.addons.jwt-parser</provides>
+              </capabilities>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>io.quarkus</groupId>
+              <artifactId>quarkus-extension-processor</artifactId>
+              <version>${version.io.quarkus}</version>
+            </path>
+          </annotationProcessorPaths>
+          <compilerArgs>
+            <arg>-AlegacyConfigRoot=true</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/quarkus/addons/jwt-parser/runtime/src/main/java/org/kie/kogito/addons/jwt/JwtParserTypeHandler.java
+++ b/quarkus/addons/jwt-parser/runtime/src/main/java/org/kie/kogito/addons/jwt/JwtParserTypeHandler.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.addons.jwt;
+
+import org.jbpm.ruleflow.core.RuleFlowNodeContainerFactory;
+import org.jbpm.ruleflow.core.factory.WorkItemNodeFactory;
+import org.kie.kogito.serverless.workflow.parser.ParserContext;
+import org.kie.kogito.serverless.workflow.parser.types.WorkItemTypeHandler;
+
+import io.serverlessworkflow.api.Workflow;
+import io.serverlessworkflow.api.functions.FunctionDefinition;
+
+import static org.kie.kogito.serverless.workflow.parser.FunctionTypeHandlerFactory.trimCustomOperation;
+
+/**
+ * Function type handler for JWT parsing operations in SonataFlow
+ * Handles custom functions with type "jwt-parser"
+ */
+public class JwtParserTypeHandler extends WorkItemTypeHandler {
+
+    @Override
+    protected <T extends RuleFlowNodeContainerFactory<T, ?>> WorkItemNodeFactory<T> fillWorkItemHandler(
+            Workflow workflow, ParserContext context, WorkItemNodeFactory<T> node, FunctionDefinition functionDef) {
+
+        String operation = trimCustomOperation(functionDef);
+        if (operation != null && !operation.isEmpty()) {
+            node.workParameter(JwtParserWorkItemHandler.OPERATION_PARAM, operation);
+        }
+
+        return node.workName(JwtParserWorkItemHandler.NAME);
+    }
+
+    @Override
+    public String type() {
+        return JwtParserWorkItemHandler.NAME;
+    }
+}

--- a/quarkus/addons/jwt-parser/runtime/src/main/java/org/kie/kogito/addons/jwt/JwtParserWorkItemHandler.java
+++ b/quarkus/addons/jwt-parser/runtime/src/main/java/org/kie/kogito/addons/jwt/JwtParserWorkItemHandler.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.addons.jwt;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.kie.kogito.internal.process.workitem.KogitoWorkItem;
+import org.kie.kogito.internal.process.workitem.KogitoWorkItemHandler;
+import org.kie.kogito.internal.process.workitem.KogitoWorkItemManager;
+import org.kie.kogito.internal.process.workitem.WorkItemTransition;
+import org.kie.kogito.jackson.utils.JsonObjectUtils;
+import org.kie.kogito.process.workitems.impl.DefaultKogitoWorkItemHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * WorkItem handler for JWT token parsing operations in SonataFlow
+ */
+public class JwtParserWorkItemHandler extends DefaultKogitoWorkItemHandler {
+
+    public static final String NAME = "jwt-parser";
+    public static final String TOKEN_PARAM = "token";
+    public static final String CLAIM_PARAM = "claim";
+    public static final String OPERATION_PARAM = "operation";
+
+    // Operations
+    public static final String PARSE_OPERATION = "parse";
+    public static final String EXTRACT_USER_OPERATION = "extractUser";
+    public static final String EXTRACT_CLAIM_OPERATION = "extractClaim";
+
+    private static final Logger logger = LoggerFactory.getLogger(JwtParserWorkItemHandler.class);
+
+    private final JwtTokenParser jwtTokenParser;
+
+    public JwtParserWorkItemHandler() {
+        this.jwtTokenParser = new JwtTokenParser();
+    }
+
+    public JwtParserWorkItemHandler(JwtTokenParser jwtTokenParser) {
+        this.jwtTokenParser = jwtTokenParser;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public Optional<WorkItemTransition> activateWorkItemHandler(KogitoWorkItemManager manager, KogitoWorkItemHandler handler, KogitoWorkItem workItem, WorkItemTransition transition) {
+        try {
+            Map<String, Object> parameters = workItem.getParameters();
+            String token = (String) parameters.get(TOKEN_PARAM);
+            String operation = (String) parameters.getOrDefault(OPERATION_PARAM, PARSE_OPERATION);
+
+            logger.debug("Executing JWT parser operation: {}", operation);
+
+            JsonNode result;
+            switch (operation.toLowerCase()) {
+                case EXTRACT_USER_OPERATION:
+                    result = jwtTokenParser.extractUser(token);
+                    break;
+                case EXTRACT_CLAIM_OPERATION:
+                    String claimName = (String) parameters.get(CLAIM_PARAM);
+                    if (claimName == null) {
+                        throw new IllegalArgumentException("Claim name is required for extractClaim operation");
+                    }
+                    result = jwtTokenParser.extractClaim(token, claimName);
+                    break;
+                case PARSE_OPERATION:
+                default:
+                    result = jwtTokenParser.parseToken(token);
+                    break;
+            }
+
+            // Complete the work item with the parsed result
+            // Use JsonObjectUtils.fromValue to ensure proper serialization for workflow data access
+            // Note: "Result" with capital R is the standard constant used by SonataFlow
+            return Optional.of(handler.completeTransition(workItem.getPhaseStatus(), Map.of("Result", JsonObjectUtils.fromValue(result))));
+
+        } catch (Exception e) {
+            logger.error("Error executing JWT parser work item: {}", e.getMessage(), e);
+            return Optional.of(handler.abortTransition(workItem.getPhaseStatus()));
+        }
+    }
+}

--- a/quarkus/addons/jwt-parser/runtime/src/main/java/org/kie/kogito/addons/jwt/JwtParserWorkItemHandlerFactory.java
+++ b/quarkus/addons/jwt-parser/runtime/src/main/java/org/kie/kogito/addons/jwt/JwtParserWorkItemHandlerFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.addons.jwt;
+
+import java.util.List;
+
+import org.kie.kogito.internal.process.workitem.KogitoWorkItemHandler;
+import org.kie.kogito.internal.process.workitem.KogitoWorkItemHandlerFactory;
+
+/**
+ * Factory for creating JWT parser work item handlers
+ * This allows the handler to be discovered and registered automatically via ServiceLoader
+ */
+public class JwtParserWorkItemHandlerFactory implements KogitoWorkItemHandlerFactory {
+
+    @Override
+    public List<KogitoWorkItemHandler> provide() {
+        return List.of(new JwtParserWorkItemHandler());
+    }
+}

--- a/quarkus/addons/jwt-parser/runtime/src/main/java/org/kie/kogito/addons/jwt/JwtTokenParser.java
+++ b/quarkus/addons/jwt-parser/runtime/src/main/java/org/kie/kogito/addons/jwt/JwtTokenParser.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.addons.jwt;
+
+import java.util.Base64;
+
+import org.kie.kogito.jackson.utils.ObjectMapperFactory;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * JWT Token Parser utility for extracting claims from JWT tokens
+ * Used by SonataFlow workflows to parse JWT tokens and access claims
+ */
+public class JwtTokenParser {
+
+    private static final String BEARER = "Bearer ";
+
+    /**
+     * Parses a JWT token and returns the payload as a JsonNode
+     * 
+     * @param token The JWT token string (can include "Bearer " prefix)
+     * @return JsonNode containing the JWT payload/claims
+     * @throws RuntimeException if token parsing fails
+     */
+    public JsonNode parseToken(String token) {
+        if (token == null || token.trim().isEmpty()) {
+            throw new IllegalArgumentException("JWT token cannot be null or empty");
+        }
+
+        // Remove "Bearer " prefix if present
+        String cleanToken = token.startsWith(BEARER) ? token.substring(BEARER.length()) : token;
+
+        try {
+            // Parse JWT token without signature verification (for claim extraction only)
+            // In production, you might want to verify signatures with proper keys
+            String[] parts = cleanToken.split("\\.");
+            if (parts.length != 3) {
+                throw new IllegalArgumentException("Invalid JWT token format");
+            }
+
+            // Decode the payload (second part) using Base64
+            StringBuilder payloadBuilder = new StringBuilder(parts[1]);
+            // Add padding if necessary using StringBuilder for efficiency
+            while (payloadBuilder.length() % 4 != 0) {
+                payloadBuilder.append('=');
+            }
+
+            // Parse the JSON payload directly from bytes using ObjectMapperFactory singleton
+            return ObjectMapperFactory.get().readTree(Base64.getUrlDecoder().decode(payloadBuilder.toString()));
+
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to parse JWT token: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Extracts a specific claim from a JWT token
+     * 
+     * @param token The JWT token string
+     * @param claimName The name of the claim to extract
+     * @return The claim value as a JsonNode, or null if not found
+     */
+    public JsonNode extractClaim(String token, String claimName) {
+        JsonNode payload = parseToken(token);
+        return payload.get(claimName);
+    }
+
+    /**
+     * Extracts user information from standard JWT claims
+     * 
+     * @param token The JWT token string
+     * @return JsonNode containing user info (sub, preferred_username, email, etc.)
+     */
+    public JsonNode extractUser(String token) {
+        JsonNode payload = parseToken(token);
+        ObjectNode userInfo = ObjectMapperFactory.get().createObjectNode();
+
+        // Standard JWT claims for user identification
+        if (payload.has("sub")) {
+            userInfo.set("sub", payload.get("sub"));
+        }
+        if (payload.has("preferred_username")) {
+            userInfo.set("preferred_username", payload.get("preferred_username"));
+        }
+        if (payload.has("email")) {
+            userInfo.set("email", payload.get("email"));
+        }
+        if (payload.has("name")) {
+            userInfo.set("name", payload.get("name"));
+        }
+        if (payload.has("given_name")) {
+            userInfo.set("given_name", payload.get("given_name"));
+        }
+        if (payload.has("family_name")) {
+            userInfo.set("family_name", payload.get("family_name"));
+        }
+
+        return userInfo;
+    }
+}

--- a/quarkus/addons/jwt-parser/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/quarkus/addons/jwt-parser/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,34 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+---
+name: SonataFlow JWT Parser Add-On
+description: Add-on for SonataFlow to parse JWT tokens and extract claims in workflows
+metadata:
+  keywords:
+    - sonataflow
+    - jwt
+    - token
+    - authentication
+    - serverless
+    - workflows
+  categories:
+    - "security"
+    - "cloud"
+  status: "preview"

--- a/quarkus/addons/jwt-parser/runtime/src/main/resources/META-INF/services/org.kie.kogito.internal.process.workitem.KogitoWorkItemHandlerFactory
+++ b/quarkus/addons/jwt-parser/runtime/src/main/resources/META-INF/services/org.kie.kogito.internal.process.workitem.KogitoWorkItemHandlerFactory
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+org.kie.kogito.addons.jwt.JwtParserWorkItemHandlerFactory
+

--- a/quarkus/addons/jwt-parser/runtime/src/main/resources/META-INF/services/org.kie.kogito.serverless.workflow.parser.FunctionTypeHandler
+++ b/quarkus/addons/jwt-parser/runtime/src/main/resources/META-INF/services/org.kie.kogito.serverless.workflow.parser.FunctionTypeHandler
@@ -1,0 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+org.kie.kogito.addons.jwt.JwtParserTypeHandler


### PR DESCRIPTION
…021)

Backported from f130cc08699da2d309f2fc0e2fa5e9ff4da9905a

* Introducing jwt parser handler and associated classes

* Add missing Apache license headers to JWT parser files

- Added Apache license header to FunctionTypeHandler service file
- Added Apache license header to quarkus-extension.yaml

Fixes review comments from @gmunozfe in PR #4021



* Fix PR review comments: simplify type handler, add end-to-end tests

- Simplified JwtParserTypeHandler following CamelWorkItemTypeHandler pattern
- Removed getActionNode override, moved operation parsing to fillWorkItemHandler
- Removed manual metadata handling as it should be automatic
- Added comprehensive end-to-end integration tests with real JWT tokens
- Added kogito-test-utils dependency for ProcessInstancesRESTTestUtils
- Tests now verify complete workflow execution with JWT parsing

Addresses review comments from fjtirado and wmedvede in PR #4021



* Improve JwtParserIT to follow TokenExchangeIT pattern

- Changed @QuarkusTest to @QuarkusIntegrationTest following serverless workflow integration test patterns
- Added assertProcessInstanceNotExists check to verify process cleanup like TokenExchangeIT
- Now fully matches the integration test pattern referenced by wmedvede in PR review

Addresses wmedvede's review comment about following TokenExchangeIT example



* Optimize JwtTokenParser per fjtirado review feedback

- Use ObjectMapperFactory.get() singleton instead of creating new ObjectMapper
- Avoid unnecessary string conversion by parsing bytes directly
- More concise and efficient JWT parsing implementation
- Removes unused imports (StandardCharsets, ObjectMapper)

Addresses fjtirado's review comment about making the parsing block more concise



* Optimize JWT padding logic with StringBuilder

- Use StringBuilder instead of string concatenation in loop to avoid creating multiple string objects
- Use char literal '=' instead of string "=" for better performance
- Call toString() only once at the end for Base64 decoding
- More efficient memory usage during JWT token padding

Addresses fjtirado's review comment about improving the padding block



* Use constant for Bearer prefix to improve safety and maintainability

- Add private static final String BEARER = "Bearer " constant at class level
- Use BEARER.length() instead of hardcoded 7 for safer substring operation
- Eliminates magic string and makes code more maintainable
- Prevents potential typos and makes intent clearer

Addresses fjtirado's review comment about safer Bearer prefix handling



* Fix integration tests based on wmedvede review comments

- Remove @Inject JwtTokenParser from @QuarkusIntegrationTest (not supported)
- Remove unit tests, focus only on end-to-end workflow tests
- Simplify tests for one-shot workflows (results immediately available)
- Use assertProcessInstanceNotExists for process cleanup verification
- Add WorkItemHandlerFactory pattern for proper handler registration
- Fix runtime dependencies to avoid extension conflicts
- Add quarkus-rest dependencies for REST endpoint generation
- Follow TokenExchangeIT pattern for integration testing



* [FLPATH-2212] : improving the pom structure

* Fix work item handler registration by removing CDI dependency

- Changed JwtParserWorkItemHandler and JwtTokenParser to plain Java classes (no CDI)
- Updated JwtParserWorkItemHandlerFactory to directly instantiate handlers
- Removed bean registration from JwtParserProcessor (handlers discovered via ServiceLoader)
- This fixes the 'Could not find work item handler for jwt-parser' runtime error



* Trigger CI rebuild



* [apache/incubator-kie-issues#1899] Fix JWT parser handler registration and test workflow

- Override getName() method in JwtParserWorkItemHandler to return 'jwt-parser'
- Remove workItem.getId() call that throws UnsupportedOperationException
- Simplify workflow and test to directly access parsed JWT claims in workflowdata
- All integration tests now pass successfully



* [apache/incubator-kie-issues#1899] Complete JWT parser addon with loan approval workflow example

- Add realistic loan approval workflow demonstrating personalized response
- Update integration tests to verify both JWT parsing and personalized message
- All tests pass successfully



---------

This is MIDSTREAM if you want to send your PR to UPSTREAM use https://github.com/apache/incubator-kie-kogito-runtimes 

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](CONTRIBUTING.md)
- [ ] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] tests</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [kogito-runtimes|kogito-apps|kogito-examples] native</b>

</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>