### PR TITLE
[SRVLOGIC-888] -  fix after osl cut-off automation run: enable productization maven profile (1/2)

### DIFF
--- a/.github/workflows/pr-downstream.yml
+++ b/.github/workflows/pr-downstream.yml
@@ -25,8 +25,7 @@ jobs:
         include:
           - job_name: kogito-apps
             repository: kogito-apps
-            env:
-              env_BUILD_MVN_OPTS: " -Dproductized"
+            env_BUILD_MVN_OPTS: " -Dproductized"
           - job_name: serverless-workflow-examples
             repository: kogito-examples
             env_KOGITO_EXAMPLES_SUBFOLDER_POM: serverless-workflow-examples/


### PR DESCRIPTION
This is MIDSTREAM if you want to send your PR to UPSTREAM use https://github.com/apache/incubator-kie-kogito-runtimes 

**JIRA**  https://redhat.atlassian.net/browse/SRVLOGIC-888

**Related PRs**
- https://github.com/kiegroup/kogito-pipelines/pull/106/changes

**Fix in the OSL cut-off automation** 
https://github.com/jankrystof-ibm/osl_cut_off_automation/commit/5ec03779a616f30b83b17dc825888f34f60e0b81


Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](CONTRIBUTING.md)
- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [x] Pull Request title is properly formatted: `SRVLOGIC-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] SRVLOGIC-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
This is an alternative fix to the https://github.com/kiegroup/kogito-pipelines/pull/106/changes supporting the way the osl cut-off automation should enable the productiozation profile. 
</summary>

</details>
