### PR TITLE
[SRVLOGIC-963] Changes for snapshots publishing.

### DIFF
--- a/.ci/jenkins/tests/pom.xml
+++ b/.ci/jenkins/tests/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.kie.jenkins</groupId>
     <artifactId>jenkins-tests</artifactId>
     <name>Kogito :: Jenkins Spock Tests</name>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <repositories>

--- a/.ci/jenkins/tests/pom.xml
+++ b/.ci/jenkins/tests/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.kie.jenkins</groupId>
     <artifactId>jenkins-tests</artifactId>
     <name>Kogito :: Jenkins Spock Tests</name>
-    <version>111-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <repositories>

--- a/.github/workflows/pr-downstream.yml
+++ b/.github/workflows/pr-downstream.yml
@@ -53,8 +53,7 @@ jobs:
           starting-project: kiegroup/${{ matrix.repository }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           definition-file: https://raw.githubusercontent.com/${GROUP:kiegroup}/kogito-pipelines/${BRANCH:main}/.ci/pull-request-config.yaml
-        env: 
-          BUILD_MVN_OPTS: ${{ matrix.env_BUILD_MVN_OPTS }}
+        env:
           KOGITO_EXAMPLES_SUBFOLDER_POM: ${{ matrix.env_KOGITO_EXAMPLES_SUBFOLDER_POM }}
       - name: Junit Report
         uses: kiegroup/kogito-pipelines/.ci/actions/action-junit-report@main

--- a/.github/workflows/pr-kogito-runtimes.yml
+++ b/.github/workflows/pr-kogito-runtimes.yml
@@ -45,8 +45,6 @@ jobs:
           annotations-prefix: ${{ runner.os }}-${{ matrix.java-version }}/${{ matrix.maven-version }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           definition-file: https://raw.githubusercontent.com/${GROUP:kiegroup}/kogito-pipelines/${BRANCH:main}/.ci/pull-request-config.yaml
-        env:
-          BUILD_MVN_OPTS_CURRENT: '-Dvalidate-formatting'
       - name: Junit Report
         uses: kiegroup/kogito-pipelines/.ci/actions/action-junit-report@main
         if: ${{ always() }}

--- a/addons/common/events/decisions/pom.xml
+++ b/addons/common/events/decisions/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-events-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-addons-events-decisions</artifactId>

--- a/addons/common/events/mongodb/pom.xml
+++ b/addons/common/events/mongodb/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-events-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-addons-events-mongodb</artifactId>

--- a/addons/common/events/pom.xml
+++ b/addons/common/events/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-common-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-events-parent</artifactId>
   <packaging>pom</packaging>

--- a/addons/common/events/predictions/pom.xml
+++ b/addons/common/events/predictions/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-events-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-addons-events-predictions</artifactId>

--- a/addons/common/events/rules/pom.xml
+++ b/addons/common/events/rules/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-events-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <groupId>org.drools</groupId>

--- a/addons/common/explainability/pom.xml
+++ b/addons/common/explainability/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons-common-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/common/flyway/pom.xml
+++ b/addons/common/flyway/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons-common-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/common/human-task-prediction/api/pom.xml
+++ b/addons/common/human-task-prediction/api/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.jbpm</groupId>
     <artifactId>jbpm-addons-human-task-prediction-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>jbpm-addons-human-task-prediction-api</artifactId>
   <name>jBPM :: Add-Ons :: Predictions :: API</name>

--- a/addons/common/human-task-prediction/pom.xml
+++ b/addons/common/human-task-prediction/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-common-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <groupId>org.jbpm</groupId>
   <artifactId>jbpm-addons-human-task-prediction-parent</artifactId>

--- a/addons/common/human-task-prediction/smile/pom.xml
+++ b/addons/common/human-task-prediction/smile/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.jbpm</groupId>
     <artifactId>jbpm-addons-human-task-prediction-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>jbpm-addons-human-task-prediction-smile</artifactId>
   <name>jBPM :: Add-Ons :: Predictions :: SMILE</name>

--- a/addons/common/jbpm-usertask-storage-jpa/pom.xml
+++ b/addons/common/jbpm-usertask-storage-jpa/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>kogito-addons-common-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jbpm</groupId>

--- a/addons/common/jobs/api/pom.xml
+++ b/addons/common/jobs/api/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-jobs-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-jobs-api</artifactId>
   <name>Kogito :: Add-Ons :: Jobs :: API</name>

--- a/addons/common/jobs/management-common/pom.xml
+++ b/addons/common/jobs/management-common/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons-jobs-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/common/jobs/pom.xml
+++ b/addons/common/jobs/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-common-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-jobs-parent</artifactId>
   <packaging>pom</packaging>

--- a/addons/common/kie-addons-process-migration/pom.xml
+++ b/addons/common/kie-addons-process-migration/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>kogito-addons-common-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>kie-addons-process-instance-migration</artifactId>

--- a/addons/common/knative/eventing/pom.xml
+++ b/addons/common/knative/eventing/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons-knative-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/common/knative/pom.xml
+++ b/addons/common/knative/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons-common-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/common/kubernetes-service-catalog/pom.xml
+++ b/addons/common/kubernetes-service-catalog/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>kogito-addons-common-parent</artifactId>
         <groupId>org.kie</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/addons/common/kubernetes/pom.xml
+++ b/addons/common/kubernetes/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons-common-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/common/mail/pom.xml
+++ b/addons/common/mail/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons-common-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/common/marshallers/avro/pom.xml
+++ b/addons/common/marshallers/avro/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-marshallers-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-addons-marshallers-avro</artifactId>

--- a/addons/common/marshallers/pom.xml
+++ b/addons/common/marshallers/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-common-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-marshallers-parent</artifactId>
   <packaging>pom</packaging>

--- a/addons/common/messaging/pom.xml
+++ b/addons/common/messaging/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-common-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-addons-messaging</artifactId>

--- a/addons/common/monitoring/core/pom.xml
+++ b/addons/common/monitoring/core/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kie-addons-monitoring-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <name>Kogito :: Add-Ons :: Monitoring Core</name>

--- a/addons/common/monitoring/elastic/pom.xml
+++ b/addons/common/monitoring/elastic/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kie-addons-monitoring-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/common/monitoring/pom.xml
+++ b/addons/common/monitoring/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-common-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-monitoring-parent</artifactId>
   <name>KIE :: Add-Ons :: Monitoring</name>

--- a/addons/common/monitoring/prometheus/pom.xml
+++ b/addons/common/monitoring/prometheus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kie-addons-monitoring-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/common/persistence/ddl/pom.xml
+++ b/addons/common/persistence/ddl/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-persistence-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/addons/common/persistence/filesystem/pom.xml
+++ b/addons/common/persistence/filesystem/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-persistence-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-persistence-filesystem</artifactId>
   <name>KIE :: Add-Ons :: Persistence :: File System</name>

--- a/addons/common/persistence/infinispan/pom.xml
+++ b/addons/common/persistence/infinispan/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-persistence-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-persistence-infinispan</artifactId>
   <name>KIE :: Add-Ons :: Persistence :: Infinispan</name>

--- a/addons/common/persistence/jdbc/pom.xml
+++ b/addons/common/persistence/jdbc/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-persistence-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-persistence-jdbc</artifactId>
   <name>KIE :: Add-Ons :: Persistence :: JDBC</name>

--- a/addons/common/persistence/mongodb/pom.xml
+++ b/addons/common/persistence/mongodb/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-persistence-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/common/persistence/pom.xml
+++ b/addons/common/persistence/pom.xml
@@ -35,11 +35,6 @@
   <modules>
     <module>jdbc</module>
     <module>ddl</module>
-    <module>infinispan</module>
-    <module>filesystem</module>
-    <module>mongodb</module>
-    <module>postgresql</module>
-    <module>rocksdb</module>
   </modules>
 
 </project>

--- a/addons/common/persistence/pom.xml
+++ b/addons/common/persistence/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-common-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-persistence-parent</artifactId>
   <packaging>pom</packaging>

--- a/addons/common/persistence/postgresql/pom.xml
+++ b/addons/common/persistence/postgresql/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-persistence-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-persistence-postgresql</artifactId>
   <name>KIE :: Add-Ons :: Persistence :: PostgreSQL</name>

--- a/addons/common/persistence/rocksdb/pom.xml
+++ b/addons/common/persistence/rocksdb/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-persistence-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-persistence-rocksdb</artifactId>
   <name>KIE :: Add-Ons :: Persistence :: RocksDB</name>

--- a/addons/common/pom.xml
+++ b/addons/common/pom.xml
@@ -47,16 +47,8 @@
     <module>kubernetes</module>
     <module>kubernetes-service-catalog</module>
     <module>jobs</module>
-    <module>events</module>
     <module>monitoring</module>
-    <module>explainability</module>
-    <module>human-task-prediction</module>
-    <module>mail</module>
-    <module>tracing</module>
-    <module>task-management</module>
-    <module>marshallers</module>
     <module>flyway</module>
-    <module>jbpm-usertask-storage-jpa</module>
     <module>source-files</module>
   </modules>
 

--- a/addons/common/pom.xml
+++ b/addons/common/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/common/process-dynamic/pom.xml
+++ b/addons/common/process-dynamic/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-common-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-process-dynamic</artifactId>
   <name>KIE Add-On Process Instance Dynamic Calls</name>

--- a/addons/common/process-instance-migration/pom.xml
+++ b/addons/common/process-instance-migration/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons-common-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/common/process-management/pom.xml
+++ b/addons/common/process-management/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons-common-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/common/process-svg/pom.xml
+++ b/addons/common/process-svg/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons-common-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/common/rest-exception-handler/pom.xml
+++ b/addons/common/rest-exception-handler/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons-common-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/common/source-files/pom.xml
+++ b/addons/common/source-files/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>kogito-addons-common-parent</artifactId>
         <groupId>org.kie</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/addons/common/task-management/pom.xml
+++ b/addons/common/task-management/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons-common-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/common/tracing/decision-common/pom.xml
+++ b/addons/common/tracing/decision-common/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kie-addons-tracing-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/common/tracing/pom.xml
+++ b/addons/common/tracing/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons-common-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/common/tracing/tracing-api/pom.xml
+++ b/addons/common/tracing/tracing-api/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kie-addons-tracing-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/common/tracing/typedvalue-api/pom.xml
+++ b/addons/common/tracing/typedvalue-api/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kie-addons-tracing-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/pom.xml
+++ b/addons/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kogito-build/kogito-build-parent/pom.xml</relativePath>
   </parent>
 

--- a/api/kogito-api-incubation-application/pom.xml
+++ b/api/kogito-api-incubation-application/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-api-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-api-incubation-application</artifactId>

--- a/api/kogito-api-incubation-common-objectmapper/pom.xml
+++ b/api/kogito-api-incubation-common-objectmapper/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-api-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-api-incubation-common-objectmapper</artifactId>

--- a/api/kogito-api-incubation-common/pom.xml
+++ b/api/kogito-api-incubation-common/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-api-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-api-incubation-common</artifactId>

--- a/api/kogito-api-incubation-decisions-services/pom.xml
+++ b/api/kogito-api-incubation-decisions-services/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-api-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-api-incubation-decisions-services</artifactId>

--- a/api/kogito-api-incubation-decisions/pom.xml
+++ b/api/kogito-api-incubation-decisions/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-api-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-api-incubation-decisions</artifactId>

--- a/api/kogito-api-incubation-predictions-services/pom.xml
+++ b/api/kogito-api-incubation-predictions-services/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-api-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-api-incubation-predictions-services</artifactId>

--- a/api/kogito-api-incubation-predictions/pom.xml
+++ b/api/kogito-api-incubation-predictions/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-api-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-api-incubation-predictions</artifactId>

--- a/api/kogito-api-incubation-processes-services/pom.xml
+++ b/api/kogito-api-incubation-processes-services/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-api-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-api-incubation-processes-services</artifactId>

--- a/api/kogito-api-incubation-processes/pom.xml
+++ b/api/kogito-api-incubation-processes/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-api-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-api-incubation-processes</artifactId>

--- a/api/kogito-api-incubation-rules-services/pom.xml
+++ b/api/kogito-api-incubation-rules-services/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-api-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-api-incubation-rules-services</artifactId>

--- a/api/kogito-api-incubation-rules/pom.xml
+++ b/api/kogito-api-incubation-rules/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-api-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-api-incubation-rules</artifactId>

--- a/api/kogito-api/pom.xml
+++ b/api/kogito-api/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-api-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-api</artifactId>

--- a/api/kogito-events-api/pom.xml
+++ b/api/kogito-events-api/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-api-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-events-api</artifactId>

--- a/api/kogito-events-core/pom.xml
+++ b/api/kogito-events-core/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-api-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-events-core</artifactId>

--- a/api/kogito-jobs-service-api/pom.xml
+++ b/api/kogito-jobs-service-api/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>kogito-api-parent</artifactId>
         <groupId>org.kie.kogito</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/api/kogito-services/pom.xml
+++ b/api/kogito-services/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-api-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-services</artifactId>

--- a/api/kogito-timer/pom.xml
+++ b/api/kogito-timer/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-api-parent</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -43,17 +43,6 @@
     <module>kogito-services</module>
     <module>kogito-timer</module>
     <module>kogito-jobs-service-api</module>
-    <module>kogito-api-incubation-common</module>
-    <module>kogito-api-incubation-common-objectmapper</module>
-    <module>kogito-api-incubation-application</module>
-    <module>kogito-api-incubation-processes</module>
-    <module>kogito-api-incubation-processes-services</module>
-    <module>kogito-api-incubation-predictions</module>
-    <module>kogito-api-incubation-predictions-services</module>
-    <module>kogito-api-incubation-decisions</module>
-    <module>kogito-api-incubation-decisions-services</module>
-    <module>kogito-api-incubation-rules</module>
-    <module>kogito-api-incubation-rules-services</module>
   </modules>
 
 </project>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kogito-build/kogito-build-parent/pom.xml</relativePath>
   </parent>
 

--- a/drools/kogito-dmn/pom.xml
+++ b/drools/kogito-dmn/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>drools</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-dmn</artifactId>

--- a/drools/kogito-drools/pom.xml
+++ b/drools/kogito-drools/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>drools</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-drools</artifactId>

--- a/drools/kogito-efesto-drl/pom.xml
+++ b/drools/kogito-efesto-drl/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>drools</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/drools/kogito-pmml-api-dependencies/pom.xml
+++ b/drools/kogito-pmml-api-dependencies/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>drools</artifactId>
-     <version>999-SNAPSHOT</version>
+     <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-pmml-api-dependencies</artifactId>

--- a/drools/kogito-pmml-dependencies/pom.xml
+++ b/drools/kogito-pmml-dependencies/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>drools</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-pmml-dependencies</artifactId>

--- a/drools/kogito-pmml-openapi/pom.xml
+++ b/drools/kogito-pmml-openapi/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>drools</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools/kogito-pmml/pom.xml
+++ b/drools/kogito-pmml/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>drools</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-pmml</artifactId>

--- a/drools/kogito-scenario-simulation/pom.xml
+++ b/drools/kogito-scenario-simulation/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>drools</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-scenario-simulation</artifactId>

--- a/drools/pom.xml
+++ b/drools/pom.xml
@@ -46,12 +46,6 @@
   <modules>
     <module>kogito-drools</module>
     <module>kogito-dmn</module>
-    <module>kogito-pmml-api-dependencies</module>
-    <module>kogito-efesto-drl</module>
-    <module>kogito-pmml-dependencies</module>
-    <module>kogito-pmml-openapi</module>
-    <module>kogito-pmml</module>
-    <module>kogito-scenario-simulation</module>
   </modules>
 
   <build>

--- a/drools/pom.xml
+++ b/drools/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kogito-build/kogito-build-parent/pom.xml</relativePath>
   </parent>
 

--- a/grafana-api/pom.xml
+++ b/grafana-api/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kogito-build/kogito-build-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/jbpm/jbpm-bpmn2/pom.xml
+++ b/jbpm/jbpm-bpmn2/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>jbpm</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>jbpm-bpmn2</artifactId>

--- a/jbpm/jbpm-deps-groups/jbpm-deps-group-bpmn2-compiler/pom.xml
+++ b/jbpm/jbpm-deps-groups/jbpm-deps-group-bpmn2-compiler/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <artifactId>jbpm-deps-groups</artifactId>
         <groupId>org.kie.kogito</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>jbpm-deps-group-bpmn2-compiler</artifactId>

--- a/jbpm/jbpm-deps-groups/jbpm-deps-group-compiler/pom.xml
+++ b/jbpm/jbpm-deps-groups/jbpm-deps-group-compiler/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <artifactId>jbpm-deps-groups</artifactId>
         <groupId>org.kie.kogito</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>jbpm-deps-group-compiler</artifactId>

--- a/jbpm/jbpm-deps-groups/jbpm-deps-group-engine/pom.xml
+++ b/jbpm/jbpm-deps-groups/jbpm-deps-group-engine/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <artifactId>jbpm-deps-groups</artifactId>
         <groupId>org.kie.kogito</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
 

--- a/jbpm/jbpm-deps-groups/pom.xml
+++ b/jbpm/jbpm-deps-groups/pom.xml
@@ -28,7 +28,7 @@ under the License.
     <parent>
         <artifactId>jbpm</artifactId>
         <groupId>org.kie.kogito</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>jbpm-deps-groups</artifactId>

--- a/jbpm/jbpm-flow-builder/pom.xml
+++ b/jbpm/jbpm-flow-builder/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>jbpm</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>jbpm-flow-builder</artifactId>

--- a/jbpm/jbpm-flow-migration/pom.xml
+++ b/jbpm/jbpm-flow-migration/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>jbpm</artifactId>
         <groupId>org.kie.kogito</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>jbpm-flow-migration</artifactId>

--- a/jbpm/jbpm-flow/pom.xml
+++ b/jbpm/jbpm-flow/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>jbpm</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>jbpm-flow</artifactId>

--- a/jbpm/jbpm-tests/pom.xml
+++ b/jbpm/jbpm-tests/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>jbpm</artifactId>
         <groupId>org.kie.kogito</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>jbpm-tests</artifactId>

--- a/jbpm/jbpm-tools/jbpm-tools-maven-plugin/pom.xml
+++ b/jbpm/jbpm-tools/jbpm-tools-maven-plugin/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>jbpm-tools</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>jbpm-tools-maven-plugin</artifactId>

--- a/jbpm/jbpm-tools/jbpm-tools-maven-plugin/src/test/resources/unit/project/pom.xml
+++ b/jbpm/jbpm-tools/jbpm-tools-maven-plugin/src/test/resources/unit/project/pom.xml
@@ -25,7 +25,7 @@
     <groupId>com.javaxp</groupId>
     <artifactId>project-name</artifactId>
     <packaging>jar</packaging>
-    <version>1.0-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <name>project-name</name>
     <url>http://maven.apache.org</url>
 

--- a/jbpm/jbpm-tools/pom.xml
+++ b/jbpm/jbpm-tools/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>jbpm</artifactId>
         <groupId>org.kie.kogito</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>jbpm-tools</artifactId>

--- a/jbpm/jbpm-usertask-workitem/pom.xml
+++ b/jbpm/jbpm-usertask-workitem/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>jbpm</artifactId>
         <groupId>org.kie.kogito</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>jbpm-usertask-workitem</artifactId>

--- a/jbpm/jbpm-usertask/pom.xml
+++ b/jbpm/jbpm-usertask/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <artifactId>jbpm</artifactId>
         <groupId>org.kie.kogito</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>jbpm-usertask</artifactId>

--- a/jbpm/jbpm-xsd-resources/pom.xml
+++ b/jbpm/jbpm-xsd-resources/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>jbpm</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>jbpm-xsd-resources</artifactId>

--- a/jbpm/pom.xml
+++ b/jbpm/pom.xml
@@ -47,8 +47,6 @@
     <module>jbpm-flow-migration</module>
     <module>jbpm-usertask</module>
     <module>jbpm-usertask-workitem</module>
-    <module>jbpm-tests</module>
-    <module>jbpm-tools</module>
     <module>jbpm-xsd-resources</module>
     <module>process-serialization-protobuf</module>
     <module>process-workitems</module>
@@ -63,7 +61,6 @@
         </property>
       </activation>
       <modules>
-        <module>jbpm-tests</module>
       </modules>
     </profile>
   </profiles>

--- a/jbpm/pom.xml
+++ b/jbpm/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kogito-build/kogito-build-parent/pom.xml</relativePath>
 
   </parent>

--- a/jbpm/process-serialization-protobuf/pom.xml
+++ b/jbpm/process-serialization-protobuf/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>jbpm</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
 

--- a/jbpm/process-workitems/pom.xml
+++ b/jbpm/process-workitems/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>jbpm</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>process-workitems</artifactId>

--- a/kogito-bom/pom.xml
+++ b/kogito-bom/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-runtimes</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/kogito-build/kogito-build-no-bom-parent/pom.xml
+++ b/kogito-build/kogito-build-no-bom-parent/pom.xml
@@ -28,7 +28,7 @@
     <groupId>org.kie.kogito</groupId>
     <!-- The Kogito Dependencies BOM is inherited here to reuse all the version properties defined there and used across our internal modules. -->
     <artifactId>kogito-dependencies-bom</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kogito-dependencies-bom/pom.xml</relativePath>
   </parent>
 

--- a/kogito-build/kogito-build-parent/pom.xml
+++ b/kogito-build/kogito-build-parent/pom.xml
@@ -28,7 +28,7 @@
     <groupId>org.kie.kogito</groupId>
     <!-- The Kogito Dependencies BOM is transitively inherited here to reuse all the version properties defined there and used across our internal modules. -->
     <artifactId>kogito-build-no-bom-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kogito-build-no-bom-parent/pom.xml</relativePath>
   </parent>
 

--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>kogito-build</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kogito-build/kogito-ide-config/pom.xml
+++ b/kogito-build/kogito-ide-config/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>kogito-runtimes</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/kogito-build/kogito-kie-bom/pom.xml
+++ b/kogito-build/kogito-kie-bom/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-build</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
@@ -37,7 +37,7 @@
   </description>
 
   <properties>
-    <version.org.kie>999-SNAPSHOT</version.org.kie>
+    <version.org.kie>111-SNAPSHOT</version.org.kie>
   </properties>
 
   <dependencyManagement>

--- a/kogito-build/kogito-kie-bom/pom.xml
+++ b/kogito-build/kogito-kie-bom/pom.xml
@@ -37,7 +37,7 @@
   </description>
 
   <properties>
-    <version.org.kie>111-SNAPSHOT</version.org.kie>
+    <version.org.kie>${project.version}</version.org.kie>
   </properties>
 
   <dependencyManagement>

--- a/kogito-build/pom.xml
+++ b/kogito-build/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-runtimes</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/kogito-codegen-modules/kogito-codegen-api/pom.xml
+++ b/kogito-codegen-modules/kogito-codegen-api/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-codegen-modules</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>kogito-codegen-api</artifactId>

--- a/kogito-codegen-modules/kogito-codegen-core/pom.xml
+++ b/kogito-codegen-modules/kogito-codegen-core/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-codegen-modules</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>kogito-codegen-core</artifactId>

--- a/kogito-codegen-modules/kogito-codegen-decisions/pom.xml
+++ b/kogito-codegen-modules/kogito-codegen-decisions/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-codegen-modules</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>kogito-codegen-decisions</artifactId>

--- a/kogito-codegen-modules/kogito-codegen-events/pom.xml
+++ b/kogito-codegen-modules/kogito-codegen-events/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-codegen-modules</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <artifactId>kogito-codegen-events</artifactId>
     <name>Kogito :: Codegen Events</name>

--- a/kogito-codegen-modules/kogito-codegen-integration-tests/pom.xml
+++ b/kogito-codegen-modules/kogito-codegen-integration-tests/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-codegen-modules</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>kogito-codegen-integration-tests</artifactId>

--- a/kogito-codegen-modules/kogito-codegen-manager/pom.xml
+++ b/kogito-codegen-modules/kogito-codegen-manager/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-codegen-modules</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-codegen-manager</artifactId>

--- a/kogito-codegen-modules/kogito-codegen-predictions/pom.xml
+++ b/kogito-codegen-modules/kogito-codegen-predictions/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-codegen-modules</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>kogito-codegen-predictions</artifactId>

--- a/kogito-codegen-modules/kogito-codegen-processes-integration-tests/pom.xml
+++ b/kogito-codegen-modules/kogito-codegen-processes-integration-tests/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-codegen-modules</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>kogito-codegen-processes-integration-tests</artifactId>

--- a/kogito-codegen-modules/kogito-codegen-processes/pom.xml
+++ b/kogito-codegen-modules/kogito-codegen-processes/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-codegen-modules</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>kogito-codegen-processes</artifactId>

--- a/kogito-codegen-modules/kogito-codegen-rules/pom.xml
+++ b/kogito-codegen-modules/kogito-codegen-rules/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-codegen-modules</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>kogito-codegen-rules</artifactId>

--- a/kogito-codegen-modules/kogito-codegen-sample/kogito-codegen-sample-generator/pom.xml
+++ b/kogito-codegen-modules/kogito-codegen-sample/kogito-codegen-sample-generator/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-codegen-sample</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>kogito-codegen-sample-generator</artifactId>

--- a/kogito-codegen-modules/kogito-codegen-sample/kogito-codegen-sample-runtime/pom.xml
+++ b/kogito-codegen-modules/kogito-codegen-sample/kogito-codegen-sample-runtime/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-codegen-sample</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>kogito-codegen-sample-runtime</artifactId>

--- a/kogito-codegen-modules/kogito-codegen-sample/pom.xml
+++ b/kogito-codegen-modules/kogito-codegen-sample/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-codegen-modules</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-codegen-sample</artifactId>

--- a/kogito-codegen-modules/pom.xml
+++ b/kogito-codegen-modules/pom.xml
@@ -38,14 +38,8 @@
   <modules>
     <module>kogito-codegen-api</module>
     <module>kogito-codegen-core</module>
-    <module>kogito-codegen-decisions</module>
-    <module>kogito-codegen-integration-tests</module>
-    <module>kogito-codegen-manager</module>
-    <module>kogito-codegen-predictions</module>
     <module>kogito-codegen-processes</module>
     <module>kogito-codegen-processes-integration-tests</module>
-    <module>kogito-codegen-rules</module>
-    <module>kogito-codegen-sample</module>
     <module>kogito-codegen-events</module>
   </modules>
 

--- a/kogito-codegen-modules/pom.xml
+++ b/kogito-codegen-modules/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kogito-build/kogito-build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kogito-gradle-plugin-test/pom.xml
+++ b/kogito-gradle-plugin-test/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kogito-build/kogito-build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kogito-gradle-plugin/pom.xml
+++ b/kogito-gradle-plugin/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kogito-build/kogito-build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kogito-maven-plugin-test/pom.xml
+++ b/kogito-maven-plugin-test/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kogito-build/kogito-build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kogito-maven-plugin/pom.xml
+++ b/kogito-maven-plugin/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kogito-build/kogito-build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kogito-maven-plugin/src/test/resources/unit/generate-model/pom.xml
+++ b/kogito-maven-plugin/src/test/resources/unit/generate-model/pom.xml
@@ -24,7 +24,7 @@
   <groupId>org.kie.kogito</groupId>
   <artifactId>project-name</artifactId>
   <packaging>jar</packaging>
-  <version>1.0-SNAPSHOT</version>
+  <version>111-SNAPSHOT</version>
   <name>project-name</name>
 
   <build>

--- a/kogito-serverless-workflow/kogito-jq-expression/pom.xml
+++ b/kogito-serverless-workflow/kogito-jq-expression/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-serverless-workflow</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-jq-expression</artifactId>

--- a/kogito-serverless-workflow/kogito-jsonpath-expression/pom.xml
+++ b/kogito-serverless-workflow/kogito-jsonpath-expression/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-serverless-workflow</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-jsonpath-expression</artifactId>

--- a/kogito-serverless-workflow/kogito-serverless-workflow-builder/pom.xml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-builder/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-serverless-workflow</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-serverless-workflow-builder</artifactId>

--- a/kogito-serverless-workflow/kogito-serverless-workflow-dmn-parser/pom.xml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-dmn-parser/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-serverless-workflow</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
    <name>Kogito :: Serverless Workflow :: DMN :: Parser</name>
    

--- a/kogito-serverless-workflow/kogito-serverless-workflow-dmn/pom.xml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-dmn/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-serverless-workflow</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-serverless-workflow-dmn</artifactId>
   <name>Kogito :: Serverless Workflow :: DMN :: Runtime</name>

--- a/kogito-serverless-workflow/kogito-serverless-workflow-executor-core/pom.xml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-executor-core/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-serverless-workflow</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-serverless-workflow-executor-core</artifactId>

--- a/kogito-serverless-workflow/kogito-serverless-workflow-executor-grpc/pom.xml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-executor-grpc/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-serverless-workflow</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-serverless-workflow-executor-grpc</artifactId>

--- a/kogito-serverless-workflow/kogito-serverless-workflow-executor-kafka/pom.xml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-executor-kafka/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-serverless-workflow</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-serverless-workflow-executor-kafka</artifactId>

--- a/kogito-serverless-workflow/kogito-serverless-workflow-executor-python/pom.xml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-executor-python/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-serverless-workflow</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-serverless-workflow-executor-python</artifactId>

--- a/kogito-serverless-workflow/kogito-serverless-workflow-executor-rest/pom.xml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-executor-rest/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-serverless-workflow</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-serverless-workflow-executor-rest</artifactId>

--- a/kogito-serverless-workflow/kogito-serverless-workflow-executor-service/pom.xml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-executor-service/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-serverless-workflow</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-serverless-workflow-executor-service</artifactId>

--- a/kogito-serverless-workflow/kogito-serverless-workflow-executor-tests/pom.xml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-executor-tests/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-serverless-workflow</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-serverless-workflow-executor-tests</artifactId>

--- a/kogito-serverless-workflow/kogito-serverless-workflow-executor/pom.xml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-executor/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-serverless-workflow</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-serverless-workflow-executor</artifactId>

--- a/kogito-serverless-workflow/kogito-serverless-workflow-fluent/pom.xml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-fluent/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-serverless-workflow</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-serverless-workflow-fluent</artifactId>

--- a/kogito-serverless-workflow/kogito-serverless-workflow-grpc-parser/pom.xml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-grpc-parser/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-serverless-workflow</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-serverless-workflow-grpc-parser</artifactId>

--- a/kogito-serverless-workflow/kogito-serverless-workflow-grpc-runtime/pom.xml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-grpc-runtime/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-serverless-workflow</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-serverless-workflow-grpc-runtime</artifactId>

--- a/kogito-serverless-workflow/kogito-serverless-workflow-monitoring/pom.xml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-monitoring/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-serverless-workflow</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-serverless-workflow-monitoring</artifactId>
   <name>Kogito :: Serverless Workflow :: Monitoring</name>

--- a/kogito-serverless-workflow/kogito-serverless-workflow-openapi-common/pom.xml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-openapi-common/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-serverless-workflow</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-serverless-workflow-openapi-common</artifactId>

--- a/kogito-serverless-workflow/kogito-serverless-workflow-openapi-generated-deployment/pom.xml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-openapi-generated-deployment/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-serverless-workflow</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 <properties>
       <java.module.name>org.kie.kogito.serverless.workflow.openapi.generated.deployment</java.module.name>

--- a/kogito-serverless-workflow/kogito-serverless-workflow-openapi-generated/pom.xml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-openapi-generated/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-serverless-workflow</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-serverless-workflow-openapi-generated</artifactId>

--- a/kogito-serverless-workflow/kogito-serverless-workflow-openapi-parser/pom.xml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-openapi-parser/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-serverless-workflow</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-serverless-workflow-openapi-parser</artifactId>

--- a/kogito-serverless-workflow/kogito-serverless-workflow-python-runtime/pom.xml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-python-runtime/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-serverless-workflow</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-serverless-workflow-python-runtime</artifactId>

--- a/kogito-serverless-workflow/kogito-serverless-workflow-rest-parser/pom.xml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-rest-parser/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-serverless-workflow</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-serverless-workflow-rest-parser</artifactId>

--- a/kogito-serverless-workflow/kogito-serverless-workflow-rest-runtime/pom.xml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-rest-runtime/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-serverless-workflow</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-serverless-workflow-rest-runtime</artifactId>

--- a/kogito-serverless-workflow/kogito-serverless-workflow-runtime/pom.xml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-runtime/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-serverless-workflow</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-serverless-workflow-runtime</artifactId>

--- a/kogito-serverless-workflow/kogito-serverless-workflow-utils/pom.xml
+++ b/kogito-serverless-workflow/kogito-serverless-workflow-utils/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-serverless-workflow</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-serverless-workflow-utils</artifactId>

--- a/kogito-serverless-workflow/pom.xml
+++ b/kogito-serverless-workflow/pom.xml
@@ -54,7 +54,6 @@
     <module>kogito-jsonpath-expression</module>
     <module>kogito-jq-expression</module>
     <module>kogito-serverless-workflow-executor</module>
-    <module>kogito-serverless-workflow-executor-tests</module>
     <module>kogito-serverless-workflow-dmn-parser</module>
     <module>kogito-serverless-workflow-dmn</module>
     <module>kogito-serverless-workflow-monitoring</module>

--- a/kogito-serverless-workflow/pom.xml
+++ b/kogito-serverless-workflow/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kogito-build/kogito-build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kogito-test-utils/pom.xml
+++ b/kogito-test-utils/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kogito-build/kogito-build-parent/pom.xml</relativePath>
   </parent>
 

--- a/kogito-workitems/kogito-jackson-utils/pom.xml
+++ b/kogito-workitems/kogito-jackson-utils/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-workitems</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-jackson-utils</artifactId>

--- a/kogito-workitems/kogito-rest-utils/pom.xml
+++ b/kogito-workitems/kogito-rest-utils/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-workitems</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-rest-utils</artifactId>

--- a/kogito-workitems/kogito-rest-workitem/pom.xml
+++ b/kogito-workitems/kogito-rest-workitem/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-workitems</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-rest-workitem</artifactId>

--- a/kogito-workitems/pom.xml
+++ b/kogito-workitems/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kogito-build/kogito-build-parent/pom.xml</relativePath>
   </parent>
   <artifactId>kogito-workitems</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -34,14 +34,10 @@
   <packaging>pom</packaging>
 
   <name>Kogito Runtimes</name>
-  <description>Kogito Runtimes</description>
+  <description>This repository is a fork of https://github.com/apache/incubator-kie-kogito-runtimes used for the purposes od SonataFlow.</description>
 
   <url>http://kogito.kie.org</url>
   <inceptionYear>2019</inceptionYear>
-  <organization>
-    <name>The Apache Software Foundation</name>
-    <url>https://apache.org/</url>
-  </organization>
 
   <licenses>
     <license>
@@ -52,44 +48,69 @@
   </licenses>
 
   <scm>
-    <connection>scm:git:https://github.com/apache/incubator-kie-kogito-runtimes.git</connection>
-    <developerConnection>scm:git:https://github.com/apache/incubator-kie-kogito-runtimes.git</developerConnection>
-    <url>https://github.com/apache/incubator-kie-kogito-runtimes</url>
+    <connection>scm:git:https://github.com/kiegroup/kogito-runtimes.git</connection>
+    <developerConnection>scm:git:https://github.com/kiegroup/kogito-runtimes.git</developerConnection>
+    <url>https://github.com/kiegroup/kogito-runtimes</url>
   </scm>
 
-  <developers>
-    <developer>
-      <name>The Apache KIE Team</name>
-      <email>dev@kie.apache.org</email>
-      <url>https://kie.apache.org</url>
-      <organization>Apache Software Foundation</organization>
-      <organizationUrl>http://apache.org/</organizationUrl>
-    </developer>
-  </developers>
+  <distributionManagement>
+    <repository>
+      <id>github</id>
+      <name>GitHub Packages</name>
+      <url>https://maven.pkg.github.com/kubesmarts/sonataflow-maven-repository</url>
+    </repository>
+    <snapshotRepository>
+      <id>github</id>
+      <name>GitHub Packages</name>
+      <url>https://maven.pkg.github.com/kubesmarts/sonataflow-maven-repository</url>
+    </snapshotRepository>
+  </distributionManagement>
 
-  <mailingLists>
-    <mailingList>
-      <name>Development List</name>
-      <subscribe>dev-subscribe@kie.apache.org</subscribe>
-      <unsubscribe>dev-unsubscribe@kie.apache.org</unsubscribe>
-      <post>dev@kie.apache.org</post>
-      <archive>https://lists.apache.org/list.html?dev@kie.apache.org</archive>
-    </mailingList>
-    <mailingList>
-      <name>User List</name>
-      <subscribe>users-subscribe@kie.apache.org</subscribe>
-      <unsubscribe>users-unsubscribe@kie.apache.org</unsubscribe>
-      <post>users@kie.apache.org</post>
-      <archive>https://lists.apache.org/list.html?users@kie.apache.org</archive>
-    </mailingList>
-    <mailingList>
-      <name>Commits List</name>
-      <subscribe>commits-subscribe@kie.apache.org</subscribe>
-      <unsubscribe>commits-unsubscribe@kie.apache.org</unsubscribe>
-      <post>commits@kie.apache.org</post>
-      <archive>https://lists.apache.org/list.html?commits@kie.apache.org</archive>
-    </mailingList>
-  </mailingLists>
+  <repositories>
+    <repository>
+      <id>central</id>
+      <name>Central</name>
+      <url>https://repo1.maven.org/maven2/</url>
+    </repository>
+    <repository>
+      <id>github</id>
+      <name>GitHub Repository</name>
+      <url>https://maven.pkg.github.com/kubesmarts/sonataflow-maven-repository</url>
+    </repository>
+    <repository>
+      <id>redhat-ga-repository</id>
+      <url>https://maven.repository.redhat.com/ga</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>central</id>
+      <name>Central</name>
+      <url>https://repo1.maven.org/maven2/</url>
+    </pluginRepository>
+    <pluginRepository>
+      <id>github</id>
+      <name>GitHub Repository</name>
+      <url>https://maven.pkg.github.com/kubesmarts/sonataflow-maven-repository</url>
+    </pluginRepository>
+    <pluginRepository>
+      <id>redhat-ga-plugin-repository</id>
+      <url>https://maven.repository.redhat.com/ga</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
+
 
   <!--
       CONVENTIONS:

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,10 @@
 
   <url>http://kogito.kie.org</url>
   <inceptionYear>2019</inceptionYear>
-
+  <organization>
+    <name>The Apache Software Foundation</name>
+    <url>https://apache.org/</url>
+  </organization>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>

--- a/pom.xml
+++ b/pom.xml
@@ -152,11 +152,6 @@
     <module>addons</module>
     <module>kogito-workitems</module>
     <module>kogito-serverless-workflow</module>
-    <module>kogito-maven-plugin</module>
-    <module>kogito-gradle-plugin</module>
-    <module>springboot</module>
-    <module>kogito-maven-plugin-test</module>
-    <module>kogito-gradle-plugin-test</module>
   </modules>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.kie.kogito</groupId>
   <artifactId>kogito-runtimes</artifactId>
-  <version>999-SNAPSHOT</version>
+  <version>111-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Kogito Runtimes</name>
@@ -70,7 +70,7 @@
     <repository>
       <id>central</id>
       <name>Central</name>
-      <url>https://repo1.maven.org/maven2/</url>
+      <url>https://repo.maven.apache.org/maven2/</url>
     </repository>
     <repository>
       <id>github</id>
@@ -92,7 +92,7 @@
     <pluginRepository>
       <id>central</id>
       <name>Central</name>
-      <url>https://repo1.maven.org/maven2/</url>
+      <url>https://repo.maven.apache.org/maven2/</url>
     </pluginRepository>
     <pluginRepository>
       <id>github</id>

--- a/quarkus/addons/asyncapi/deployment/pom.xml
+++ b/quarkus/addons/asyncapi/deployment/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.kie.sonataflow</groupId>
         <artifactId>sonataflow-addons-quarkus-asyncapi-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <artifactId>sonataflow-addons-quarkus-asyncapi-deployment</artifactId>
     <name>SonataFlow:: Addons :: Quarkus:: Serverless Workflow :: AsyncAPI :: Deployment</name>

--- a/quarkus/addons/asyncapi/pom.xml
+++ b/quarkus/addons/asyncapi/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <groupId>org.apache.kie.sonataflow</groupId>
   <artifactId>sonataflow-addons-quarkus-asyncapi-parent</artifactId>

--- a/quarkus/addons/asyncapi/runtime/pom.xml
+++ b/quarkus/addons/asyncapi/runtime/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.kie.sonataflow</groupId>
     <artifactId>sonataflow-addons-quarkus-asyncapi-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <name>SonataFlow:: Addons :: Quarkus :: Serverless Workflow:: AsyncAPI :: Runtime</name>
   <description>AsyncAPI support for serverless workflow</description>

--- a/quarkus/addons/camel/deployment/pom.xml
+++ b/quarkus/addons/camel/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>sonataflow-addons-quarkus-camel-parent</artifactId>
     <groupId>org.apache.kie.sonataflow</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/camel/integration-tests/pom.xml
+++ b/quarkus/addons/camel/integration-tests/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>sonataflow-addons-quarkus-camel-parent</artifactId>
     <groupId>org.apache.kie.sonataflow</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/camel/pom.xml
+++ b/quarkus/addons/camel/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/camel/runtime/pom.xml
+++ b/quarkus/addons/camel/runtime/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>sonataflow-addons-quarkus-camel-parent</artifactId>
     <groupId>org.apache.kie.sonataflow</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/common/deployment/pom.xml
+++ b/quarkus/addons/common/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-common-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/common/kogito-addons-quarkus-common-health/pom.xml
+++ b/quarkus/addons/common/kogito-addons-quarkus-common-health/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>kogito-addons-quarkus-common-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <artifactId>kogito-addons-quarkus-common-health</artifactId>
     <name>kogito-addons-quarkus-common-health</name>

--- a/quarkus/addons/common/kogito-addons-quarkus-data-index-health/pom.xml
+++ b/quarkus/addons/common/kogito-addons-quarkus-data-index-health/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>kogito-addons-quarkus-common-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <artifactId>kogito-addons-quarkus-data-index-health</artifactId>
     <name>kogito-addons-quarkus-data-index-health</name>

--- a/quarkus/addons/common/kogito-addons-quarkus-jobs-service-health/pom.xml
+++ b/quarkus/addons/common/kogito-addons-quarkus-jobs-service-health/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>kogito-addons-quarkus-common-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <artifactId>kogito-addons-quarkus-jobs-service-health</artifactId>
     <name>kogito-addons-quarkus-jobs-service-health</name>

--- a/quarkus/addons/common/pom.xml
+++ b/quarkus/addons/common/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/common/reactive-messaging/pom.xml
+++ b/quarkus/addons/common/reactive-messaging/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>kogito-addons-quarkus-common-parent</artifactId>
         <groupId>org.kie</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/common/sonataflow-deployment/pom.xml
+++ b/quarkus/addons/common/sonataflow-deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-common-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.kie.sonataflow</groupId>

--- a/quarkus/addons/dynamic/deployment/pom.xml
+++ b/quarkus/addons/dynamic/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-process-dynamic-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-process-dynamic-deployment</artifactId>
   <name>KIE Add-On Process Instance Dynamic Calls - Deployment</name>

--- a/quarkus/addons/dynamic/integration-tests/pom.xml
+++ b/quarkus/addons/dynamic/integration-tests/pom.xml
@@ -24,7 +24,7 @@ under the License.
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-process-dynamic-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-addons-quarkus-process-dynamic-integration-tests</artifactId>

--- a/quarkus/addons/dynamic/pom.xml
+++ b/quarkus/addons/dynamic/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/dynamic/runtime/pom.xml
+++ b/quarkus/addons/dynamic/runtime/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-process-dynamic-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-process-dynamic</artifactId>
   <name>KIE Add-On Process Instance Dynamic Calls</name>

--- a/quarkus/addons/events/decisions/deployment/pom.xml
+++ b/quarkus/addons/events/decisions/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-events-decisions-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-events-decisions-deployment</artifactId>
   <name>KIE Add-On Events Decisions - Deployment</name>

--- a/quarkus/addons/events/decisions/pom.xml
+++ b/quarkus/addons/events/decisions/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-events-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-addons-quarkus-events-decisions-parent</artifactId>

--- a/quarkus/addons/events/decisions/runtime/pom.xml
+++ b/quarkus/addons/events/decisions/runtime/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-events-decisions-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-addons-quarkus-events-decisions</artifactId>

--- a/quarkus/addons/events/mongodb/deployment/pom.xml
+++ b/quarkus/addons/events/mongodb/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-events-mongodb-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-events-mongodb-deployment</artifactId>
   <name>KIE Add-On Events MongoDB - Deployment</name>

--- a/quarkus/addons/events/mongodb/pom.xml
+++ b/quarkus/addons/events/mongodb/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-events-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-addons-quarkus-events-mongodb-parent</artifactId>

--- a/quarkus/addons/events/mongodb/runtime/pom.xml
+++ b/quarkus/addons/events/mongodb/runtime/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-events-mongodb-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-addons-quarkus-events-mongodb</artifactId>

--- a/quarkus/addons/events/pom.xml
+++ b/quarkus/addons/events/pom.xml
@@ -36,10 +36,6 @@
 
   <modules>
     <module>process</module>
-    <module>decisions</module>
-    <module>predictions</module>
-    <module>rules</module>
-    <module>mongodb</module>
   </modules>
 
 </project>

--- a/quarkus/addons/events/pom.xml
+++ b/quarkus/addons/events/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/events/predictions/deployment/pom.xml
+++ b/quarkus/addons/events/predictions/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-events-predictions-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-events-predictions-deployment</artifactId>
   <name>KIE Add-On Events Predictions - Deployment</name>

--- a/quarkus/addons/events/predictions/pom.xml
+++ b/quarkus/addons/events/predictions/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-events-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-addons-quarkus-events-predictions-parent</artifactId>

--- a/quarkus/addons/events/predictions/runtime/pom.xml
+++ b/quarkus/addons/events/predictions/runtime/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-events-predictions-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-addons-quarkus-events-predictions</artifactId>

--- a/quarkus/addons/events/process/deployment/pom.xml
+++ b/quarkus/addons/events/process/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-events-process-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-events-process-deployment</artifactId>
   <name>KIE Add-On Events Process - Deployment</name>

--- a/quarkus/addons/events/process/pom.xml
+++ b/quarkus/addons/events/process/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-events-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-addons-quarkus-events-process-parent</artifactId>

--- a/quarkus/addons/events/process/runtime/pom.xml
+++ b/quarkus/addons/events/process/runtime/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-events-process-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-events-process</artifactId>
   <name>KIE Add-On Events Process</name>

--- a/quarkus/addons/events/rules/deployment/pom.xml
+++ b/quarkus/addons/events/rules/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-addons-quarkus-events-rules-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>drools-addons-quarkus-events-rules-deployment</artifactId>
   <name>Drools Add-On Events Rules - Deployment</name>

--- a/quarkus/addons/events/rules/pom.xml
+++ b/quarkus/addons/events/rules/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-events-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <groupId>org.drools</groupId>

--- a/quarkus/addons/events/rules/runtime/pom.xml
+++ b/quarkus/addons/events/rules/runtime/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-addons-quarkus-events-rules-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>drools-addons-quarkus-events-rules</artifactId>

--- a/quarkus/addons/explainability/deployment/pom.xml
+++ b/quarkus/addons/explainability/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-explainability-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-explainability-deployment</artifactId>
   <name>KIE Add-On Explainability - Deployment</name>

--- a/quarkus/addons/explainability/integration-tests/pom.xml
+++ b/quarkus/addons/explainability/integration-tests/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-explainability-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-explainability-it</artifactId>
   <name>KIE Add-On Explainability - Integration tests</name>

--- a/quarkus/addons/explainability/pom.xml
+++ b/quarkus/addons/explainability/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-addons-quarkus-explainability-parent</artifactId>

--- a/quarkus/addons/explainability/runtime/pom.xml
+++ b/quarkus/addons/explainability/runtime/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>kie-addons-quarkus-explainability-parent</artifactId>
         <groupId>org.kie</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/fabric8-kubernetes-service-catalog/deployment/pom.xml
+++ b/quarkus/addons/fabric8-kubernetes-service-catalog/deployment/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>kogito-addons-quarkus-fabric8-kubernetes-service-catalog-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-addons-quarkus-fabric8-kubernetes-service-catalog-deployment</artifactId>

--- a/quarkus/addons/fabric8-kubernetes-service-catalog/pom.xml
+++ b/quarkus/addons/fabric8-kubernetes-service-catalog/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>kogito-addons-quarkus-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-addons-quarkus-fabric8-kubernetes-service-catalog-parent</artifactId>

--- a/quarkus/addons/fabric8-kubernetes-service-catalog/runtime/pom.xml
+++ b/quarkus/addons/fabric8-kubernetes-service-catalog/runtime/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>kogito-addons-quarkus-fabric8-kubernetes-service-catalog-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-addons-quarkus-fabric8-kubernetes-service-catalog</artifactId>

--- a/quarkus/addons/flyway/deployment/pom.xml
+++ b/quarkus/addons/flyway/deployment/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>kie-addons-quarkus-flyway-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <artifactId>kie-addons-quarkus-flyway-deployment</artifactId>
     <name>Kie :: Add-Ons :: Quarkus :: Flyway :: Deployment</name>

--- a/quarkus/addons/flyway/pom.xml
+++ b/quarkus/addons/flyway/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>kogito-addons-quarkus-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>kie-addons-quarkus-flyway-parent</artifactId>

--- a/quarkus/addons/flyway/runtime/pom.xml
+++ b/quarkus/addons/flyway/runtime/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>kie-addons-quarkus-flyway-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <artifactId>kie-addons-quarkus-flyway</artifactId>
     <name>Kie :: Add-Ons :: Quarkus :: Flyway :: Runtime</name>

--- a/quarkus/addons/grpc/deployment/pom.xml
+++ b/quarkus/addons/grpc/deployment/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.kie.sonataflow</groupId>
         <artifactId>sonataflow-addons-quarkus-grpc-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <artifactId>sonataflow-addons-quarkus-grpc-deployment</artifactId>
     <name>SonataFlow:: Addons :: Quarkus:: Serverless Workflow :: gRPC :: Deployment</name>

--- a/quarkus/addons/grpc/pom.xml
+++ b/quarkus/addons/grpc/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <groupId>org.apache.kie.sonataflow</groupId>
   <artifactId>sonataflow-addons-quarkus-grpc-parent</artifactId>

--- a/quarkus/addons/grpc/runtime/pom.xml
+++ b/quarkus/addons/grpc/runtime/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.kie.sonataflow</groupId>
     <artifactId>sonataflow-addons-quarkus-grpc-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <name>SonataFlow:: Addons :: Quarkus :: Serverless Workflow:: gRPC :: Runtime</name>
   <description>gRPC support for serverless workflow</description>

--- a/quarkus/addons/jbpm-usertask-storage-jpa/deployment/pom.xml
+++ b/quarkus/addons/jbpm-usertask-storage-jpa/deployment/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>jbpm-addon-quarkus-usertask-storage-jpa-parent</artifactId>
         <groupId>org.jbpm</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/jbpm-usertask-storage-jpa/pom.xml
+++ b/quarkus/addons/jbpm-usertask-storage-jpa/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>kogito-addons-quarkus-parent</artifactId>
         <groupId>org.kie</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/jbpm-usertask-storage-jpa/runtime/pom.xml
+++ b/quarkus/addons/jbpm-usertask-storage-jpa/runtime/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>jbpm-addon-quarkus-usertask-storage-jpa-parent</artifactId>
         <groupId>org.jbpm</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/jobs/common/messaging/pom.xml
+++ b/quarkus/addons/jobs/common/messaging/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-jobs-common-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-addons-quarkus-jobs-common-messaging</artifactId>

--- a/quarkus/addons/jobs/common/pom.xml
+++ b/quarkus/addons/jobs/common/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-jobs-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-addons-quarkus-jobs-common-parent</artifactId>

--- a/quarkus/addons/jobs/common/rest-callback/pom.xml
+++ b/quarkus/addons/jobs/common/rest-callback/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-jobs-common-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-addons-quarkus-rest-callback</artifactId>

--- a/quarkus/addons/jobs/knative-eventing/deployment/pom.xml
+++ b/quarkus/addons/jobs/knative-eventing/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-jobs-knative-eventing-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-jobs-knative-eventing-deployment</artifactId>
   <name>Kogito Add-Ons Quarkus Jobs Knative Eventing - Deployment</name>

--- a/quarkus/addons/jobs/knative-eventing/pom.xml
+++ b/quarkus/addons/jobs/knative-eventing/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-jobs-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-addons-quarkus-jobs-knative-eventing-parent</artifactId>

--- a/quarkus/addons/jobs/knative-eventing/runtime/pom.xml
+++ b/quarkus/addons/jobs/knative-eventing/runtime/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-jobs-knative-eventing-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-jobs-knative-eventing</artifactId>
   <name>Kogito Add-Ons Quarkus Jobs - Knative Eventing</name>

--- a/quarkus/addons/jobs/management/deployment/pom.xml
+++ b/quarkus/addons/jobs/management/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-jobs-management-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-jobs-management-deployment</artifactId>
   <name>Kogito Add-Ons Quarkus Jobs Management - Deployment</name>

--- a/quarkus/addons/jobs/management/pom.xml
+++ b/quarkus/addons/jobs/management/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-jobs-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-addons-quarkus-jobs-management-parent</artifactId>

--- a/quarkus/addons/jobs/management/runtime/pom.xml
+++ b/quarkus/addons/jobs/management/runtime/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-jobs-management-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-jobs-management</artifactId>
   <name>Kogito Add-Ons Quarkus Jobs - Management</name>

--- a/quarkus/addons/jobs/messaging/deployment/pom.xml
+++ b/quarkus/addons/jobs/messaging/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-jobs-messaging-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-jobs-messaging-deployment</artifactId>
   <name>Kogito Add-Ons Quarkus Jobs Messaging - Deployment</name>

--- a/quarkus/addons/jobs/messaging/pom.xml
+++ b/quarkus/addons/jobs/messaging/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-jobs-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-addons-quarkus-jobs-messaging-parent</artifactId>

--- a/quarkus/addons/jobs/messaging/runtime/pom.xml
+++ b/quarkus/addons/jobs/messaging/runtime/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-jobs-messaging-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-jobs-messaging</artifactId>
   <name>Kogito Add-Ons Quarkus Jobs - Messaging</name>

--- a/quarkus/addons/jobs/pom.xml
+++ b/quarkus/addons/jobs/pom.xml
@@ -36,7 +36,6 @@
   <modules>
     <module>common</module>
     <module>management</module>
-    <module>messaging</module>
     <module>knative-eventing</module>
   </modules>
 

--- a/quarkus/addons/jobs/pom.xml
+++ b/quarkus/addons/jobs/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-addons-quarkus-jobs-parent</artifactId>

--- a/quarkus/addons/jwt-parser/deployment/pom.xml
+++ b/quarkus/addons/jwt-parser/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>sonataflow-addons-quarkus-jwt-parser-parent</artifactId>
     <groupId>org.apache.kie.sonataflow</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/jwt-parser/integration-tests/pom.xml
+++ b/quarkus/addons/jwt-parser/integration-tests/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>sonataflow-addons-quarkus-jwt-parser-parent</artifactId>
     <groupId>org.apache.kie.sonataflow</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/jwt-parser/pom.xml
+++ b/quarkus/addons/jwt-parser/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/jwt-parser/runtime/pom.xml
+++ b/quarkus/addons/jwt-parser/runtime/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>sonataflow-addons-quarkus-jwt-parser-parent</artifactId>
     <groupId>org.apache.kie.sonataflow</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/knative/eventing/deployment/pom.xml
+++ b/quarkus/addons/knative/eventing/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-knative-eventing-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-knative-eventing-deployment</artifactId>
   <name>KIE Add-On Knative Eventing - Deployment</name>

--- a/quarkus/addons/knative/eventing/integration-tests/pom.xml
+++ b/quarkus/addons/knative/eventing/integration-tests/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>kie-addons-quarkus-knative-eventing-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>kie-addons-quarkus-knative-eventing-integration-tests</artifactId>

--- a/quarkus/addons/knative/eventing/pom.xml
+++ b/quarkus/addons/knative/eventing/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-knative-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-addons-quarkus-knative-eventing-parent</artifactId>

--- a/quarkus/addons/knative/eventing/runtime/pom.xml
+++ b/quarkus/addons/knative/eventing/runtime/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kie-addons-quarkus-knative-eventing-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/knative/pom.xml
+++ b/quarkus/addons/knative/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/knative/serving/deployment/pom.xml
+++ b/quarkus/addons/knative/serving/deployment/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>kogito-addons-quarkus-knative-serving-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-addons-quarkus-knative-serving-deployment</artifactId>

--- a/quarkus/addons/knative/serving/integration-tests/pom.xml
+++ b/quarkus/addons/knative/serving/integration-tests/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>kogito-addons-quarkus-knative-serving-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-addons-quarkus-knative-serving-integration-tests</artifactId>

--- a/quarkus/addons/knative/serving/pom.xml
+++ b/quarkus/addons/knative/serving/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>kogito-addons-quarkus-knative-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-addons-quarkus-knative-serving-parent</artifactId>

--- a/quarkus/addons/knative/serving/runtime/pom.xml
+++ b/quarkus/addons/knative/serving/runtime/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>kogito-addons-quarkus-knative-serving-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/kubernetes/deployment/pom.xml
+++ b/quarkus/addons/kubernetes/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-kubernetes-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-kubernetes-deployment</artifactId>
   <name>KIE Add-On Kubernetes - Deployment</name>

--- a/quarkus/addons/kubernetes/integration-tests/pom.xml
+++ b/quarkus/addons/kubernetes/integration-tests/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>kie-addons-quarkus-kubernetes-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>kie-addons-quarkus-kubernetes-integration-tests</artifactId>

--- a/quarkus/addons/kubernetes/pom.xml
+++ b/quarkus/addons/kubernetes/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/kubernetes/runtime/pom.xml
+++ b/quarkus/addons/kubernetes/runtime/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-kubernetes-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-kubernetes</artifactId>
   <name>KIE Add-On Kubernetes</name>

--- a/quarkus/addons/kubernetes/test-utils/pom.xml
+++ b/quarkus/addons/kubernetes/test-utils/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>kie-addons-quarkus-kubernetes-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <artifactId>kie-addons-quarkus-kubernetes-test-utils</artifactId>
     <name>KIE Add-On Kubernetes Tests Utils</name>

--- a/quarkus/addons/mail/deployment/pom.xml
+++ b/quarkus/addons/mail/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.jbpm</groupId>
     <artifactId>jbpm-addons-quarkus-mail-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>jbpm-addons-quarkus-mail-deployment</artifactId>
   <name>jBPM Add-On Mail - Deployment</name>

--- a/quarkus/addons/mail/pom.xml
+++ b/quarkus/addons/mail/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <groupId>org.jbpm</groupId>

--- a/quarkus/addons/mail/runtime/pom.xml
+++ b/quarkus/addons/mail/runtime/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.jbpm</groupId>
     <artifactId>jbpm-addons-quarkus-mail-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>jbpm-addons-quarkus-mail</artifactId>
   <name>jBPM Add-On Mail</name>

--- a/quarkus/addons/marshallers/avro/deployment/pom.xml
+++ b/quarkus/addons/marshallers/avro/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-marshallers-avro-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-addons-quarkus-marshallers-avro-deployment</artifactId>

--- a/quarkus/addons/marshallers/avro/pom.xml
+++ b/quarkus/addons/marshallers/avro/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-marshallers-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-marshallers-avro-parent</artifactId>
   <packaging>pom</packaging>

--- a/quarkus/addons/marshallers/avro/runtime/pom.xml
+++ b/quarkus/addons/marshallers/avro/runtime/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-marshallers-avro-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-addons-quarkus-marshallers-avro</artifactId>

--- a/quarkus/addons/marshallers/pom.xml
+++ b/quarkus/addons/marshallers/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-quarkus-marshallers-parent</artifactId>
   <packaging>pom</packaging>

--- a/quarkus/addons/messaging/common/pom.xml
+++ b/quarkus/addons/messaging/common/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-messaging-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-messaging-common</artifactId>
   <name>KIE Add-On Messaging - Common</name>

--- a/quarkus/addons/messaging/deployment/pom.xml
+++ b/quarkus/addons/messaging/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kie-addons-quarkus-messaging-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/messaging/integration-tests/pom.xml
+++ b/quarkus/addons/messaging/integration-tests/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-messaging-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-messaging-it</artifactId>
   <name>KIE Add-On Messaging - Integration Tests</name>

--- a/quarkus/addons/messaging/pom.xml
+++ b/quarkus/addons/messaging/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-messaging-parent</artifactId>
   <packaging>pom</packaging>

--- a/quarkus/addons/messaging/runtime/pom.xml
+++ b/quarkus/addons/messaging/runtime/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kie-addons-quarkus-messaging-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/microprofile-config-service-catalog/deployment/pom.xml
+++ b/quarkus/addons/microprofile-config-service-catalog/deployment/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>kogito-addons-quarkus-microprofile-config-service-catalog-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-addons-quarkus-microprofile-config-service-catalog-deployment</artifactId>

--- a/quarkus/addons/microprofile-config-service-catalog/integration-tests/pom.xml
+++ b/quarkus/addons/microprofile-config-service-catalog/integration-tests/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>kogito-addons-quarkus-microprofile-config-service-catalog-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-addons-quarkus-microprofile-config-service-catalog-integration-tests</artifactId>

--- a/quarkus/addons/microprofile-config-service-catalog/pom.xml
+++ b/quarkus/addons/microprofile-config-service-catalog/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>kogito-addons-quarkus-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-addons-quarkus-microprofile-config-service-catalog-parent</artifactId>

--- a/quarkus/addons/microprofile-config-service-catalog/runtime/pom.xml
+++ b/quarkus/addons/microprofile-config-service-catalog/runtime/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>kogito-addons-quarkus-microprofile-config-service-catalog-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>kogito-addons-quarkus-microprofile-config-service-catalog</artifactId>

--- a/quarkus/addons/monitoring/core/pom.xml
+++ b/quarkus/addons/monitoring/core/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kie-addons-quarkus-monitoring-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>kie-addons-quarkus-monitoring-core</artifactId>

--- a/quarkus/addons/monitoring/elastic/deployment/pom.xml
+++ b/quarkus/addons/monitoring/elastic/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-monitoring-elastic-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-monitoring-elastic-deployment</artifactId>
   <name>KIE Add-On Monitoring Elastic - Deployment</name>

--- a/quarkus/addons/monitoring/elastic/pom.xml
+++ b/quarkus/addons/monitoring/elastic/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-monitoring-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-monitoring-elastic-parent</artifactId>
   <packaging>pom</packaging>

--- a/quarkus/addons/monitoring/elastic/runtime/pom.xml
+++ b/quarkus/addons/monitoring/elastic/runtime/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kie-addons-quarkus-monitoring-elastic-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/monitoring/pom.xml
+++ b/quarkus/addons/monitoring/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/monitoring/prometheus/deployment/pom.xml
+++ b/quarkus/addons/monitoring/prometheus/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-monitoring-prometheus-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-monitoring-prometheus-deployment</artifactId>
   <name>KIE Add-On Monitoring Prometheus - Deployment</name>

--- a/quarkus/addons/monitoring/prometheus/pom.xml
+++ b/quarkus/addons/monitoring/prometheus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-monitoring-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-monitoring-prometheus-parent</artifactId>
   <packaging>pom</packaging>

--- a/quarkus/addons/monitoring/prometheus/runtime/pom.xml
+++ b/quarkus/addons/monitoring/prometheus/runtime/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kie-addons-quarkus-monitoring-prometheus-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/monitoring/sonataflow/pom.xml
+++ b/quarkus/addons/monitoring/sonataflow/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-monitoring-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-monitoring-sonataflow</artifactId>
   <name>KIE Add-On Monitoring Sonataflow</name>

--- a/quarkus/addons/openapi/deployment/pom.xml
+++ b/quarkus/addons/openapi/deployment/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.kie.sonataflow</groupId>
     <artifactId>sonataflow-addons-quarkus-openapi-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>sonataflow-addons-quarkus-openapi-deployment</artifactId>
   <name>SonataFlow:: Addons :: Quarkus:: Serverless Workflow:: OpenAPI:: Deployment</name>

--- a/quarkus/addons/openapi/pom.xml
+++ b/quarkus/addons/openapi/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <groupId>org.apache.kie.sonataflow</groupId>
   <artifactId>sonataflow-addons-quarkus-openapi-parent</artifactId>

--- a/quarkus/addons/openapi/runtime/pom.xml
+++ b/quarkus/addons/openapi/runtime/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.kie.sonataflow</groupId>
     <artifactId>sonataflow-addons-quarkus-openapi-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <name>SonataFlow:: Addons :: Quarkus:: Serverless Workflow:: OpenAPI:: Runtime</name>
   <description>OpenAPI support for serverless workflow</description>

--- a/quarkus/addons/opentelemetry/deployment/pom.xml
+++ b/quarkus/addons/opentelemetry/deployment/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>sonataflow-addons-quarkus-opentelemetry-parent</artifactId>
     <groupId>org.apache.kie.sonataflow</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/opentelemetry/integration-tests/pom.xml
+++ b/quarkus/addons/opentelemetry/integration-tests/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>sonataflow-addons-quarkus-opentelemetry-parent</artifactId>
     <groupId>org.apache.kie.sonataflow</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/opentelemetry/pom.xml
+++ b/quarkus/addons/opentelemetry/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/opentelemetry/runtime/pom.xml
+++ b/quarkus/addons/opentelemetry/runtime/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>sonataflow-addons-quarkus-opentelemetry-parent</artifactId>
     <groupId>org.apache.kie.sonataflow</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/persistence/filesystem/deployment/pom.xml
+++ b/quarkus/addons/persistence/filesystem/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-persistence-filesystem-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-persistence-filesystem-deployment</artifactId>
   <name>KIE Add-On Persistence FileSystem - Deployment</name>

--- a/quarkus/addons/persistence/filesystem/pom.xml
+++ b/quarkus/addons/persistence/filesystem/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-persistence-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-persistence-filesystem-parent</artifactId>
   <packaging>pom</packaging>

--- a/quarkus/addons/persistence/filesystem/runtime/pom.xml
+++ b/quarkus/addons/persistence/filesystem/runtime/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kie-addons-quarkus-persistence-filesystem-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/persistence/infinispan/deployment/pom.xml
+++ b/quarkus/addons/persistence/infinispan/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-persistence-infinispan-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-persistence-infinispan-deployment</artifactId>
   <name>KIE Add-On Persistence Infinispan - Deployment</name>

--- a/quarkus/addons/persistence/infinispan/health/pom.xml
+++ b/quarkus/addons/persistence/infinispan/health/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kie-addons-quarkus-persistence-infinispan-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/persistence/infinispan/pom.xml
+++ b/quarkus/addons/persistence/infinispan/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-persistence-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-persistence-infinispan-parent</artifactId>
   <packaging>pom</packaging>

--- a/quarkus/addons/persistence/infinispan/runtime/pom.xml
+++ b/quarkus/addons/persistence/infinispan/runtime/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kie-addons-quarkus-persistence-infinispan-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/persistence/jdbc/deployment/pom.xml
+++ b/quarkus/addons/persistence/jdbc/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-persistence-jdbc-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-persistence-jdbc-deployment</artifactId>
   <name>KIE Add-On Persistence JDBC - Deployment</name>

--- a/quarkus/addons/persistence/jdbc/pom.xml
+++ b/quarkus/addons/persistence/jdbc/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-persistence-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-persistence-jdbc-parent</artifactId>
   <packaging>pom</packaging>

--- a/quarkus/addons/persistence/jdbc/runtime/pom.xml
+++ b/quarkus/addons/persistence/jdbc/runtime/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kie-addons-quarkus-persistence-jdbc-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/persistence/kafka/deployment/pom.xml
+++ b/quarkus/addons/persistence/kafka/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-persistence-kafka-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-persistence-kafka-deployment</artifactId>
   <name>KIE Add-On Persistence Kafka Streams - Deployment</name>

--- a/quarkus/addons/persistence/kafka/pom.xml
+++ b/quarkus/addons/persistence/kafka/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-persistence-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-persistence-kafka-parent</artifactId>
   <packaging>pom</packaging>

--- a/quarkus/addons/persistence/kafka/runtime/pom.xml
+++ b/quarkus/addons/persistence/kafka/runtime/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-persistence-kafka-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/persistence/mongodb/deployment/pom.xml
+++ b/quarkus/addons/persistence/mongodb/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-persistence-mongodb-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-persistence-mongodb-deployment</artifactId>
   <name>KIE Add-On Persistence MongoDB - Deployment</name>

--- a/quarkus/addons/persistence/mongodb/pom.xml
+++ b/quarkus/addons/persistence/mongodb/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-persistence-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-persistence-mongodb-parent</artifactId>
   <packaging>pom</packaging>

--- a/quarkus/addons/persistence/mongodb/runtime/pom.xml
+++ b/quarkus/addons/persistence/mongodb/runtime/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kie-addons-quarkus-persistence-mongodb-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/persistence/pom.xml
+++ b/quarkus/addons/persistence/pom.xml
@@ -36,12 +36,6 @@
 
   <modules>
     <module>jdbc</module>
-    <module>infinispan</module>
-    <module>kafka</module>
-    <module>filesystem</module>
-    <module>mongodb</module>
-    <module>postgresql</module>
-    <module>rocksdb</module>
   </modules>
 
 </project>

--- a/quarkus/addons/persistence/pom.xml
+++ b/quarkus/addons/persistence/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/persistence/postgresql/deployment/pom.xml
+++ b/quarkus/addons/persistence/postgresql/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-persistence-postgresql-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-persistence-postgresql-deployment</artifactId>
   <name>KIE Add-On Persistence PostgreSQL - Deployment</name>

--- a/quarkus/addons/persistence/postgresql/pom.xml
+++ b/quarkus/addons/persistence/postgresql/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-persistence-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-persistence-postgresql-parent</artifactId>
   <packaging>pom</packaging>

--- a/quarkus/addons/persistence/postgresql/runtime/pom.xml
+++ b/quarkus/addons/persistence/postgresql/runtime/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kie-addons-quarkus-persistence-postgresql-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/persistence/rocksdb/deployment/pom.xml
+++ b/quarkus/addons/persistence/rocksdb/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-persistence-rocksdb-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-persistence-rocksdb-deployment</artifactId>
   <name>KIE Add-On Persistence Rocksdb - Deployment</name>

--- a/quarkus/addons/persistence/rocksdb/pom.xml
+++ b/quarkus/addons/persistence/rocksdb/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-persistence-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-persistence-rocksdb-parent</artifactId>
   <packaging>pom</packaging>

--- a/quarkus/addons/persistence/rocksdb/runtime/pom.xml
+++ b/quarkus/addons/persistence/rocksdb/runtime/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kie-addons-quarkus-persistence-rocksdb-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/pom.xml
+++ b/quarkus/addons/pom.xml
@@ -51,19 +51,10 @@
     <module>fabric8-kubernetes-service-catalog</module>
     <module>microprofile-config-service-catalog</module>
     <module>jobs</module>
-    <module>explainability</module>
-    <module>mail</module>
     <module>monitoring</module>
-    <module>process-svg</module>
-    <module>task-notification</module>
-    <module>task-management</module>
-    <module>marshallers</module>
-    <module>process-definitions</module>
     <module>dynamic</module>
-    <module>jbpm-usertask-storage-jpa</module>
     <module>jwt-parser</module>
     <module>token-exchange</module>
-    <module>process-instance-migration</module>
     <module>openapi</module>
     <module>opentelemetry</module>
     <module>grpc</module>

--- a/quarkus/addons/pom.xml
+++ b/quarkus/addons/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-quarkus-bom</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../bom/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/quarkus/addons/process-definitions/deployment/pom.xml
+++ b/quarkus/addons/process-definitions/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-process-definitions-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-process-definitions-deployment</artifactId>
   <name>KIE Add-On Process Definitions - Deployment</name>

--- a/quarkus/addons/process-definitions/pom.xml
+++ b/quarkus/addons/process-definitions/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/process-definitions/runtime/pom.xml
+++ b/quarkus/addons/process-definitions/runtime/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-process-definitions-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-process-definitions</artifactId>
   <name>KIE Add-On Process Definitions</name>

--- a/quarkus/addons/process-instance-migration/deployment/pom.xml
+++ b/quarkus/addons/process-instance-migration/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-process-instance-migration-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-process-instance-migration-deployment</artifactId>
   <name>KIE Add-On Process Migration - Deployment</name>

--- a/quarkus/addons/process-instance-migration/integration-tests/pom.xml
+++ b/quarkus/addons/process-instance-migration/integration-tests/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-process-instance-migration-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-process-instance-migration-integration-tests</artifactId>
   <name>KIE:: Addons :: Quarkus:: Process Migration :: Integration Test</name>

--- a/quarkus/addons/process-instance-migration/pom.xml
+++ b/quarkus/addons/process-instance-migration/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/process-instance-migration/runtime/pom.xml
+++ b/quarkus/addons/process-instance-migration/runtime/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-process-instance-migration-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-process-instance-migration</artifactId>
   <name>KIE Add-On Process Migration</name>

--- a/quarkus/addons/process-management/deployment/pom.xml
+++ b/quarkus/addons/process-management/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-process-management-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-process-management-deployment</artifactId>
   <name>KIE Add-On Process Management - Deployment</name>

--- a/quarkus/addons/process-management/integration-tests/pom.xml
+++ b/quarkus/addons/process-management/integration-tests/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-process-management-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-process-management-integration-tests</artifactId>
   <name>KIE:: Addons :: Quarkus:: Process Management :: Integration Test</name>

--- a/quarkus/addons/process-management/pom.xml
+++ b/quarkus/addons/process-management/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/process-management/runtime/pom.xml
+++ b/quarkus/addons/process-management/runtime/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-process-management-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-process-management</artifactId>
   <name>KIE Add-On Process Management</name>

--- a/quarkus/addons/process-svg/deployment/pom.xml
+++ b/quarkus/addons/process-svg/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-process-svg-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-process-svg-deployment</artifactId>
   <name>KIE Add-On Process SVG - Deployment</name>

--- a/quarkus/addons/process-svg/pom.xml
+++ b/quarkus/addons/process-svg/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/process-svg/runtime/pom.xml
+++ b/quarkus/addons/process-svg/runtime/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-process-svg-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-process-svg</artifactId>
   <name>KIE Add-On Process SVG</name>

--- a/quarkus/addons/python/deployment/pom.xml
+++ b/quarkus/addons/python/deployment/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.kie.sonataflow</groupId>
     <artifactId>sonataflow-addons-quarkus-python-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>sonataflow-addons-quarkus-python-deployment</artifactId>
   <name>SonataFlow:: Addons :: Quarkus:: Serverless Workflow:: Python:: Deployment</name>

--- a/quarkus/addons/python/integration-tests/pom.xml
+++ b/quarkus/addons/python/integration-tests/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.kie.sonataflow</groupId>
     <artifactId>sonataflow-addons-quarkus-python-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>sonataflow-addons-quarkus-python-integration-tests</artifactId>
   <name>SonataFlow:: Addons :: Quarkus:: Serverless Workflow:: Python:: Integration Test</name>

--- a/quarkus/addons/python/pom.xml
+++ b/quarkus/addons/python/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <groupId>org.apache.kie.sonataflow</groupId>
   <artifactId>sonataflow-addons-quarkus-python-parent</artifactId>

--- a/quarkus/addons/python/runtime/pom.xml
+++ b/quarkus/addons/python/runtime/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.kie.sonataflow</groupId>
     <artifactId>sonataflow-addons-quarkus-python-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <name>SonataFlow:: Addons :: Quarkus:: Serverless Workflow:: Python:: Runtime</name>
   <description>Python support for serverless workflow</description>

--- a/quarkus/addons/rest-exception-handler/pom.xml
+++ b/quarkus/addons/rest-exception-handler/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-rest-exception-handler</artifactId>
   <name>KIE :: Rest Exception Handler :: Quarkus</name>

--- a/quarkus/addons/source-files/deployment/pom.xml
+++ b/quarkus/addons/source-files/deployment/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <artifactId>kie-addons-quarkus-source-files-parent</artifactId>
         <groupId>org.kie</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <artifactId>kie-addons-quarkus-source-files-deployment</artifactId>
     <name>KIE Add-On Source Files - Deployment</name>

--- a/quarkus/addons/source-files/pom.xml
+++ b/quarkus/addons/source-files/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <artifactId>kogito-addons-quarkus-parent</artifactId>
         <groupId>org.kie</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <artifactId>kie-addons-quarkus-source-files-parent</artifactId>
     <packaging>pom</packaging>

--- a/quarkus/addons/source-files/runtime/pom.xml
+++ b/quarkus/addons/source-files/runtime/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <artifactId>kie-addons-quarkus-source-files-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-addons-quarkus-source-files</artifactId>

--- a/quarkus/addons/task-management/deployment/pom.xml
+++ b/quarkus/addons/task-management/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.jbpm</groupId>
     <artifactId>jbpm-addons-quarkus-task-management-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>jbpm-addons-quarkus-task-management-deployment</artifactId>

--- a/quarkus/addons/task-management/pom.xml
+++ b/quarkus/addons/task-management/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/task-management/runtime/pom.xml
+++ b/quarkus/addons/task-management/runtime/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.jbpm</groupId>
     <artifactId>jbpm-addons-quarkus-task-management-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>jbpm-addons-quarkus-task-management</artifactId>
   <name>jBPM Add-On Task Management</name>

--- a/quarkus/addons/task-notification/deployment/pom.xml
+++ b/quarkus/addons/task-notification/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.jbpm</groupId>
     <artifactId>jbpm-addons-quarkus-task-notification-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>jbpm-addons-quarkus-task-notification-deployment</artifactId>
   <name>jBPM Add-On Task Notification - Deployment</name>

--- a/quarkus/addons/task-notification/pom.xml
+++ b/quarkus/addons/task-notification/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/task-notification/runtime/pom.xml
+++ b/quarkus/addons/task-notification/runtime/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.jbpm</groupId>
     <artifactId>jbpm-addons-quarkus-task-notification-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>jbpm-addons-quarkus-task-notification</artifactId>
   <name>jBPM Add-On Task Notification</name>

--- a/quarkus/addons/token-exchange/deployment/pom.xml
+++ b/quarkus/addons/token-exchange/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-token-exchange-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-token-exchange-deployment</artifactId>
   <name>KIE Add-On Token Exchange - Deployment</name>

--- a/quarkus/addons/token-exchange/pom.xml
+++ b/quarkus/addons/token-exchange/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <groupId>org.kie</groupId>

--- a/quarkus/addons/token-exchange/runtime/pom.xml
+++ b/quarkus/addons/token-exchange/runtime/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-token-exchange-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-token-exchange</artifactId>
   <name>KIE Add-On Token Exchange</name>

--- a/quarkus/addons/tracing-decision/deployment/pom.xml
+++ b/quarkus/addons/tracing-decision/deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-tracing-decision-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-tracing-decision-deployment</artifactId>
   <name>KIE Add-On Tracing Decision - Deployment</name>

--- a/quarkus/addons/tracing-decision/integration-tests/pom.xml
+++ b/quarkus/addons/tracing-decision/integration-tests/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-quarkus-tracing-decision-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-quarkus-tracing-decision-it</artifactId>
   <name>KIE Add-On Tracing Decision - Integration tests</name>

--- a/quarkus/addons/tracing-decision/pom.xml
+++ b/quarkus/addons/tracing-decision/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons-quarkus-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/addons/tracing-decision/runtime/pom.xml
+++ b/quarkus/addons/tracing-decision/runtime/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kie-addons-quarkus-tracing-decision-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/bom/pom.xml
+++ b/quarkus/bom/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>quarkus</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-quarkus-bom</artifactId>

--- a/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-deployment/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-deployment/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.drools</groupId>
         <artifactId>drools-quarkus-decisions-extension</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test-hot-reload/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test-hot-reload/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.drools</groupId>
         <artifactId>drools-quarkus-decisions-extension</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions-integration-test/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.drools</groupId>
         <artifactId>drools-quarkus-decisions-extension</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-decisions-extension/kogito-quarkus-decisions/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.drools</groupId>
         <artifactId>drools-quarkus-decisions-extension</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-decisions-extension/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-decisions-extension/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>quarkus-extensions</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-quarkus-extension-common</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>kogito-quarkus-extension-common</artifactId>
         <groupId>org.kie.kogito</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-extension-common/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-extension-common/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>quarkus-extensions</artifactId>
         <groupId>org.kie.kogito</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-extension-spi/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-extension-spi/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>quarkus-extensions</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-deployment/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-deployment/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.jbpm</groupId>
     <artifactId>jbpm-with-drools-quarkus-extension</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>jbpm-with-drools-quarkus-deployment</artifactId>

--- a/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-integration-test-maven-devmode/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-integration-test-maven-devmode/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.jbpm</groupId>
     <artifactId>jbpm-with-drools-quarkus-extension</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>jbpm-with-drools-quarkus-integration-test-maven-devmode</artifactId>

--- a/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-integration-test-maven-devmode/src/test/resources/projects/classic-inst/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-integration-test-maven-devmode/src/test/resources/projects/classic-inst/pom.xml
@@ -25,7 +25,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.company</groupId>
   <artifactId>sample-kogito</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <version>111-SNAPSHOT</version>
 
   <description>Generated project sample-kogito</description>
 

--- a/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-integration-test-maven-devmode/src/test/resources/projects/simple-dmn/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-integration-test-maven-devmode/src/test/resources/projects/simple-dmn/pom.xml
@@ -25,7 +25,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.company</groupId>
   <artifactId>simple-dmn</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <version>111-SNAPSHOT</version>
 
   <description>Simple DMN project</description>
 

--- a/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-integration-test/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus-integration-test/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.jbpm</groupId>
         <artifactId>jbpm-with-drools-quarkus-extension</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>jbpm-with-drools-quarkus-integration-test</artifactId>

--- a/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-extension/kogito-quarkus/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.jbpm</groupId>
     <artifactId>jbpm-with-drools-quarkus-extension</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>jbpm-with-drools-quarkus</artifactId>

--- a/quarkus/extensions/kogito-quarkus-extension/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-extension/pom.xml
@@ -38,8 +38,6 @@
   <modules>
     <module>kogito-quarkus-deployment</module>
     <module>kogito-quarkus</module>
-    <module>kogito-quarkus-integration-test</module>
-    <module>kogito-quarkus-integration-test-maven-devmode</module>
   </modules>
 
 </project>

--- a/quarkus/extensions/kogito-quarkus-extension/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-extension/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>quarkus-extensions</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-incubation-common/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-incubation-common/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>quarkus-extensions</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions-deployment/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions-deployment/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>kie-quarkus-predictions-extension</artifactId>
         <groupId>org.kie</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions-integration-test/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions-integration-test/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>kie-quarkus-predictions-extension</artifactId>
         <groupId>org.kie</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-predictions-extension/kogito-quarkus-predictions/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>kie-quarkus-predictions-extension</artifactId>
         <groupId>org.kie</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-predictions-extension/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-predictions-extension/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>quarkus-extensions</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-deployment/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>jbpm-quarkus-extension</artifactId>
     <groupId>org.jbpm</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-integration-test-hot-reload/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-integration-test-hot-reload/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.jbpm</groupId>
         <artifactId>jbpm-quarkus-extension</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>jbpm-quarkus-integration-test-hot-reload</artifactId>

--- a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-integration-test/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes-integration-test/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.jbpm</groupId>
         <artifactId>jbpm-quarkus-extension</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>jbpm-quarkus-integration-test</artifactId>

--- a/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-processes-extension/kogito-quarkus-processes/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>jbpm-quarkus-extension</artifactId>
     <groupId>org.jbpm</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-processes-extension/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-processes-extension/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>quarkus-extensions</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-deployment/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-deployment/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>drools-quarkus-rules-extension</artifactId>
         <groupId>org.drools</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test-hot-reload/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test-hot-reload/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>drools-quarkus-rules-extension</artifactId>
         <groupId>org.drools</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules-integration-test/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>drools-quarkus-rules-extension</artifactId>
         <groupId>org.drools</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-rules-extension/kogito-quarkus-rules/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>drools-quarkus-rules-extension</artifactId>
         <groupId>org.drools</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-rules-extension/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-rules-extension/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>quarkus-extensions</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>sonataflow-quarkus-extension</artifactId>
     <groupId>org.apache.kie.sonataflow</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-extension-live-reload-test/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-extension-live-reload-test/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.apache.kie.sonataflow</groupId>
         <artifactId>sonataflow-quarkus-extension</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <artifactId>sonataflow-quarkus-extension-live-reload-test</artifactId>

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-image-integration-test/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-image-integration-test/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>sonataflow-quarkus-extension</artifactId>
     <groupId>org.apache.kie.sonataflow</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>sonataflow-quarkus-extension</artifactId>
     <groupId>org.apache.kie.sonataflow</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>sonataflow-quarkus-extension</artifactId>
     <groupId>org.apache.kie.sonataflow</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>quarkus-extensions</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-jdbc-token-persistence-extension/kogito-quarkus-serverless-workflow-jdbc-token-persistence-deployment/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-jdbc-token-persistence-extension/kogito-quarkus-serverless-workflow-jdbc-token-persistence-deployment/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>sonataflow-quarkus-jdbc-token-persistence-extension</artifactId>
     <groupId>org.apache.kie.sonataflow</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-jdbc-token-persistence-extension/kogito-quarkus-serverless-workflow-jdbc-token-persistence-integration-test/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-jdbc-token-persistence-extension/kogito-quarkus-serverless-workflow-jdbc-token-persistence-integration-test/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>sonataflow-quarkus-jdbc-token-persistence-extension</artifactId>
     <groupId>org.apache.kie.sonataflow</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-jdbc-token-persistence-extension/kogito-quarkus-serverless-workflow-jdbc-token-persistence/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-jdbc-token-persistence-extension/kogito-quarkus-serverless-workflow-jdbc-token-persistence/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>sonataflow-quarkus-jdbc-token-persistence-extension</artifactId>
     <groupId>org.apache.kie.sonataflow</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-jdbc-token-persistence-extension/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-jdbc-token-persistence-extension/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>quarkus-extensions</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-test-list/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-test-list/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>quarkus-extensions</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/kogito-quarkus-workflow-extension-common/kogito-quarkus-workflow-common-deployment/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-workflow-extension-common/kogito-quarkus-workflow-common-deployment/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-quarkus-workflow-extension-common</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-quarkus-workflow-common-deployment</artifactId>

--- a/quarkus/extensions/kogito-quarkus-workflow-extension-common/kogito-quarkus-workflow-common/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-workflow-extension-common/kogito-quarkus-workflow-common/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-quarkus-workflow-extension-common</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-quarkus-workflow-common</artifactId>

--- a/quarkus/extensions/kogito-quarkus-workflow-extension-common/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-workflow-extension-common/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>quarkus-extensions</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/quarkus/extensions/pom.xml
+++ b/quarkus/extensions/pom.xml
@@ -53,12 +53,6 @@
     <module>kogito-quarkus-workflow-extension-common</module>
     <module>kogito-quarkus-serverless-workflow-extension</module>
     <module>kogito-quarkus-serverless-workflow-jdbc-token-persistence-extension</module>
-    <module>kogito-quarkus-extension</module>
-    <module>kogito-quarkus-incubation-common</module>
-    <module>kogito-quarkus-processes-extension</module>
-    <module>kogito-quarkus-rules-extension</module>
-    <module>kogito-quarkus-decisions-extension</module>
-    <module>kogito-quarkus-predictions-extension</module>
   </modules>
 
   <profiles>

--- a/quarkus/extensions/pom.xml
+++ b/quarkus/extensions/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>quarkus</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>quarkus-extensions</artifactId>

--- a/quarkus/integration-tests/integration-tests-kogito-plugin/pom.xml
+++ b/quarkus/integration-tests/integration-tests-kogito-plugin/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-quarkus-integration-tests</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>integration-tests-kogito-plugin</artifactId>
   <name>Kogito :: Integration Tests :: Maven Plugin</name>

--- a/quarkus/integration-tests/integration-tests-kogito-plugin/src/it/integration-tests-kogito-plugin-it/pom.xml
+++ b/quarkus/integration-tests/integration-tests-kogito-plugin/src/it/integration-tests-kogito-plugin-it/pom.xml
@@ -23,7 +23,7 @@
 
     <groupId>org.kie.kogito</groupId>
     <artifactId>integration-tests-kogito-plugin-it</artifactId>
-    <version>@project.version@</version>
+    <version>111-SNAPSHOT</version>
 
     <properties>
         <quarkus.version>@version.io.quarkus@</quarkus.version>

--- a/quarkus/integration-tests/integration-tests-quarkus-decisions/pom.xml
+++ b/quarkus/integration-tests/integration-tests-quarkus-decisions/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-quarkus-integration-tests</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>integration-tests-quarkus-decisions</artifactId>
   <name>Kogito :: Integration Tests :: Quarkus :: Decisions</name>

--- a/quarkus/integration-tests/integration-tests-quarkus-gradle/pom.xml
+++ b/quarkus/integration-tests/integration-tests-quarkus-gradle/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-quarkus-integration-tests</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>integration-tests-quarkus-gradle</artifactId>
   <name>Kogito :: Integration Tests :: Quarkus :: Gradle</name>

--- a/quarkus/integration-tests/integration-tests-quarkus-legacy-rules/pom.xml
+++ b/quarkus/integration-tests/integration-tests-quarkus-legacy-rules/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-quarkus-integration-tests</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>integration-tests-quarkus-legacy-rules</artifactId>
   <name>Kogito :: Integration Tests :: Quarkus :: Legacy Rules</name>

--- a/quarkus/integration-tests/integration-tests-quarkus-norest/pom.xml
+++ b/quarkus/integration-tests/integration-tests-quarkus-norest/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-quarkus-integration-tests</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>integration-tests-quarkus-norest</artifactId>
   <name>Kogito :: Integration Tests :: Quarkus :: Without REST</name>

--- a/quarkus/integration-tests/integration-tests-quarkus-openapi-client/pom.xml
+++ b/quarkus/integration-tests/integration-tests-quarkus-openapi-client/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-quarkus-integration-tests</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <name>Kogito :: Integration Tests :: Quarkus :: OpenAPI Client Codegen</name>
   <artifactId>integration-tests-quarkus-openapi-client</artifactId>

--- a/quarkus/integration-tests/integration-tests-quarkus-predictions/pom.xml
+++ b/quarkus/integration-tests/integration-tests-quarkus-predictions/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-quarkus-integration-tests</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>integration-tests-quarkus-predictions</artifactId>
   <name>Kogito :: Integration Tests :: Quarkus :: Predictions</name>

--- a/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-processes-persistence-common/pom.xml
+++ b/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-processes-persistence-common/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>integration-tests-quarkus-processes-persistence</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-filesystem/pom.xml
+++ b/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-filesystem/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>integration-tests-quarkus-processes-persistence</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-infinispan/pom.xml
+++ b/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-infinispan/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>integration-tests-quarkus-processes-persistence</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-jdbc/pom.xml
+++ b/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-jdbc/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>integration-tests-quarkus-processes-persistence</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-kafka-persistence/pom.xml
+++ b/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-kafka-persistence/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>integration-tests-quarkus-processes-persistence</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-mongodb/pom.xml
+++ b/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-mongodb/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>integration-tests-quarkus-processes-persistence</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-postgresql/pom.xml
+++ b/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/integration-tests-quarkus-processes-postgresql/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>integration-tests-quarkus-processes-persistence</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/pom.xml
+++ b/quarkus/integration-tests/integration-tests-quarkus-processes-persistence/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-quarkus-integration-tests</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/quarkus/integration-tests/integration-tests-quarkus-processes-reactive/pom.xml
+++ b/quarkus/integration-tests/integration-tests-quarkus-processes-reactive/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-quarkus-integration-tests</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>integration-tests-quarkus-processes-reactive</artifactId>
   <name>Kogito :: Integration Tests :: Quarkus :: Processes :: Reactive</name>

--- a/quarkus/integration-tests/integration-tests-quarkus-processes/pom.xml
+++ b/quarkus/integration-tests/integration-tests-quarkus-processes/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-quarkus-integration-tests</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>integration-tests-quarkus-processes</artifactId>
   <name>Kogito :: Integration Tests :: Quarkus :: Processes</name>

--- a/quarkus/integration-tests/integration-tests-quarkus-resteasy-classic/pom.xml
+++ b/quarkus/integration-tests/integration-tests-quarkus-resteasy-classic/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-quarkus-integration-tests</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>integration-tests-quarkus-resteasy-classic</artifactId>
   <name>Kogito :: Integration Tests :: Quarkus :: RESTEasy Classic</name>

--- a/quarkus/integration-tests/integration-tests-quarkus-resteasy-reactive/pom.xml
+++ b/quarkus/integration-tests/integration-tests-quarkus-resteasy-reactive/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-quarkus-integration-tests</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>integration-tests-quarkus-resteasy-reactive</artifactId>
   <name>Kogito :: Integration Tests :: Quarkus :: RESTEasy Reactive</name>

--- a/quarkus/integration-tests/integration-tests-quarkus-rules/pom.xml
+++ b/quarkus/integration-tests/integration-tests-quarkus-rules/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-quarkus-integration-tests</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>integration-tests-quarkus-rules</artifactId>
   <name>Kogito :: Integration Tests :: Quarkus :: Rules</name>

--- a/quarkus/integration-tests/integration-tests-quarkus-source-files/pom.xml
+++ b/quarkus/integration-tests/integration-tests-quarkus-source-files/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-quarkus-integration-tests</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>integration-tests-quarkus-source-files</artifactId>
   <name>Kogito :: Integration Tests :: Quarkus :: Processes :: Source Files</name>

--- a/quarkus/integration-tests/integration-tests-quarkus-usertask-listeners-rollback/pom.xml
+++ b/quarkus/integration-tests/integration-tests-quarkus-usertask-listeners-rollback/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-quarkus-integration-tests</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>integration-tests-quarkus-usertask-listeners-rollback</artifactId>

--- a/quarkus/integration-tests/integration-tests-quarkus-usertasks/pom.xml
+++ b/quarkus/integration-tests/integration-tests-quarkus-usertasks/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-quarkus-integration-tests</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>integration-tests-quarkus-usertasks</artifactId>

--- a/quarkus/integration-tests/integration-tests-quarkus-wshumantasks/pom.xml
+++ b/quarkus/integration-tests/integration-tests-quarkus-wshumantasks/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-quarkus-integration-tests</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>integration-tests-quarkus-wshumantasks</artifactId>

--- a/quarkus/integration-tests/pom.xml
+++ b/quarkus/integration-tests/pom.xml
@@ -37,21 +37,7 @@
   <modules>
     <module>integration-tests-quarkus-openapi-client</module>
     <!-- TODO:Figure out Kafka containers, ports, resources -->
-    <module>integration-tests-quarkus-rules</module>
-    <module>integration-tests-quarkus-legacy-rules</module>
-    <module>integration-tests-quarkus-decisions</module>
     <!-- module>integration-tests-quarkus-predictions</module -->
-    <module>integration-tests-quarkus-resteasy-classic</module>
-    <module>integration-tests-quarkus-resteasy-reactive</module>
-    <module>integration-tests-kogito-plugin</module>
-    <module>integration-tests-quarkus-norest</module>
-    <module>integration-tests-quarkus-processes</module>
-    <module>integration-tests-quarkus-processes-reactive</module>
-    <module>integration-tests-quarkus-processes-persistence</module>
-    <module>integration-tests-quarkus-usertasks</module>
-    <module>integration-tests-quarkus-usertask-listeners-rollback</module>
-    <module>integration-tests-quarkus-wshumantasks</module>
-    <module>integration-tests-quarkus-source-files</module>
   </modules>
 
 </project>

--- a/quarkus/integration-tests/pom.xml
+++ b/quarkus/integration-tests/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>quarkus</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-quarkus-integration-tests</artifactId>
   <name>Kogito :: Integration Tests :: Quarkus</name>

--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kogito-build/kogito-build-parent/pom.xml</relativePath>
   </parent>
 

--- a/quarkus/test/pom.xml
+++ b/quarkus/test/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>quarkus</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-quarkus-test-utils</artifactId>

--- a/springboot/addons/common/common-auth/pom.xml
+++ b/springboot/addons/common/common-auth/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>kogito-addons-springboot-common-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <artifactId>kie-addons-springboot-common-auth</artifactId>
     <name>Kie Add-On Common - Spring-Boot Auth</name>

--- a/springboot/addons/common/pom.xml
+++ b/springboot/addons/common/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>kogito-addons-springboot-parent</artifactId>
         <groupId>org.kie</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/addons/events/decisions/pom.xml
+++ b/springboot/addons/events/decisions/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-springboot-events-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-addons-springboot-events-decisions</artifactId>

--- a/springboot/addons/events/kafka/pom.xml
+++ b/springboot/addons/events/kafka/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-springboot-events-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-springboot-events-process-kafka</artifactId>
   <name>KIE :: Add-Ons :: Events :: SprintBoot :: Process :: Kafka</name>

--- a/springboot/addons/events/mongodb/pom.xml
+++ b/springboot/addons/events/mongodb/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.kie</groupId>
         <artifactId>kie-addons-springboot-events-parent</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/addons/events/pom.xml
+++ b/springboot/addons/events/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons-springboot-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/addons/events/predictions/pom.xml
+++ b/springboot/addons/events/predictions/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-springboot-events-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-addons-springboot-events-predictions</artifactId>

--- a/springboot/addons/events/rules/pom.xml
+++ b/springboot/addons/events/rules/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-springboot-events-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <groupId>org.drools</groupId>

--- a/springboot/addons/explainability/pom.xml
+++ b/springboot/addons/explainability/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons-springboot-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/addons/flyway/pom.xml
+++ b/springboot/addons/flyway/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>kogito-addons-springboot-parent</artifactId>
         <groupId>org.kie</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/addons/jbpm-usertask-storage-jpa/pom.xml
+++ b/springboot/addons/jbpm-usertask-storage-jpa/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>kogito-addons-springboot-parent</artifactId>
         <groupId>org.kie</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/addons/jobs/pom.xml
+++ b/springboot/addons/jobs/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-springboot-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-addons-springboot-jobs-management</artifactId>
   <name>Kogito :: Add-Ons :: Jobs :: Management SprintBoot Addon</name>

--- a/springboot/addons/kubernetes/pom.xml
+++ b/springboot/addons/kubernetes/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons-springboot-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/addons/mail/pom.xml
+++ b/springboot/addons/mail/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons-springboot-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/addons/messaging/implementation/pom.xml
+++ b/springboot/addons/messaging/implementation/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-springboot-messaging-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-springboot-messaging</artifactId>
   <name>KIE :: Add-Ons :: Messaging :: Spring Boot</name>

--- a/springboot/addons/messaging/integration-tests/pom.xml
+++ b/springboot/addons/messaging/integration-tests/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-springboot-messaging-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-springboot-messaging-it</artifactId>
   <name>KIE :: Add-Ons :: Messaging :: Spring Boot (ITs)</name>

--- a/springboot/addons/messaging/integration-tests/src/it/cloudevents-spring-boot-addon-it-invoked/pom.xml
+++ b/springboot/addons/messaging/integration-tests/src/it/cloudevents-spring-boot-addon-it-invoked/pom.xml
@@ -27,12 +27,12 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>@version.org.springframework.boot@</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <groupId>org.kie.kogito</groupId>
   <artifactId>kogito-cloudevents-spring-boot-addon-it-invoked</artifactId>
-  <version>@project.version@</version>
+  <version>111-SNAPSHOT</version>
 
   <properties>
     <java.version>@maven.compiler.release@</java.version>

--- a/springboot/addons/messaging/pom.xml
+++ b/springboot/addons/messaging/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons-springboot-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/addons/monitoring/core/pom.xml
+++ b/springboot/addons/monitoring/core/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kie-addons-springboot-monitoring-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <name>KIE :: Add-Ons :: Monitoring Core Springboot</name>

--- a/springboot/addons/monitoring/elastic/pom.xml
+++ b/springboot/addons/monitoring/elastic/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kie-addons-springboot-monitoring-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/addons/monitoring/pom.xml
+++ b/springboot/addons/monitoring/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons-springboot-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/addons/monitoring/prometheus/pom.xml
+++ b/springboot/addons/monitoring/prometheus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kie-addons-springboot-monitoring-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <name>KIE :: Add-Ons :: Monitoring Prometheus Springboot</name>

--- a/springboot/addons/persistence/filesystem/pom.xml
+++ b/springboot/addons/persistence/filesystem/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-springboot-persistence-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <name>KIE :: Add-Ons :: Persistence File System :: Springboot</name>

--- a/springboot/addons/persistence/infinispan/pom.xml
+++ b/springboot/addons/persistence/infinispan/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-springboot-persistence-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <name>KIE :: Add-Ons :: Persistence Infinispan :: Springboot</name>

--- a/springboot/addons/persistence/jdbc/pom.xml
+++ b/springboot/addons/persistence/jdbc/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-springboot-persistence-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <name>KIE :: Add-Ons :: Persistence JDBC :: Springboot</name>

--- a/springboot/addons/persistence/mongodb/pom.xml
+++ b/springboot/addons/persistence/mongodb/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-springboot-persistence-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <name>KIE :: Add-Ons :: Persistence MongoDB :: Springboot</name>

--- a/springboot/addons/persistence/pom.xml
+++ b/springboot/addons/persistence/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-springboot-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/addons/persistence/postgresql/pom.xml
+++ b/springboot/addons/persistence/postgresql/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-addons-springboot-persistence-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <name>KIE :: Add-Ons :: Persistence PostgreSQL :: Springboot</name>

--- a/springboot/addons/pom.xml
+++ b/springboot/addons/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>springboot</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/addons/process-instance-migration/pom.xml
+++ b/springboot/addons/process-instance-migration/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>kogito-addons-springboot-parent</artifactId>
         <groupId>org.kie</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/addons/process-management/pom.xml
+++ b/springboot/addons/process-management/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons-springboot-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/addons/process-svg/pom.xml
+++ b/springboot/addons/process-svg/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-springboot-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kie-addons-springboot-process-svg</artifactId>
   <name>KIE :: Add-Ons :: Process SVG :: Spring Boot Addon</name>

--- a/springboot/addons/rest-exception-handler/pom.xml
+++ b/springboot/addons/rest-exception-handler/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kogito-addons-springboot-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/addons/source-files/pom.xml
+++ b/springboot/addons/source-files/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>kogito-addons-springboot-parent</artifactId>
         <groupId>org.kie</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/addons/task-management/pom.xml
+++ b/springboot/addons/task-management/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons-springboot-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/addons/task-notification/pom.xml
+++ b/springboot/addons/task-notification/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons-springboot-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/addons/tracing-decision/pom.xml
+++ b/springboot/addons/tracing-decision/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>kogito-addons-springboot-parent</artifactId>
     <groupId>org.kie</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/archetype/pom.xml
+++ b/springboot/archetype/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>springboot</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-spring-boot-archetype</artifactId>

--- a/springboot/archetype/src/main/resources/archetype-resources/pom.xml
+++ b/springboot/archetype/src/main/resources/archetype-resources/pom.xml
@@ -25,13 +25,13 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>${version.org.springframework.boot}</version>
+    <version>111-SNAPSHOT</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
 
   <groupId>\${groupId}</groupId>
   <artifactId>\${artifactId}</artifactId>
-  <version>\${version}</version>
+  <version>111-SNAPSHOT</version>
 
   <description>Generated project \${artifactId}</description>
 

--- a/springboot/bom/pom.xml
+++ b/springboot/bom/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>springboot</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/integration-tests/integration-tests-springboot-decisions-it/pom.xml
+++ b/springboot/integration-tests/integration-tests-springboot-decisions-it/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-spring-boot-integration-tests</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>integration-tests-springboot-decisions-it</artifactId>

--- a/springboot/integration-tests/integration-tests-springboot-kafka-it/pom.xml
+++ b/springboot/integration-tests/integration-tests-springboot-kafka-it/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-spring-boot-integration-tests</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>integration-tests-springboot-kafka-it</artifactId>

--- a/springboot/integration-tests/integration-tests-springboot-norest-it/pom.xml
+++ b/springboot/integration-tests/integration-tests-springboot-norest-it/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-spring-boot-integration-tests</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>integration-tests-springboot-norest-it</artifactId>

--- a/springboot/integration-tests/integration-tests-springboot-processes-it/pom.xml
+++ b/springboot/integration-tests/integration-tests-springboot-processes-it/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-spring-boot-integration-tests</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>integration-tests-springboot-processes-it</artifactId>

--- a/springboot/integration-tests/integration-tests-springboot-processes-persistence-it/integration-tests-springboot-processes-filesystem/pom.xml
+++ b/springboot/integration-tests/integration-tests-springboot-processes-persistence-it/integration-tests-springboot-processes-filesystem/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>integration-tests-springboot-processes-persistence-it</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/springboot/integration-tests/integration-tests-springboot-processes-persistence-it/integration-tests-springboot-processes-infinispan/pom.xml
+++ b/springboot/integration-tests/integration-tests-springboot-processes-persistence-it/integration-tests-springboot-processes-infinispan/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>integration-tests-springboot-processes-persistence-it</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/springboot/integration-tests/integration-tests-springboot-processes-persistence-it/integration-tests-springboot-processes-jdbc/pom.xml
+++ b/springboot/integration-tests/integration-tests-springboot-processes-persistence-it/integration-tests-springboot-processes-jdbc/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>integration-tests-springboot-processes-persistence-it</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/springboot/integration-tests/integration-tests-springboot-processes-persistence-it/integration-tests-springboot-processes-mongodb/pom.xml
+++ b/springboot/integration-tests/integration-tests-springboot-processes-persistence-it/integration-tests-springboot-processes-mongodb/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>integration-tests-springboot-processes-persistence-it</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/springboot/integration-tests/integration-tests-springboot-processes-persistence-it/integration-tests-springboot-processes-persistence-common/pom.xml
+++ b/springboot/integration-tests/integration-tests-springboot-processes-persistence-it/integration-tests-springboot-processes-persistence-common/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>integration-tests-springboot-processes-persistence-it</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/springboot/integration-tests/integration-tests-springboot-processes-persistence-it/integration-tests-springboot-processes-postgresql/pom.xml
+++ b/springboot/integration-tests/integration-tests-springboot-processes-persistence-it/integration-tests-springboot-processes-postgresql/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>integration-tests-springboot-processes-persistence-it</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/springboot/integration-tests/integration-tests-springboot-processes-persistence-it/pom.xml
+++ b/springboot/integration-tests/integration-tests-springboot-processes-persistence-it/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-spring-boot-integration-tests</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>integration-tests-springboot-processes-persistence-it</artifactId>

--- a/springboot/integration-tests/integration-tests-springboot-usertask-listeners-rollback-it/pom.xml
+++ b/springboot/integration-tests/integration-tests-springboot-usertask-listeners-rollback-it/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-spring-boot-integration-tests</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/springboot/integration-tests/integration-tests-springboot-usertasks-it/pom.xml
+++ b/springboot/integration-tests/integration-tests-springboot-usertasks-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-spring-boot-integration-tests</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/springboot/integration-tests/integration-tests-springboot-wshumantasks-it/pom.xml
+++ b/springboot/integration-tests/integration-tests-springboot-wshumantasks-it/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kie.kogito</groupId>
         <artifactId>kogito-spring-boot-integration-tests</artifactId>
-        <version>999-SNAPSHOT</version>
+        <version>111-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/springboot/integration-tests/pom.xml
+++ b/springboot/integration-tests/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>springboot</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-spring-boot-integration-tests</artifactId>
   <name>Kogito :: Integration Tests :: Spring Boot</name>

--- a/springboot/pom.xml
+++ b/springboot/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-build-parent</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
     <relativePath>../kogito-build/kogito-build-parent/pom.xml</relativePath>
   </parent>
 

--- a/springboot/starters/kogito-decisions-spring-boot-starter/pom.xml
+++ b/springboot/starters/kogito-decisions-spring-boot-starter/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>spring-boot-starters</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/starters/kogito-predictions-spring-boot-starter/pom.xml
+++ b/springboot/starters/kogito-predictions-spring-boot-starter/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>spring-boot-starters</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/starters/kogito-processes-spring-boot-starter/pom.xml
+++ b/springboot/starters/kogito-processes-spring-boot-starter/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>spring-boot-starters</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/starters/kogito-rules-spring-boot-starter/pom.xml
+++ b/springboot/starters/kogito-rules-spring-boot-starter/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>spring-boot-starters</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/starters/kogito-spring-boot-starter/pom.xml
+++ b/springboot/starters/kogito-spring-boot-starter/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>spring-boot-starters</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/starters/pom.xml
+++ b/springboot/starters/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>springboot</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/springboot/test/pom.xml
+++ b/springboot/test/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <artifactId>springboot</artifactId>
     <groupId>org.kie.kogito</groupId>
-    <version>999-SNAPSHOT</version>
+    <version>111-SNAPSHOT</version>
   </parent>
 
   <artifactId>kogito-spring-boot-test-utils</artifactId>


### PR DESCRIPTION
Ticket: https://redhat.atlassian.net/browse/SRVLOGIC-963

- Updates distributionManagement and repositories section.
- Changes 999-SNAPSHOT to 111-SNAPSHOT to distinct from Apache snapshots.
- Removed modules defined in the productized/modules directory from pom.xmls. (Basically the remove_modules.sh script was executed on this branch).

Related PRs:
https://github.com/kiegroup/drools/pull/180
https://github.com/kiegroup/kogito-apps/pull/119
https://github.com/kiegroup/kogito-examples/pull/107
https://github.com/kubesmarts/kie-tools/pull/301
https://github.com/kiegroup/kogito-pipelines/pull/111