### PR TITLE
SRVLOGIC-1017 Startup check to validate user provided workflow id and version are available in the runtime

### DIFF
--- a/kogito-bom/pom.xml
+++ b/kogito-bom/pom.xml
@@ -2464,6 +2464,31 @@
           <artifactId>sonataflow-addons-quarkus-opentelemetry-deployment</artifactId>
           <version>${project.version}</version>
       </dependency>
+
+      <!-- Startup validation addon -->
+      <dependency>
+        <groupId>org.apache.kie.sonataflow</groupId>
+        <artifactId>sonataflow-addons-quarkus-startup-validation</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.kie.sonataflow</groupId>
+        <artifactId>sonataflow-addons-quarkus-startup-validation</artifactId>
+        <version>${project.version}</version>
+        <classifier>sources</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.kie.sonataflow</groupId>
+        <artifactId>sonataflow-addons-quarkus-startup-validation-deployment</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.kie.sonataflow</groupId>
+        <artifactId>sonataflow-addons-quarkus-startup-validation-deployment</artifactId>
+        <version>${project.version}</version>
+        <classifier>sources</classifier>
+      </dependency>
+
       <dependency>
         <groupId>org.jbpm</groupId>
         <artifactId>jbpm-quarkus</artifactId>

--- a/quarkus/addons/pom.xml
+++ b/quarkus/addons/pom.xml
@@ -59,6 +59,7 @@
     <module>opentelemetry</module>
     <module>grpc</module>
     <module>asyncapi</module>
+    <module>startup-validation</module>
   </modules>
 
   <profiles>

--- a/quarkus/addons/startup-validation/deployment/pom.xml
+++ b/quarkus/addons/startup-validation/deployment/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.kie.sonataflow</groupId>
+        <artifactId>sonataflow-addons-quarkus-startup-validation-parent</artifactId>
+        <version>111-SNAPSHOT</version>
+    </parent>
+    <artifactId>sonataflow-addons-quarkus-startup-validation-deployment</artifactId>
+    <name>SonataFlow :: Add-Ons :: Quarkus :: Startup :: Validation :: Deployment</name>
+
+    <properties>
+        <java.module.name>org.kie.kogito.quarkus.serverless.workflow.startup.validation.deployment</java.module.name>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.kie</groupId>
+            <artifactId>kogito-addons-quarkus-common-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.kie.kogito</groupId>
+            <artifactId>kogito-quarkus-extension-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-datasource-deployment-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-agroal-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-messaging-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kie.sonataflow</groupId>
+            <artifactId>sonataflow-addons-quarkus-startup-validation</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.quarkus</groupId>
+                                    <artifactId>quarkus-extension-processor</artifactId>
+                                    <version>${version.io.quarkus}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/quarkus/addons/startup-validation/deployment/src/main/java/org/kie/kogito/quarkus/serverless/workflow/startup/validation/deployment/SonataflowAddOnStartupValidationProcessor.java
+++ b/quarkus/addons/startup-validation/deployment/src/main/java/org/kie/kogito/quarkus/serverless/workflow/startup/validation/deployment/SonataflowAddOnStartupValidationProcessor.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.quarkus.serverless.workflow.startup.validation.deployment;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.kie.kogito.codegen.process.ProcessExecutableModelGenerator;
+import org.kie.kogito.codegen.process.ProcessGenerator;
+import org.kie.kogito.quarkus.addons.common.deployment.KogitoCapability;
+import org.kie.kogito.quarkus.addons.common.deployment.OneOfCapabilityKogitoAddOnProcessor;
+import org.kie.kogito.quarkus.extensions.spi.deployment.KogitoProcessContainerGeneratorBuildItem;
+import org.kie.kogito.quarkus.serverless.workflow.startup.validation.StartupValidationRecorder;
+
+import io.quarkus.agroal.spi.JdbcDataSourceBuildItem;
+import io.quarkus.datasource.deployment.spi.DefaultDataSourceDbKindBuildItem;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Produce;
+import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.ServiceStartBuildItem;
+import io.quarkus.smallrye.reactivemessaging.deployment.items.ConnectorBuildItem;
+
+public class SonataflowAddOnStartupValidationProcessor extends OneOfCapabilityKogitoAddOnProcessor {
+
+    private static final String FEATURE = "sonataflow-addons-quarkus-startup-validation";
+
+    public SonataflowAddOnStartupValidationProcessor() {
+        super(KogitoCapability.SERVERLESS_WORKFLOW);
+    }
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(FEATURE);
+    }
+
+    @BuildStep
+    @Produce(DefaultDataSourceDbKindBuildItem.class)
+    @Produce(JdbcDataSourceBuildItem.class)
+    @Produce(ConnectorBuildItem.class)
+    @Record(ExecutionTime.RUNTIME_INIT)
+    public ServiceStartBuildItem recordValidation(StartupValidationRecorder recorder,
+            List<KogitoProcessContainerGeneratorBuildItem> processContainerGeneratorBuildItems) {
+
+        Map<String, List<String>> generatedWorkflowVersions = new HashMap<>();
+        processContainerGeneratorBuildItems.stream().flatMap(it -> it.getProcessContainerGenerators().stream())
+                .flatMap(processContainerGenerator -> processContainerGenerator.getProcesses().stream())
+                .map(ProcessGenerator::getProcessExecutable)
+                .map(ProcessExecutableModelGenerator::process)
+                .forEach(process -> generatedWorkflowVersions.computeIfAbsent(process.getId(), s -> new ArrayList<>()).add(process.getVersion()));
+        recorder.executeValidation(generatedWorkflowVersions);
+
+        // Ensure this runs before StartupEvents.
+        return new ServiceStartBuildItem("sonataflow-swf-startup-validation");
+    }
+}

--- a/quarkus/addons/startup-validation/pom.xml
+++ b/quarkus/addons/startup-validation/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>kogito-addons-quarkus-parent</artifactId>
+        <groupId>org.kie</groupId>
+        <version>111-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.kie.sonataflow</groupId>
+    <artifactId>sonataflow-addons-quarkus-startup-validation-parent</artifactId>
+    <packaging>pom</packaging>
+    <name>SonataFlow :: Add-Ons :: Quarkus :: Startup :: Validation :: Parent</name>
+    <description>SonataFlow Quarkus Startup Workflow Validations</description>
+
+    <modules>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-maven-plugin</artifactId>
+                    <version>${version.io.quarkus}</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <configuration>
+                        <argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+                        <systemPropertyVariables>
+                            <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                            <maven.home>${maven.home}</maven.home>
+                            <maven.repo>${settings.localRepository}</maven.repo>
+                        </systemPropertyVariables>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <configuration>
+                        <argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+                        <systemPropertyVariables>
+                            <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                            <maven.home>${maven.home}</maven.home>
+                            <maven.repo>${settings.localRepository}</maven.repo>
+                        </systemPropertyVariables>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <configuration>
+                        <parameters>true</parameters>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/quarkus/addons/startup-validation/runtime/pom.xml
+++ b/quarkus/addons/startup-validation/runtime/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.kie.sonataflow</groupId>
+        <artifactId>sonataflow-addons-quarkus-startup-validation-parent</artifactId>
+        <version>111-SNAPSHOT</version>
+    </parent>
+    <artifactId>sonataflow-addons-quarkus-startup-validation</artifactId>
+    <name>SonataFlow :: Add-Ons :: Quarkus :: Startup :: Validation :: Runtime</name>
+
+    <properties>
+        <java.module.name>org.kie.kogito.quarkus.serverless.workflow.startup.validation.runtime</java.module.name>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-messaging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <version>${version.io.quarkus}</version>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>extension-descriptor</goal>
+                        </goals>
+                        <configuration>
+                            <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}</deployment>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.quarkus</groupId>
+                                    <artifactId>quarkus-extension-processor</artifactId>
+                                    <version>${version.io.quarkus}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                            <annotationProcessorPathsUseDepMgmt>true</annotationProcessorPathsUseDepMgmt>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/quarkus/addons/startup-validation/runtime/src/main/java/org/kie/kogito/quarkus/serverless/workflow/startup/validation/StartupValidationConfig.java
+++ b/quarkus/addons/startup-validation/runtime/src/main/java/org/kie/kogito/quarkus/serverless/workflow/startup/validation/StartupValidationConfig.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.quarkus.serverless.workflow.startup.validation;
+
+import java.util.List;
+import java.util.Map;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+
+@ConfigMapping(prefix = "kogito.validation")
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+public interface StartupValidationConfig {
+
+    Map<String, StartupValidationConfigGroup> swf();
+
+    @ConfigGroup
+    interface StartupValidationConfigGroup {
+        /**
+         * Configures the list of versions to execute for a given workflow.
+         * 
+         * @return the list desired versions.
+         */
+        List<String> versions();
+
+    }
+
+}

--- a/quarkus/addons/startup-validation/runtime/src/main/java/org/kie/kogito/quarkus/serverless/workflow/startup/validation/StartupValidationRecorder.java
+++ b/quarkus/addons/startup-validation/runtime/src/main/java/org/kie/kogito/quarkus/serverless/workflow/startup/validation/StartupValidationRecorder.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.quarkus.serverless.workflow.startup.validation;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.quarkus.runtime.RuntimeValue;
+import io.quarkus.runtime.annotations.Recorder;
+
+@Recorder
+public class StartupValidationRecorder {
+
+    private final Logger LOGGER = LoggerFactory.getLogger(StartupValidationRecorder.class);
+
+    private RuntimeValue<StartupValidationConfig> configRuntimeValue;
+
+    public StartupValidationRecorder(RuntimeValue<StartupValidationConfig> configRuntimeValue) {
+        this.configRuntimeValue = configRuntimeValue;
+    }
+
+    public void executeValidation(Map<String, List<String>> generatedWorkflowVersions) {
+        AtomicBoolean halt = new AtomicBoolean();
+        StartupValidationConfig config = configRuntimeValue.getValue();
+        outerLoop: if (config.swf() != null) {
+            for (Map.Entry<String, StartupValidationConfig.StartupValidationConfigGroup> entry : config.swf().entrySet()) {
+                List<String> generatedVersions = generatedWorkflowVersions.get(entry.getKey());
+                if (generatedVersions == null) {
+                    System.err.println(">>> [FATAL] Runtime Startup Validation failed: workflow: '" + entry.getKey() + "' is not present in current runtime.");
+                    halt.set(true);
+                    break outerLoop;
+                } else {
+                    for (String configuredVersion : entry.getValue().versions()) {
+                        if (!generatedVersions.contains(configuredVersion)) {
+                            System.err.println(
+                                    ">>> [FATAL] Runtime Startup Validation failed: version: '" + configuredVersion + "' of workflow: '" + entry.getKey() + "' is not present in current runtime.");
+                            halt.set(true);
+                            break outerLoop;
+                        }
+                    }
+                }
+            }
+        }
+        if (halt.get()) {
+            if (generatedWorkflowVersions.isEmpty()) {
+                System.err.println(">>> [FATAL] There are no workflows in current runtime.");
+            } else {
+                System.err.println(">>> [FATAL] You must execute any of the available workflow versions:");
+                for (Map.Entry<String, List<String>> entry : generatedWorkflowVersions.entrySet()) {
+                    System.out.println(" - > workflow: '" + entry.getKey() + "', versions: " + entry.getValue().stream().map(version -> "'" + version + "'").toList());
+                }
+            }
+            System.err.println(">>> [FATAL] Halting JVM before runtime starts!.");
+            doHalt();
+        } else {
+            for (Map.Entry<String, StartupValidationConfig.StartupValidationConfigGroup> entry : config.swf().entrySet()) {
+                LOGGER.debug("Workflow: " + entry.getKey() + " is available to execute the configured versions in current runtime: " + entry.getValue().versions());
+            }
+        }
+    }
+
+    /**
+     * Facilitates testing.
+     */
+    void doHalt() {
+        throw new Error("Invalid workflow version configuration.");
+    }
+}

--- a/quarkus/addons/startup-validation/runtime/src/test/java/org/kie/kogito/quarkus/serverless/workflow/startup/validation/StartupValidationRecorderTest.java
+++ b/quarkus/addons/startup-validation/runtime/src/test/java/org/kie/kogito/quarkus/serverless/workflow/startup/validation/StartupValidationRecorderTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.quarkus.serverless.workflow.startup.validation;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.quarkus.runtime.RuntimeValue;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class StartupValidationRecorderTest {
+
+    @ParameterizedTest
+    @MethodSource("getCases")
+    void executeValidation(StartupValidationConfig validationConfig, Map<String, List<String>> generatedWorkflowVersions, int wantedHalts) {
+        StartupValidationRecorder recorder = spy(new StartupValidationRecorder(new RuntimeValue<>(validationConfig)));
+        lenient().doNothing().when(recorder).doHalt();
+        recorder.executeValidation(generatedWorkflowVersions);
+        verify(recorder, times(wantedHalts)).doHalt();
+    }
+
+    private static Stream<Arguments> getCases() {
+        return Stream.of(
+                Arguments.of(mockValidationConfig("hello-world", List.of("1.0")), Map.of("hello-world", List.of("1.0")), 0),
+                Arguments.of(mockValidationConfig("hello-world", List.of("1.0")), Map.of("hello-world", List.of("2.0")), 1),
+                Arguments.of(mockValidationConfig("hello-world", List.of("1.0", "2.0")), Map.of("hello-world", List.of("1.0")), 1),
+                Arguments.of(mockValidationConfig("hello-world", List.of("1.0", "2.0")), Map.of("hello-world", List.of("2.0")), 1),
+                Arguments.of(mockValidationConfig("hello-world", List.of("1.0", "2.0")), Map.of("hello-world", List.of("1.0", "2.0")), 0),
+                Arguments.of(mockValidationConfig("hello-world", List.of("1.0", "2.0")), Map.of("hello-world", List.of("1.0", "2.0", "3.0")), 0),
+                Arguments.of(mock(StartupValidationConfig.class), Map.of("hello-world", List.of("1.0", "2.0", "3.0")), 0));
+    }
+
+    private static StartupValidationConfig mockValidationConfig(String workflowId, List<String> versions) {
+        StartupValidationConfig.StartupValidationConfigGroup validationConfigGroup = mock(StartupValidationConfig.StartupValidationConfigGroup.class);
+        doReturn(versions).when(validationConfigGroup).versions();
+        StartupValidationConfig validationConfig = mock(StartupValidationConfig.class);
+        doReturn(Map.of(workflowId, validationConfigGroup)).when(validationConfig).swf();
+        return validationConfig;
+    }
+}


### PR DESCRIPTION

This is MIDSTREAM if you want to send your PR to UPSTREAM use https://github.com/apache/incubator-kie-kogito-runtimes 

**REQUIRED** Add link to SRVLOGIC Jira!

Please make sure that your PR meets the following requirements:

- [X] You have read the [contributors guide](CONTRIBUTING.md)
- [X] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [X] Pull Request title is properly formatted: `SRVLOGIC-XYZ Subject`
- [X] Pull Request title contains the target branch if not targeting main: `[0.9.x] SRVLOGIC-XYZ Subject`
- [X] Pull Request contains link to the JIRA issue
- [X] Pull Request contains link to any dependent or related Pull Request
- [X] Pull Request contains description of the issue
- [X] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>
