### PR TITLE
[Security] Upgrade jackson-databind to 2.22.1 and other jackson to 2.21.5

### DIFF
--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -50,8 +50,8 @@
 
     <!-- dependencies versions -->
     <version.com.networknt>1.0.86</version.com.networknt>
-    <version.com.fasterxml.jackson>2.21.2</version.com.fasterxml.jackson>
-    <version.com.fasterxml.jackson.databind>2.22.0</version.com.fasterxml.jackson.databind>
+    <version.com.fasterxml.jackson>2.21.5</version.com.fasterxml.jackson>
+    <version.com.fasterxml.jackson.databind>2.22.1</version.com.fasterxml.jackson.databind>
     <version.com.fasterxml.jackson.annotations>2.21</version.com.fasterxml.jackson.annotations>
     <version.com.jayway.jsonpath>2.9.0</version.com.jayway.jsonpath>
     <version.com.ongres.scram>3.3</version.com.ongres.scram>
@@ -64,7 +64,6 @@
     <version.io.quarkiverse.embedded.postgresql>0.8.0</version.io.quarkiverse.embedded.postgresql>
     <version.com.github.haifengl.smile>1.5.2</version.com.github.haifengl.smile>
     <version.com.github.javaparser>3.27.0</version.com.github.javaparser>
-    <version.com.fasterxml.jackson.datatype>2.21.1</version.com.fasterxml.jackson.datatype>
     <version.com.github.victools>4.37.0</version.com.github.victools>
     <version.org.wiremock>3.13.0</version.org.wiremock>
     <version.com.google.protobuf>3.25.5</version.com.google.protobuf>
@@ -1253,7 +1252,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-json-org</artifactId>
-        <version>${version.com.fasterxml.jackson.datatype}</version>
+        <version>${version.com.fasterxml.jackson}</version>
       </dependency>
       <!-- Serverless Workflow -->
       <dependency>


### PR DESCRIPTION
- Fixes dependabot alerts for jackson. 