### PR TITLE
[Fix #208] Adding sensitive data filter

### DIFF
--- a/quarkus/addons/asyncapi/deployment/src/main/java/org/kie/kogito/quarkus/serverless/workflow/asyncapi/AsyncAPIProcessor.java
+++ b/quarkus/addons/asyncapi/deployment/src/main/java/org/kie/kogito/quarkus/serverless/workflow/asyncapi/AsyncAPIProcessor.java
@@ -18,6 +18,7 @@
  */
 package org.kie.kogito.quarkus.serverless.workflow.asyncapi;
 
+import java.util.Optional;
 import java.util.ServiceLoader;
 
 import org.kie.kogito.quarkus.common.deployment.KogitoAddonsPreGeneratedSourcesBuildItem;
@@ -33,8 +34,9 @@ import io.quarkus.deployment.annotations.BuildStep;
 public class AsyncAPIProcessor {
 
     @BuildStep
-    void asyncAPIContext(LiveReloadExecutionBuildItem reload, KogitoBuildContextBuildItem context, BuildProducer<KogitoAddonsPreGeneratedSourcesBuildItem> sources) {
+    void asyncAPIContext(Optional<LiveReloadExecutionBuildItem> reload, KogitoBuildContextBuildItem context, BuildProducer<KogitoAddonsPreGeneratedSourcesBuildItem> sources) {
         context.getKogitoBuildContext().addContextAttribute(ParserContext.ASYNC_CONVERTER_KEY, new AsyncAPIInfoConverter(
-                new MapAsyncAPIRegistry(ServiceLoader.load(AsyncAPISupplier.class, reload.getClassLoader().orElse(Thread.currentThread().getContextClassLoader())))));
+                new MapAsyncAPIRegistry(
+                        ServiceLoader.load(AsyncAPISupplier.class, reload.flatMap(LiveReloadExecutionBuildItem::getClassLoader).orElse(Thread.currentThread().getContextClassLoader())))));
     }
 }

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/pom.xml
@@ -234,6 +234,11 @@
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-serverless-workflow-builder</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5-internal</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/application.properties
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/main/resources/application.properties
@@ -333,6 +333,9 @@ quarkus.log.file.path=target/quarkus.log
 quarkus.log.file.json.enabled=true
 quarkus.log.console.json=false
 
+org.sonataflow.logger.sensitive-data-filter.mask=...
+org.sonataflow.logger.sensitive-data-filter.patterns=espa\u00F1oles
+quarkus.log.console.filter=sensitive-data-filter
 
 # Optional: debug logging for process instance context
 quarkus.log.category."org.kie.kogito.services.context".level=DEBUG

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/SensitiveDataFilterTest.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow-integration-test/src/test/java/org/kie/kogito/quarkus/workflows/SensitiveDataFilterTest.java
@@ -1,0 +1,41 @@
+package org.kie.kogito.quarkus.workflows;
+
+import java.util.logging.LogRecord;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.quarkus.test.InMemoryLogHandler;
+import io.quarkus.test.junit.QuarkusTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+public class SensitiveDataFilterTest {
+
+    private final static Logger logger = LoggerFactory.getLogger(SensitiveDataFilterTest.class);
+
+    private InMemoryLogHandler logHandler;
+    private org.jboss.logmanager.Logger logContext;
+
+    @BeforeEach
+    void setup() {
+        logHandler = new InMemoryLogHandler(r -> true);
+        logContext = org.jboss.logmanager.LogContext.getLogContext().getLogger(logger.getName());
+        logContext.addHandler(logHandler);
+    }
+
+    @AfterEach
+    void close() {
+        logContext.removeHandler(logHandler);
+    }
+
+    @Test
+    void testLogger() {
+        logger.info("Los españoles son muy españoles y mucho españoles");
+        assertThat(logHandler.getRecords()).singleElement().extracting(LogRecord::getMessage).isEqualTo("Los ... son muy ... y mucho ...");
+    }
+}

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/pom.xml
@@ -128,30 +128,16 @@
       <artifactId>kogito-services</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
-      <scope>test</scope>
-    </dependency>
-     <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5-internal</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.jboss.logmanager</groupId>
-      <artifactId>jboss-logmanager</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.kie.kogito</groupId>
-      <artifactId>kogito-quarkus-common-deployment</artifactId>
-      <scope>test</scope>
-    </dependency>
+
   </dependencies>
 
   <build>

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/pom.xml
@@ -127,7 +127,26 @@
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-services</artifactId>
     </dependency>
-
+       <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+     <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5-internal</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.logmanager</groupId>
+      <artifactId>jboss-logmanager</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/pom.xml
@@ -127,7 +127,7 @@
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-services</artifactId>
     </dependency>
-       <dependency>
+    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
       <scope>test</scope>
@@ -145,6 +145,11 @@
     <dependency>
       <groupId>org.jboss.logmanager</groupId>
       <artifactId>jboss-logmanager</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-quarkus-common-deployment</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/src/main/java/org/kie/kogito/serverless/workflow/logger/SensitiveDataFilter.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/src/main/java/org/kie/kogito/serverless/workflow/logger/SensitiveDataFilter.java
@@ -1,0 +1,66 @@
+package org.kie.kogito.serverless.workflow.logger;
+
+import java.util.Set;
+import java.util.logging.Filter;
+import java.util.logging.LogRecord;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import io.quarkus.logging.LoggingFilter;
+
+@LoggingFilter(name = SensitiveDataFilter.FILTER_NAME)
+public class SensitiveDataFilter implements Filter {
+
+    static final String FILTER_NAME = "sensitive-data-filter";
+    private static final String CONFIG_PREFIX = "org.sonataflow.logger." + FILTER_NAME + ".";
+    private static final String DEFAULT_MASK = "***MASKED***";
+
+    private final Set<Pattern> patterns;
+    private final String mask;
+
+    public SensitiveDataFilter(@ConfigProperty(name = CONFIG_PREFIX + "patterns", defaultValue = "(Authorization\\s*[:=]\\s*)(Bearer\\s+)?[A-Za-z0-9\\-_\\.]+" + ","
+            + "(X-Authorization[A-Za-z\\-]*\\s*[:=]\\s*)(Bearer\\s+)?[A-Za-z0-9\\-_\\.]+" + ","
+            + "eyJ[A-Za-z0-9\\-_]+\\.eyJ[A-Za-z0-9\\-_]+\\.[A-Za-z0-9\\-_]+" + "," +
+            "gh[os]_[A-Za-z0-9]{20,}" + "," +
+            "(\"[^\"]*[Tt]oken\"\\s*:\\s*\")(gh[os]_[A-Za-z0-9]+)(\")") Set<String> patterns, @ConfigProperty(name = CONFIG_PREFIX + "mask", defaultValue = DEFAULT_MASK) String mask) {
+        this.patterns = patterns.stream().map(Pattern::compile).collect(Collectors.toSet());
+        this.mask = mask;
+    }
+
+    @Override
+    public boolean isLoggable(LogRecord record) {
+        if (record.getMessage() != null) {
+            record.setMessage(maskSensitiveData(record.getMessage()));
+        }
+        Object[] params = record.getParameters();
+        if (params != null) {
+            for (int i = 0; i < params.length; i++) {
+                if (params[i] instanceof String param) {
+                    params[i] = maskSensitiveData(param);
+                }
+            }
+        }
+        return true;
+    }
+
+    private String maskSensitiveData(String message) {
+        String result = message;
+        for (Pattern pattern : patterns) {
+            result = pattern.matcher(result).replaceAll(match -> {
+                if (match.groupCount() == 0) {
+                    return mask;
+                }
+                StringBuilder sb = new StringBuilder();
+                for (int i = 1; i <= match.groupCount(); i++) {
+                    if (match.group(i) != null) {
+                        sb.append(i % 2 != 0 ? match.group(i) : mask);
+                    }
+                }
+                return sb.length() > 0 ? sb.toString() : mask;
+            });
+        }
+        return result;
+    }
+}

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/src/main/java/org/kie/kogito/serverless/workflow/logger/SensitiveDataFilter.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/src/main/java/org/kie/kogito/serverless/workflow/logger/SensitiveDataFilter.java
@@ -3,10 +3,10 @@ package org.kie.kogito.serverless.workflow.logger;
 import java.util.Set;
 import java.util.logging.Filter;
 import java.util.logging.LogRecord;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logmanager.filters.AllFilter;
+import org.jboss.logmanager.filters.SubstituteFilter;
 
 import io.quarkus.logging.LoggingFilter;
 
@@ -14,53 +14,23 @@ import io.quarkus.logging.LoggingFilter;
 public class SensitiveDataFilter implements Filter {
 
     static final String FILTER_NAME = "sensitive-data-filter";
+    static final String DEFAULT_PATTERNS = "(Authorization\\s*[:=]\\s*)(Bearer\\s+)?[A-Za-z0-9\\-_\\.]+" + ","
+            + "(X-Authorization[A-Za-z\\-]*\\s*[:=]\\s*)(Bearer\\s+)?[A-Za-z0-9\\-_\\.]+" + ","
+            + "eyJ[A-Za-z0-9\\-_]+\\.eyJ[A-Za-z0-9\\-_]+\\.[A-Za-z0-9\\-_]+" + "," +
+            "(\"[^\"]*[Tt]oken\"\\s*:\\s*\")(gh[os]_[A-Za-z0-9]+)(\")" + ","
+            + "gh[os]_[A-Za-z0-9]{20\\,}";
     private static final String CONFIG_PREFIX = "org.sonataflow.logger." + FILTER_NAME + ".";
     private static final String DEFAULT_MASK = "***MASKED***";
 
-    private final Set<Pattern> patterns;
-    private final String mask;
+    private final AllFilter filter;
 
-    public SensitiveDataFilter(@ConfigProperty(name = CONFIG_PREFIX + "patterns", defaultValue = "(Authorization\\s*[:=]\\s*)(Bearer\\s+)?[A-Za-z0-9\\-_\\.]+" + ","
-            + "(X-Authorization[A-Za-z\\-]*\\s*[:=]\\s*)(Bearer\\s+)?[A-Za-z0-9\\-_\\.]+" + ","
-            + "eyJ[A-Za-z0-9\\-_]+\\.eyJ[A-Za-z0-9\\-_]+\\.[A-Za-z0-9\\-_]+" + "," +
-            "gh[os]_[A-Za-z0-9]{20,}" + "," +
-            "(\"[^\"]*[Tt]oken\"\\s*:\\s*\")(gh[os]_[A-Za-z0-9]+)(\")") Set<String> patterns, @ConfigProperty(name = CONFIG_PREFIX + "mask", defaultValue = DEFAULT_MASK) String mask) {
-        this.patterns = patterns.stream().map(Pattern::compile).collect(Collectors.toSet());
-        this.mask = mask;
+    public SensitiveDataFilter(@ConfigProperty(name = CONFIG_PREFIX + "patterns", defaultValue = DEFAULT_PATTERNS) Set<String> patterns,
+            @ConfigProperty(name = CONFIG_PREFIX + "mask", defaultValue = DEFAULT_MASK) String mask) {
+        this.filter = new AllFilter(patterns.stream().map(p -> new SubstituteFilter(p, mask, true)).toArray(Filter[]::new));
     }
 
     @Override
     public boolean isLoggable(LogRecord record) {
-        if (record.getMessage() != null) {
-            record.setMessage(maskSensitiveData(record.getMessage()));
-        }
-        Object[] params = record.getParameters();
-        if (params != null) {
-            for (int i = 0; i < params.length; i++) {
-                if (params[i] instanceof String param) {
-                    params[i] = maskSensitiveData(param);
-                }
-            }
-        }
-        return true;
-    }
-
-    private String maskSensitiveData(String message) {
-        String result = message;
-        for (Pattern pattern : patterns) {
-            result = pattern.matcher(result).replaceAll(match -> {
-                if (match.groupCount() == 0) {
-                    return mask;
-                }
-                StringBuilder sb = new StringBuilder();
-                for (int i = 1; i <= match.groupCount(); i++) {
-                    if (match.group(i) != null) {
-                        sb.append(i % 2 != 0 ? match.group(i) : mask);
-                    }
-                }
-                return sb.length() > 0 ? sb.toString() : mask;
-            });
-        }
-        return result;
+        return filter.isLoggable(record);
     }
 }

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/src/test/java/org/kie/kogito/serverless/workflow/logger/SensitiveDataFilterTest.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/src/test/java/org/kie/kogito/serverless/workflow/logger/SensitiveDataFilterTest.java
@@ -1,0 +1,40 @@
+package org.kie.kogito.serverless.workflow.logger;
+
+import java.util.logging.LogRecord;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.quarkus.test.InMemoryLogHandler;
+import io.quarkus.test.junit.QuarkusTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+public class SensitiveDataFilterTest {
+
+    private final static Logger logger = LoggerFactory.getLogger(SensitiveDataFilterTest.class);
+
+    private final static InMemoryLogHandler logHandler = new InMemoryLogHandler(r -> true);
+    private final static org.jboss.logmanager.Logger logContext = org.jboss.logmanager.LogContext.getLogContext().getLogger(logger.getName());
+
+    @BeforeEach
+    void setup() {
+        logContext.addHandler(logHandler);
+    }
+
+    @AfterEach
+    void close() {
+        logContext.removeHandler(logHandler);
+    }
+
+    @Test
+    void testLogger() {
+        logger.info("Fulanito es un mierda, cabron y bastardo sevillista");
+        assertThat(logHandler.getRecords()).singleElement().extracting(LogRecord::getMessage).isEqualTo("Fulanito es un ..., ... y ... sevillista");
+    }
+
+}

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/src/test/java/org/kie/kogito/serverless/workflow/logger/SensitiveDataFilterTest.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/src/test/java/org/kie/kogito/serverless/workflow/logger/SensitiveDataFilterTest.java
@@ -1,42 +1,31 @@
 package org.kie.kogito.serverless.workflow.logger;
 
+import java.util.Set;
+import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import io.quarkus.test.InMemoryLogHandler;
-import io.quarkus.test.junit.QuarkusTest;
+import io.smallrye.config.common.utils.StringUtil;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@QuarkusTest
 public class SensitiveDataFilterTest {
 
-    private final static Logger logger = LoggerFactory.getLogger(SensitiveDataFilterTest.class);
-
-    private InMemoryLogHandler logHandler;
-    private org.jboss.logmanager.Logger logContext;
-
-    @BeforeEach
-    void setup() {
-        logHandler = new InMemoryLogHandler(r -> true);
-        logContext = org.jboss.logmanager.LogContext.getLogContext().getLogger(logger.getName());
-        logContext.addHandler(logHandler);
-    }
-
-    @AfterEach
-    void close() {
-        logContext.removeHandler(logHandler);
+    @Test
+    void testMask() {
+        SensitiveDataFilter filter = new SensitiveDataFilter(Set.of("Javierito", "Fulanito"), "...");
+        LogRecord record = new LogRecord(Level.INFO, "Javierito and Fulanito are uncommon names");
+        filter.isLoggable(record);
+        assertThat(record.getMessage()).isEqualTo("... and ... are uncommon names");
     }
 
     @Test
-    void testLogger() {
-        logger.info("The culprits are Fulanito and Menganito");
-        assertThat(logHandler.getRecords()).singleElement().extracting(LogRecord::getMessage).isEqualTo("The culprits are ... and ...");
+    void testDefaultPattern() {
+        SensitiveDataFilter filter = new SensitiveDataFilter(Set.of(StringUtil.split(SensitiveDataFilter.DEFAULT_PATTERNS)), "****");
+        LogRecord record = new LogRecord(Level.INFO,
+                "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c");
+        filter.isLoggable(record);
+        assertThat(record.getMessage()).isEqualTo("Authorization: Bearer ****");
     }
-
 }

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/src/test/java/org/kie/kogito/serverless/workflow/logger/SensitiveDataFilterTest.java
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/src/test/java/org/kie/kogito/serverless/workflow/logger/SensitiveDataFilterTest.java
@@ -18,11 +18,13 @@ public class SensitiveDataFilterTest {
 
     private final static Logger logger = LoggerFactory.getLogger(SensitiveDataFilterTest.class);
 
-    private final static InMemoryLogHandler logHandler = new InMemoryLogHandler(r -> true);
-    private final static org.jboss.logmanager.Logger logContext = org.jboss.logmanager.LogContext.getLogContext().getLogger(logger.getName());
+    private InMemoryLogHandler logHandler;
+    private org.jboss.logmanager.Logger logContext;
 
     @BeforeEach
     void setup() {
+        logHandler = new InMemoryLogHandler(r -> true);
+        logContext = org.jboss.logmanager.LogContext.getLogContext().getLogger(logger.getName());
         logContext.addHandler(logHandler);
     }
 
@@ -33,8 +35,8 @@ public class SensitiveDataFilterTest {
 
     @Test
     void testLogger() {
-        logger.info("Fulanito es un mierda, cabron y bastardo sevillista");
-        assertThat(logHandler.getRecords()).singleElement().extracting(LogRecord::getMessage).isEqualTo("Fulanito es un ..., ... y ... sevillista");
+        logger.info("The culprits are Fulanito and Menganito");
+        assertThat(logHandler.getRecords()).singleElement().extracting(LogRecord::getMessage).isEqualTo("The culprits are ... and ...");
     }
 
 }

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/src/test/resources/application.properties
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/src/test/resources/application.properties
@@ -1,5 +1,0 @@
-org.sonataflow.logger.sensitive-data-filter.mask=...
-org.sonataflow.logger.sensitive-data-filter.patterns=Fulanito,Menganito
-quarkus.log.console.filter=sensitive-data-filter
-kogito.generate.rest = false
-quarkus.devservices.enabled=false

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/src/test/resources/application.properties
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/src/test/resources/application.properties
@@ -1,0 +1,4 @@
+org.sonataflow.logger.sensitive-data-filter.mask=...
+org.sonataflow.logger.sensitive-data-filter.patterns=mierda,cabron,bastardo
+quarkus.log.console.filter=sensitive-data-filter
+quarkus.log.category."org.kie.kogito.serverless.workflow.logger".level=debug

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/src/test/resources/application.properties
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/kogito-quarkus-serverless-workflow/src/test/resources/application.properties
@@ -1,4 +1,5 @@
 org.sonataflow.logger.sensitive-data-filter.mask=...
-org.sonataflow.logger.sensitive-data-filter.patterns=mierda,cabron,bastardo
+org.sonataflow.logger.sensitive-data-filter.patterns=Fulanito,Menganito
 quarkus.log.console.filter=sensitive-data-filter
-quarkus.log.category."org.kie.kogito.serverless.workflow.logger".level=debug
+kogito.generate.rest = false
+quarkus.devservices.enabled=false


### PR DESCRIPTION
Fix https://github.com/kiegroup/kogito-runtimes/issues/208

Users can now specify a set of regular expression patterns

`org.sonataflow.logger.sensitive-data-filter.pattern=<set of patterns>`

Note that in Quarkus a set of properties can be specified either by comma separated or as indexed property. For more details, see https://quarkus.io/guides/config-reference#indexed-properties

If no pattern is specified, security tokens are masked by default

If any string in the logs matches any of the patterns, then it is replaced by a mask.

The mask is specified through property

`org.sonataflow.logger.sensitive-data-filter.mask=<mask>`

If not propery is speficied the default mask is `***MASKED***`

To enable the filter, you need to add filter to the quarkus logger, as per https://quarkus.io/guides/logging#add-a-logging-filter-to-your-log-handler

For example, for output console, user should add
`quarkus.log.console.filter=sensitive-data-filter
`
