### PR TITLE
[SRVLOGIC-1086] Update Quarkus to 3.27.4.1.

### DIFF
--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -40,7 +40,7 @@
     <!-- End of various transitive overrides. -->
 
     <!-- this version property is used in plugins but also in dependencies too -->
-    <version.io.quarkus>3.27.4</version.io.quarkus>
+    <version.io.quarkus>3.27.4.1</version.io.quarkus>
     <version.io.quarkus.quarkus-test>${version.io.quarkus}</version.io.quarkus.quarkus-test>
     <version.org.springframework>6.2.18</version.org.springframework>
     <version.org.springframework.boot>3.5.12</version.org.springframework.boot>
@@ -101,7 +101,7 @@
 
     <version.io.smallrye.reactive.mutiny-vertx-web-client>3.21.3</version.io.smallrye.reactive.mutiny-vertx-web-client>
 
-    <version.io.vertx>4.5.27</version.io.vertx>
+    <version.io.vertx>4.5.28</version.io.vertx>
     <version.io.grpc>1.76.0</version.io.grpc>
 
     <version.io.quarkus.camel>3.27.3</version.io.quarkus.camel>

--- a/quarkus/bom/pom.xml
+++ b/quarkus/bom/pom.xml
@@ -37,7 +37,7 @@
   <description>Internal BOM descriptor for Kogito modules targeting Quarkus use-cases. Specific dependencies targeting the Quarkus platform must be added here.</description>
 
   <properties>
-    <!-- Keep it aligned with https://github.com/quarkusio/quarkus/blob/3.27.3/pom.xml#L72 -->
+    <!-- Keep it aligned with https://github.com/quarkusio/quarkus/blob/3.27.4.1/pom.xml#L72 -->
     <version.io.fabric8.kubernetes-client>7.3.1</version.io.fabric8.kubernetes-client>
   </properties>
 


### PR DESCRIPTION
Ticket: https://redhat.atlassian.net/browse/SRVLOGIC-1086

Updates Quarkus to 3.27.4.1 and aligns other dependencies with the changes in the new Quarkus version.