### PR TITLE
Provide SourceFilesProvider fallback

### DIFF
--- a/quarkus/addons/source-files/runtime/src/main/java/org/kie/kogito/addon/source/files/FallbackSourceFilesProviderProducer.java
+++ b/quarkus/addons/source-files/runtime/src/main/java/org/kie/kogito/addon/source/files/FallbackSourceFilesProviderProducer.java
@@ -1,0 +1,20 @@
+package org.kie.kogito.addon.source.files;
+
+import org.kie.kogito.source.files.SourceFilesProvider;
+import org.kie.kogito.source.files.SourceFilesProviderImpl;
+
+import io.quarkus.arc.DefaultBean;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+@ApplicationScoped
+public class FallbackSourceFilesProviderProducer {
+
+    @Produces
+    @DefaultBean
+    @ApplicationScoped
+    public SourceFilesProvider fallbackSourceFileProvider() {
+        return new SourceFilesProviderImpl();
+    }
+}


### PR DESCRIPTION
This will be useful, whem, for some reason beyond my knowledge, source addon is added to dependencies and process generation is skipped
