### PR TITLE
[9.106.x-prod] kogito-dependencies-bom overrides Vert.x to 4.5.31 incompatible with Quarkus 3.33.2

### DIFF
--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -101,7 +101,6 @@
 
     <version.io.smallrye.reactive.mutiny-vertx-web-client>3.21.6</version.io.smallrye.reactive.mutiny-vertx-web-client>
 
-    <version.io.vertx>4.5.31</version.io.vertx>
     <version.io.grpc>1.81.0</version.io.grpc>
 
     <version.io.quarkus.camel>3.33.2</version.io.quarkus.camel>
@@ -1179,12 +1178,10 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-pg-client</artifactId>
-        <version>${version.io.vertx}</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web</artifactId>
-        <version>${version.io.vertx}</version>
       </dependency>
 
       <!-- predictions/machine learning related -->


### PR DESCRIPTION
Root cause identified: kogito-dependencies-bom overrides Vert.x to 4.5.31, while Quarkus 3.33.2.redhat-00003 manages the rest of the Vert.x stack at 4.5.27.redhat-00001.

This leaves a mixed Vert.x runtime (vertx-web 4.5.31 + vertx-core/vertx-web-graphql 4.5.27), causing the NoSuchMethodError in HttpServerRequestInternal.isUseSemicolonAsQueryParamDelimiter().

Fix: remove the Vert.x override

Also depends on https://github.com/kiegroup/drools/pull/221