### PR TITLE
[9.106.x-prod] SRVLOGIC-1127: Fix reverse event ordering in TxEventEmitter caused by Narayana LIFO synchronization

### DIFF
--- a/kogito-codegen-modules/kogito-codegen-events/src/main/resources/class-templates/events/TxEventEmitterQuarkusTemplate.java
+++ b/kogito-codegen-modules/kogito-codegen-events/src/main/resources/class-templates/events/TxEventEmitterQuarkusTemplate.java
@@ -20,15 +20,17 @@ package $Package$;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.event.Event;
-import jakarta.enterprise.event.Observes;
-import jakarta.enterprise.event.TransactionPhase;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
+import jakarta.transaction.Status;
+import jakarta.transaction.Synchronization;
 import jakarta.transaction.Transactional;
+import jakarta.transaction.TransactionSynchronizationRegistry;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 import org.kie.kogito.addon.quarkus.messaging.common.KogitoMessaging;
@@ -44,7 +46,6 @@ import org.kie.kogito.event.EventUnmarshaller;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 import io.quarkus.runtime.Startup;
 
 @Startup
@@ -59,33 +60,43 @@ public class $ClassName$ extends AbstractQuarkusCloudEventEmitter<$Type$> {
     Emitter<$Type$> emitter;
 
     @Inject
-    Event<EmitEventType> event;
-
-    @Inject
     MessageDecoratorProvider messageDecorator;
 
-    class EmitEventType {
-        DataEvent<?> data;
-
-        public EmitEventType(DataEvent<?> data) {
-            this.data = data;
-        }
-    }
-
-    public void observe(@Observes(during = TransactionPhase.AFTER_SUCCESS) EmitEventType emitEventType) {
-        logger.debug("publishing event {}", emitEventType.data);
-        try {
-            Message<$Type$> message = messageDecorator.decorate(getMessage(emitEventType.data));
-            emitter.send(message);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
+    @Inject
+    TransactionSynchronizationRegistry txSyncRegistry;
 
     @Override
     @Transactional
+    @SuppressWarnings("unchecked")
     public void emit(DataEvent<?> dataEvent) {
-        event.fire(new EmitEventType(dataEvent));
+        List<DataEvent<?>> bufferedEvents = (List<DataEvent<?>>) txSyncRegistry.getResource(this);
+        if (bufferedEvents == null) {
+            bufferedEvents = new ArrayList<>();
+            txSyncRegistry.putResource(this, bufferedEvents);
+            final List<DataEvent<?>> events = bufferedEvents;
+            txSyncRegistry.registerInterposedSynchronization(new Synchronization() {
+                @Override
+                public void beforeCompletion() {
+                }
+
+                @Override
+                public void afterCompletion(int status) {
+                    if (status == Status.STATUS_COMMITTED) {
+                        for (DataEvent<?> event : events) {
+                            logger.debug("publishing event {}", event);
+                            try {
+                                Message<$Type$> message = messageDecorator.decorate(getMessage(event));
+                                emitter.send(message);
+                            } catch (IOException e) {
+                                logger.error("error while publishing event {}", event, e);
+                                throw new UncheckedIOException(e);
+                            }
+                        }
+                    }
+                }
+            });
+        }
+        bufferedEvents.add(dataEvent);
     }
 
     protected EventMarshaller<$Type$> getEventMarshaller() {

--- a/quarkus/addons/messaging/common/pom.xml
+++ b/quarkus/addons/messaging/common/pom.xml
@@ -92,6 +92,11 @@
     </dependency>
 
     <dependency>
+      <groupId>jakarta.transaction</groupId>
+      <artifactId>jakarta.transaction-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>

--- a/quarkus/addons/messaging/common/src/test/java/org/kie/kogito/addon/quarkus/messaging/common/TxEventEmitterOrderingTest.java
+++ b/quarkus/addons/messaging/common/src/test/java/org/kie/kogito/addon/quarkus/messaging/common/TxEventEmitterOrderingTest.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.addon.quarkus.messaging.common;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.kie.kogito.addon.quarkus.common.reactive.messaging.MessageDecoratorProvider;
+import org.kie.kogito.event.CloudEventMarshaller;
+import org.kie.kogito.event.DataEvent;
+import org.kie.kogito.event.EventMarshaller;
+
+import jakarta.transaction.Status;
+import jakarta.transaction.Synchronization;
+import jakarta.transaction.TransactionSynchronizationRegistry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TxEventEmitterOrderingTest {
+
+    private Emitter<String> emitter;
+    private MessageDecoratorProvider messageDecorator;
+    private TransactionSynchronizationRegistry txSyncRegistry;
+    private Map<Object, Object> txResources;
+    private List<Synchronization> registeredSyncs;
+    private List<String> sentPayloads;
+
+    @SuppressWarnings("unchecked")
+    @BeforeEach
+    void setUp() {
+        emitter = mock(Emitter.class);
+        messageDecorator = mock(MessageDecoratorProvider.class);
+        txSyncRegistry = mock(TransactionSynchronizationRegistry.class);
+        txResources = new HashMap<>();
+        registeredSyncs = new ArrayList<>();
+        sentPayloads = new ArrayList<>();
+
+        when(txSyncRegistry.getResource(any())).thenAnswer(inv -> txResources.get(inv.getArgument(0)));
+        doAnswer(inv -> {
+            txResources.put(inv.getArgument(0), inv.getArgument(1));
+            return null;
+        }).when(txSyncRegistry).putResource(any(), any());
+        doAnswer(inv -> {
+            registeredSyncs.add(inv.getArgument(0));
+            return null;
+        }).when(txSyncRegistry).registerInterposedSynchronization(any());
+
+        doAnswer(inv -> {
+            Message<String> msg = inv.getArgument(0);
+            sentPayloads.add(msg.getPayload());
+            return null;
+        }).when(emitter).send(any(Message.class));
+
+        when(messageDecorator.decorate(any())).thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    @Test
+    void eventsArePublishedInEmitOrder() {
+        TestTxEventEmitter txEmitter = new TestTxEventEmitter(emitter, messageDecorator, txSyncRegistry);
+
+        txEmitter.emit(createMockEvent("processing-2"));
+        txEmitter.emit(createMockEvent("processing-3"));
+        txEmitter.emit(createMockEvent("output-1"));
+        txEmitter.emit(createMockEvent("output"));
+
+        assertThat(sentPayloads).as("no events should be published before transaction commit").isEmpty();
+        assertThat(registeredSyncs).as("exactly one synchronization should be registered").hasSize(1);
+
+        registeredSyncs.get(0).afterCompletion(Status.STATUS_COMMITTED);
+
+        assertThat(sentPayloads).containsExactly("processing-2", "processing-3", "output-1", "output");
+    }
+
+    @Test
+    void eventsAreNotPublishedOnRollback() {
+        TestTxEventEmitter txEmitter = new TestTxEventEmitter(emitter, messageDecorator, txSyncRegistry);
+
+        txEmitter.emit(createMockEvent("event-1"));
+        txEmitter.emit(createMockEvent("event-2"));
+
+        registeredSyncs.get(0).afterCompletion(Status.STATUS_ROLLEDBACK);
+
+        assertThat(sentPayloads).as("no events should be published on rollback").isEmpty();
+    }
+
+    @Test
+    void singleEventPreservesOrder() {
+        TestTxEventEmitter txEmitter = new TestTxEventEmitter(emitter, messageDecorator, txSyncRegistry);
+
+        txEmitter.emit(createMockEvent("only-event"));
+
+        registeredSyncs.get(0).afterCompletion(Status.STATUS_COMMITTED);
+
+        assertThat(sentPayloads).containsExactly("only-event");
+    }
+
+    private DataEvent<?> createMockEvent(String type) {
+        DataEvent<?> event = mock(DataEvent.class);
+        when(event.getType()).thenReturn(type);
+        return event;
+    }
+
+    /**
+     * Mirrors the generated TxEventEmitter logic from TxEventEmitterQuarkusTemplate
+     */
+    static class TestTxEventEmitter extends AbstractQuarkusCloudEventEmitter<String> {
+
+        private final Emitter<String> emitter;
+        private final MessageDecoratorProvider messageDecorator;
+        private final TransactionSynchronizationRegistry txSyncRegistry;
+
+        TestTxEventEmitter(Emitter<String> emitter, MessageDecoratorProvider messageDecorator,
+                TransactionSynchronizationRegistry txSyncRegistry) {
+            this.emitter = emitter;
+            this.messageDecorator = messageDecorator;
+            this.txSyncRegistry = txSyncRegistry;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public void emit(DataEvent<?> dataEvent) {
+            List<DataEvent<?>> bufferedEvents = (List<DataEvent<?>>) txSyncRegistry.getResource(this);
+            if (bufferedEvents == null) {
+                bufferedEvents = new ArrayList<>();
+                txSyncRegistry.putResource(this, bufferedEvents);
+                final List<DataEvent<?>> events = bufferedEvents;
+                txSyncRegistry.registerInterposedSynchronization(new Synchronization() {
+                    @Override
+                    public void beforeCompletion() {
+                    }
+
+                    @Override
+                    public void afterCompletion(int status) {
+                        if (status == Status.STATUS_COMMITTED) {
+                            for (DataEvent<?> event : events) {
+                                try {
+                                    Message<String> message = messageDecorator.decorate(getMessage(event));
+                                    emitter.send(message);
+                                } catch (Exception e) {
+                                    throw new RuntimeException(e);
+                                }
+                            }
+                        }
+                    }
+                });
+            }
+            bufferedEvents.add(dataEvent);
+        }
+
+        @Override
+        protected <T> Message<String> getMessage(DataEvent<T> event) {
+            return Message.of(event.getType());
+        }
+
+        @Override
+        protected EventMarshaller<String> getEventMarshaller() {
+            return null;
+        }
+
+        @Override
+        protected CloudEventMarshaller<String> getCloudEventMarshaller() {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
This is MIDSTREAM if you want to send your PR to UPSTREAM use https://github.com/apache/incubator-kie-kogito-runtimes 

**REQUIRED** Add link to SRVLOGIC Jira!

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](CONTRIBUTING.md)
- [ ] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [ ] Pull Request title is properly formatted: `SRVLOGIC-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] SRVLOGIC-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>
