### PR TITLE
Revert vertx version removal.

### DIFF
--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -101,6 +101,7 @@
 
     <version.io.smallrye.reactive.mutiny-vertx-web-client>3.21.6</version.io.smallrye.reactive.mutiny-vertx-web-client>
 
+    <version.io.vertx>4.5.31</version.io.vertx>
     <version.io.grpc>1.81.0</version.io.grpc>
 
     <version.io.quarkus.camel>3.33.2</version.io.quarkus.camel>
@@ -1178,10 +1179,12 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-pg-client</artifactId>
+        <version>${version.io.vertx}</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web</artifactId>
+        <version>${version.io.vertx}</version>
       </dependency>
 
       <!-- predictions/machine learning related -->

--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -101,7 +101,6 @@
 
     <version.io.smallrye.reactive.mutiny-vertx-web-client>3.21.6</version.io.smallrye.reactive.mutiny-vertx-web-client>
 
-    <version.io.vertx>4.5.31</version.io.vertx>
     <version.io.grpc>1.81.0</version.io.grpc>
 
     <version.io.quarkus.camel>3.33.2</version.io.quarkus.camel>
@@ -169,17 +168,17 @@
 
     <version.tomcat.embed.core>10.1.55</version.tomcat.embed.core>
     <version.org.hibernate>7.2.19.Final</version.org.hibernate>
-    <version.com.graphql-java>24.3</version.com.graphql-java>
     <version.com.github.zafarkhaja>0.10.2</version.com.github.zafarkhaja>
   </properties>
 
   <dependencyManagement>
     <dependencies>
-      <!-- Force spring boot to be in sync with quarkus for graphql-java dependencies -->
       <dependency>
-        <groupId>com.graphql-java</groupId>
-        <artifactId>graphql-java</artifactId>
-        <version>${version.com.graphql-java}</version>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-bom</artifactId>
+        <version>${version.io.quarkus}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
 
       <!-- These versions are overrides for transitive dependencies, to fix security vulnerabilities. -->
@@ -1173,18 +1172,6 @@
         <groupId>org.rocksdb</groupId>
         <artifactId>rocksdbjni</artifactId>
         <version>${version.org.rocksdb}</version>
-      </dependency>
-
-      <!-- Vertx libraries, including PostgreSQL client -->
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-pg-client</artifactId>
-        <version>${version.io.vertx}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-web</artifactId>
-        <version>${version.io.vertx}</version>
       </dependency>
 
       <!-- predictions/machine learning related -->

--- a/quarkus/bom/pom.xml
+++ b/quarkus/bom/pom.xml
@@ -43,13 +43,7 @@
 
   <dependencyManagement>
     <dependencies>
-      <dependency>
-        <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-bom</artifactId>
-        <version>${version.io.quarkus}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
+      <!-- Quarkus bom is imported higher in the hierarchy in kogito-dependencies-bom. -->
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-devtools-testing</artifactId>


### PR DESCRIPTION
The version was removed as a hotfix for downstream alignment here https://github.com/kiegroup/kogito-runtimes/pull/229

- We need the version, because the module vertx-pg-client is used in one of the repositories modules. What was previously modified were dependencyManagement declarations, those need to have versions there. The vertx-web is declared to override the vertx-web version in transitive dependencies for security reasons. 
- The version 4.5.31 is aligned with Quarkus 3.33.3 used in the repository. If we need some other alignment in downstream, it needs to be done in the build-configurations. 

@saumya1singh - just fyi, If there is any similar problem with vertx alignment, we can align it in the future in the downstream build configurations. 

Please do not backport this to 9.106.x.  