### PR TITLE
Add nightly integration tests against quarkus-openapi-generator 3.0.0-SNAPSHOT

### DIFF
--- a/.github/quarkus-openapi-generator-snapshot-settings.xml
+++ b/.github/quarkus-openapi-generator-snapshot-settings.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Maven settings used by the nightly quarkus-openapi-generator SNAPSHOT integration workflow.
+  Activates the Maven Central Snapshots repository so that SNAPSHOT versions of
+  io.quarkiverse.openapi.generator:quarkus-openapi-generator (and its transitive
+  SNAPSHOT dependencies) are resolved automatically without modifying any POM.
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0
+                              https://maven.apache.org/xsd/settings-1.2.0.xsd">
+
+  <profiles>
+    <profile>
+      <id>central-snapshots</id>
+      <repositories>
+        <repository>
+          <id>central-snapshots</id>
+          <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+          <releases>
+            <enabled>false</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>central-snapshots</id>
+          <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+          <releases>
+            <enabled>false</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+
+  <activeProfiles>
+    <activeProfile>central-snapshots</activeProfile>
+  </activeProfiles>
+
+</settings>

--- a/.github/workflows/nightly-quarkus-main-integration.yml
+++ b/.github/workflows/nightly-quarkus-main-integration.yml
@@ -19,14 +19,13 @@ env:
   JAVA_VERSION: 17
   MAVEN_VERSION: '3.9.11'
   OPENAPI_GENERATOR_VERSION: ${{ github.event.inputs.openapi_generator_version || '3.0.0-SNAPSHOT' }}
+  # Absolute path so it resolves correctly regardless of the step's working-directory.
+  SNAPSHOT_SETTINGS: ${{ github.workspace }}/kogito-runtimes/.github/quarkus-openapi-generator-snapshot-settings.xml
   # Maven CLI flags used in every invocation.
-  # --settings activates the Central Snapshots repository defined in the settings file
-  # so SNAPSHOT artifacts (quarkus-openapi-generator and its transitive deps) are resolved.
   MAVEN_ARGS: >-
     -B
     --no-transfer-progress
     --fail-at-end
-    --settings .github/quarkus-openapi-generator-snapshot-settings.xml
 
 jobs:
   build-kogito-runtimes:
@@ -39,7 +38,7 @@ jobs:
         uses: kiegroup/kie-ci/.ci/actions/ubuntu-disk-space@main
 
       - name: Set up Java ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: temurin
@@ -51,7 +50,7 @@ jobs:
           maven-version: ${{ env.MAVEN_VERSION }}
 
       - name: Checkout kogito-runtimes
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: kogito-runtimes
 
@@ -60,8 +59,8 @@ jobs:
       - name: Pin quarkus-openapi-generator to ${{ env.OPENAPI_GENERATOR_VERSION }}
         working-directory: kogito-runtimes
         run: |
-          mvn -B --no-transfer-progress \
-            --settings .github/quarkus-openapi-generator-snapshot-settings.xml \
+          mvn ${{ env.MAVEN_ARGS }} \
+            --settings ${{ env.SNAPSHOT_SETTINGS }} \
             -pl :kogito-dependencies-bom \
             -Dproperty=version.io.quarkiverse.openapi.generator \
             -DnewVersion=${{ env.OPENAPI_GENERATOR_VERSION }} \
@@ -72,6 +71,7 @@ jobs:
         working-directory: kogito-runtimes
         run: |
           mvn ${{ env.MAVEN_ARGS }} \
+            --settings ${{ env.SNAPSHOT_SETTINGS }} \
             -Dquickly \
             clean install
 
@@ -92,7 +92,7 @@ jobs:
         uses: kiegroup/kie-ci/.ci/actions/ubuntu-disk-space@main
 
       - name: Set up Java ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: temurin
@@ -110,7 +110,7 @@ jobs:
           key: nightly-openapi-snapshot-m2-${{ github.run_id }}
 
       - name: Checkout kogito-runtimes
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: kogito-runtimes
 
@@ -118,6 +118,7 @@ jobs:
         working-directory: kogito-runtimes/quarkus/integration-tests/integration-tests-quarkus-openapi-client
         run: |
           mvn ${{ env.MAVEN_ARGS }} \
+            --settings ${{ env.SNAPSHOT_SETTINGS }} \
             clean verify
 
       - name: JUnit Report
@@ -137,7 +138,7 @@ jobs:
         uses: kiegroup/kie-ci/.ci/actions/ubuntu-disk-space@main
 
       - name: Set up Java ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: temurin
@@ -154,8 +155,13 @@ jobs:
           path: ~/.m2/repository
           key: nightly-openapi-snapshot-m2-${{ github.run_id }}
 
+      - name: Checkout kogito-runtimes
+        uses: actions/checkout@v7
+        with:
+          path: kogito-runtimes
+
       - name: Checkout kogito-examples
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: kiegroup/kogito-examples
           ref: main
@@ -165,6 +171,8 @@ jobs:
         working-directory: kogito-examples/serverless-workflow-examples
         run: |
           mvn ${{ env.MAVEN_ARGS }} \
+            --settings ${{ env.SNAPSHOT_SETTINGS }} \
+            -Dversion.io.quarkiverse.openapi.generator=${{ env.OPENAPI_GENERATOR_VERSION }} \
             clean verify
 
       - name: JUnit Report
@@ -189,22 +197,49 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const version = '${{ env.OPENAPI_GENERATOR_VERSION }}';
-            const title = `[Nightly] Integration test failure – quarkus-openapi-generator ${version} (run #${context.runNumber})`;
+            const label = 'quarkus-oapi-compatibility';
+
+            // Check for an existing open issue to avoid duplicates
+            const { data: existing } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: label,
+              state: 'open',
+              per_page: 1,
+            });
+            if (existing.length > 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing[0].number,
+                body: `Nightly run [#${context.runNumber}](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) also failed against \`${version}\`.`,
+              });
+              return;
+            }
+
+            // Determine which jobs actually failed
+            const jobs = [
+              { id: 'build-kogito-runtimes', result: '${{ needs.build-kogito-runtimes.result }}' },
+              { id: 'integration-tests-runtimes', result: '${{ needs.integration-tests-runtimes.result }}' },
+              { id: 'integration-tests-kogito-examples', result: '${{ needs.integration-tests-kogito-examples.result }}' },
+            ];
+            const failed = jobs.filter(j => j.result === 'failure').map(j => `- \`${j.id}\``);
+            const skipped = jobs.filter(j => j.result === 'skipped').map(j => `- \`${j.id}\` (skipped)`);
+            const affectedLines = [...failed, ...skipped];
+
+            const title = `[Nightly] Integration test failure – quarkus-openapi-generator ${version}`;
             const body = [
               '## Nightly quarkus-openapi-generator SNAPSHOT integration test failure',
               '',
               `**quarkus-openapi-generator version:** \`${version}\``,
               `**Workflow run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
-              `**Triggered at:** ${new Date().toISOString()}`,
               '',
               'One or more jobs in the nightly integration test pipeline failed.',
               'Please investigate whether a breaking change was introduced in',
               '[quarkiverse/quarkus-openapi-generator](https://github.com/quarkiverse/quarkus-openapi-generator).',
               '',
-              '### Affected jobs',
-              '- `build-kogito-runtimes`',
-              '- `integration-tests-runtimes` (OpenAPI client)',
-              '- `integration-tests-kogito-examples` (serverless-workflow-examples)',
+              '### Failed jobs',
+              ...affectedLines,
             ].join('\n');
 
             await github.rest.issues.create({
@@ -212,5 +247,5 @@ jobs:
               repo: context.repo.repo,
               title,
               body,
-              labels: ['quarkus-oapi-compatibility'],
+              labels: [label],
             });

--- a/.github/workflows/nightly-quarkus-main-integration.yml
+++ b/.github/workflows/nightly-quarkus-main-integration.yml
@@ -1,0 +1,216 @@
+name: Nightly Integration Tests – quarkus-openapi-generator SNAPSHOT
+
+on:
+  schedule:
+    # Run every night at 03:00 UTC
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+    inputs:
+      openapi_generator_version:
+        description: 'quarkus-openapi-generator version to test against'
+        required: false
+        default: '3.0.0-SNAPSHOT'
+
+concurrency:
+  group: nightly-quarkus-openapi-generator-snapshot
+  cancel-in-progress: true
+
+env:
+  JAVA_VERSION: 17
+  MAVEN_VERSION: '3.9.11'
+  OPENAPI_GENERATOR_VERSION: ${{ github.event.inputs.openapi_generator_version || '3.0.0-SNAPSHOT' }}
+  # Maven CLI flags used in every invocation.
+  # --settings activates the Central Snapshots repository defined in the settings file
+  # so SNAPSHOT artifacts (quarkus-openapi-generator and its transitive deps) are resolved.
+  MAVEN_ARGS: >-
+    -B
+    --no-transfer-progress
+    --fail-at-end
+    --settings .github/quarkus-openapi-generator-snapshot-settings.xml
+
+jobs:
+  build-kogito-runtimes:
+    name: Build kogito-runtimes (quarkus-openapi-generator ${{ github.event.inputs.openapi_generator_version || '3.0.0-SNAPSHOT' }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    steps:
+      - name: Clean Disk Space
+        uses: kiegroup/kie-ci/.ci/actions/ubuntu-disk-space@main
+
+      - name: Set up Java ${{ env.JAVA_VERSION }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: temurin
+          check-latest: true
+
+      - name: Set up Maven ${{ env.MAVEN_VERSION }}
+        uses: stCarolas/setup-maven@v5
+        with:
+          maven-version: ${{ env.MAVEN_VERSION }}
+
+      - name: Checkout kogito-runtimes
+        uses: actions/checkout@v4
+        with:
+          path: kogito-runtimes
+
+      # Pin version.io.quarkiverse.openapi.generator to the target SNAPSHOT in
+      # the BOM so every downstream module picks it up without further changes.
+      - name: Pin quarkus-openapi-generator to ${{ env.OPENAPI_GENERATOR_VERSION }}
+        working-directory: kogito-runtimes
+        run: |
+          mvn -B --no-transfer-progress \
+            --settings .github/quarkus-openapi-generator-snapshot-settings.xml \
+            -pl :kogito-dependencies-bom \
+            -Dproperty=version.io.quarkiverse.openapi.generator \
+            -DnewVersion=${{ env.OPENAPI_GENERATOR_VERSION }} \
+            -DgenerateBackupPoms=false \
+            versions:set-property
+
+      - name: Build kogito-runtimes (install, skip slow checks)
+        working-directory: kogito-runtimes
+        run: |
+          mvn ${{ env.MAVEN_ARGS }} \
+            -Dquickly \
+            clean install
+
+      - name: Cache local Maven repository for downstream jobs
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.m2/repository
+          key: nightly-openapi-snapshot-m2-${{ github.run_id }}
+
+  integration-tests-runtimes:
+    name: Integration Tests – kogito-runtimes OpenAPI client
+    runs-on: ubuntu-latest
+    needs: build-kogito-runtimes
+    timeout-minutes: 60
+
+    steps:
+      - name: Clean Disk Space
+        uses: kiegroup/kie-ci/.ci/actions/ubuntu-disk-space@main
+
+      - name: Set up Java ${{ env.JAVA_VERSION }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: temurin
+          check-latest: true
+
+      - name: Set up Maven ${{ env.MAVEN_VERSION }}
+        uses: stCarolas/setup-maven@v5
+        with:
+          maven-version: ${{ env.MAVEN_VERSION }}
+
+      - name: Restore Maven cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.m2/repository
+          key: nightly-openapi-snapshot-m2-${{ github.run_id }}
+
+      - name: Checkout kogito-runtimes
+        uses: actions/checkout@v4
+        with:
+          path: kogito-runtimes
+
+      - name: Run OpenAPI client integration tests
+        working-directory: kogito-runtimes/quarkus/integration-tests/integration-tests-quarkus-openapi-client
+        run: |
+          mvn ${{ env.MAVEN_ARGS }} \
+            clean verify
+
+      - name: JUnit Report
+        uses: kiegroup/kogito-pipelines/.ci/actions/action-junit-report@main
+        if: always()
+        with:
+          report_paths: '**/*-reports/TEST-*.xml'
+
+  integration-tests-kogito-examples:
+    name: Integration Tests – kogito-examples serverless-workflow
+    runs-on: ubuntu-latest
+    needs: build-kogito-runtimes
+    timeout-minutes: 120
+
+    steps:
+      - name: Clean Disk Space
+        uses: kiegroup/kie-ci/.ci/actions/ubuntu-disk-space@main
+
+      - name: Set up Java ${{ env.JAVA_VERSION }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: temurin
+          check-latest: true
+
+      - name: Set up Maven ${{ env.MAVEN_VERSION }}
+        uses: stCarolas/setup-maven@v5
+        with:
+          maven-version: ${{ env.MAVEN_VERSION }}
+
+      - name: Restore Maven cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.m2/repository
+          key: nightly-openapi-snapshot-m2-${{ github.run_id }}
+
+      - name: Checkout kogito-examples
+        uses: actions/checkout@v4
+        with:
+          repository: kiegroup/kogito-examples
+          ref: main
+          path: kogito-examples
+
+      - name: Run serverless-workflow-examples integration tests
+        working-directory: kogito-examples/serverless-workflow-examples
+        run: |
+          mvn ${{ env.MAVEN_ARGS }} \
+            clean verify
+
+      - name: JUnit Report
+        uses: kiegroup/kogito-pipelines/.ci/actions/action-junit-report@main
+        if: always()
+        with:
+          report_paths: '**/*-reports/TEST-*.xml'
+
+  notify-on-failure:
+    name: Notify on failure
+    runs-on: ubuntu-latest
+    needs:
+      - build-kogito-runtimes
+      - integration-tests-runtimes
+      - integration-tests-kogito-examples
+    if: failure()
+
+    steps:
+      - name: Create GitHub Issue on failure
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const version = '${{ env.OPENAPI_GENERATOR_VERSION }}';
+            const title = `[Nightly] Integration test failure – quarkus-openapi-generator ${version} (run #${context.runNumber})`;
+            const body = [
+              '## Nightly quarkus-openapi-generator SNAPSHOT integration test failure',
+              '',
+              `**quarkus-openapi-generator version:** \`${version}\``,
+              `**Workflow run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              `**Triggered at:** ${new Date().toISOString()}`,
+              '',
+              'One or more jobs in the nightly integration test pipeline failed.',
+              'Please investigate whether a breaking change was introduced in',
+              '[quarkiverse/quarkus-openapi-generator](https://github.com/quarkiverse/quarkus-openapi-generator).',
+              '',
+              '### Affected jobs',
+              '- `build-kogito-runtimes`',
+              '- `integration-tests-runtimes` (OpenAPI client)',
+              '- `integration-tests-kogito-examples` (serverless-workflow-examples)',
+            ].join('\n');
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: ['quarkus-oapi-compatibility'],
+            });

--- a/kogito-build/kogito-build-no-bom-parent/pom.xml
+++ b/kogito-build/kogito-build-no-bom-parent/pom.xml
@@ -1143,5 +1143,38 @@
         </plugins>
       </build>
     </profile>
+
+    <profile>
+      <!--
+        Enables resolution of artifacts from the Maven Central Snapshots repository.
+        Used by the nightly CI to test against quarkus-openapi-generator SNAPSHOT builds.
+        Activate with: -Pcentral-snapshots
+      -->
+      <id>central-snapshots</id>
+      <repositories>
+        <repository>
+          <id>central-snapshots</id>
+          <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+          <releases>
+            <enabled>false</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>central-snapshots</id>
+          <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+          <releases>
+            <enabled>false</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
   </profiles>
 </project>

--- a/kogito-build/kogito-build-no-bom-parent/pom.xml
+++ b/kogito-build/kogito-build-no-bom-parent/pom.xml
@@ -1147,8 +1147,8 @@
     <profile>
       <!--
         Enables resolution of artifacts from the Maven Central Snapshots repository.
-        Used by the nightly CI to test against quarkus-openapi-generator SNAPSHOT builds.
-        Activate with: -Pcentral-snapshots
+        For local development use: activate with -Pcentral-snapshots.
+        CI uses .github/quarkus-openapi-generator-snapshot-settings.xml instead (via - -settings).
       -->
       <id>central-snapshots</id>
       <repositories>


### PR DESCRIPTION
This is MIDSTREAM if you want to send your PR to UPSTREAM use https://github.com/apache/incubator-kie-kogito-runtimes 

**REQUIRED** Add link to SRVLOGIC Jira!

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](CONTRIBUTING.md)
- [ ] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [ ] Pull Request title is properly formatted: `SRVLOGIC-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] SRVLOGIC-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>
