### PR TITLE
[Security] Update netty to 4.1.137.Final.

### DIFF
--- a/kogito-build/kogito-dependencies-bom/pom.xml
+++ b/kogito-build/kogito-dependencies-bom/pom.xml
@@ -79,7 +79,7 @@
     <version.jakarta.validation-api>3.1.1</version.jakarta.validation-api>
     <version.jakarta.xml.bind-api>4.0.4</version.jakarta.xml.bind-api>
 
-    <version.io.netty>4.1.136.Final</version.io.netty>
+    <version.io.netty>4.1.137.Final</version.io.netty>
 
     <version.io.cloudevents>3.0.0</version.io.cloudevents>
     <!--


### PR DESCRIPTION
Updates netty to 4.1.137.Final

Related PRs:
https://github.com/kiegroup/drools/pull/223
https://github.com/kubesmarts/kie-tools/pull/444